### PR TITLE
ng-dep [rem] dep to @angular/http

### DIFF
--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -39,7 +39,6 @@
     "@angular/compiler": "^4.3.6",
     "@angular/core": "^4.3.6",
     "@angular/forms": "^4.3.6",
-    "@angular/http": "^4.3.6",
     "@angular/material": "^2.0.0-beta.10",
     "@angular/platform-browser": "^4.3.6",
     "@angular/platform-browser-dynamic": "^4.3.6",


### PR DESCRIPTION
we'll use `@angular/common/http` if we need to use a http service