### PR TITLE
Select.operators

### DIFF
--- a/packages/ng/docs/demo/src/app/select/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.html
@@ -1,4 +1,4 @@
-<section class="contentSection">
+<!-- <section class="contentSection">
 	<h3>Component basic</h3>
 	<div class="textfield">
 		<lu-select [(ngModel)]="itemSelect" class="textfield-input">
@@ -24,6 +24,21 @@
 	</div>
 	<code class="code mod-block">{{ number | json }}</code>
 
+</section> -->
+
+<section class="contentSection">
+	<h3>Component basic</h3>
+	<div class="textfield">
+		<lu-select [(ngModel)]="number" class="textfield-input">
+			<lu-option-picker>
+				<lu-option-feeder [options]="[red, green]"></lu-option-feeder>
+				<lu-option-template>
+					{{option?.name}}
+				</lu-option-template>
+			</lu-option-picker>
+		</lu-select>
+		<label class="textfield-label" for="itemOptions">my label</label>
+	</div>
+	<code class="code mod-block">{{ number | json }}</code>
+
 </section>
-
-

--- a/packages/ng/docs/demo/src/app/select/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.html
@@ -31,7 +31,7 @@
 	<lu-select [(ngModel)]="withOperators" class="textfield-input">
 		<lu-option-picker>
 			<lu-option-feeder [options]="options$ | async"></lu-option-feeder>
-			<!-- <lu-option-searcher></lu-option-searcher> -->
+			<lu-option-searcher [searchFn]="searchFn"></lu-option-searcher>
 			<lu-option-pager></lu-option-pager>
 			<lu-option-template>
 				<ng-template let-option>{{option.name}}</ng-template>

--- a/packages/ng/docs/demo/src/app/select/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.html
@@ -28,16 +28,15 @@
 <section class="contentSection">
 	<h3>Component basic</h3>
 	<div class="textfield">
-	<lu-select [(ngModel)]="number" class="textfield-input">
+	<lu-select [(ngModel)]="withOperators" class="textfield-input">
 		<lu-option-picker>
-			<lu-option-feeder [options]="[red, green]"></lu-option-feeder>
+			<lu-option-feeder [options]="options$ | async"></lu-option-feeder>
 			<!-- <lu-option-searcher></lu-option-searcher> -->
-			<!-- <lu-option-pager></lu-option-pager> -->
-			<!-- <lu-option *luOptionTemplate let-option [value]="option">{{option?.name}}</lu-option> -->
-			<!-- <lu-option *luOptionTemplate let-option [value]="option">{{option?.name}}</lu-option> -->
+			<lu-option-pager></lu-option-pager>
 			<lu-option-template>
 				<ng-template let-option>{{option.name}}</ng-template>
 			</lu-option-template>
+			<!-- target synthax -->
 			<!-- <lu-options>
 				<lu-option-template let-option>{{option.name}}</lu-option-template>
 			</lu-options> -->
@@ -46,6 +45,6 @@
 
 		<label class="textfield-label" for="itemOptions">my label</label>
 	</div>
-	<code class="code mod-block">{{ number | json }}</code>
+	<code class="code mod-block">{{ withOperators | json }}</code>
 
 </section>

--- a/packages/ng/docs/demo/src/app/select/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.html
@@ -1,4 +1,4 @@
-<!-- <section class="contentSection">
+<section class="contentSection">
 	<h3>Component basic</h3>
 	<div class="textfield">
 		<lu-select [(ngModel)]="itemSelect" class="textfield-input">
@@ -23,20 +23,27 @@
 		<label class="textfield-label" for="itemOptions">my label</label>
 	</div>
 	<code class="code mod-block">{{ number | json }}</code>
-
-</section> -->
+</section>
 
 <section class="contentSection">
 	<h3>Component basic</h3>
 	<div class="textfield">
-		<lu-select [(ngModel)]="number" class="textfield-input">
-			<lu-option-picker>
-				<lu-option-feeder [options]="[red, green]"></lu-option-feeder>
-				<lu-option-template>
-					{{option?.name}}
-				</lu-option-template>
-			</lu-option-picker>
-		</lu-select>
+	<lu-select [(ngModel)]="number" class="textfield-input">
+		<lu-option-picker>
+			<lu-option-feeder [options]="[red, green]"></lu-option-feeder>
+			<!-- <lu-option-searcher></lu-option-searcher> -->
+			<!-- <lu-option-pager></lu-option-pager> -->
+			<!-- <lu-option *luOptionTemplate let-option [value]="option">{{option?.name}}</lu-option> -->
+			<!-- <lu-option *luOptionTemplate let-option [value]="option">{{option?.name}}</lu-option> -->
+			<lu-option-template>
+				<ng-template let-option>{{option.name}}</ng-template>
+			</lu-option-template>
+			<!-- <lu-options>
+				<lu-option-template let-option>{{option.name}}</lu-option-template>
+			</lu-options> -->
+		</lu-option-picker>
+	</lu-select>
+
 		<label class="textfield-label" for="itemOptions">my label</label>
 	</div>
 	<code class="code mod-block">{{ number | json }}</code>

--- a/packages/ng/docs/demo/src/app/select/basic/basic.ts
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.ts
@@ -25,6 +25,9 @@ export class BasicSelectComponent {
 
 	number = { id: 1, name: 1 };
 	options$ = interval(1000)
-	.map(i => ({ id: i, name: i }))
+	.map(i => ({ id: i, name: '' + i }))
 	.scan((acc, curr) => [ ...acc, curr], []);
+	searchFn(o, c) {
+		return o.name.startsWith(c);
+	}
 }

--- a/packages/ng/docs/demo/src/app/select/basic/basic.ts
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.ts
@@ -30,5 +30,5 @@ export class BasicSelectComponent {
 	searchFn(o, c) {
 		return o.name.startsWith(c);
 	}
-	withOperators = number;
+	withOperators = this.number;
 }

--- a/packages/ng/docs/demo/src/app/select/basic/basic.ts
+++ b/packages/ng/docs/demo/src/app/select/basic/basic.ts
@@ -30,4 +30,5 @@ export class BasicSelectComponent {
 	searchFn(o, c) {
 		return o.name.startsWith(c);
 	}
+	withOperators = number;
 }

--- a/packages/ng/libraries/core/src/lib/option/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/index.ts
@@ -1,3 +1,4 @@
 export * from './item/index';
 export * from './picker/index';
+export * from './operator/index';
 export * from './option.module';

--- a/packages/ng/libraries/core/src/lib/option/item/option-item.component.scss
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.component.scss
@@ -1,3 +1,4 @@
 :host {
 	display: block;
+	cursor: pointer;
 }

--- a/packages/ng/libraries/core/src/lib/option/item/option-item.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.component.ts
@@ -1,14 +1,20 @@
-import { ChangeDetectionStrategy, Component, Output, HostListener, Input, EventEmitter, TemplateRef } from '@angular/core';
-import { ILuOptionItem } from './option-item.model';
+import { ChangeDetectionStrategy, Component, Output, HostListener, Input, EventEmitter, TemplateRef, forwardRef } from '@angular/core';
+import { ILuOptionItem, ALuOptionItem } from './option-item.model';
 
 @Component({
 	selector: 'lu-option',
 	templateUrl: './option-item.component.html',
 	styleUrls: ['./option-item.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuOptionItem,
+			useExisting: forwardRef(() => LuOptionItemComponent),
+			multi: true,
+		},
+	],
 })
-export class LuOptionItemComponent<T = any> implements ILuOptionItem<T> {
-	constructor() {}
+export class LuOptionItemComponent<T = any> extends ALuOptionItem<T> implements ILuOptionItem<T> {
 	@Input() value: T;
 	@Output() onSelect = new EventEmitter<T>();
 	@HostListener('click')

--- a/packages/ng/libraries/core/src/lib/option/item/option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.model.ts
@@ -3,3 +3,6 @@ import { Observable } from 'rxjs/Observable';
 export interface ILuOptionItem<T = any> {
 	onSelect: Observable<T>;
 }
+export abstract class ALuOptionItem<T = any> implements ILuOptionItem<T> {
+	onSelect: Observable<T>;
+}

--- a/packages/ng/libraries/core/src/lib/option/operator/feeder/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/feeder/index.ts
@@ -1,0 +1,2 @@
+export * from './option-feeder.component';
+export * from './option-feeder.module';

--- a/packages/ng/libraries/core/src/lib/option/operator/feeder/option-feeder.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/feeder/option-feeder.component.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, forwardRef, Input } from '@angular/
 import { ILuOptionItem } from '../../item/index';
 import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
 import { Subject } from 'rxjs/Subject';
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 
 @Component({
 	selector: 'lu-option-feeder',
@@ -17,8 +18,8 @@ import { Subject } from 'rxjs/Subject';
 	],
 })
 export class LuOptionFeederComponent<T = any> implements ILuOptionOperator<T> {
-	outOptions$ = new Subject<ILuOptionItem<T>[]>();
-	@Input() set options(options: ILuOptionItem<T>[]) {
+	outOptions$ = new BehaviorSubject<T[]>([]);
+	@Input() set options(options: T[]) {
 		this.outOptions$.next(options);
 	}
 }

--- a/packages/ng/libraries/core/src/lib/option/operator/feeder/option-feeder.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/feeder/option-feeder.component.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component, forwardRef, Input } from '@angular/core';
+import { ILuOptionItem } from '../../item/index';
+import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
+import { Subject } from 'rxjs/Subject';
+
+@Component({
+	selector: 'lu-option-feeder',
+	template: '',
+	styleUrls: [],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuOptionOperator,
+			useExisting: forwardRef(() => LuOptionFeederComponent),
+			multi: true,
+		},
+	],
+})
+export class LuOptionFeederComponent<T = any> implements ILuOptionOperator<T> {
+	outOptions$ = new Subject<ILuOptionItem<T>[]>();
+	@Input() set options(options: ILuOptionItem<T>[]) {
+		this.outOptions$.next(options);
+	}
+}

--- a/packages/ng/libraries/core/src/lib/option/operator/feeder/option-feeder.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/feeder/option-feeder.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { LuOptionFeederComponent } from './option-feeder.component';
+
+@NgModule({
+	imports: [
+	],
+	declarations: [
+		LuOptionFeederComponent,
+	],
+	exports: [
+		LuOptionFeederComponent,
+	],
+})
+export class LuOptionFeederModule {}

--- a/packages/ng/libraries/core/src/lib/option/operator/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/index.ts
@@ -1,0 +1,3 @@
+export * from './pager/index';
+export * from './option-operator.module';
+export * from './option-operator.model';

--- a/packages/ng/libraries/core/src/lib/option/operator/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/index.ts
@@ -1,5 +1,6 @@
 export * from './feeder/index';
 export * from './pager/index';
+export * from './searcher/index';
 export * from './template/index';
 export * from './option-operator.module';
 export * from './option-operator.model';

--- a/packages/ng/libraries/core/src/lib/option/operator/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/index.ts
@@ -1,3 +1,5 @@
+export * from './feeder/index';
 export * from './pager/index';
+export * from './template/index';
 export * from './option-operator.module';
 export * from './option-operator.model';

--- a/packages/ng/libraries/core/src/lib/option/operator/option-operator.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/option-operator.model.ts
@@ -2,10 +2,17 @@ import { ILuOptionItem } from '../item/index';
 import { Observable } from 'rxjs/Observable';
 
 export interface ILuOptionOperator<T = any> {
-	inOptions$?: Observable<ILuOptionItem<T>[]>;
-	outOptions$?: Observable<ILuOptionItem<T>[]>;
+	inOptions$?: Observable<T[]>;
+	outOptions$?: Observable<T[]>;
 }
 export abstract class ALuOptionOperator<T = any> implements ILuOptionOperator<T> {
-	inOptions$?: Observable<ILuOptionItem<T>[]>;
-	outOptions$?: Observable<ILuOptionItem<T>[]>;
+	inOptions$?: Observable<T[]>;
+	outOptions$?: Observable<T[]>;
+}
+export interface ILuOptionProvider<T = any> {
+	luOptions$: Observable<ILuOptionItem<T>[]>;
+}
+export abstract class ALuOptionProvider<T = any> implements ILuOptionProvider<T> {
+	luOptions$: Observable<ILuOptionItem<T>[]>;
+
 }

--- a/packages/ng/libraries/core/src/lib/option/operator/option-operator.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/option-operator.model.ts
@@ -9,10 +9,3 @@ export abstract class ALuOptionOperator<T = any> implements ILuOptionOperator<T>
 	inOptions$?: Observable<T[]>;
 	outOptions$?: Observable<T[]>;
 }
-export interface ILuOptionProvider<T = any> {
-	luOptions$: Observable<ILuOptionItem<T>[]>;
-}
-export abstract class ALuOptionProvider<T = any> implements ILuOptionProvider<T> {
-	luOptions$: Observable<ILuOptionItem<T>[]>;
-
-}

--- a/packages/ng/libraries/core/src/lib/option/operator/option-operator.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/option-operator.model.ts
@@ -1,0 +1,11 @@
+import { ILuOptionItem } from '../item/index';
+import { Observable } from 'rxjs/Observable';
+
+export interface ILuOptionOperator<T = any> {
+	inOptions$?: Observable<ILuOptionItem<T>[]>;
+	outOptions$?: Observable<ILuOptionItem<T>[]>;
+}
+export abstract class ALuOptionOperator<T = any> implements ILuOptionOperator<T> {
+	inOptions$?: Observable<ILuOptionItem<T>[]>;
+	outOptions$?: Observable<ILuOptionItem<T>[]>;
+}

--- a/packages/ng/libraries/core/src/lib/option/operator/option-operator.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/option-operator.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { LuOptionPagerModule } from './pager/index';
+import { LuOptionFeederModule } from './feeder/index';
+
+@NgModule({
+	imports: [
+		LuOptionPagerModule,
+		LuOptionFeederModule,
+	],
+	exports: [
+		LuOptionPagerModule,
+		LuOptionFeederModule,
+	],
+})
+export class LuOptionOperatorModule {}

--- a/packages/ng/libraries/core/src/lib/option/operator/option-operator.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/option-operator.module.ts
@@ -1,15 +1,18 @@
 import { NgModule } from '@angular/core';
 import { LuOptionPagerModule } from './pager/index';
 import { LuOptionFeederModule } from './feeder/index';
+import { LuOptionTemplateModule } from './template/index';
 
 @NgModule({
 	imports: [
 		LuOptionPagerModule,
 		LuOptionFeederModule,
+		LuOptionTemplateModule,
 	],
 	exports: [
 		LuOptionPagerModule,
 		LuOptionFeederModule,
+		LuOptionTemplateModule,
 	],
 })
 export class LuOptionOperatorModule {}

--- a/packages/ng/libraries/core/src/lib/option/operator/option-operator.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/option-operator.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { LuOptionPagerModule } from './pager/index';
 import { LuOptionFeederModule } from './feeder/index';
+import { LuOptionSearcherModule } from './searcher/index';
 import { LuOptionTemplateModule } from './template/index';
 
 @NgModule({
@@ -8,11 +9,13 @@ import { LuOptionTemplateModule } from './template/index';
 		LuOptionPagerModule,
 		LuOptionFeederModule,
 		LuOptionTemplateModule,
+		LuOptionSearcherModule,
 	],
 	exports: [
 		LuOptionPagerModule,
 		LuOptionFeederModule,
 		LuOptionTemplateModule,
+		LuOptionSearcherModule,
 	],
 })
 export class LuOptionOperatorModule {}

--- a/packages/ng/libraries/core/src/lib/option/operator/pager/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/pager/index.ts
@@ -1,0 +1,2 @@
+export * from './option-pager.component';
+export * from './option-pager.module';

--- a/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
 import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-// import 'rxjs/add/operators/do';
-
+import { BehaviorSubject } from 'rxjs/BehaviorSubject';
+import { combineLatest } from 'rxjs/observable/combineLatest';
+const MAGIC_STEP = 5;
 @Component({
 	selector: 'lu-option-pager',
-	template: '',
+	template: '0 - {{paging$.value}} <button (click)="next()">next</button>',
 	styleUrls: [],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	providers: [
@@ -17,11 +17,18 @@ import { Subject } from 'rxjs/Subject';
 		},
 	],
 })
-export class LuOptionPagerComponent<T = any> implements ILuOptionOperator<T> {
+export class LuOptionPagerComponent<T = any> extends ALuOptionOperator<T> implements ILuOptionOperator<T> {
 	set inOptions$(in$: Observable<T[]>) {
-		// in$.do(options => this.outOptions$.next(options))
+		this.outOptions$ = combineLatest(
+			in$,
+			this.paging$,
+			(options, paging) => {
+				return (options || []).slice(0, paging);
+			}
+		);
 	}
-	outOptions$: Observable<T[]> = new Subject<T[]>();
-	// paging$ = new Subject<number>();
-
+	paging$ = new BehaviorSubject<number>(MAGIC_STEP);
+	next() {
+		this.paging$.next(this.paging$.value + MAGIC_STEP);
+	}
 }

--- a/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.component.ts
@@ -1,0 +1,28 @@
+import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import { ILuOptionItem } from '../../item/index';
+import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+// import 'rxjs/add/operators/do';
+
+@Component({
+	selector: 'lu-option-pager',
+	template: '',
+	styleUrls: [],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuOptionOperator,
+			useExisting: forwardRef(() => LuOptionPagerComponent),
+			multi: true,
+		},
+	],
+})
+export class LuOptionPagerComponent<T = any> implements ILuOptionOperator<T> {
+	set inOptions$(in$: Observable<ILuOptionItem<T>[]>) {
+		// in$.do(options => this.outOptions$.next(options))
+	}
+	outOptions$: Observable<ILuOptionItem<T>[]> = new Subject<ILuOptionItem<T>[]>();
+	// paging$ = new Subject<number>();
+
+}

--- a/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
-import { ILuOptionItem } from '../../item/index';
 import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
@@ -19,10 +18,10 @@ import { Subject } from 'rxjs/Subject';
 	],
 })
 export class LuOptionPagerComponent<T = any> implements ILuOptionOperator<T> {
-	set inOptions$(in$: Observable<ILuOptionItem<T>[]>) {
+	set inOptions$(in$: Observable<T[]>) {
 		// in$.do(options => this.outOptions$.next(options))
 	}
-	outOptions$: Observable<ILuOptionItem<T>[]> = new Subject<ILuOptionItem<T>[]>();
+	outOptions$: Observable<T[]> = new Subject<T[]>();
 	// paging$ = new Subject<number>();
 
 }

--- a/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/pager/option-pager.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { LuOptionPagerComponent } from './option-pager.component';
+
+@NgModule({
+	imports: [
+	],
+	declarations: [
+		LuOptionPagerComponent,
+	],
+	exports: [
+		LuOptionPagerComponent,
+	],
+})
+export class LuOptionPagerModule {}

--- a/packages/ng/libraries/core/src/lib/option/operator/searcher/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/searcher/index.ts
@@ -1,0 +1,2 @@
+export * from './option-searcher.component';
+export * from './option-searcher.module';

--- a/packages/ng/libraries/core/src/lib/option/operator/searcher/option-searcher.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/searcher/option-searcher.component.ts
@@ -1,0 +1,34 @@
+import { ChangeDetectionStrategy, Component, forwardRef, Input, OnInit } from '@angular/core';
+import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
+import { Observable } from 'rxjs/Observable';
+import { combineLatest } from 'rxjs/observable/combineLatest';
+import { merge } from 'rxjs/observable/merge';
+import { of } from 'rxjs/observable/of';
+import { FormControl } from '@angular/forms';
+@Component({
+	selector: 'lu-option-searcher',
+	template: '<input [formControl]="searchControl">',
+	styleUrls: [],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuOptionOperator,
+			useExisting: forwardRef(() => LuOptionSearcherComponent),
+			multi: true,
+		},
+	],
+})
+export class LuOptionSearcherComponent<T = any> extends ALuOptionOperator<T> implements ILuOptionOperator<T> {
+	searchControl = new FormControl();
+	clue$ = merge(of(''), this.searchControl.valueChanges);
+	set inOptions$(in$: Observable<T[]>) {
+		this.outOptions$ = combineLatest(
+			in$,
+			this.clue$,
+			(options, clue) => {
+				return !!clue ? (options || []).filter(o => this.searchFn(o, clue)) : options || [];
+			}
+		);
+	}
+	@Input() searchFn: (option: T, clue: string) => boolean = () => true;
+}

--- a/packages/ng/libraries/core/src/lib/option/operator/searcher/option-searcher.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/searcher/option-searcher.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { LuOptionSearcherComponent } from './option-searcher.component';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@NgModule({
+	imports: [
+		ReactiveFormsModule,
+	],
+	declarations: [
+		LuOptionSearcherComponent,
+	],
+	exports: [
+		LuOptionSearcherComponent,
+	],
+})
+export class LuOptionSearcherModule {}

--- a/packages/ng/libraries/core/src/lib/option/operator/template/index.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/index.ts
@@ -1,0 +1,2 @@
+export * from './option-template.component';
+export * from './option-template.module';

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.html
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.html
@@ -1,7 +1,5 @@
-<ng-template #template let-option>
-	<!-- <ng-content></ng-content> -->
-	<lu-option [value]="option">{{ option?.name }}</lu-option>
-</ng-template>
 <ng-container *ngFor="let option of options$ | async">
-	<ng-container *ngTemplateOutlet="template; context: {$implicit: option}"></ng-container>
+	<lu-option [value]="option">
+		<ng-container *ngTemplateOutlet="optionTemplate; context: {$implicit: option}"></ng-container>
+	</lu-option>
 </ng-container>

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.html
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.html
@@ -1,6 +1,7 @@
 <ng-template #template let-option>
-	<ng-content></ng-content>
+	<!-- <ng-content></ng-content> -->
+	<lu-option [value]="option">{{ option?.name }}</lu-option>
 </ng-template>
-<ng-template *ngFor="let option of inOptions$ | async">
+<ng-container *ngFor="let option of options$ | async">
 	<ng-container *ngTemplateOutlet="template; context: {$implicit: option}"></ng-container>
-</ng-template>
+</ng-container>

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.html
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.html
@@ -1,0 +1,6 @@
+<ng-template #template let-option>
+	<ng-content></ng-content>
+</ng-template>
+<ng-template *ngFor="let option of inOptions$ | async">
+	<ng-container *ngTemplateOutlet="template; context: {$implicit: option}"></ng-container>
+</ng-template>

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.ts
@@ -1,0 +1,21 @@
+import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import { ILuOptionItem } from '../../item/index';
+import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
+import { Observable } from 'rxjs/Observable';
+
+@Component({
+	selector: 'lu-option-template',
+	templateUrl: './option-template.component.html',
+	styleUrls: ['./option-template.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuOptionOperator,
+			useExisting: forwardRef(() => LuOptionTemplateComponent),
+			multi: true,
+		},
+	],
+})
+export class LuOptionTemplateComponent<T = any> implements ILuOptionOperator<T> {
+	inOptions$: Observable<ILuOptionItem<T>[]>;
+}

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.ts
@@ -1,9 +1,21 @@
-import { ChangeDetectionStrategy, Component, forwardRef, QueryList, ViewChildren, AfterViewInit, Output, EventEmitter } from '@angular/core';
+import {
+	ChangeDetectionStrategy,
+	Component,
+	forwardRef,
+	QueryList,
+	ViewChildren,
+	AfterViewInit,
+	Output,
+	EventEmitter,
+	TemplateRef,
+	ContentChild,
+} from '@angular/core';
 import { ILuOptionItem, ALuOptionItem } from '../../item/index';
-import { ILuOptionOperator, ALuOptionOperator, ALuOptionProvider, ILuOptionProvider } from '../option-operator.model';
+import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
 import { Observable } from 'rxjs/Observable';
 import { merge } from 'rxjs/observable/merge';
 import 'rxjs/add/operator/mergeMap';
+import 'rxjs/add/operator/do';
 
 @Component({
 	selector: 'lu-option-template',
@@ -24,13 +36,13 @@ import 'rxjs/add/operator/mergeMap';
 	],
 })
 export class LuOptionTemplateComponent<T = any> implements ILuOptionOperator<T>, ILuOptionItem<T>, AfterViewInit {
+	@ContentChild(TemplateRef, { read: TemplateRef }) optionTemplate: TemplateRef<any>;
 	@Output() onSelect = new EventEmitter<T>();
 	set inOptions$(options$: Observable<T[]>) {
 		this.options$ = options$;
 	}
 	get outOptions$() { return this.options$; }
 	options$: Observable<T[]>;
-	// luOptions$: Observable<ILuOptionItem<T>[]>;
 
 	@ViewChildren(ALuOptionItem) optionsVC: QueryList<ILuOptionItem<T>>;
 	ngAfterViewInit() {

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.component.ts
@@ -1,7 +1,9 @@
-import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
-import { ILuOptionItem } from '../../item/index';
-import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
+import { ChangeDetectionStrategy, Component, forwardRef, QueryList, ViewChildren, AfterViewInit, Output, EventEmitter } from '@angular/core';
+import { ILuOptionItem, ALuOptionItem } from '../../item/index';
+import { ILuOptionOperator, ALuOptionOperator, ALuOptionProvider, ILuOptionProvider } from '../option-operator.model';
 import { Observable } from 'rxjs/Observable';
+import { merge } from 'rxjs/observable/merge';
+import 'rxjs/add/operator/mergeMap';
 
 @Component({
 	selector: 'lu-option-template',
@@ -14,8 +16,30 @@ import { Observable } from 'rxjs/Observable';
 			useExisting: forwardRef(() => LuOptionTemplateComponent),
 			multi: true,
 		},
+		{
+			provide: ALuOptionItem,
+			useExisting: forwardRef(() => LuOptionTemplateComponent),
+			multi: true,
+		},
 	],
 })
-export class LuOptionTemplateComponent<T = any> implements ILuOptionOperator<T> {
-	inOptions$: Observable<ILuOptionItem<T>[]>;
+export class LuOptionTemplateComponent<T = any> implements ILuOptionOperator<T>, ILuOptionItem<T>, AfterViewInit {
+	@Output() onSelect = new EventEmitter<T>();
+	set inOptions$(options$: Observable<T[]>) {
+		this.options$ = options$;
+	}
+	get outOptions$() { return this.options$; }
+	options$: Observable<T[]>;
+	// luOptions$: Observable<ILuOptionItem<T>[]>;
+
+	@ViewChildren(ALuOptionItem) optionsVC: QueryList<ILuOptionItem<T>>;
+	ngAfterViewInit() {
+		const allOptionsOnSelect$ =
+			merge(Observable.of(this.optionsVC), this.optionsVC.changes)
+			.map<QueryList<ILuOptionItem<T>>, ILuOptionItem<T>[]>(ql => ql.toArray())
+			.map(optionItems => merge(...optionItems.map(oi => oi.onSelect)))
+			.mergeMap(val => val);
+
+		allOptionsOnSelect$.subscribe(value => this.onSelect.emit(value));
+	}
 }

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { LuOptionTemplateComponent } from './option-template.component';
 import { CommonModule } from '@angular/common';
+import { LuOptionItemModule } from '../../item/index';
 
 @NgModule({
 	imports: [
 		CommonModule,
+		LuOptionItemModule,
 	],
 	declarations: [
 		LuOptionTemplateComponent,

--- a/packages/ng/libraries/core/src/lib/option/operator/template/option-template.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/template/option-template.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { LuOptionTemplateComponent } from './option-template.component';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+	imports: [
+		CommonModule,
+	],
+	declarations: [
+		LuOptionTemplateComponent,
+	],
+	exports: [
+		LuOptionTemplateComponent,
+	],
+})
+export class LuOptionTemplateModule {}

--- a/packages/ng/libraries/core/src/lib/option/option.module.ts
+++ b/packages/ng/libraries/core/src/lib/option/option.module.ts
@@ -1,15 +1,18 @@
 import { NgModule } from '@angular/core';
 import { LuOptionItemModule } from './item/index';
 import { LuOptionPickerModule } from './picker/index';
+import { LuOptionOperatorModule } from './operator/index';
 
 @NgModule({
 	imports: [
 		LuOptionItemModule,
 		LuOptionPickerModule,
+		LuOptionOperatorModule,
 	],
 	exports: [
 		LuOptionItemModule,
 		LuOptionPickerModule,
+		LuOptionOperatorModule,
 	],
 })
 export class LuOptionModule {}

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -22,7 +22,7 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import { ALuPickerPanel } from '../../input/index';
-import { ALuOptionOperator, ILuOptionOperator, ILuOptionProvider, ALuOptionProvider } from '../operator/index';
+import { ALuOptionOperator, ILuOptionOperator } from '../operator/index';
 
 /**
 * Displays user'picture or a placeholder with his/her initials and random bg color'
@@ -44,7 +44,7 @@ import { ALuOptionOperator, ILuOptionOperator, ILuOptionProvider, ALuOptionProvi
 })
 export class LuOptionPickerComponent<T = any>
 extends LuPopoverPanelComponent
-implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
+implements ILuOptionPickerPanel<T>, OnDestroy, AfterContentInit {
 	subs: Subscription;
 	@Output() onSelectValue = new EventEmitter<T>();
 	setValue(value: T) {}
@@ -56,7 +56,6 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 	}
 	@ContentChildren(ALuOptionItem, { descendants: true }) optionsQL: QueryList<ILuOptionItem<T>>;
 	@ContentChildren(ALuOptionOperator, { descendants: true }) operatorsQL: QueryList<ILuOptionOperator<T>>;
-	// @ContentChildren(ALuOptionProvider, { descendants: true }) providersQL: QueryList<ILuOptionProvider<T>>;
 
 	subToOptionSelected() {
 		const allOptionsOnSelect$ =
@@ -77,7 +76,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 		this.onSelectValue.emit(val);
 		this._emitCloseEvent();
 	}
-	ngAfterViewInit() {
+	ngAfterContentInit() {
 		this.subs = new Subscription();
 		this.subToOptionSelected();
 		this.initOperators();
@@ -93,16 +92,6 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 			operator.inOptions$ = options$;
 			options$ = operator.outOptions$;
 		});
-		// const providers: ILuOptionProvider<T>[] = this.providersQL.toArray();
-		// const lol = providers[0].luOptions$;
-		// const allOptionsOnSelect$ =
-		// merge(...providers.map(p => p.luOptions$))
-		// .map(options => merge(...options.map(o => o.onSelect)))
-		// .mergeMap(o => o);
-		// this.subs.add(
-		// 	allOptionsOnSelect$
-		// 	.subscribe((val: T) => this._select(val))
-		// );
 	}
 
 }

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -10,9 +10,10 @@ import {
 	EventEmitter,
 	OnDestroy,
 	forwardRef,
+	AfterViewInit,
 } from '@angular/core';
 import { LuPopoverPanelComponent, luTransformPopover } from '../../popover/index';
-import { ILuOptionItem, LuOptionItemComponent } from '../item/index';
+import { ILuOptionItem, ALuOptionItem } from '../item/index';
 import { ILuOptionPickerPanel } from './option-picker.model';
 import { Subscription } from 'rxjs/Subscription';
 import { Observable } from 'rxjs/Observable';
@@ -21,6 +22,7 @@ import 'rxjs/add/observable/of';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/mergeMap';
 import { ALuPickerPanel } from '../../input/index';
+import { ALuOptionOperator, ILuOptionOperator, ILuOptionProvider, ALuOptionProvider } from '../operator/index';
 
 /**
 * Displays user'picture or a placeholder with his/her initials and random bg color'
@@ -42,7 +44,7 @@ import { ALuPickerPanel } from '../../input/index';
 })
 export class LuOptionPickerComponent<T = any>
 extends LuPopoverPanelComponent
-implements ILuOptionPickerPanel<T>, OnDestroy, AfterContentInit {
+implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 	subs: Subscription;
 	@Output() onSelectValue = new EventEmitter<T>();
 	setValue(value: T) {}
@@ -52,10 +54,11 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterContentInit {
 		super(_elementRef);
 		this.triggerEvent = 'click';
 	}
-	@ContentChildren(LuOptionItemComponent, { descendants: true }) optionsQL: QueryList<ILuOptionItem<T>>;
+	@ContentChildren(ALuOptionItem, { descendants: true }) optionsQL: QueryList<ILuOptionItem<T>>;
+	@ContentChildren(ALuOptionOperator, { descendants: true }) operatorsQL: QueryList<ILuOptionOperator<T>>;
+	// @ContentChildren(ALuOptionProvider, { descendants: true }) providersQL: QueryList<ILuOptionProvider<T>>;
 
 	subToOptionSelected() {
-		this.subs = new Subscription();
 		const allOptionsOnSelect$ =
 		merge(Observable.of(this.optionsQL), this.optionsQL.changes)
 			.map<QueryList<ILuOptionItem<T>>, Observable<T>>(ql => {
@@ -74,10 +77,32 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterContentInit {
 		this.onSelectValue.emit(val);
 		this._emitCloseEvent();
 	}
-	ngAfterContentInit() {
+	ngAfterViewInit() {
+		this.subs = new Subscription();
 		this.subToOptionSelected();
+		this.initOperators();
 	}
 	ngOnDestroy() {
 		this.unSubToOptionSelected();
 	}
+
+	initOperators() {
+		const operators: ILuOptionOperator<T>[] = this.operatorsQL.toArray();
+		let options$: Observable<T[]>;
+		operators.forEach(operator => {
+			operator.inOptions$ = options$;
+			options$ = operator.outOptions$;
+		});
+		// const providers: ILuOptionProvider<T>[] = this.providersQL.toArray();
+		// const lol = providers[0].luOptions$;
+		// const allOptionsOnSelect$ =
+		// merge(...providers.map(p => p.luOptions$))
+		// .map(options => merge(...options.map(o => o.onSelect)))
+		// .mergeMap(o => o);
+		// this.subs.add(
+		// 	allOptionsOnSelect$
+		// 	.subscribe((val: T) => this._select(val))
+		// );
+	}
+
 }

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -114,7 +114,7 @@ implements ControlValueAccessor, ILuInputWithPicker<TValue> {
 	}
 
 	displayTemplate: TemplateRef<any>;
-	@ContentChild(TemplateRef) set _contentChildDisplayTemplate(templateRef: TemplateRef<any>) {
-		this.displayTemplate = templateRef;
-	}
+	// @ContentChild(TemplateRef) set _contentChildDisplayTemplate(templateRef: TemplateRef<any>) {
+	// 	this.displayTemplate = templateRef;
+	// }
 }


### PR DESCRIPTION
adds the notion of _option operator_, being stuff that take `Obs<T[]>` in and return `Obs<T[]>` out
then the option picker chains them together. it allows writting this kind of html
```html
<lu-select [(ngModel)]="withOperators" class="textfield-input">
	<lu-option-picker>
		<lu-option-feeder [options]="options$ | async"></lu-option-feeder>
		<lu-option-searcher [searchFn]="searchFn"></lu-option-searcher>
		<lu-option-pager></lu-option-pager>
		<lu-option-template>
			<ng-template let-option>{{option.name}}</ng-template>
		</lu-option-template>
	</lu-option-picker>
</lu-select>
```
to have a searchable paged select