### PR TITLE
[NG][FIX] Fixes issues post textfield classic update

### DIFF
--- a/packages/ng/src/app/formly/types/formly-field.common.scss
+++ b/packages/ng/src/app/formly/types/formly-field.common.scss
@@ -2,4 +2,5 @@
 	width: 100%;
 	display: inherit;
 	align-items: inherit;
+	flex-direction: inherit;
 }

--- a/packages/ng/src/app/formly/wrappers/button.ts
+++ b/packages/ng/src/app/formly/wrappers/button.ts
@@ -5,6 +5,7 @@ import { FieldWrapper, FormlyFieldConfig, FormlyConfig, FieldType } from '@ngx-f
 // wrapper component
 @Component({
 	selector: 'lu-formly-wrapper-button',
+	styleUrls: ['flex-layout.scss'],
 	templateUrl: './button.html',
 })
 export class LuFormlyWrapperButton extends FieldWrapper {

--- a/packages/ng/src/app/formly/wrappers/flex-layout.scss
+++ b/packages/ng/src/app/formly/wrappers/flex-layout.scss
@@ -1,4 +1,5 @@
 :host {
 	display: inherit;
+	flex-direction: inherit;
 	flex: 1 1 auto;
 }

--- a/packages/ng/src/style/components/_formly.scss
+++ b/packages/ng/src/style/components/_formly.scss
@@ -1,5 +1,6 @@
 formly-form, formly-group, formly-field {
 	display: inherit;
 	flex-wrap: inherit;
+	flex-direction: inherit;
 	width: 100%;
 }

--- a/packages/ng/src/style/components/_input.scss
+++ b/packages/ng/src/style/components/_input.scss
@@ -1,7 +1,13 @@
-
-.textfield.mod-compact input.ng-invalid.ng-touched, .textfield.mod-compact textarea.ng-invalid.ng-touched {
-	border-color: _color("error");
-}
 input.ng-invalid.ng-touched, textarea.ng-invalid.ng-touched {
-  @include textfieldError();
+	@include textfieldError();
 }
+
+.textfield.mod-material input.ng-invalid.ng-touched, .textfield.mod-material textarea.ng-invalid.ng-touched {
+	@include textfieldMaterialError();
+}
+
+.textfield.mod-framed input.ng-invalid.ng-touched, .textfield.mod-framed textarea.ng-invalid.ng-touched {
+	@include textfieldFramedError();
+}
+
+


### PR DESCRIPTION
Merge #176 first

Fixes layout issues due to formly wrappers after the rollout of textfield refactoring.
Adds better ng-invalid support.