### PR TITLE
ng-formly - fix - api-select and user seklect diodnt support multiple

### DIFF
--- a/packages/ng/libraries/formly/src/lib/types/api.html
+++ b/packages/ng/libraries/formly/src/lib/types/api.html
@@ -1,3 +1,3 @@
-<lu-api-select class="textfield-input" [formControl]="formControl" [formlyAttributes]="field" (focus)="focus()" (blur)="blur()" [placeholder]="to.placeholder" [api]="_api" [filters]="_filters">
+<lu-api-select class="textfield-input" [formControl]="formControl" [formlyAttributes]="field" [multiple]="to.multiple" (focus)="focus()" (blur)="blur()" [placeholder]="to.placeholder" [api]="_api" [filters]="_filters">
 </lu-api-select>
 <label [attr.for]="id" class="textfield-label">{{ to.label }}</label>

--- a/packages/ng/libraries/formly/src/lib/types/user.html
+++ b/packages/ng/libraries/formly/src/lib/types/user.html
@@ -1,3 +1,3 @@
-<lu-user-select class="textfield-input" [formControl]="formControl" [formlyAttributes]="field" (focus)="focus()" (blur)="blur()" [placeholder]="to.placeholder">
+<lu-user-select class="textfield-input" [formControl]="formControl" [formlyAttributes]="field" [multiple]="to.multiple" (focus)="focus()" (blur)="blur()" [placeholder]="to.placeholder">
 </lu-user-select>
 <label [attr.for]="id" class="textfield-label">{{ to.label }}</label>


### PR DESCRIPTION
formly fields of type `api` and `user` didnt support template-option _multiple_