### PR TITLE
Ng.usertile.defaultformat

### DIFF
--- a/packages/ng/CHANGELOG.md
+++ b/packages/ng/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## In Dev
 ### New features
 - :sparkles: add default value to user display pipe - default _first name last name_ -> `John Doe`
+- :sparkles: use said default value for user-tile
+
 ### Fixes
 - `user tile` word break
 

--- a/packages/ng/libraries/core/src/lib/user/tile/user-tile.component.ts
+++ b/packages/ng/libraries/core/src/lib/user/tile/user-tile.component.ts
@@ -33,20 +33,12 @@ export class LuUserTileComponent {
 		return this._user;
 	}
 
-	private _displayFormat: LuDisplayFormat = LuDisplayFullname.lastfirst;
 	/**
 	 * User Display format.
-	 * It is set to 'fl' by default
+	 * It is set to 'lf' by default
 	 */
 	@Input()
-	set displayFormat(displayFormat: LuDisplayFormat) {
-		this._displayFormat = displayFormat;
-		this._changeDetector.markForCheck();
-	}
-
-	get displayFormat(): LuDisplayFormat {
-		return this._displayFormat;
-	}
+	displayFormat: LuDisplayFormat;
 
 	private _role: string;
 	/**


### PR DESCRIPTION
same as #333 but for the user tile

it sets the display format as undefined so it falls back on `userDisplay`'s default format