### PR TITLE
[SCSS] navSide bottom section

### DIFF
--- a/packages/scss/CHANGELOG.md
+++ b/packages/scss/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## In Dev
+### New features
+- `navSide` can now have a `navSide-bottomSection` to add navSide items fixed to the bottom of the screen.
 ### Breaking changes
 - `textfield` default look is now classic. Use `mod-material` to get the material default look.
 - `navSide` supports mobile view but needs a `.navSide-item.mod-mobileToggle` that can toggle a `.is-open` state on `.navSide` to work.

--- a/packages/scss/demo/templates/fullmenu.html
+++ b/packages/scss/demo/templates/fullmenu.html
@@ -110,6 +110,14 @@
 		&lt;/div&gt;
 		[...]
 	&lt;/nav&gt;
+	&lt;div class=&quot;navSide-bottomSection&quot;&gt;
+		&lt;div class=&quot;navSide-item&quot;&gt;
+			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&quot;&gt;
+				&lt;i class=&quot;lucca-icon&quot;&gt;icon_ligature&lt;/i&gt;
+				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Bottom Section&lt;/span&gt;
+			&lt;/a&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
 &lt;/main&gt;
 </code>
 				</div>

--- a/packages/scss/demo/templates/fullmenu.html
+++ b/packages/scss/demo/templates/fullmenu.html
@@ -11,7 +11,7 @@
 	</head>
 	<body>
 		<main class="main">
-			<aside class="navSide" id="navSide">	
+			<aside class="navSide mod-withBottomSection" id="navSide">	
 				<nav class="navSide-scrollWrapper">
 					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
 						<a href="#" class="navSide-item-link">
@@ -65,6 +65,14 @@
 						</nav>
 					</div>
 				</nav>
+				<div class="navSide-bottomSection">
+					<div class="navSide-item">
+						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
+							<i class="lucca-icon">analytics</i>
+							<span class="navSide-item-link-title">BOTTOM LINK</span>
+						</a>
+					</div>
+				</div>
 			</aside>
 			<section class="main-content">
 				<div class="container">

--- a/packages/scss/demo/templates/side.html
+++ b/packages/scss/demo/templates/side.html
@@ -69,6 +69,14 @@
 			&lt;/div&gt;
 			[...]
 		&lt;/nav&gt;
+		&lt;div class=&quot;navSide-bottomSection&quot;&gt;
+			&lt;div class=&quot;navSide-item&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&quot;&gt;
+					&lt;i class=&quot;lucca-icon&quot;&gt;icon_ligature&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Bottom Section&lt;/span&gt;
+				&lt;/a&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
 	&lt;/aside&gt;
 	&lt;section class="main-content"&gt;
 		&lt;div class="container"&gt;

--- a/packages/scss/demo/templates/side.html
+++ b/packages/scss/demo/templates/side.html
@@ -11,7 +11,7 @@
 	</head>
 	<body>
 		<main class="main">
-			<aside class="navSide mod-compact" id="navSide">
+			<aside class="navSide mod-compact mod-withBottomSection" id="navSide">
 				<nav class="navSide-scrollWrapper">
 					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
 						<a href="#" class="navSide-item-link">
@@ -39,6 +39,14 @@
 						<a href="#" class="navSide-item-link">Entry</a>
 					</div>
 				</nav>
+				<div class="navSide-bottomSection">
+					<div class="navSide-item">
+						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
+							<i class="lucca-icon">analytics</i>
+							<span class="navSide-item-link-title">BOTTOM LINK</span>
+						</a>
+					</div>
+				</div>
 			</aside>
 			<section class="main-content">
 				<div class="container">

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -117,6 +117,32 @@
 	vertical-align: middle;
 }
 
+// BOTTOM MENU
+// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+.navSide-bottomSection {
+	background: _component("navSide.bottom-section-palette.bg-color");
+	position: fixed;
+	left: 0;
+	bottom: 0;
+	width: _component("navSide.width");
+
+	.navSide-item-link {
+		color: _component("navSide.bottom-section-palette.text");
+		&:hover {
+			background-color: _component("navSide.bottom-section-palette.selected-bg");
+			color: _component("navSide.bottom-section-palette.selected-text");
+			.navSide-item-alert {
+				background: _component("navSide.bottom-section-palette.alert-color");
+				color: _component("navSide.bottom-section-palette.alert-text");
+			}
+		}
+	}
+}
+
+.navSide.mod-withBottomSection {
+		padding-bottom: _component("navSide.bottom-section-height");
+}
+
 // ACTIVE & OPEN STATE
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 .navSide-item.is-active {
@@ -285,6 +311,16 @@
 				opacity: 1;
 			}
 		}
+
+		.navSide-bottomSection {
+			background: _component("navSide.compact-palette.bg-color");
+			text-align: center;
+			width: _component("navSide.compact.width");
+		}
+
+		&.mod-withBottomSection {
+			padding-bottom: _component("navSide.compact.bottom-section-height");
+		}
 	}
 }
 
@@ -316,6 +352,16 @@
 
 	.navSide-item.mod-mobileToggle {
 		display: block;
+	}
+
+	.navSide-bottomSection {
+		background: transparent;
+		position: relative;
+		width: auto;
+	}
+
+	.navSide.mod-withBottomSection {
+		padding-bottom: 0;
 	}
 
 	.navSide.is-open {

--- a/packages/scss/src/theming/components/_nav-side.theme.scss
+++ b/packages/scss/src/theming/components/_nav-side.theme.scss
@@ -18,6 +18,16 @@ $navSide: (
 		alert-text: _theme("palettes.secondary.text")
 	),
 
+	"bottom-section-palette": (
+		bg-color: darken(_theme("palettes.primary.color"), 23%),
+		text: white,
+		selected-bg:  _theme("palettes.primary.color"),
+		selected-text: _theme("palettes.primary.text"),
+		alert-color: _theme("palettes.secondary.color"),
+		alert-text: _theme("palettes.secondary.text")
+	),
+
+	"bottom-section-height": 3.5rem,
 	"offset-top": 0,
 	"padding-top": 0,
 	"main-font-size": _theme("sizes.standard.font-size"),
@@ -33,6 +43,7 @@ $navSide: (
 
 	"compact": (
 		"width": 8.1rem,
+		"bottom-section-height": 5rem,
 	),
 
 	"placeholder": (


### PR DESCRIPTION
Adds a `.navSide-bottomSection` to handle navSide-item that needs to be stuck to the bottom of the screen.
It has its own palette to ease its customisation. If you need more than one button stucked to the bottom, you'll have to adjust the bottom-section-height variable in the theme.
![chrome_2017-12-18_16-07-20](https://user-images.githubusercontent.com/26228000/34112740-ced40c84-e40d-11e7-8152-421651097c3f.png)
