### PR TITLE
Input.directive

### DIFF
--- a/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.ts
@@ -7,7 +7,8 @@ import {
 	ElementRef,
 	HostListener,
 	ViewChild,
-	Input
+	Input,
+	Renderer2
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -51,6 +52,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T> {
 		protected _overlay: Overlay,
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
 		protected _service: ALuApiPagedSearcherService<T>,
 	) {
 		super(
@@ -58,6 +60,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T> {
 			_overlay,
 			_elementRef,
 			_viewContainerRef,
+			_renderer,
 		);
 	}
 

--- a/packages/ng/libraries/core/src/lib/input/index.ts
+++ b/packages/ng/libraries/core/src/lib/input/index.ts
@@ -3,3 +3,4 @@ export * from './clearer/index';
 export * from './displayer/index';
 export * from './input.model';
 export * from './input.module';
+export * from './input.directive';

--- a/packages/ng/libraries/core/src/lib/input/input.directive.ts
+++ b/packages/ng/libraries/core/src/lib/input/input.directive.ts
@@ -16,7 +16,7 @@ import { ALuInput } from './input.model';
 		},
 	],
 })
-export class LuInputDirective<T> extends ALuInput<T> {
+export class LuInputDirective<T = any> extends ALuInput<T> {
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _elementRef: ElementRef,

--- a/packages/ng/libraries/core/src/lib/input/input.directive.ts
+++ b/packages/ng/libraries/core/src/lib/input/input.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, ElementRef, Input, OnInit, Renderer2, ChangeDetectorRef, forwardRef, ChangeDetectionStrategy } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ALuInput } from './input.model';
+
+/**
+ * adds class is-filled when model is empty
+ */
+@Directive({
+	selector: '[luInput]',
+	// changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => LuInputDirective),
+			multi: true,
+		},
+	],
+})
+export class LuInputDirective<T> extends ALuInput<T> {
+	constructor(
+		protected _changeDetectorRef: ChangeDetectorRef,
+		protected _elementRef: ElementRef,
+		protected _renderer: Renderer2,
+	) {
+		super(_changeDetectorRef, _elementRef, _renderer);
+	}
+	protected render() {}
+}

--- a/packages/ng/libraries/core/src/lib/input/input.model.ts
+++ b/packages/ng/libraries/core/src/lib/input/input.model.ts
@@ -1,7 +1,58 @@
 import { ControlValueAccessor } from '@angular/forms';
 import { ILuPickerPanel } from './picker/input-picker.model';
 import { ILuPopoverTrigger } from '../popover/index';
+import { ChangeDetectorRef, Renderer2, ElementRef } from '@angular/core';
+
+export interface ILuInput<T = any> extends ControlValueAccessor {}
 
 export interface ILuInputWithPicker<TValue = any, TPanel extends ILuPickerPanel<TValue> = ILuPickerPanel<TValue>>
-extends ControlValueAccessor, ILuPopoverTrigger<TPanel> {
+extends ILuInput<TValue>, ControlValueAccessor, ILuPopoverTrigger<TPanel> {}
+
+export abstract class ALuInput<T> implements ILuInput<T> {
+	protected _value: T;
+	constructor(
+		protected _changeDetectorRef: ChangeDetectorRef,
+		protected _elementRef: ElementRef,
+		protected _renderer: Renderer2,
+	) {}
+	setValue(value) {
+		this.value = value;
+		this._cvaOnChange(value);
+		this._onTouched();
+	}
+	get value(): T {
+		return this._value;
+	}
+	set value(value: T) {
+		this._value = value;
+		this.render();
+		this.applyClasses();
+		this._changeDetectorRef.markForCheck();
+	}
+	// From ControlValueAccessor interface
+	writeValue(value: T) {
+		this.value = value;
+	}
+	// From ControlValueAccessor interface
+	protected _cvaOnChange = (v: T) => {};
+	registerOnChange(fn: any) {
+		this._cvaOnChange = fn;
+	}
+	// From ControlValueAccessor interface
+	protected _onTouched = () => {};
+	registerOnTouched(fn: any) {
+		this._onTouched = fn;
+	}
+	protected isEmpty() {
+		return this.value === null || this.value === undefined;
+	}
+	protected applyClasses() {
+		if (this.isEmpty()) {
+			this._renderer.removeClass(this._elementRef.nativeElement, 'is-filled');
+		} else {
+			this._renderer.addClass(this._elementRef.nativeElement, 'is-filled');
+		}
+	}
+
+	protected abstract render(): void;
 }

--- a/packages/ng/libraries/core/src/lib/input/input.model.ts
+++ b/packages/ng/libraries/core/src/lib/input/input.model.ts
@@ -8,7 +8,7 @@ export interface ILuInput<T = any> extends ControlValueAccessor {}
 export interface ILuInputWithPicker<TValue = any, TPanel extends ILuPickerPanel<TValue> = ILuPickerPanel<TValue>>
 extends ILuInput<TValue>, ControlValueAccessor, ILuPopoverTrigger<TPanel> {}
 
-export abstract class ALuInput<T> implements ILuInput<T> {
+export abstract class ALuInput<T = any> implements ILuInput<T> {
 	protected _value: T;
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,

--- a/packages/ng/libraries/core/src/lib/input/input.module.ts
+++ b/packages/ng/libraries/core/src/lib/input/input.module.ts
@@ -1,7 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuInputDisplayerModule } from './displayer/index';
+import { LuInputDirective } from './input.directive';
 
 @NgModule({
+	declarations: [LuInputDirective],
 	imports: [LuInputDisplayerModule],
 	exports: [LuInputDisplayerModule],
 })

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -63,6 +63,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit {
 			_overlay,
 			_elementRef,
 			_viewContainerRef,
+			_renderer,
 		);
 	}
 

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.model.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.model.ts
@@ -2,20 +2,22 @@ import {
 	ChangeDetectorRef,
 	ViewContainerRef,
 	ElementRef,
+	Renderer2,
 } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
 import { ALuPopoverTrigger } from '../../popover/index';
 import { Overlay, OverlayConfig } from '@angular/cdk/overlay';
-import { ILuInputWithPicker, ILuPickerPanel, ALuPickerPanel, ILuClearer } from '../../input/index';
+import { ILuInputWithPicker, ILuPickerPanel, ALuPickerPanel, ILuClearer, ILuInput } from '../../input/index';
 
 export abstract class ALuSelectInput<T = any, P extends ILuPickerPanel<T> = ILuPickerPanel<T>, C extends ILuClearer<T> = ILuClearer<T>>
 extends ALuPopoverTrigger<P>
-implements ControlValueAccessor, ILuInputWithPicker<T> {
+implements ControlValueAccessor, ILuInputWithPicker<T>, ILuInput<T> {
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
 	) {
 		super(
 			_overlay,
@@ -38,6 +40,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T> {
 	set value(value: T) {
 		this._value = value;
 		this.render();
+		this.applyClasses();
 		this._changeDetectorRef.markForCheck();
 	}
 	// From ControlValueAccessor interface
@@ -54,7 +57,16 @@ implements ControlValueAccessor, ILuInputWithPicker<T> {
 	registerOnTouched(fn: any) {
 		this._onTouched = fn;
 	}
-
+	protected isEmpty() {
+		return this.value === null || this.value === undefined;
+	}
+	protected applyClasses() {
+		if (this.isEmpty()) {
+			this._renderer.removeClass(this._elementRef.nativeElement, 'is-filled');
+		} else {
+			this._renderer.addClass(this._elementRef.nativeElement, 'is-filled');
+		}
+	}
 	/**
 	 * popover trigger class extension
 	 */

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.ts
@@ -8,7 +8,8 @@ import {
 	HostListener,
 	TemplateRef,
 	ViewChild,
-	Input
+	Input,
+	Renderer2
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -57,6 +58,7 @@ implements ControlValueAccessor, ILuInputWithPicker<U> {
 		protected _overlay: Overlay,
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
 		protected _service: ALuUserPagedSearcherService<U>,
 	) {
 		super(
@@ -64,6 +66,7 @@ implements ControlValueAccessor, ILuInputWithPicker<U> {
 			_overlay,
 			_elementRef,
 			_viewContainerRef,
+			_renderer,
 		);
 	}
 


### PR DESCRIPTION
add 
- ILuInput<T> - pretty empty interface that extends `ControlValueAccessor`
- ALuInput<T> - adds class `is-filled` when value is not empty
- LuInputDirective<T> - extends ALuInput
- ALuSelect - implements ILuInput<T> and add `is-filled` class to host element - affects all selects (normal, api, user, ...)