### PR TITLE
[enh] arrow position improved for large table heads

### DIFF
--- a/packages/scss/CHANGELOG.md
+++ b/packages/scss/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Adding
 ### Enhancements
 ### Fixes
+- `table` sortable arrow always stay on the last line
 
 ## 0.7.1
 ### Adding

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -45,6 +45,14 @@
 	&.mod-small {
 		font-size: _theme("sizes.small.font-size");
 		line-height: _theme("sizes.small.line-height");
+
+		.table-head-row-cell {
+			&.mod-sortable {
+				&::after {
+					margin-top: 0;
+				}
+			}
+		}
 	}
 
 	&.mod-zebra {
@@ -108,14 +116,16 @@
 .table-head-row-cell {
 	&.mod-sortable {
 		cursor: pointer;
+		padding-right: 2rem;
+		position: relative;
 
 		&::after {
 			@include makeIcon("arrow_full_south");
 			font-weight: 400;
 			font-size: .95rem;
-			margin-left: .15rem;
+			margin: .2rem 0 0 .2rem;
 			opacity: 0;
-			position: relative;
+			position: absolute;
 			transform: translateY(-.25rem);
 			transition: opacity _theme("commons.animations.durations.fast") ease, transform _theme("commons.animations.durations.fast") ease;
 		}


### PR DESCRIPTION
Table sortable arrow always stay on the last label line
+ fix its vertical alignment for mod-small tables 