### PR TITLE
[SCSS] is-focused state for textfield

### DIFF
--- a/packages/scss/src/components/inputs/textfield/_textfield.compact.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.compact.scss
@@ -83,6 +83,13 @@
 				color: #A6A6A6;
 			}
 		}
+		
+		// Needed when not next to input (formly)
+		&.is-focused {
+			.textfield-label {
+				color: #A6A6A6;
+			}
+		}
 	}
 
 	// default color
@@ -181,6 +188,19 @@
 			~ .textfield-label {
 				color: _color("error");
 			}
+		}
+	}
+
+	&.is-error {
+		.textfield-label {
+			color: _color("error");
+		}
+	}
+
+	&.is-focused, &.is-filled {
+		.textfield-label {
+			font-size: inherit;
+			top: auto;
 		}
 	}
 }

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -76,6 +76,12 @@
 				color: _get($palette, "color");
 			}
 		}
+		// Needed when textfield label is not next to the textfield-input
+		&.is-focused {
+			.textfield-label {
+				color: _get($palette, "color");
+			}
+		}
 	}
 
 	@include inputColoring(_component("textfield.framed.default-palette"));
@@ -182,6 +188,19 @@
 			~ .textfield-label, ~ .textfield-suffix {
 				color: _color("error") !important;
 			}
+		}
+	}
+
+	// Needed when not next to input-field (formly)
+	&.is-error {
+		.textfield-label, .textfield-suffix {
+				color: _color("error") !important;
+			}
+	}
+	// Needed when not next to input-field (formly)
+	&.is-focused, &:hover {
+		.textfield-messages {
+			transform: translateY(100%);
 		}
 	}
 }

--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -123,6 +123,13 @@
 				color: _get($palette, "color");
 			}
 		}
+
+		// Needed when textfield label is not next to the textfield-input
+		&.is-focused {
+			.textfield-label {
+				color: _get($palette, "color");
+			}
+		}
 	}
 
 	// default color
@@ -294,6 +301,14 @@
 			font-size: 1.2rem;
 			margin-left: .25em;
 			position: absolute;
+		}
+	}
+
+	// Needed when textfield label is not next to the textfield-input
+	&.is-focused {
+		.textfield-label {
+			font-size: _theme("sizes.small.font-size");
+			top: 0;
 		}
 	}
 }


### PR DESCRIPTION
Adds the `is-focused` state on `textfield` to handle cases where the sibling selector ~ cannot be used.