### PR TITLE
ng-build [mod] dont fix rxjs version

### DIFF
--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -46,7 +46,7 @@
     "@lucca-front/scss": "^0.2.2",
     "@ngx-translate/core": "^8.0.0",
     "core-js": "^2.4.1",
-    "rxjs": "5.5.2",
+    "rxjs": "^5.5.2",
     "zone.js": "^0.8.14"
   },
   "devDependencies": {


### PR DESCRIPTION
i have some transpilation problems cuz different libs want different versions of rxjs, by doing that i can tweak my lock file to stop having these issues