### PR TITLE
Select.fix.keyboardevents

### DIFF
--- a/packages/ng/libraries/core/src/lib/option/item/option-item.component.scss
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.component.scss
@@ -6,18 +6,14 @@
 	padding: 0.5rem;
 	transition: background 50ms ease;
 
-	&:hover {
-		background: _theme('commons.background.dark');
-	}
-
-	&.is-focus {
+	&:hover, &.is-highlighted, &.is-focus{
 		background: _theme('commons.background.dark');
 	}
 }
 
 :host-context(.lu-select-value) {
 	padding: 0;
-	&:hover, &.is-focus {
+	&:hover, &.is-focus, &.is-highlighted {
 		background: inherit;
 	}
 }

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -18,6 +18,7 @@ import {
 	ChangeDetectorRef,
 	OnInit,
 	AfterViewInit,
+	Input,
 } from '@angular/core';
 import { luTransformPopover } from '../../popover/index';
 import { ILuOptionItem, ALuOptionItem } from '../item/index';
@@ -58,6 +59,10 @@ import { UP_ARROW, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 export class LuOptionPickerComponent<T = any>
 extends ALuOptionPicker<T>
 implements ILuOptionPickerPanel<T>, OnDestroy, ILuInputDisplayer<T>, AfterViewInit {
+	@Input('overlap-trigger')
+	set inputOverlapTrigger(v: boolean) {
+		this.overlapTrigger = v;
+	}
 	@Output() close = new EventEmitter<void>();
 	@Output() open = new EventEmitter<void>();
 	@Output() onSelectValue = new EventEmitter<T>();

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -149,9 +149,11 @@ implements ILuOptionPickerPanel<T>, OnDestroy, ILuInputDisplayer<T>, AfterViewIn
 				break;
 			case UP_ARROW:
 				this._decrHighlight();
+				event.preventDefault();
 				break;
 			case DOWN_ARROW:
 				this._incrHighlight();
+				event.preventDefault();
 				break;
 		}
 	}

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
@@ -47,7 +47,6 @@ export abstract class ALuOptionPicker<T = any> extends ALuPickerPanel<T> impleme
 		this._subs.unsubscribe();
 	}
 	_handleKeydown(event: KeyboardEvent) {
-		event.preventDefault();
 		switch (event.keyCode) {
 			case ESCAPE:
 				this.onClose();

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.common.scss
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.common.scss
@@ -32,6 +32,10 @@
 	white-space: nowrap;
 }
 
+.lu-select-value {
+	display: none;
+}
+
 .lu-select-suffix {
 	position: absolute;
 	bottom: 0.45rem;
@@ -84,12 +88,6 @@
 			display: none;
 		}
 	}
-
-	&.is-filled {
-		.lu-select-value {
-			opacity: 1;
-		}
-	}
 }
 
 :host-context(.textfield.mod-material .textfield-input.is-focused) {
@@ -105,5 +103,8 @@
 :host-context(.textfield-input.is-filled) {
 	.lu-select-placeholder {
 		display: none;
+	}
+	.lu-select-value {
+		display: block;
 	}
 }


### PR DESCRIPTION
- :bug: fix bug with keyboard events being stopped so searchers just dont work no more
- :sparkles: add `overlap-trigger` input on option-picker
- :bug: minor display bug