### PR TITLE
Demo quick wins

### DIFF
--- a/packages/ng/docs/demo/src/app/app.module.ts
+++ b/packages/ng/docs/demo/src/app/app.module.ts
@@ -27,7 +27,7 @@ import { DemoTooltipModule } from './tooltip/tooltip.module';
 	],
 	imports: [
 		CommonModule,
-		RouterModule.forRoot(appRoutes{
+		RouterModule.forRoot(appRoutes, {
 			useHash: true,
 		}),
 		BrowserModule,

--- a/packages/ng/docs/demo/src/app/app.module.ts
+++ b/packages/ng/docs/demo/src/app/app.module.ts
@@ -27,7 +27,9 @@ import { DemoTooltipModule } from './tooltip/tooltip.module';
 	],
 	imports: [
 		CommonModule,
-		RouterModule.forRoot(appRoutes),
+		RouterModule.forRoot(appRoutes{
+			useHash: true,
+		}),
 		BrowserModule,
 		BrowserAnimationsModule,
 

--- a/packages/ng/docs/demo/src/app/shared/redirect/redirect.component.ts
+++ b/packages/ng/docs/demo/src/app/shared/redirect/redirect.component.ts
@@ -29,9 +29,9 @@ export class RedirectComponent implements OnInit {
 	) {}
 
 	ngOnInit() {
-		if (!this.env.redirect) {
-			this.connect();
-		}
+		// if (!this.env.redirect) {
+		// 	this.connect();
+		// }
 	}
 
 	connect() {


### PR DESCRIPTION
some quick wins for the demo
- use `#` for navigation so we have shareable url with surge deployment
  - before https://latest-lucca-front-luccasa.surge.sh/ng/user/picture
  - after https://456-pr-lucca-front-luccasa.surge.sh/ng/#/user/picture
- do not auto try to redirect to lucca.local.dev cuz most people dont have this env, also when it crashed, it kept the `is-laoding` class forever
  - some more better stuff with the redirect are integrated in PR #450 