### PR TITLE
Ng.apipicker.formly

### DIFF
--- a/packages/ng/demo/app/formly/basic/basic.ts
+++ b/packages/ng/demo/app/formly/basic/basic.ts
@@ -82,6 +82,15 @@ export class BasicComponent {
 				]
 			},
 		},
+		{
+			key: 'department',
+			type: 'api',
+			templateOptions: {
+				label: 'department - api',
+				placeholder: 'pings /api/v3/departments',
+				api: '/api/v3/departments',
+			},
+		},
 	];
 
 	user = {};

--- a/packages/ng/demo/app/formly/formly.component.html
+++ b/packages/ng/demo/app/formly/formly.component.html
@@ -1,4 +1,5 @@
 <h2>Formly</h2>
+<demo-redirect></demo-redirect>
 <h3>Examples</h3>
 <demo-example-box [snippets]="snippets" demo="debug">
 	<demo-formly-debug></demo-formly-debug>

--- a/packages/ng/demo/app/formly/formly.module.ts
+++ b/packages/ng/demo/app/formly/formly.module.ts
@@ -8,6 +8,7 @@ import { MatMomentDateModule } from '@angular/material-moment-adapter';
 import { DemoFormlyComponent } from './formly.component';
 import { LuFormlyModule } from '../../../src/app/formly';
 import { LuEmptyModule } from '../../../src/app/empty';
+import { LuApiPickerModule } from '../../../src/app/api/picker';
 import { SharedModule } from '../shared/index';
 
 import { BasicComponent } from './basic/basic';
@@ -26,6 +27,8 @@ import { OptionComponent } from './option/option';
 		FormlyModule.forRoot(),
 		LuFormlyModule,
 		LuEmptyModule,
+
+		LuApiPickerModule,
 
 		MatAutocompleteModule,
 		MatInputModule,

--- a/packages/ng/src/app/api/picker/api-picker.component.ts
+++ b/packages/ng/src/app/api/picker/api-picker.component.ts
@@ -14,6 +14,7 @@ import { LuPopoverComponent, transformPopover, PopoverTriggerEvent } from '../..
 import { IApiItem } from '../api.model';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
+import { Subscription } from 'rxjs/Subscription';
 import {BehaviorSubject} from 'rxjs/BehaviorSubject';
 import { standardApiPickerTemplate } from './api-picker.template';
 
@@ -28,11 +29,18 @@ import { standardApiPickerTemplate } from './api-picker.template';
 		transformPopover
 	],
 })
-export class LuApiPickerComponent<T extends IApiItem> extends LuPopoverComponent implements OnInit {
+export class LuApiPickerComponent<T extends IApiItem> extends LuPopoverComponent implements OnInit, OnDestroy {
 	triggerEvent = 'none' as PopoverTriggerEvent;
 
-	private _options$ = new BehaviorSubject<IApiItem[]>([]);
+	private _options$ = new BehaviorSubject<T[]>([]);
 	options$ = this._options$.asObservable();
+	private highlightIndex = 0;
+	private optionsLength = 0;
+	private _highlightIndex$ = new BehaviorSubject<number>(this.highlightIndex);
+	highlightIndex$ = this._highlightIndex$.asObservable();
+
+	highlightedOption: T;
+	highlightedOptionSub: Subscription;
 
 	/** emits when the user selects an element */
 	@Output() itemSelected  = new EventEmitter<T>();
@@ -44,6 +52,19 @@ export class LuApiPickerComponent<T extends IApiItem> extends LuPopoverComponent
 		super(_elementRef);
 	}
 	ngOnInit() {
+		this.highlightedOptionSub = Observable.combineLatest(
+			this.options$,
+			this.highlightIndex$,
+			(options, index) => {
+				if (!!options) {
+					return options[index];
+				}
+				return undefined;
+			}
+		).subscribe(o => this.highlightedOption = o);
+	}
+	ngOnDestroy() {
+		this.highlightedOptionSub.unsubscribe();
 	}
 	onMouseDown($e) {
 		$e.preventDefault();
@@ -52,10 +73,27 @@ export class LuApiPickerComponent<T extends IApiItem> extends LuPopoverComponent
 	search(api: string, clue: string = '', filter: string = ''): void {
 		this._http.get<{ data: { items: T[] } }>(`${api}?name=like,${clue}&paging=0,10&fields=id,name`)
 		.subscribe(r => {
+			this.highlightIndex = 0;
+			this._highlightIndex$.next(this.highlightIndex);
+			const options = r.data.items;
+			this.optionsLength = options.length;
 			this._options$.next(r.data.items);
 		});
 	}
 	selectOption(option: T) {
 		this.itemSelected.emit(option);
+	}
+	onEnterKeydown() {
+		this.selectOption(this.highlightedOption);
+	}
+	onDownKeydown() {
+		this.highlightIndex++;
+		this.highlightIndex = Math.min(this.highlightIndex, this.optionsLength - 1);
+		this._highlightIndex$.next(this.highlightIndex);
+	}
+	onUpKeydown() {
+		this.highlightIndex--;
+		this.highlightIndex = Math.max(this.highlightIndex, 0);
+		this._highlightIndex$.next(this.highlightIndex);
 	}
 }

--- a/packages/ng/src/app/api/picker/api-picker.directive.ts
+++ b/packages/ng/src/app/api/picker/api-picker.directive.ts
@@ -42,6 +42,10 @@ import { IApiItem, ICoerce } from '../api.model';
 import { LuPopoverTrigger, IPopoverPanel, PopoverTriggerEvent } from '../../popover';
 import { LuApiPickerComponent } from './api-picker.component';
 
+const ENTER_KEY = 'Enter';
+const UP_KEY = 'ArrowUp';
+const DOWN_KEY = 'ArrowDown';
+
 /**
  * Directive to put on a input to allow it to match the text inputed to an item available on an api
  */
@@ -113,12 +117,18 @@ implements ControlValueAccessor, OnDestroy, OnInit, Validator {
 	}
 
 	// host listening
-	@HostListener('document:keydown.enter', ['$event'])
-	onEnterKeydown() {
-		if (!!this.value) {
-			this.render();
+	@HostListener('document:keydown', ['$event'])
+	onKeydown($event) {
+		switch ($event.key) {
+			case ENTER_KEY:
+			return this.popover.onEnterKeydown();
+			case DOWN_KEY:
+			return this.popover.onDownKeydown();
+			case UP_KEY:
+			return this.popover.onUpKeydown();
 		}
 	}
+	
 	// @HostListener('blur')
 	// blur() {
 	// 	this._onTouched();

--- a/packages/ng/src/app/api/picker/api-picker.template.ts
+++ b/packages/ng/src/app/api/picker/api-picker.template.ts
@@ -1,6 +1,12 @@
 import { customPopoverTemplate } from '../../popover/popover.template';
 export const standardApiPickerTemplate = customPopoverTemplate(`
 <ul class="api-picker-options">
-	<li *ngFor="let option of (options$ | async)" (click)="selectOption(option)" class="api-picker-option">{{ option.name }}</li>
+	<li
+	*ngFor="let option of (options$ | async); let i = index"
+	(click)="selectOption(option)"
+	[ngClass]="{'is-focus': (i === (highlightIndex$ | async))}"
+	class="api-picker-option">
+		{{ option.name }}
+	</li>
 </ul>
 `);

--- a/packages/ng/src/app/formly/formly.config.ts
+++ b/packages/ng/src/app/formly/formly.config.ts
@@ -5,6 +5,7 @@ import { LuFormlyFieldDate } from './types/date';
 import { LuFormlyFieldTextarea } from './types/textarea';
 import { LuFormlyFieldAutocomplete } from './types/autocomplete';
 import { LuFormlyFieldSelect } from './types/select';
+import { LuFormlyFieldApi } from './types/api';
 // wrappers
 import { LuFormlyWrapperHelper, TemplateHelper } from './wrappers/helper';
 import { LuFormlyWrapperTitle, TemplateTitle } from './wrappers/title';
@@ -24,6 +25,7 @@ export const LU_FORMLY_COMPONENTS = [
 	LuFormlyFieldTextarea,
 	LuFormlyFieldAutocomplete,
 	LuFormlyFieldSelect,
+	LuFormlyFieldApi,
 
 	LuFormlyWrapperHelper,
 	LuFormlyWrapperLabel,
@@ -61,6 +63,11 @@ export const LU_FORMLY_CONFIG = {
 			name: 'select',
 			// component: LuFormlyFieldSelect,
 			component: LuFormlyFieldAutocomplete,
+			wrappers: ['textfield-layout'],
+		},
+		{
+			name: 'api',
+			component: LuFormlyFieldApi,
 			wrappers: ['textfield-layout'],
 		},
 	],

--- a/packages/ng/src/app/formly/formly.module.ts
+++ b/packages/ng/src/app/formly/formly.module.ts
@@ -5,6 +5,7 @@ import { FormlyModule } from '@ngx-formly/core';
 import { MatAutocompleteModule, MatInputModule, MatOptionModule, MatSelectModule, MatDatepickerModule } from '@angular/material';
 import { LU_FORMLY_COMPONENTS, LU_FORMLY_CONFIG } from './formly.config';
 import { LuEmptyModule } from '../empty/empty.module';
+import { LuApiPickerModule } from '../api/picker/api-picker.module';
 
 @NgModule({
 	declarations: [
@@ -19,6 +20,8 @@ import { LuEmptyModule } from '../empty/empty.module';
 		MatOptionModule,
 		MatSelectModule,
 		MatDatepickerModule,
+
+		LuApiPickerModule,
 
 		LuEmptyModule,
 

--- a/packages/ng/src/app/formly/types/api.html
+++ b/packages/ng/src/app/formly/types/api.html
@@ -1,0 +1,3 @@
+<input [luApiPicker]="picker" type="text" [formControl]="formControl" luEmpty class="textfield-input" [formlyAttributes]="field" (focus)="focus()" (blur)="blur()" [api]="api">
+<label [attr.for]="id" class="textfield-label">{{ to.label }}</label>
+<lu-api-picker #picker></lu-api-picker>

--- a/packages/ng/src/app/formly/types/api.ts
+++ b/packages/ng/src/app/formly/types/api.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+@Component({
+	selector: 'lu-formly-field-api',
+	styleUrls: ['formly-field.common.scss'],
+	templateUrl: './api.html',
+})
+export class LuFormlyFieldApi extends FieldType {
+	get api() {
+		return this.to.api || '';
+	}
+	focus() {
+		this.to._isFocused = true;
+	}
+	blur() {
+		this.to._isFocused = false;
+	}
+}

--- a/packages/ng/src/app/formly/wrappers/icon.ts
+++ b/packages/ng/src/app/formly/wrappers/icon.ts
@@ -18,6 +18,10 @@ export class TemplateIcon {
 				field.templateOptions.icon = 'calendar';
 				return 'icon';
 			}
+			if (field && field.type === 'api') {
+				field.templateOptions.icon = 'search';
+				return 'icon';
+			}
 			if (field && field.templateOptions && field.templateOptions.icon) {
 				return 'icon';
 			}


### PR DESCRIPTION
 - fixes #186 - adds formly wrapper, 
 - fixes #183 - adds `v` `^` keydown to navigate options in dropdown and `enter` to select it