### PR TITLE
[SCSS][fix] Remove relicat

### DIFF
--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -19,7 +19,6 @@
 	position: relative;
 	transition: box-shadow 150ms ease, color 150ms ease;
 	width: 100%;
-	height: 2rem;
 
 	&::placeholder {
 		color: _color("text.placeholder");


### PR DESCRIPTION
Remove relicat from lu-select development that broke the textfield style.