### PR TITLE
Ng.user tile

### DIFF
--- a/packages/ng/demo/app/app.component.html
+++ b/packages/ng/demo/app/app.component.html
@@ -8,4 +8,5 @@
 <div class="demos">
 	<demo-lol></demo-lol>
 	<demo-date-range-picker></demo-date-range-picker>
+	<demo-user-tile></demo-user-tile>
 </div>

--- a/packages/ng/demo/app/app.module.ts
+++ b/packages/ng/demo/app/app.module.ts
@@ -7,6 +7,7 @@ import { AppComponent } from './app.component';
 
 import { DemoLolModule } from './lol/lol.module';
 import {DemoDateRangePickerModule} from './date-range-picker/date-range-picker.module';
+import {DemoUserTileModule} from './user-tile/user-tile.module';
 
 @NgModule({
 	declarations: [
@@ -15,6 +16,7 @@ import {DemoDateRangePickerModule} from './date-range-picker/date-range-picker.m
 	imports: [
 		DemoLolModule,
 		DemoDateRangePickerModule,
+		DemoUserTileModule,
 		BrowserModule,
 		FormsModule,
 		HttpModule,

--- a/packages/ng/demo/app/user-tile/basic/basic.component.html
+++ b/packages/ng/demo/app/user-tile/basic/basic.component.html
@@ -1,0 +1,12 @@
+<div class="tiles">
+	<lu-user-tile class="user-tile" [user]="user"></lu-user-tile>
+	<lu-user-tile class="user-tile" [user]="user" [role]="'French actress'"></lu-user-tile>
+	<lu-user-tile class="user-tile" [user]="user" [role]="'French actress'">
+		<a href="/">Contact</a>
+	</lu-user-tile>
+	<lu-user-tile class="user-tile" [user]="user" [role]="'Approved by'">
+		<div mdTooltip="This guy, that other guy" [mdTooltipPosition]="'above'">
+			and two others
+		</div>
+	</lu-user-tile>
+</div>

--- a/packages/ng/demo/app/user-tile/basic/basic.component.html
+++ b/packages/ng/demo/app/user-tile/basic/basic.component.html
@@ -1,4 +1,5 @@
 <div class="tiles">
+	<lu-user-tile class="user-tile" [user]="noPicUser"></lu-user-tile>
 	<lu-user-tile class="user-tile" [user]="user"></lu-user-tile>
 	<lu-user-tile class="user-tile" [user]="user" [role]="'French actress'"></lu-user-tile>
 	<lu-user-tile class="user-tile" [user]="user" [role]="'French actress'">

--- a/packages/ng/demo/app/user-tile/basic/basic.component.html
+++ b/packages/ng/demo/app/user-tile/basic/basic.component.html
@@ -5,9 +5,16 @@
 	<lu-user-tile class="user-tile" [user]="user" [role]="'French actress'">
 		<a href="/">Contact</a>
 	</lu-user-tile>
+
 	<lu-user-tile class="user-tile" [user]="user" [role]="'Approved by'">
 		<div mdTooltip="This guy, that other guy" [mdTooltipPosition]="'above'">
 			and two others
+		</div>
+	</lu-user-tile>
+
+	<lu-user-tile class="user-tile" [user]="user" [role]="'Approved by'">
+		<div>
+			Be careful <br/> what you put <br/> inside <br/> this footer !
 		</div>
 	</lu-user-tile>
 </div>

--- a/packages/ng/demo/app/user-tile/basic/basic.component.ts
+++ b/packages/ng/demo/app/user-tile/basic/basic.component.ts
@@ -14,6 +14,12 @@ export class BasicComponent implements OnInit {
 		jobTitle: 'Actress'
 	};
 
+	noPicUser: User = {
+		displayName: 'Jean-Michel Pasdephoto',
+		picture: {url: ''},
+		jobTitle: 'Actor'
+	};
+
 	constructor() { }
 
 	ngOnInit() {

--- a/packages/ng/demo/app/user-tile/basic/basic.component.ts
+++ b/packages/ng/demo/app/user-tile/basic/basic.component.ts
@@ -1,0 +1,22 @@
+import { Component, OnInit } from '@angular/core';
+import {User} from '../../../../src/app/user-tile/user-tile.models';
+
+@Component({
+	selector: 'demo-basic',
+	templateUrl: './basic.component.html',
+	styles: [' .tiles{display: flex} .user-tile {background: rgba(0, 0, 0, 0.05); margin: 5px;}']
+})
+export class BasicComponent implements OnInit {
+
+	user: User = {
+		displayName: 'Anaïs Lemoustier',
+		picture: {url: 'https://upload.wikimedia.org/wikipedia/commons/e/ec/Ana%C3%AFs_Demoustier_Cabourg_2015.jpg'},
+		jobTitle: 'Actress'
+	};
+
+	constructor() { }
+
+	ngOnInit() {
+	}
+
+}

--- a/packages/ng/demo/app/user-tile/basic/basic.component.ts
+++ b/packages/ng/demo/app/user-tile/basic/basic.component.ts
@@ -4,7 +4,7 @@ import {User} from '../../../../src/app/user-tile/user-tile.models';
 @Component({
 	selector: 'demo-basic',
 	templateUrl: './basic.component.html',
-	styles: [' .tiles{display: flex} .user-tile {background: rgba(0, 0, 0, 0.05); margin: 5px;}']
+	styles: [' .tiles{display: inline-table} .user-tile {background: rgba(0, 0, 0, 0.05); margin: 5px; float: left}']
 })
 export class BasicComponent implements OnInit {
 

--- a/packages/ng/demo/app/user-tile/user-tile.component.html
+++ b/packages/ng/demo/app/user-tile/user-tile.component.html
@@ -1,0 +1,5 @@
+<demo-api-docs directive="LuUserTileComponent"></demo-api-docs>
+
+<demo-example-box [snippets]="snippets" demo="basic">
+	<demo-basic></demo-basic>
+</demo-example-box>

--- a/packages/ng/demo/app/user-tile/user-tile.component.ts
+++ b/packages/ng/demo/app/user-tile/user-tile.component.ts
@@ -1,0 +1,23 @@
+import { Component, OnInit } from '@angular/core';
+declare var require: any;
+
+@Component({
+	selector: 'demo-user-tile',
+	templateUrl: './user-tile.component.html',
+	styles: []
+})
+export class DemoUserTileComponent implements OnInit {
+
+	constructor() { }
+
+	snippets = {
+		basic: {
+			code: require('!!prismjs-loader?lang=typescript!./basic/basic.component'),
+			markup: require('!!prismjs-loader?lang=markup!./basic/basic.component.html')
+		},
+	};
+
+	ngOnInit() {
+	}
+
+}

--- a/packages/ng/demo/app/user-tile/user-tile.module.ts
+++ b/packages/ng/demo/app/user-tile/user-tile.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { DemoUserTileComponent } from './user-tile.component';
+import { LuUserTileModule } from '../../../src/app/user-tile/user-tile.module';
+import {SharedModule} from '../shared/index';
+import { BasicComponent } from './basic/basic.component';
+import {MdTooltipModule} from '@angular/material';
+
+@NgModule({
+	imports: [
+		CommonModule,
+		LuUserTileModule,
+		SharedModule,
+		MdTooltipModule
+	],
+	declarations: [DemoUserTileComponent, BasicComponent],
+	exports: [DemoUserTileComponent, BasicComponent]
+})
+export class DemoUserTileModule { }

--- a/packages/ng/src/app/lu-root.module.ts
+++ b/packages/ng/src/app/lu-root.module.ts
@@ -1,18 +1,21 @@
 import { CommonModule } from '@angular/common';
-import { LuLolModule } from './lol/lol.module';
 import { NgModule } from '@angular/core';
 import { MD_RIPPLE_GLOBAL_OPTIONS } from '@angular/material';
+import { LuLolModule } from './lol/lol.module';
 import {LuDateRangePickerModule} from './date-range-picker/date-range-picker.module';
+import {LuUserTileModule} from './user-tile/user-tile.module';
 
 @NgModule({
 	imports: [
 		CommonModule,
 		LuLolModule,
 		LuDateRangePickerModule,
+		LuUserTileModule,
 	],
 	exports: [
 		LuLolModule,
 		LuDateRangePickerModule,
+		LuUserTileModule,
 	],
 	providers: [{provide: MD_RIPPLE_GLOBAL_OPTIONS, useValue: {disabled: true}}],
 })

--- a/packages/ng/src/app/user-tile/user-tile.component.html
+++ b/packages/ng/src/app/user-tile/user-tile.component.html
@@ -1,4 +1,6 @@
-<div class="picture" [ngStyle]="{'background-image': 'url(' + user.picture.url + '?width=100)'}"></div>
+<div class="picture" [ngStyle]=" this.hasUserPicture() ? this.getBackgroundImageStyle() : this.getDefaultColorStyle()">
+	<span *ngIf="!hasUserPicture()">{{getPictureTextPlaceholder()}}</span>
+</div>
 <div class="user-info">
 	<span class="user-tile-label">{{role ? role : user.jobTitle}}</span>
 	<span class="user-tile-label">{{user.displayName}}</span>

--- a/packages/ng/src/app/user-tile/user-tile.component.html
+++ b/packages/ng/src/app/user-tile/user-tile.component.html
@@ -1,0 +1,6 @@
+<div class="picture" [ngStyle]="{'background-image': 'url(' + user.picture.url + '?width=100)'}"></div>
+<div class="user-info">
+	<span class="user-tile-label">{{role ? role : user.jobTitle}}</span>
+	<span class="user-tile-label">{{user.displayName}}</span>
+	<span class="user-tile-label ng-content"><ng-content></ng-content></span>
+</div>

--- a/packages/ng/src/app/user-tile/user-tile.component.scss
+++ b/packages/ng/src/app/user-tile/user-tile.component.scss
@@ -9,6 +9,13 @@
 		background-position: center;
 		background-size: 55px auto;
 		margin: 5px;
+
+		text-align: center;
+		vertical-align: middle;
+		line-height: 55px;
+
+		color: white;
+		font-size: 1.2em;
 	}
 	.user-info {
 		margin: auto 0;

--- a/packages/ng/src/app/user-tile/user-tile.component.scss
+++ b/packages/ng/src/app/user-tile/user-tile.component.scss
@@ -1,0 +1,25 @@
+:host {
+	display: flex;
+	align-items: stretch;
+	width: 300px;
+	.picture {
+		width: 55px;
+		height: 55px;
+		border-radius: 100%;
+		background-position: center;
+		background-size: 55px auto;
+		margin: 5px;
+	}
+	.user-info {
+		margin: auto 0;
+		* { display: block; }
+		.user-tile-label {
+			font-size: .9em;
+			line-height: 1.2;
+			color: _color('text.light');
+			&.ng-content {
+				font-size: .8em;
+			}
+		}
+	}
+}

--- a/packages/ng/src/app/user-tile/user-tile.component.scss
+++ b/packages/ng/src/app/user-tile/user-tile.component.scss
@@ -1,18 +1,19 @@
 :host {
 	display: flex;
 	align-items: stretch;
-	width: 300px;
+	width: 18em;
+	min-height: 4em;
 	.picture {
-		width: 55px;
-		height: 55px;
+		width: 3em;
+		height: 3em;
 		border-radius: 100%;
 		background-position: center;
-		background-size: 55px auto;
-		margin: 5px;
+		background-size: 3em auto;
+		margin: auto 0.26em;
 
 		text-align: center;
 		vertical-align: middle;
-		line-height: 55px;
+		line-height: 3em;
 
 		color: white;
 		font-size: 1.2em;

--- a/packages/ng/src/app/user-tile/user-tile.component.spec.ts
+++ b/packages/ng/src/app/user-tile/user-tile.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LuUserTileComponent } from './user-tile.component';
+
+describe('LuUserTileComponent', () => {
+	let component: LuUserTileComponent;
+	let fixture: ComponentFixture<LuUserTileComponent>;
+
+	beforeEach(async(() => {
+		TestBed.configureTestingModule({
+			declarations: [ LuUserTileComponent ]
+		})
+			.compileComponents();
+	}));
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(LuUserTileComponent);
+		component = fixture.componentInstance;
+		fixture.detectChanges();
+	});
+
+	it('should create', () => {
+		expect(component).toBeTruthy();
+	});
+});

--- a/packages/ng/src/app/user-tile/user-tile.component.ts
+++ b/packages/ng/src/app/user-tile/user-tile.component.ts
@@ -1,0 +1,29 @@
+import {Component, Input, OnInit} from '@angular/core';
+import {User} from './user-tile.models';
+
+/**
+ * Displays user picture and name. User's role can be specified, and the footer is customizable.
+ */
+@Component({
+	selector: 'lu-user-tile',
+	templateUrl: './user-tile.component.html',
+	styleUrls: ['./user-tile.component.scss']
+})
+export class LuUserTileComponent implements OnInit {
+
+	/**
+	 * User to display.
+	 */
+	@Input() user: User;
+
+	/**
+	 * User role to display
+	 */
+	@Input() role: string;
+
+	constructor() { }
+
+	ngOnInit() {
+	}
+
+}

--- a/packages/ng/src/app/user-tile/user-tile.component.ts
+++ b/packages/ng/src/app/user-tile/user-tile.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnInit} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {User} from './user-tile.models';
 
 /**
@@ -9,7 +9,7 @@ import {User} from './user-tile.models';
 	templateUrl: './user-tile.component.html',
 	styleUrls: ['./user-tile.component.scss']
 })
-export class LuUserTileComponent implements OnInit {
+export class LuUserTileComponent {
 
 	/**
 	 * User to display.
@@ -21,9 +21,11 @@ export class LuUserTileComponent implements OnInit {
 	 */
 	@Input() role: string;
 
-	constructor() { }
+	hasUserPicture = () => !!this.user.picture && !!this.user.picture.url;
 
-	ngOnInit() {
-	}
+	getDefaultColorStyle = () => ({'background-color': 'rgb(215, 92, 112)'});  // TODO replace hardcoded color with algo
 
+	getBackgroundImageStyle = () => ({'background-image': 'url(' + this.user.picture.url + '?width=100)'});
+
+	getPictureTextPlaceholder = () => this.user.displayName.trim().toUpperCase().split(' ').map(str => str[0]).join('')
 }

--- a/packages/ng/src/app/user-tile/user-tile.component.ts
+++ b/packages/ng/src/app/user-tile/user-tile.component.ts
@@ -23,9 +23,13 @@ export class LuUserTileComponent {
 
 	hasUserPicture = () => !!this.user.picture && !!this.user.picture.url;
 
-	getDefaultColorStyle = () => ({'background-color': 'rgb(215, 92, 112)'});  // TODO replace hardcoded color with algo
+	getPictureTextPlaceholder = () => this.getUserNamesListUpperCase().map(str => str[0]).join('');
 
-	getBackgroundImageStyle = () => ({'background-image': 'url(' + this.user.picture.url + '?width=100)'});
+	getBackgroundImageStyle = () => ({'background-image': `url('${this.user.picture.url}?width=100)`});
 
-	getPictureTextPlaceholder = () => this.user.displayName.trim().toUpperCase().split(' ').map(str => str[0]).join('')
+	getDefaultColorStyle = () => ({'background-color': `hsl(${this.getNameHue()}, 60%, 60%)`});
+
+	private getNameHue = () => this.getUserNamesListUpperCase().map(str => str.charCodeAt(0)).reduce((sum, a) => sum + a, 0) * 2 % 360;
+
+	private getUserNamesListUpperCase = () => this.user.displayName.trim().toUpperCase().split(' ');
 }

--- a/packages/ng/src/app/user-tile/user-tile.models.ts
+++ b/packages/ng/src/app/user-tile/user-tile.models.ts
@@ -1,0 +1,5 @@
+export interface User {
+	displayName: string;
+	picture: {url: string};
+	jobTitle: string;
+}

--- a/packages/ng/src/app/user-tile/user-tile.module.ts
+++ b/packages/ng/src/app/user-tile/user-tile.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LuUserTileComponent } from './user-tile.component';
+
+@NgModule({
+	imports: [
+		CommonModule,
+	],
+	declarations: [LuUserTileComponent],
+	exports: [LuUserTileComponent]
+})
+export class LuUserTileModule { }

--- a/packages/ng/src/index.ts
+++ b/packages/ng/src/index.ts
@@ -1,4 +1,5 @@
 export * from './app/lol/lol.module';
 export * from './app/date-range-picker/date-range-picker.module';
+export * from './app/user-tile/user-tile.module'
 export {DateRangeSelectChoice, DateRange} from './app/date-range-picker/date-range-picker.models';
 export { LuRootModule } from './app/lu-root.module';


### PR DESCRIPTION
Tile for user display. By default, the header displays the user's `jobTitle` but is customizable. A footer can be added via `ng-content`. 

This branch is based on `ng.datepicker` for convenience, but will be rebased and merged onto master after `ng.datepicker` is merged.  This PR is for review only.