### PR TITLE
[SCSS][FIX] Fix textfield.is-focused behaviour

### DIFF
--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -203,15 +203,7 @@
 		}
 
 		&.is-error {
-			background-color: transparentize(_color("error"), .9);
-			&:focus, &:hover {
-				@include fakeBorder(1px, _color("error"));
-				background-color: transparentize(_color("error"), .9);
-			}
-
-			~ .textfield-label, ~ .textfield-suffix {
-				color: _color("error") !important;
-			}
+			@include textfieldFramedError();
 		}
 	}
 

--- a/packages/scss/src/components/inputs/textfield/_textfield.material.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.material.scss
@@ -139,4 +139,12 @@
 			@include textfieldMaterialError();
 		}
 	}
+
+	// Needed when textfield label is not next to the textfield-input
+	&.is-focused {
+		.textfield-label {
+			font-size: _theme("sizes.small.font-size");
+			top: 0;
+		}
+	}
 }

--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -246,14 +246,6 @@
 			position: absolute;
 		}
 	}
-
-	// Needed when textfield label is not next to the textfield-input
-	&.is-focused {
-		.textfield-label {
-			font-size: _theme("sizes.small.font-size");
-			top: 0;
-		}
-	}
 }
 
 .textfield-input {

--- a/packages/scss/src/mixins/_forms.scss
+++ b/packages/scss/src/mixins/_forms.scss
@@ -22,6 +22,18 @@
 	}
 }
 
+@mixin textfieldFramedError() {
+	background-color: transparentize(_color("error"), .9);
+	&:focus, &:hover {
+		@include fakeBorder(1px, _color("error"));
+		background-color: transparentize(_color("error"), .9);
+	}
+
+	~ .textfield-label, ~ .textfield-suffix {
+		color: _color("error") !important;
+	}
+}
+
 @mixin textfieldMaterialFilled() {
 	~ .textfield-label {
 		font-size: _theme("sizes.small.font-size");


### PR DESCRIPTION
Fixes `textfield.is-focused` behaviour, moving material specific part to its rightful place.
Adds textfieldFramedError() mixin to handle this mod error state in the `ng` package