### PR TITLE
Formly.version

### DIFF
--- a/packages/ng/docs/demo/src/styles.scss
+++ b/packages/ng/docs/demo/src/styles.scss
@@ -1,8 +1,11 @@
 /* You can add global styles to this file, and also import other style files */
 @import '~@lucca-front/scss/src/main.overridable';
-@import 'libraries/core/src/style/main';
-@import 'libraries/material/src/style/main';
-@import 'libraries/formly/src/style/main';
+// @import 'libraries/core/src/style/main';
+// @import 'libraries/material/src/style/main';
+// @import 'libraries/formly/src/style/main';
+@import 'dist/style/main';
+@import 'dist/material/style/main';
+@import 'dist/formly/style/main';
 
 
 .demo-box {

--- a/packages/ng/libraries/core/src/lib/user/picture/user-picture.component.scss
+++ b/packages/ng/libraries/core/src/lib/user/picture/user-picture.component.scss
@@ -1,5 +1,5 @@
 @import '~@lucca-front/scss/src/theming.scss';
-@import '../../../style/theming';
+@import '../../../style/theme/user-picture.theme';
 :host {
 	.picture {
 		border-radius: 100%;

--- a/packages/ng/libraries/core/src/style/_theming.scss
+++ b/packages/ng/libraries/core/src/style/_theming.scss
@@ -1,2 +1,2 @@
-@import '~@lucca-front/scss/src/theming';
+@import '~@lucca-front/scss/src/theming.scss';
 @import 'theme/user-picture.theme';

--- a/packages/ng/libraries/formly/package.json
+++ b/packages/ng/libraries/formly/package.json
@@ -1,8 +1,17 @@
 {
-  "name": "formly",
-  "version": "0.0.1",
+  "name": "@lucca-front/ng/formly",
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
-  }
+    "@angular/common": "^6.0.0",
+    "@angular/core": "^6.0.0",
+    "@angular/forms": "^6.0.0",
+    "@angular/cdk": "^6.0.0",
+    "@angular/material": "^6.0.0",
+    "@ngx-formly/core": "^4.0.0",
+    "rxjs": "^6.1.0",
+    "rxjs-compat": "^6.1.0"
+  },
+  "files": [
+    "style"
+  ],
+  "script": {}
 }

--- a/packages/ng/libraries/material/package.json
+++ b/packages/ng/libraries/material/package.json
@@ -1,8 +1,16 @@
 {
-  "name": "material",
-  "version": "0.0.1",
+  "name": "@lucca-front/ng/material",
   "peerDependencies": {
-    "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
-  }
+    "@angular/common": "^6.0.0",
+    "@angular/core": "^6.0.0",
+    "@angular/forms": "^6.0.0",
+    "@angular/cdk": "^6.0.0",
+    "@angular/material": "^6.0.0",
+    "rxjs": "^6.1.0",
+    "rxjs-compat": "^6.1.0"
+  },
+  "files": [
+    "style"
+  ],
+  "script": {}
 }

--- a/packages/ng/libraries/material/src/style/_theming.scss
+++ b/packages/ng/libraries/material/src/style/_theming.scss
@@ -1,1 +1,1 @@
-@import '~@lucca-front/scss/src/theming';
+@import '~@lucca-front/scss/src/theming.scss';

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -103,7 +103,7 @@
     "@angular/material": "6.0.1",
     "@lucca-front/icons": "^0.7.0",
     "@lucca-front/scss": "^0.7.0",
-    "@ngx-formly/core": "^2.0.0-beta.3",
+    "@ngx-formly/core": "^4.0.0",
     "moment": "^2.19.1"
   }
 }

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -32,7 +32,7 @@
     "pretravis": "npm run build-aot",
     "travis": "npm test",
     "posttravis": "npm run build-demo",
-    "build:demo": "ng build:demo",
+    "build:demo": "ng build demo",
     "build:core": "ng build core",
     "postbuild:core": "gulp copy:core-style",
     "build:material": "ng build material",

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -53,6 +53,7 @@
     "@angular/platform-browser-dynamic": "6.0.1",
     "@lucca-front/icons": "^0.7.0",
     "@lucca-front/scss": "^0.7.0",
+    "@ngx-formly/core": "^4.0.0",
     "@ngx-translate/core": "^8.0.0",
     "core-js": "^2.4.1",
     "rxjs": "^6.1.0",

--- a/packages/ng/tsconfig.json
+++ b/packages/ng/tsconfig.json
@@ -26,7 +26,7 @@
       "@api-docs": [
         "docs/demo/api-docs"
       ],
-      "material": [
+      "@material": [
         "dist/material"
       ]
     }

--- a/packages/ng/yarn.lock
+++ b/packages/ng/yarn.lock
@@ -213,9 +213,9 @@
     tree-kill "^1.0.0"
     webpack-sources "^1.1.0"
 
-"@ngx-formly/core@^2.0.0-beta.3":
-  version "2.0.0-rc.29"
-  resolved "https://registry.yarnpkg.com/@ngx-formly/core/-/core-2.0.0-rc.29.tgz#fb20ccdb7e35b3647d43e29790ad49a8eaa136ec"
+"@ngx-formly/core@^4.0.0":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@ngx-formly/core/-/core-4.0.3.tgz#b7b40d958cb8f72eaac10e655085ca47328d33bc"
   dependencies:
     tslib "^1.7.1"
 


### PR DESCRIPTION
follow up of PR #308 and #310 

-------------

 - updated formly version
 - updated package.json for entry points /formly and /material

> :warning: some shenanigans with scss build 
> for some reason that i dont wanna look for, when building with ng-packagr, it seems node-sass cant resolve `@import '~@lucca-front/scss/src/theming';`
> cuz `theming` can be the flder `/theming` or the file `_theming`
> so i have to specify `@import '~@lucca-front/scss/src/theming.scss';` (n /libs/xxx/src/style/_theming.scss) or the libs tont build
> **BUT**
> when i build the demo and import `/libs/xxx/src/style/main` via the /demo/style.scss, it does'nt build if i specify the .scss
> as a result me and sandy we gonna rename the folder `/theming` -> `/theme` and hope it fixes [everything](https://media3.giphy.com/media/wLXo0vTZSM7GU/giphy.gif)