### PR TITLE
[feat] select - keep highlighted option visible

### DIFF
--- a/packages/ng/docs/demo/src/app/shared/redirect/redirect.component.ts
+++ b/packages/ng/docs/demo/src/app/shared/redirect/redirect.component.ts
@@ -29,9 +29,9 @@ export class RedirectComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
-		if (!this.env.redirect) {
-			this.connect();
-		}
+		// if (!this.env.redirect) {
+		// 	this.connect();
+		// }
 	}
 
 	connect() {

--- a/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, HostBinding } from '@angular/core';
 import { ALuOptionOperator } from '../../../option/index';
 import { ALuApiOptionSearcher, ALuApiSearcherService, ALuApiOptionPagedSearcher, ALuApiPagedSearcherService } from './api-searcher.model';
 import { IApiItem } from '../../api.model';
@@ -25,6 +25,7 @@ import { debounceTime } from 'rxjs/operators/debounceTime';
 })
 export class LuApiSearcherComponent<T extends IApiItem = IApiItem, S extends ALuApiSearcherService<T> = ALuApiSearcherService<T>>
 extends ALuApiOptionSearcher<T, S> {
+	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef }) searchInput: ElementRef;
 	@Input() set api(api: string) {
 		this._service.api = api;
@@ -77,6 +78,7 @@ extends ALuApiOptionSearcher<T, S> {
 })
 export class LuApiPagedSearcherComponent<T extends IApiItem = IApiItem, S extends ALuApiPagedSearcherService<T> = ALuApiPagedSearcherService<T>>
 extends ALuApiOptionPagedSearcher<T, S> {
+	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef }) searchInput: ElementRef;
 	@Input() set api(api: string) { this._service.api = api; }
 	@Input() set fields(fields: string) { this._service.fields = fields; }

--- a/packages/ng/libraries/core/src/lib/option/operator/searcher/option-searcher.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/searcher/option-searcher.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, forwardRef, Input, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, HostBinding } from '@angular/core';
 import { ILuOptionOperator, ALuOptionOperator } from '../option-operator.model';
 import { Observable } from 'rxjs/Observable';
 import { combineLatest } from 'rxjs/observable/combineLatest';
@@ -19,6 +19,7 @@ import { FormControl } from '@angular/forms';
 	],
 })
 export class LuOptionSearcherComponent<T = any> extends ALuOptionOperator<T> implements ILuOptionOperator<T> {
+	@HostBinding('class.position-fixed') fixed = true;
 	searchControl = new FormControl();
 	clue$ = merge(of(''), this.searchControl.valueChanges);
 	@ViewChild('searchInput', { read: ElementRef }) searchInput: ElementRef;

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -56,7 +56,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 	@Output() open = new EventEmitter<void>();
 	@Output() onSelectValue = new EventEmitter<T>();
 
-	protected _isOptionItemsInited: boolean;
+	protected _isOptionItemsInitialized: boolean;
 
 	constructor(
 		protected _vcr: ViewContainerRef,
@@ -64,7 +64,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 		protected _renderer: Renderer2) {
 		super();
 		this.triggerEvent = 'click';
-		this._isOptionItemsInited = false;
+		this._isOptionItemsInitialized = false;
 	}
 	protected _options: ILuOptionItem<T>[] = [];
 	protected _optionsQL: QueryList<ILuOptionItem<T>>;
@@ -100,6 +100,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 	onOpen() {
 		super.onOpen();
 		this.highlightIndex = -1;
+		// this._initObserver();
 		this._applySelected();
 	}
 	@ViewChild(TemplateRef)
@@ -128,6 +129,10 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 				break;
 		}
 	}
+	// protected _highlightObserver: IntersectionObserver;
+	// protected _initObserver() {
+
+	// }
 	protected _highlightIndex = -1;
 	get highlightIndex() { return this._highlightIndex; }
 	set highlightIndex(i: number) {
@@ -151,6 +156,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 		this.highlightIndex = Math.max(this.highlightIndex - 1, -1);
 	}
 	protected _applyHighlight() {
+		if (!this.isOpen) { return; }
 		const highlightClass = 'is-highlighted';
 		const options = this.optionsQLVR.toArray();
 		// remove `is-highlighted` class from all other options
@@ -160,9 +166,27 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 		if (!!highlightedOption) {
 			this._renderer.addClass(highlightedOption.element.nativeElement, highlightClass);
 			// scroll to let the highlighted option visible
-			// TODO
+			setTimeout(() => {
+				this._scrollToHighlight(highlightedOption.element.nativeElement);
+			}, 1);
 		}
 		this._changeDetectorRef.markForCheck();
+	}
+	protected _scrollToHighlight(targetElt: HTMLElement) {
+		const contentElt = document.querySelector('.lu-popover-content') as HTMLElement;
+		const contentFixedElt = document.querySelector('.lu-popover-content .position-fixed') as HTMLElement;
+		const offsetTop = contentFixedElt ? contentFixedElt.offsetHeight : 0;
+		// highlighted option is too high
+		if (contentElt.scrollTop + offsetTop > targetElt.offsetTop) {
+			contentElt.scrollTop = targetElt.offsetTop - offsetTop;
+			return;
+		}
+		// highlight option is too low
+		const offsetHeight = contentElt.offsetHeight;
+		if (contentElt.scrollTop + offsetHeight < targetElt.offsetTop + targetElt.offsetHeight) {
+			contentElt.scrollTop = targetElt.offsetTop + targetElt.offsetHeight - offsetHeight;
+			return;
+		}
 	}
 	protected _selectHighlighted() {
 		const options = this._optionsQL ? this._optionsQL.toArray() : [];
@@ -207,11 +231,11 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 	}
 
 	protected initOptionItemsObservable() {
-		if (this._isOptionItemsInited) {
+		if (this._isOptionItemsInitialized) {
 			return;
 		}
 
-		this._isOptionItemsInited = true;
+		this._isOptionItemsInitialized = true;
 
 		this._optionItems$ =
 			merge(of(this._optionsQL), this._optionsQL.changes)

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
@@ -92,13 +92,13 @@ export abstract class ALuOptionPicker<T = any> extends ALuPickerPanel<T> impleme
 			if (!o.onOpen) { return; }
 			o.onOpen();
 		});
-		this._emitOpenEvent();
+		super.onOpen();
 	}
 	onClose() {
 		this.__operators.forEach(o => {
 			if (!o.onClose) { return; }
 			o.onClose();
 		});
-		this._emitCloseEvent();
+		super.onClose();
 	}
 }

--- a/packages/ng/libraries/core/src/lib/popover/panel/popover-panel.model.ts
+++ b/packages/ng/libraries/core/src/lib/popover/panel/popover-panel.model.ts
@@ -56,6 +56,9 @@ export interface ILuPopoverPanel {
 </ng-template>
  */
 export abstract class ALuPopoverPanel implements ILuPopoverPanel {
+	protected _isOpen: boolean;
+	get isOpen() { return this._isOpen; }
+
 	protected _position: LuPopoverPosition = 'below';
 	get position(): LuPopoverPosition { return this._position; }
 	set position(position: LuPopoverPosition) {
@@ -197,9 +200,11 @@ export abstract class ALuPopoverPanel implements ILuPopoverPanel {
 	}
 
 	onOpen() {
+		this._isOpen = true;
 		this._emitOpenEvent();
 	}
 	onClose() {
+		this._isOpen = false;
 		this._emitCloseEvent();
 	}
 	/**

--- a/packages/ng/libraries/core/src/lib/user/select/searcher/user-searcher.component.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/searcher/user-searcher.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, HostBinding } from '@angular/core';
 import { ALuOptionOperator } from '../../../option/index';
 import { FormControl } from '@angular/forms';
 import { debounceTime } from 'rxjs/operators/debounceTime';
@@ -26,6 +26,7 @@ import { ALuApiOptionPagedSearcher } from '../../../api/index';
 })
 export class LuUserPagedSearcherComponent<U extends IUser = IUser, S extends ALuUserPagedSearcherService<U> = ALuUserPagedSearcherService<U>>
 extends ALuApiOptionPagedSearcher<U, S> {
+	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef }) searchInput: ElementRef;
 	@Input() set fields(fields: string) { this._service.fields = fields; }
 	@Input() set filters(filters: string[]) { this._service.filters = filters; }


### PR DESCRIPTION
fixes #401 

when changing the highlighted option via `^` `v`, we ensure that the highlighted option is fully visible by scrolling to it if its not

as a result the `scrollBottom` event is triggered when we get to the last option, allowing for full navigation of a select with a pager just with the keyboard