### PR TITLE
[fix] round radio

### DIFF
--- a/packages/scss/src/components/_radio.scss
+++ b/packages/scss/src/components/_radio.scss
@@ -30,7 +30,6 @@
 		content: "";
 		display: block;
 		height: 1rem;
-		height: .95rem;
 		left: 0;
 		position: absolute;
 		top: .3rem;


### PR DESCRIPTION
Height was duplicated. CombCSS inverted the two values. 