### PR TITLE
[FIX] Safari **** bug

### DIFF
--- a/packages/icons/src/_font.scss
+++ b/packages/icons/src/_font.scss
@@ -5,10 +5,10 @@ $font-path: "lucca-icons" !default;
 		font-style: normal;
 		font-weight: 400;
 		src:  url('#{$font-path}.eot');
-		src:  url('#{$font-path}.eot') format('embedded-opentype'),
-			url('#{$font-path}.svg') format('svg'),
-			url('#{$font-path}.woff') format('woff'),
-			url('#{$font-path}.ttf') format('truetype');
+		src:  url('#{$font-path}.eot'),
+			url('#{$font-path}.svg'),
+			url('#{$font-path}.woff'),
+			url('#{$font-path}.ttf');
 
 		/* Enable Ligatures ================ */
 		letter-spacing: normal;


### PR DESCRIPTION
Safari Mac wasn't supporting the "format" in the src font definition