### PR TITLE
[fix] lu-select clearer causing unexpected form submit

### DIFF
--- a/packages/ng/libraries/core/src/lib/select/clearer/select-clearer.component.html
+++ b/packages/ng/libraries/core/src/lib/select/clearer/select-clearer.component.html
@@ -1,3 +1,3 @@
-<button class="actionIcon" (click)="onClick($event)" tabindex="-1">
+<button type="button" class="actionIcon" (click)="onClick($event)" tabindex="-1">
 	<i class="lucca-icon">thin_cross</i>
 </button>


### PR DESCRIPTION
fixes #461 

lu-select clearer was causing unexpected form submit, because button default type is submit.