### PR TITLE
Ng.demo.redirect

### DIFF
--- a/packages/ng/demo/app/api/api.component.html
+++ b/packages/ng/demo/app/api/api.component.html
@@ -10,3 +10,5 @@
 </demo-example-box> -->
 
 <demo-redirect></demo-redirect>
+
+<button class="button" (click)="whoami()">who am i</button>{{me | json}}

--- a/packages/ng/demo/app/api/api.component.html
+++ b/packages/ng/demo/app/api/api.component.html
@@ -1,0 +1,12 @@
+<!-- <demo-api-docs directive="LuApiDirective"></demo-api-docs>
+<demo-api-docs directive="LuApiPickerComponent"></demo-api-docs> -->
+
+<!-- <h3>Examples</h3>
+<demo-example-box [snippets]="snippets" demo="basic">
+	<demo-empty-basic ></demo-empty-basic>
+</demo-example-box>
+<demo-example-box [snippets]="snippets" demo="custom">
+	<demo-empty-custom-fn ></demo-empty-custom-fn>
+</demo-example-box> -->
+
+<demo-redirect></demo-redirect>

--- a/packages/ng/demo/app/api/api.component.ts
+++ b/packages/ng/demo/app/api/api.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 declare var require: any;
 
 @Component({
@@ -7,9 +8,6 @@ declare var require: any;
 	styles: []
 })
 export class DemoApiComponent implements OnInit {
-
-	constructor() { }
-
 	snippets = {
 		// basic: {
 		// 	code: require('!!prismjs-loader?lang=typescript!./basic/basic'),
@@ -28,6 +26,18 @@ export class DemoApiComponent implements OnInit {
 		// 	markup: require('!!prismjs-loader?lang=markup!./validation/validation.html')
 		// },
 	};
+	me;
+	constructor(private http: HttpClient) { }
+
+
+	whoami() {
+		this.http.get<any>('/api/v3/users/me?fields=id,firstname,lastname')
+		.subscribe(r => {
+			this.me = r.data;
+		})
+	}
+
+
 
 	ngOnInit() {
 	}

--- a/packages/ng/demo/app/api/api.component.ts
+++ b/packages/ng/demo/app/api/api.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+declare var require: any;
+
+@Component({
+	selector: 'demo-api',
+	templateUrl: './api.component.html',
+	styles: []
+})
+export class DemoApiComponent implements OnInit {
+
+	constructor() { }
+
+	snippets = {
+		// basic: {
+		// 	code: require('!!prismjs-loader?lang=typescript!./basic/basic'),
+		// 	markup: require('!!prismjs-loader?lang=markup!./basic/basic.html')
+		// },
+		// custom: {
+		// 	code: require('!!prismjs-loader?lang=typescript!./custom-fn/custom-fn'),
+		// 	markup: require('!!prismjs-loader?lang=markup!./custom-fn/custom-fn.html')
+		// },
+		// fieldgroup: {
+		// 	code: require('!!prismjs-loader?lang=typescript!./fieldgroup/fieldgroup'),
+		// 	markup: require('!!prismjs-loader?lang=markup!./fieldgroup/fieldgroup.html')
+		// },
+		// validation: {
+		// 	code: require('!!prismjs-loader?lang=typescript!./validation/validation'),
+		// 	markup: require('!!prismjs-loader?lang=markup!./validation/validation.html')
+		// },
+	};
+
+	ngOnInit() {
+	}
+
+}

--- a/packages/ng/demo/app/api/api.module.ts
+++ b/packages/ng/demo/app/api/api.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { HttpClientModule} from '@angular/common/http';
 
 import { DemoApiComponent } from './api.component';
 import { SharedModule } from '../shared/index';
@@ -12,6 +13,7 @@ import { SharedModule } from '../shared/index';
 		CommonModule,
 		FormsModule,
 		ReactiveFormsModule,
+		HttpClientModule,
 		SharedModule,
 		// LuEmptyModule,
 	],
@@ -20,7 +22,7 @@ import { SharedModule } from '../shared/index';
 		// BasicComponent,
 	],
 	exports: [
-		// DemoNotEmptyComponent,
+		DemoApiComponent,
 	]
 })
 export class DemoApiModule { }

--- a/packages/ng/demo/app/api/api.module.ts
+++ b/packages/ng/demo/app/api/api.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { DemoApiComponent } from './api.component';
+import { SharedModule } from '../shared/index';
+
+// import { BasicComponent } from './basic/basic';
+
+@NgModule({
+	imports: [
+		CommonModule,
+		FormsModule,
+		ReactiveFormsModule,
+		SharedModule,
+		// LuEmptyModule,
+	],
+	declarations: [
+		DemoApiComponent,
+		// BasicComponent,
+	],
+	exports: [
+		// DemoNotEmptyComponent,
+	]
+})
+export class DemoApiModule { }

--- a/packages/ng/demo/app/api/api.router.ts
+++ b/packages/ng/demo/app/api/api.router.ts
@@ -1,0 +1,6 @@
+import { Routes } from '@angular/router';
+import { DemoApiComponent } from './api.component';
+
+export const apiRoutes: Routes = [
+	{ path: 'api', component: DemoApiComponent },
+];

--- a/packages/ng/demo/app/app.module.ts
+++ b/packages/ng/demo/app/app.module.ts
@@ -18,6 +18,7 @@ import {DemoFormlyModule} from './formly/formly.module';
 import {DemoEmptyModule} from './empty/empty.module';
 import { DemoPopoverModule } from './lu-popover/lu-popover.module';
 import { DemoAnimationsModule } from './animations/animations.module';
+import { DemoApiModule } from './api/api.module';
 
 @NgModule({
 	declarations: [
@@ -34,6 +35,7 @@ import { DemoAnimationsModule } from './animations/animations.module';
 		DemoUserDisplayModule,
 		DemoFormlyModule,
 		DemoEmptyModule,
+		DemoApiModule,
 
 		BrowserModule,
 		BrowserAnimationsModule,

--- a/packages/ng/demo/app/app.router.ts
+++ b/packages/ng/demo/app/app.router.ts
@@ -7,6 +7,7 @@ import { formlyRoutes } from './formly/formly.router';
 import { emptyRoutes } from './empty/empty.router';
 import { luPopoverRoutes } from './lu-popover/lu-popover.router';
 import { animationsRoutes } from './animations/animations.router';
+import { apiRoutes } from './api/api.router';
 
 export const appRoutes: Routes = [
 	{ path: '', component: NavigationComponent, outlet: 'nav' },
@@ -18,5 +19,6 @@ export const appRoutes: Routes = [
 		...emptyRoutes,
 		...luPopoverRoutes,
 		...animationsRoutes,
+		...apiRoutes,
 	] },
 ];

--- a/packages/ng/demo/app/navigation/navigation.component.html
+++ b/packages/ng/demo/app/navigation/navigation.component.html
@@ -19,3 +19,6 @@
 <a href="#" class="navSide-item-link" routerLink="/animations" routerLinkActive="is-active">
 	<span class="navSide-item-link-title">Animations</span>
 </a>
+<a href="#" class="navSide-item-link" routerLink="/api" routerLinkActive="is-active">
+	<span class="navSide-item-link-title">luApi</span>
+</a>

--- a/packages/ng/demo/app/shared/index.ts
+++ b/packages/ng/demo/app/shared/index.ts
@@ -1,25 +1,29 @@
-import { NgModule } from '@angular/core'
-import { CommonModule } from '@angular/common'
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
-import { ExampleBoxComponent } from './example-box/example-box.component'
-import { DemoApiDocs, DemoApiDocsClass, DemoApiDocsConfig } from './api-docs'
+import { ExampleBoxComponent } from './example-box/example-box.component';
+import { DemoApiDocs, DemoApiDocsClass, DemoApiDocsConfig } from './api-docs';
+
+import { RedirectModule } from './redirect/redirect.module';
 
 @NgModule({
-  imports: [
-    CommonModule,
-  ],
-  declarations: [
-    ExampleBoxComponent,
-    DemoApiDocs,
-    DemoApiDocsClass,
-    DemoApiDocsConfig,
-  ],
-  exports: [
-    ExampleBoxComponent,
-    DemoApiDocs,
-    DemoApiDocsClass,
-    DemoApiDocsConfig,
-  ],
+	imports: [
+		CommonModule,
+		RedirectModule,
+	],
+	declarations: [
+		ExampleBoxComponent,
+		DemoApiDocs,
+		DemoApiDocsClass,
+		DemoApiDocsConfig,
+	],
+	exports: [
+		ExampleBoxComponent,
+		DemoApiDocs,
+		DemoApiDocsClass,
+		DemoApiDocsConfig,
+		RedirectModule,
+	],
 })
 export class SharedModule { }
 

--- a/packages/ng/demo/app/shared/redirect/redirect.component.html
+++ b/packages/ng/demo/app/shared/redirect/redirect.component.html
@@ -1,6 +1,12 @@
-<section class="callout">
+<section class="callout" [ngClass]="{'palette-success': connected$ | async}">
+	<div class="u-textRight" *ngIf="connected$ | async">
+		<span class="label palette-success">You are connected to {{ url$ | async }} as {{ login$ | async }}</span>
+	</div>
+	<div class="u-textRight" *ngIf="!(connected$ | async)">
+		<span class="label">You are not connected</span>
+	</div>
 	<div>
-		To test this component you might need to redirect all xhr to one of your local website.
+		To test this component you might need to redirect all xhr requests to one of your local website.
 	</div>
 	<div class="textfield mod-material mod-inline">
 		<input class="textfield-input" [(ngModel)]="url" name="url" luEmpty>
@@ -10,5 +16,5 @@
 		<input class="textfield-input" [(ngModel)]="login" name="login" luEmpty>
 		<label class="textfield-label" for="login">login</label>
 	</div>
-	<button class="button" (click)="connect()">Connect</button>
+	<button class="button" (click)="connect()" [ngClass]="{'is-loading': loading}">Connect</button>
 </section>

--- a/packages/ng/demo/app/shared/redirect/redirect.component.html
+++ b/packages/ng/demo/app/shared/redirect/redirect.component.html
@@ -16,5 +16,9 @@
 		<input class="textfield-input" [(ngModel)]="login" name="login" luEmpty>
 		<label class="textfield-label" for="login">login</label>
 	</div>
+	<div class="textfield mod-material mod-inline">
+		<input class="textfield-input" [(ngModel)]="password" name="password" luEmpty type="password">
+		<label class="textfield-label" for="password">password</label>
+	</div>
 	<button class="button" (click)="connect()" [ngClass]="{'is-loading': loading}">Connect</button>
 </section>

--- a/packages/ng/demo/app/shared/redirect/redirect.component.html
+++ b/packages/ng/demo/app/shared/redirect/redirect.component.html
@@ -1,0 +1,14 @@
+<section class="callout">
+	<div>
+		To test this component you might need to redirect all xhr to one of your local website.
+	</div>
+	<div class="textfield mod-material mod-inline">
+		<input class="textfield-input" [(ngModel)]="url" name="url" luEmpty>
+		<label class="textfield-label" for="url">Url</label>
+	</div>
+	<div class="textfield mod-material mod-inline">
+		<input class="textfield-input" [(ngModel)]="login" name="login" luEmpty>
+		<label class="textfield-label" for="login">login</label>
+	</div>
+	<button class="button" (click)="connect()">Connect</button>
+</section>

--- a/packages/ng/demo/app/shared/redirect/redirect.component.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+	selector: 'demo-redirect',
+	templateUrl: './redirect.component.html',
+})
+export class RedirectComponent implements OnInit {
+
+	url = 'https://lucca.local.dev';
+	login = 'passepartout';
+	constructor() { }
+
+	ngOnInit() {
+	}
+
+	connect() {	}
+
+}

--- a/packages/ng/demo/app/shared/redirect/redirect.component.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.component.ts
@@ -9,6 +9,7 @@ export class RedirectComponent implements OnInit {
 
 	url = 'lucca.local.dev';
 	login = 'passepartout';
+	password = '';
 
 	connected$ = this.env.connected$;
 	url$ = this.env.url$;
@@ -22,10 +23,9 @@ export class RedirectComponent implements OnInit {
 
 	connect() {
 		this.loading = true;
-		this.service.login(this.url, this.login)
+		this.service.login(this.url, this.login, this.password)
 		.subscribe(() => {
 			this.loading = false;
 		});
 	}
-
 }

--- a/packages/ng/demo/app/shared/redirect/redirect.component.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { RedirectService, RedirectEnvironment } from './redirect.service';
 
 @Component({
 	selector: 'demo-redirect',
@@ -6,13 +7,25 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RedirectComponent implements OnInit {
 
-	url = 'https://lucca.local.dev';
+	url = 'lucca.local.dev';
 	login = 'passepartout';
-	constructor() { }
+
+	connected$ = this.env.connected$;
+	url$ = this.env.url$;
+	login$ = this.env.login$;
+
+	loading = false;
+	constructor(private service: RedirectService, private env: RedirectEnvironment) { }
 
 	ngOnInit() {
 	}
 
-	connect() {	}
+	connect() {
+		this.loading = true;
+		this.service.login(this.url, this.login)
+		.subscribe(() => {
+			this.loading = false;
+		});
+	}
 
 }

--- a/packages/ng/demo/app/shared/redirect/redirect.interceptor.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.interceptor.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+import {HttpEvent, HttpHandler, HttpInterceptor} from '@angular/common/http';
+import {HttpRequest} from '@angular/common/http';
+import {Observable} from 'rxjs/Observable';
+import { RedirectEnvironment } from './redirect.service';
+
+@Injectable()
+export class RedirectInterceptor implements HttpInterceptor {
+
+	constructor(
+		private env: RedirectEnvironment
+	) { }
+
+	intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+		if (this.env.redirect) {
+			const clonedHeaders = req.headers;
+			clonedHeaders.set('Access-Control-Allow-Origin', '*');
+			const clonedRequest = req.clone({
+				params: req.params.set('authToken', this.env.authToken),
+				url: `https://${this.env.baseUrl}${req.url}`,
+				headers: clonedHeaders,
+			});
+			return next.handle(clonedRequest);
+		} else {
+			return next.handle(req);
+		}
+	}
+}

--- a/packages/ng/demo/app/shared/redirect/redirect.module.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.module.ts
@@ -1,16 +1,20 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 
+import { LuEmptyModule } from '../../../../src/app/empty/empty.module';
 
 import { RedirectComponent } from './redirect.component';
-import { LuEmptyModule } from '../../../../src/app/empty/empty.module';
+import { RedirectService, RedirectEnvironment } from './redirect.service';
+import { RedirectInterceptor } from './redirect.interceptor';
 
 @NgModule({
 	imports: [
 		CommonModule,
 		FormsModule,
 		LuEmptyModule,
+		HttpClientModule,
 	],
 	declarations: [
 		RedirectComponent,
@@ -19,6 +23,9 @@ import { LuEmptyModule } from '../../../../src/app/empty/empty.module';
 		RedirectComponent,
 	],
 	providers: [
+		RedirectEnvironment,
+		RedirectService,
+		{ provide: HTTP_INTERCEPTORS, useClass: RedirectInterceptor, multi: true },
 	],
 })
 export class RedirectModule { }

--- a/packages/ng/demo/app/shared/redirect/redirect.module.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+
+import { RedirectComponent } from './redirect.component';
+import { LuEmptyModule } from '../../../../src/app/empty/empty.module';
+
+@NgModule({
+	imports: [
+		CommonModule,
+		FormsModule,
+		LuEmptyModule,
+	],
+	declarations: [
+		RedirectComponent,
+	],
+	exports: [
+		RedirectComponent,
+	],
+	providers: [
+	],
+})
+export class RedirectModule { }

--- a/packages/ng/demo/app/shared/redirect/redirect.service.ts
+++ b/packages/ng/demo/app/shared/redirect/redirect.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs/Observable';
+// import { Observer } from 'rxjs/Observer';
+import {BehaviorSubject} from 'rxjs/BehaviorSubject';
+
+import 'rxjs/add/operator/map';
+// import 'rxjs/add/observable/create';
+
+@Injectable()
+export class RedirectEnvironment {
+	redirect = false;
+	baseUrl = '';
+	authToken = '';
+
+	private _connected$ = new BehaviorSubject<boolean>(false);
+	connected$ = this._connected$.asObservable();
+	private _url$ = new BehaviorSubject<string>('');
+	url$ = this._url$.asObservable();
+	private _login$ = new BehaviorSubject<string>('');
+	login$ = this._login$.asObservable();
+
+	disableRedirect() {
+		this.redirect = false;
+		this._connected$.next(false);
+		// this.connectedObserver.next(false);
+	}
+	loginSuccess(baseUrl, token, login) {
+		this.baseUrl = baseUrl;
+		this.authToken = token;
+		this.redirect = true;
+		this._connected$.next(true);
+		this._login$.next(login);
+		this._url$.next(baseUrl);
+		// this.connectedObserver.next(true);
+	}
+}
+
+@Injectable()
+export class RedirectService {
+	// redirect = false;
+	// baseUrl = '';
+	// authToken = '';
+
+	constructor(
+		private http: HttpClient,
+		private env: RedirectEnvironment,
+	) {}
+
+	login(url, login, password = ''): Observable<boolean> {
+		// disable redirection while we log in
+		this.env.disableRedirect();
+		const loginUrl = `https://${url}/auth/userlogin?login=${login}&password=${password}`;
+		const options = {
+			responseType: 'text',
+			// responseType: 'text/plain',
+		} as any;
+
+		return this.http.post(loginUrl, {}, options)
+		.map(r => {
+			const token = (<any>r).substring(1, (<any>r).length - 1);
+			this.env.loginSuccess(url, token, login);
+			return true;
+		});
+	}
+}


### PR DESCRIPTION
for the directives api-picker and user-picker, the demo needs to be able to redirect xhr requests to a lucca website. so this pr adds the redirectModule in the demo shared module to allow users to connect to one of their local website or a prod website (#totesSafe)

the component looks like this

![image](https://user-images.githubusercontent.com/10089239/33381638-dd6e0f86-d51e-11e7-83e7-0a5afb72c89d.png)

![image](https://user-images.githubusercontent.com/10089239/33381601-c8b15ed6-d51e-11e7-9683-523f92745908.png)
