### PR TITLE
[fix] still has all border with browser zoom

### DIFF
--- a/packages/scss/CHANGELOG.md
+++ b/packages/scss/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Adding
 ### Enhancements
 ### Fixes
+- `textfields` Show all borders even with browser zoom
 
 ## 0.7.0
 ### Fixes

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -380,7 +380,7 @@
 
 	.navSide.is-open {
 		height: 100vh;
-		
+
 		.navSide-item:not(.mod-mobileToggle), .navSide-item-placeholder {
 			position: static;
 			visibility: visible;

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -1,5 +1,5 @@
 .table {
-	border-bottom: _theme('commons.divider.width') solid _theme('commons.divider.color');
+	border-bottom: _theme("commons.divider.width") solid _theme("commons.divider.color");
 	border-spacing: 0;
 	display: table;
 	font-size: _theme("component.table.font-size");

--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -9,7 +9,7 @@
 	background: _component("textfield.background");
 	border: 0;
 	border-radius: _component("textfield.border-radius");
-	box-shadow: 0 0 0 1px _component("textfield.border.color");
+	box-shadow: inset 0 0 0 1px _component("textfield.border.color");
 	color: _component("textfield.input.color");
 	font-family: unquote(_theme("commons.font.family"));
 	font-size: _component("textfield.font-size");
@@ -26,7 +26,7 @@
 	}
 
 	&:focus {
-		box-shadow: 0 0 0 1px _component("textfield.border.focus");
+		box-shadow: inset 0 0 0 1px _component("textfield.border.focus");
 	}
 }
 
@@ -111,7 +111,7 @@
 
 	@mixin inputColoring($palette) {
 		.textfield-input:focus {
-			box-shadow: 0 0 0 1px _get($palette, "color");
+			box-shadow: inset 0 0 0 1px _get($palette, "color");
 
 			~ .textfield-label {
 				color: _color("text.default");

--- a/packages/scss/src/mixins/_forms.scss
+++ b/packages/scss/src/mixins/_forms.scss
@@ -1,5 +1,5 @@
 @mixin textfieldError() {
-	box-shadow: 0 0 0 1px _color("error");
+	box-shadow: inset 0 0 0 1px _color("error");
 	background-color: rgba( _color("error"), .1 );
 
 	&::placeholder {


### PR DESCRIPTION
@sanlucca Textfields looked better for me with a height of 2px less, so I did not edited component's padding.