### PR TITLE
[SCSS][fix] bottom margin was collapsing

### DIFF
--- a/packages/scss/src/components/_container.scss
+++ b/packages/scss/src/components/_container.scss
@@ -12,6 +12,11 @@
 	@media (max-width: _component("container.min-width")) {
 		width: 100%;
 	}
+
+	&:last-child {
+		padding-bottom: _component("container.margin-bottom");
+		margin-bottom: 0;
+	}
 }
 
 


### PR DESCRIPTION
With margin collapse, the bottom margin was collapsed with the container margin, leading to wrongful sizing