### PR TITLE
[FIX] Select & forms style

### DIFF
--- a/packages/ng/docs/demo/src/app/select/foundations/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/select/foundations/basic/basic.html
@@ -13,6 +13,19 @@
 		</lu-select>
 		<label class="textfield-label" for="itemOptions">my label</label>
 	</div>
+	<div class="textfield mod-framed">
+		<lu-select [(ngModel)]="item" class="textfield-input">
+			<ng-container *luDisplayer="let value">{{value.name}}</ng-container>
+			<lu-option-picker>
+				<lu-option [value]="green">{{green.name}}</lu-option>
+				<lu-option [value]="red">{{red.name}}</lu-option>
+				<lu-option [value]="yellow">{{yellow.name}}</lu-option>
+				<lu-option [value]="blue">{{blue.name}}</lu-option>
+			</lu-option-picker>
+			<lu-select-clearer></lu-select-clearer>
+		</lu-select>
+		<label class="textfield-label" for="itemOptions">my label</label>
+	</div>
 	<code class="code mod-block">{{ item | json }}</code>
 </section>
 

--- a/packages/ng/docs/demo/src/app/select/foundations/multiple/multiple.html
+++ b/packages/ng/docs/demo/src/app/select/foundations/multiple/multiple.html
@@ -13,6 +13,19 @@
 		</lu-select>
 		<label class="textfield-label" for="itemOptions">my label</label>
 	</div>
+	<div class="textfield mod-framed">
+		<lu-select [(ngModel)]="items" class="textfield-input" multiple>
+			<span class="chip mod-unkillable" *luDisplayer="let value">{{value.name}}</span>
+			<lu-option-picker>
+				<lu-option [value]="green">{{green.name}}</lu-option>
+				<lu-option [value]="red">{{red.name}}</lu-option>
+				<lu-option [value]="yellow">{{yellow.name}}</lu-option>
+				<lu-option [value]="blue">{{blue.name}}</lu-option>
+			</lu-option-picker>
+			<lu-select-clearer></lu-select-clearer>
+		</lu-select>
+		<label class="textfield-label" for="itemOptions">my label</label>
+	</div>
 	<code class="code mod-block">{{ items | json }}</code>
 </section>
 

--- a/packages/ng/docs/demo/src/app/select/multiple/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/select/multiple/basic/basic.html
@@ -13,11 +13,39 @@
 		</lu-select>
 		<label class="textfield-label" for="itemOptions">my label</label>
 	</div>
+	<div class="textfield mod-framed">
+		<lu-select [(ngModel)]="items" class="textfield-input" multiple>
+			<span class="chip mod-unkillable" *luDisplayer="let value">{{value.name}}</span>
+			<lu-option-picker>
+				<lu-option [value]="green">{{green.name}}</lu-option>
+				<lu-option [value]="red">{{red.name}}</lu-option>
+				<lu-option [value]="yellow">{{yellow.name}}</lu-option>
+				<lu-option [value]="blue">{{blue.name}}</lu-option>
+			</lu-option-picker>
+			<lu-select-clearer></lu-select-clearer>
+		</lu-select>
+		<label class="textfield-label" for="itemOptions">my label</label>
+	</div>
 </section>
 
 <section class="contentSection">
 	<h3>Displaying a summary</h3>
 	<div class="textfield">
+		<lu-select [(ngModel)]="items" class="textfield-input" multiple>
+			<ng-container *luDisplayer="let values; multiple: true">
+				<span class="label">{{values?.length || 0}}</span> colors selected
+			</ng-container>
+			<lu-option-picker>
+				<lu-option [value]="green">{{green.name}}</lu-option>
+				<lu-option [value]="red">{{red.name}}</lu-option>
+				<lu-option [value]="yellow">{{yellow.name}}</lu-option>
+				<lu-option [value]="blue">{{blue.name}}</lu-option>
+			</lu-option-picker>
+			<lu-select-clearer></lu-select-clearer>
+		</lu-select>
+		<label class="textfield-label" for="itemOptions">my label</label>
+	</div>
+	<div class="textfield mod-framed">
 		<lu-select [(ngModel)]="items" class="textfield-input" multiple>
 			<ng-container *luDisplayer="let values; multiple: true">
 				<span class="label">{{values?.length || 0}}</span> colors selected

--- a/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.html
@@ -1,6 +1,8 @@
 <div class="lu-select-placeholder">{{placeholder}}</div>
 <div class="lu-select-value">
-	<div class="lu-select-display-wrapper" #display></div>
+	<div class="lu-select-display-wrapper">
+		<ng-container #display></ng-container>
+	</div>
 </div>
 <div class="lu-select-suffix">
 	<lu-select-clearer></lu-select-clearer>

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -42,7 +42,6 @@ import { UP_ARROW, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 	templateUrl: './option-picker.component.html',
 	styleUrls: ['./option-picker.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
-	encapsulation: ViewEncapsulation.None,
 	animations: [luTransformPopover],
 	exportAs: 'LuOptionPicker',
 	providers: [

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.html
@@ -1,5 +1,7 @@
 <div class="lu-select-placeholder">{{placeholder}}</div>
 <div class="lu-select-value">
-	<div class="lu-select-display-wrapper" #display></div>
+	<div class="lu-select-display-wrapper">
+		<ng-container #display></ng-container>
+	</div>
 </div>
 <div #suffix class="lu-select-suffix"></div>

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
@@ -1,6 +1,8 @@
 <div class="lu-select-placeholder">{{ placeholder }}</div>
 <div class="lu-select-value">
-	<div class="lu-select-display-wrapper" #display></div>
+	<div class="lu-select-display-wrapper">
+		<ng-container #display></ng-container>
+	</div>
 </div>
 <div class="lu-select-suffix">
 	<lu-select-clearer></lu-select-clearer>

--- a/packages/ng/libraries/core/src/style/definitions/option/_option-item.scss
+++ b/packages/ng/libraries/core/src/style/definitions/option/_option-item.scss
@@ -5,7 +5,7 @@
 	:host {
 		display: block;
 		cursor: pointer;
-		padding: 0.5rem;
+		padding: _component("options.item.padding-vertical") _component("options.item.padding-horizontal");
 		transition: background 50ms ease;
 		&.is-selected {
 			background: _theme('commons.background.darker');
@@ -27,11 +27,11 @@
 
 	:host-context(.mod-multiple) {
 		position: relative;
-		padding-left: 2rem;
+		padding-left: _component("options.item.multiple-padding");
 		&::after, &::before {
 			display: block;
 			position: absolute;
-			left: _component("options.checkbox.left");;
+			left: _component("options.checkbox.left");
 			top: 50%;
 			transform: translateY(-50%);
 		}

--- a/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
+++ b/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
@@ -125,6 +125,10 @@
 					right: calc(4.8 * #{_component('textfield.input.padding-horizontal')});
 				}
 			}
+
+			&.mod-multiple.mod-multipleView.is-filled .lu-select-value {
+				margin-bottom: -.3rem;
+			}
 		}
 	}
 

--- a/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
+++ b/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
@@ -21,7 +21,7 @@
 		}
 	}
 	.lu-select-placeholder {
-		color: _color('text.placeholder');
+		color: _component("textfield.input.placeholder");
 	}
 	.lu-select-value, .lu-select-placeholder {
 		line-height: 1.1;
@@ -33,6 +33,8 @@
 		text-overflow: ellipsis;
 		transition: all _theme('commons.animations.durations.standard') ease;
 		white-space: nowrap;
+		display: flex;
+		align-items: center;
 	}
 
 	.lu-select-value {
@@ -86,6 +88,11 @@
 
 		.lu-select-suffix {
 			right: calc(3.5 * #{_component('textfield.input.padding-horizontal')});
+		}
+	}
+	:host(.mod-overflow) {
+		.lu-select-value, .lu-select-placeholder {
+			overflow: visible;
 		}
 	}
 	// Framed

--- a/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
+++ b/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
@@ -90,31 +90,33 @@
 	}
 	// Framed
 	:host-context(.textfield.mod-framed) {
-		padding: _component('field.framed.top-padding') 0 0;
+		&.textfield-input {
+			padding: _component('field.framed.top-padding') 0 0;
 
-		&::after {
-			bottom: 0.95rem;
-			right: _component('field.framed.side-padding');
-		}
-
-		.lu-select-value, .lu-select-placeholder {
-			padding: 0 calc(#{_component('field.framed.side-padding')} * 3)
-				_component('field.framed.bottom-padding')
-				_component('field.framed.side-padding');
-		}
-
-
-		.lu-select-suffix {
-			bottom: 0.85rem;
-			right: calc(3.75 * #{_component('textfield.input.padding-horizontal')});
-		}
-
-		&.mod-search {
 			&::after {
-				bottom: .5rem;
+				bottom: 0.95rem;
+				right: _component('field.framed.side-padding');
 			}
+
+			.lu-select-value, .lu-select-placeholder {
+				padding: 0 calc(#{_component('field.framed.side-padding')} * 3)
+					_component('field.framed.bottom-padding')
+					_component('field.framed.side-padding');
+			}
+
+
 			.lu-select-suffix {
-				right: calc(4.8 * #{_component('textfield.input.padding-horizontal')});
+				bottom: 0.85rem;
+				right: calc(3.75 * #{_component('textfield.input.padding-horizontal')});
+			}
+
+			&.mod-search {
+				&::after {
+					bottom: .5rem;
+				}
+				.lu-select-suffix {
+					right: calc(4.8 * #{_component('textfield.input.padding-horizontal')});
+				}
 			}
 		}
 	}

--- a/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
+++ b/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
@@ -51,7 +51,7 @@
 	// MODS
 	// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 	:host(.mod-multiple) {
-		&.mod-multipleView {
+		&.mod-multipleView:not(.mod-singleLine) {
 			.lu-select-value {
 				height: auto;
 				min-height: _component('select.height');

--- a/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
+++ b/packages/ng/libraries/core/src/style/definitions/select/_select-input.scss
@@ -26,15 +26,17 @@
 	.lu-select-value, .lu-select-placeholder {
 		line-height: 1.1;
 		height: _component('select.height');
-		overflow: hidden;
 		padding: _component('textfield.input.padding-vertical') 1.5rem
 			_component('textfield.input.padding-vertical')
 			_component('textfield.input.padding-horizontal');
-		text-overflow: ellipsis;
 		transition: all _theme('commons.animations.durations.standard') ease;
-		white-space: nowrap;
-		display: flex;
 		align-items: center;
+	}
+
+	.lu-select-display-wrapper, .lu-select-placeholder {
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 
 	.lu-select-value {
@@ -51,14 +53,15 @@
 	:host(.mod-multiple) {
 		&.mod-multipleView {
 			.lu-select-value {
-				overflow: visible;
-				white-space: normal;
 				height: auto;
 				min-height: _component('select.height');
 				padding-bottom: 0;
 				align-items: center;
-				flex-wrap: wrap;
 				padding-top: .3rem;
+			}
+			.lu-select-display-wrapper {
+				overflow: visible;
+				white-space: normal;
 			}
 		}
 
@@ -72,7 +75,7 @@
 				vertical-align: top;
 			}
 
-			.lu-select-value > .chip, .lu-select-value > .label {
+			.lu-select-value .lu-select-display-wrapper > .chip, .lu-select-value .lu-select-display-wrapper > .label {
 				background: _component("select.tag.background");
 				color: _component("select.tag.color");
 			}
@@ -91,7 +94,7 @@
 		}
 	}
 	:host(.mod-overflow) {
-		.lu-select-value, .lu-select-placeholder {
+		.lu-select-display-wrapper, .lu-select-placeholder {
 			overflow: visible;
 		}
 	}
@@ -180,9 +183,6 @@
 			display: none;
 		}
 		.lu-select-value {
-			display: block;
-		}
-		&.mod-multiple.mod-multipleView .lu-select-value {
 			display: flex;
 		}
 	}

--- a/packages/ng/libraries/core/src/style/theme/_options.theme.scss
+++ b/packages/ng/libraries/core/src/style/theme/_options.theme.scss
@@ -1,4 +1,9 @@
 $options: (
+	item: (
+		padding-vertical: .5rem,
+		padding-horizontal: .5rem,
+		multiple-padding: 2rem,
+	),
 	checkbox: (
 		left: .5rem,
 		size: .95rem,

--- a/packages/scss/src/components/inputs/field/_field.framed.scss
+++ b/packages/scss/src/components/inputs/field/_field.framed.scss
@@ -92,18 +92,18 @@
 
 	&.is-loading {
 		&::before, &::after {
-			bottom: inherit;
-			right: .7rem;
-			top: .7rem;
+			bottom: inherit !important;
+			right: .7rem !important;
+			top: .7rem !important;
 		}
 	}
 
 	&.is-valid {
 		&::before {
-			bottom: inherit;
-			margin: auto;
-			right: .7rem;
-			top: .5rem;
+			bottom: inherit !important;
+			margin: auto !important;
+			right: .7rem !important;
+			top: .5rem !important;
 		}
 	}
 
@@ -111,10 +111,10 @@
 		z-index: 2;
 
 		&::before {
-			bottom: inherit;
-			margin: auto;
-			right: .7rem;
-			top: .5rem;
+			bottom: inherit !important;
+			margin: auto !important;
+			right: .7rem !important;
+			top: .5rem !important;
 		}
 
 		.#{$fieldname}-input {

--- a/packages/scss/src/components/inputs/field/_field.scss
+++ b/packages/scss/src/components/inputs/field/_field.scss
@@ -75,12 +75,13 @@
 		@include loading(1rem);
 
 		&::before, &::after {
-			bottom: .6rem;
-			left: inherit;
-			right: .5rem;
-			top: inherit;
-			position: absolute;
-			z-index: 2;
+			content: '' !important;
+			bottom: .6rem !important;
+			left: inherit !important;
+			right: .5rem !important;
+			top: inherit !important;
+			position: absolute !important;
+			z-index: 2 !important;
 		}
 
 		.#{$fieldname}-input {

--- a/packages/scss/src/components/inputs/textfield/_textfield.material.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.material.scss
@@ -130,15 +130,15 @@
 	&.is-loading {
 
 		&::before, &::after {
-			bottom: .4rem;
-			right: 0;
+			bottom: .4rem !important;
+			right: 0 !important;
 		}
 	}
 
 	&.is-valid {
 		&::before {
-			bottom: .7rem;
-			right: 0;
+			bottom: .7rem !important;
+			right: 0 !important;
 		}
 
 		.textfield-label {


### PR DESCRIPTION
Fix select & forms style.
Adds `mod-overflow` if you want to go over the input size.
`lu-select-display-wrapper` is now properly wrapping the display content
`.is-loading` attributes are all using !important as they must override any ::after/::before positionning