### PR TITLE
add link script

### DIFF
--- a/tools/link.js
+++ b/tools/link.js
@@ -1,24 +1,17 @@
 const npmRun = require('npm-run');
 
+// respect dependency order here
 const packages = [
-	// { name: 'scss', dependencies: ['icons'] },
-	// { name: 'ng', dependencies: ['scss', 'icons'] },
+	{ name: 'scss', dependencies: [] },
 	{ name: 'ng', dependencies: ['scss'] },
 ];
 
-// extract dependencies to call `npm link` on each
-// equivalent to _.chain(packages).pluck('dependencies').flatten().uniq().value();
-let dependencies = [...new Set([].concat(...packages.map(d => d.dependencies)))];
-
-dependencies.forEach(d => {
-	// console.log(`${d}`);
-	npmRun.execSync('npm link', { cwd: `${__dirname}/../packages/${d}`, stdio: [0, 1, 2] });
-});
-
-// link the pck with their dependencies
 packages.forEach(pck => {
+	// link the pck with their dependencies
+	// need this first cuz `npm link` launches `prepublish`
 	pck.dependencies.forEach(d => {
-		// console.log(`${pck.name} -> ${d}`);
 		npmRun.execSync(`npm link @lucca-front/${d}`, { cwd: `${__dirname}/../packages/${pck.name}`, stdio: [0, 1, 2] });
 	});
+	// then register the pck with link
+	npmRun.execSync('npm link', { cwd: `${__dirname}/../packages/${pck.name}`, stdio: [0, 1, 2] });
 });

--- a/tools/link.js
+++ b/tools/link.js
@@ -1,0 +1,24 @@
+const npmRun = require('npm-run');
+
+const packages = [
+	// { name: 'scss', dependencies: ['icons'] },
+	// { name: 'ng', dependencies: ['scss', 'icons'] },
+	{ name: 'ng', dependencies: ['scss'] },
+];
+
+// extract dependencies to call `npm link` on each
+// equivalent to _.chain(packages).pluck('dependencies').flatten().uniq().value();
+let dependencies = [...new Set([].concat(...packages.map(d => d.dependencies)))];
+
+dependencies.forEach(d => {
+	// console.log(`${d}`);
+	npmRun.execSync('npm link', { cwd: `${__dirname}/../packages/${d}`, stdio: [0, 1, 2] });
+});
+
+// link the pck with their dependencies
+packages.forEach(pck => {
+	pck.dependencies.forEach(d => {
+		// console.log(`${pck.name} -> ${d}`);
+		npmRun.execSync(`npm link @lucca-front/${d}`, { cwd: `${__dirname}/../packages/${pck.name}`, stdio: [0, 1, 2] });
+	});
+});


### PR DESCRIPTION
[npm link](https://docs.npmjs.com/cli/link) is the way to wwork on several interdependnat npm packages.

here we will have several packages with dependencies between them, `ng` is dependant on `scss`. but in the future we'll have
`scss depends on `icons`
`webcomponents` depends on `icons` and `scss`
`ng` depends on `icons`, `scss`, `webcomponents`

this script does all the necessary linking