### PR TITLE
[ref] action buttons must be outside the list element link

### DIFF
--- a/packages/scss/demo/components/lists.html
+++ b/packages/scss/demo/components/lists.html
@@ -10,8 +10,8 @@
 				<p class="list-item-content-description">List item description</p>
 			</div>
 			<div class="list-item-actions">
- 				 <button class="actionIcon"><i class="lucca-icon">edit</i></button>
- 				 <button class="actionIcon"><i class="lucca-icon">trash</i></button>
+ 				<button class="actionIcon"><i class="lucca-icon">edit</i></button>
+ 				<button class="actionIcon"><i class="lucca-icon">trash</i></button>
  		 </div>
 		</li>
 		<li class="list-item">
@@ -49,7 +49,49 @@
 	...
 &lt;/ul&gt;
 </code>
+	<em><b>Tip:</b> Just remove <code class="code">list-item-actions</code> to have a full width content list.</em>
+</section>
+<section class="contentSection">
+	<h3>Clickable list element</h3>
+	<ul class="list">
+		<li class="list-item">
+			<a href="#" class="list-item-content mod-clickable">
+				<h4 class="list-item-content-title">List item title</h4>
+				<p class="list-item-content-description">List item description</p>
+			</a>
+			<div class="list-item-actions">
+				<button class="actionIcon"><i class="lucca-icon">edit</i></button>
+				<button class="actionIcon"><i class="lucca-icon">trash</i></button>
+		 </div>
+		</li>
+		<li class="list-item">
+			<a href="#" class="list-item-content mod-clickable">
+				<h4 class="list-item-content-title">List item title</h4>
+				<p class="list-item-content-description">List item description</p>
+			</a>
+			<div class="list-item-actions">
+				<button class="actionIcon"><i class="lucca-icon">edit</i></button>
+				<button class="actionIcon"><i class="lucca-icon">trash</i></button>
+		 </div>
+		</li>
+	</ul>
 
-<em><b>Tip:</b> Just remove <code class="code">list-item-actions</code> to have a full width content list.</em>
-<em><b>Tip:</b> You can replace <code class="code">&lt;div class="list-item-content"&gt;</code> by <code class="code">&lt;div class="list-item-content"&gt;</code> to have a clickable list element. Keep <code class="code">&lt;div class="list-item-actions"&gt;</code> outside the link.</em>
+<code class="code mod-block">&lt;ul class="list"&gt;
+	&lt;li class="list-item"&gt;
+		&lt;a href="#" class="list-item-content mod-clickable"&gt;
+			&lt;h4 class="list-item-content-title"&gt;...&lt;/h4&gt;
+			&lt;p class="list-item-content-description"&gt;...&lt;/p&gt;
+		&lt;/a&gt;
+		&lt;div class="list-item-actions"&gt;
+			&lt;button class="actionIcon"&gt;&lt;i class="lucca-icon"&gt;edit&lt;/i&gt;&lt;/button&gt;
+			&lt;button class="actionIcon"&gt;&lt;i class="lucca-icon"&gt;trash&lt;/i&gt;&lt;/button&gt;
+	 &lt;/div&gt;
+	&lt;/li&gt;
+	...
+&lt;/ul&gt;
+</code>
+
+
+
+	<em><b>Tip:</b> <code class="code">list-item-content</code> can be used as a <code class="code">div</code> for inner page interactions.</em>
 </section>

--- a/packages/scss/demo/components/lists.html
+++ b/packages/scss/demo/components/lists.html
@@ -51,56 +51,5 @@
 </code>
 
 <em><b>Tip:</b> Just remove <code class="code">list-item-actions</code> to have a full width content list.</em>
-</section>
-
-<!-- clickable list -->
-<section class="contentSection">
- <h3>Clickable list</h3>
- <p>You can use list items as clickables elements by using a <code class="code">div</code> & <code class="code">a</code> structure.</p>
- <div class="list">
-	 <a href="#" class="list-item">
-		 <div class="list-item-content">
-			 <h4 class="list-item-content-title">List item title</h4>
-			 <p class="list-item-content-description">List item description</p>
-		 </div>
-		 <div class="list-item-actions">
-			 <button class="actionIcon"><i class="lucca-icon">edit</i></button>
-			 <button class="actionIcon"><i class="lucca-icon">trash</i></button>
-		 </div>
-	 </a>
-	 <a href="#" class="list-item">
-		 <div class="list-item-content">
-			 <h4 class="list-item-content-title">List item title</h4>
-			 <p class="list-item-content-description">List item description</p>
-		 </div>
-		 <div class="list-item-actions">
-			 <button class="actionIcon"><i class="lucca-icon">edit</i></button>
-			 <button class="actionIcon"><i class="lucca-icon">trash</i></button>
-		 </div>
-	 </a>
-	 <a href="#" class="list-item">
-		 <div class="list-item-content">
-			 <h4 class="list-item-content-title">List item title</h4>
-			 <p class="list-item-content-description">List item description</p>
-		 </div>
-		 <div class="list-item-actions">
-			 <button class="actionIcon"><i class="lucca-icon">edit</i></button>
-			 <button class="actionIcon"><i class="lucca-icon">trash</i></button>
-		 </div>
-	 </a>
- </div>
-<code class="code mod-block">&lt;div class="list"&gt;
- &lt;a href="#" class="list-item"&gt;
-	 &lt;div class="list-item-content"&gt;
-		 &lt;h4 class="list-item-content-title"&gt;...&lt;/h4&gt;
-		 &lt;p class="list-item-content-description"&gt;...&lt;/p&gt;
-	 &lt;/div&gt;
-	 &lt;div class="list-item-actions"&gt;
-		 &lt;button class="actionIcon"gt;&lt;i class="lucca-icon"gt;edit&lt;&gt;&lt;/buttongt;
-		 &lt;button class="actionIcon"gt;&lt;i class="lucca-icon"gt;trash&lt;&gt;&lt;/buttongt;
-	 &lt;/div&gt;
- &lt;/a&gt;
- ...
-&lt;/div&gt;
-</code>
+<em><b>Tip:</b> You can replace <code class="code">&lt;div class="list-item-content"&gt;</code> by <code class="code">&lt;div class="list-item-content"&gt;</code> to have a clickable list element. Keep <code class="code">&lt;div class="list-item-actions"&gt;</code> outside the link.</em>
 </section>

--- a/packages/scss/src/components/_list.scss
+++ b/packages/scss/src/components/_list.scss
@@ -11,7 +11,6 @@
 	border-bottom: _theme("commons.divider.width") solid _theme("commons.divider.color");
 	color: _color("text.default");
 	display: flex;
-	padding: _component("list.padding");
 	position: relative;
 	text-decoration: none;
 
@@ -26,6 +25,13 @@
 	}
 }
 
+.list-item-content {
+	color: _color("text.default");
+	padding: _component("list.padding");
+	text-decoration: none;
+	width: 100%;
+}
+
 .list-item-content-title {
 	margin: 0;
 }
@@ -37,7 +43,8 @@
 .list-item-actions {
 	margin-left: auto;
 	opacity: 0;
-	padding-left: 1rem;
+	padding: _component("list.padding");
+	padding-left: 0;
 	transition: all _theme("commons.animations.durations.fast") ease;
 	white-space: nowrap;
 }

--- a/packages/scss/src/components/_list.scss
+++ b/packages/scss/src/components/_list.scss
@@ -48,3 +48,9 @@
 	transition: all _theme("commons.animations.durations.fast") ease;
 	white-space: nowrap;
 }
+
+.list-item-content {
+	&.mod-clickable {
+		cursor: pointer;
+	}
+}


### PR DESCRIPTION
About that : 
![image](https://user-images.githubusercontent.com/25581936/27728041-22d28c20-5d81-11e7-8901-d5c4b87d429a.png)

As I want to allow to have a link on list-item-content, padding are now on list-item-content and list-item-actions. So the default padding is applied on both, except list-item-actions left padding. 

Using a link on list also become only a suggestion. 

