### PR TITLE
1.0.lerna

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/LuccaSA/lucca-front.svg?branch=master)](https://travis-ci.org/LuccaSA/lucca-front)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lernajs.io/)
 # lucca-front
 
 A modular framework for developing web application by [lucca](http://www.lucca.fr).

--- a/lerna.json
+++ b/lerna.json
@@ -1,12 +1,15 @@
 {
   "lerna": "2.5.1",
   "packages": [
-    "packages/*"
+    "packages/*",
+    "packages/ng/dist"
   ],
   "version": "0.7.0",
   "command": {
     "publish": {
-      "message": "publish %s"
+      "message": "publish %s",
+      "force-publish": "*",
+      "ignore": "@lucca-front/ng-internal"
     }
   }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -8,8 +8,7 @@
   "command": {
     "publish": {
       "message": "publish %s",
-      "force-publish": "*",
-      "ignore": "@lucca-front/ng-internal"
+      "forcePublish": "*"
     }
   }
 }

--- a/packages/ng/libraries/core/package.json
+++ b/packages/ng/libraries/core/package.json
@@ -1,15 +1,17 @@
 {
   "name": "@lucca-front/ng",
+  "version": "0.0.0",
   "peerDependencies": {
     "@angular/common": "^6.0.0",
     "@angular/core": "^6.0.0",
-    "@angular/forms": "6.0.1",
-    "@angular/cdk": "6.0.0",
+    "@angular/forms": "^6.0.0",
+    "@angular/cdk": "^6.0.0",
     "rxjs": "^6.1.0",
     "rxjs-compat": "^6.1.0"
   },
   "files": [
     "formly",
+    "material",
     "style"
   ],
   "script": {}

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/LuccaSA/lucca-front.git"
   },
+  "private": true,
   "keywords": [
     "lucca",
     "angular",


### PR DESCRIPTION
updated lerna.json and other stuff so lerna can discover `@lucca-front/ng` which is under `/packages/ng/dist` and dont publish `ng-internal` which used to be `/packages/ng`