### PR TITLE
[NG] Add mdDialog override mod-sidePanel 

### DIFF
--- a/packages/ng/src/plugins/ngMaterial/_dialog.scss
+++ b/packages/ng/src/plugins/ngMaterial/_dialog.scss
@@ -4,3 +4,24 @@
 	overflow: visible !important;
 	padding: 0 !important;
 }
+
+.cdk-overlay-pane {
+	&.mod-sidePanel {
+		position: fixed !important;
+		top: _theme('commons.banner-height');
+		right: 0;
+		bottom: 0;
+		width: 60%;
+		max-width: 800px;
+		@include media_smaller_than("md") {
+			width: 80%;
+		}
+		@include media_smaller_than("sd") {
+			width: 100%;
+		}
+
+		.mat-dialog-container {
+			max-width: 100%;
+		}
+	}
+}

--- a/packages/ng/src/plugins/ngMaterial/_dialog.scss
+++ b/packages/ng/src/plugins/ngMaterial/_dialog.scss
@@ -16,7 +16,7 @@
 		@include media_smaller_than("md") {
 			width: 80%;
 		}
-		@include media_smaller_than("sd") {
+		@include media_smaller_than("sm") {
 			width: 100%;
 		}
 


### PR DESCRIPTION
Adds `mod-sidePanel` to the mdDialog component. 
It is yet impossible to override its animations.