### PR TITLE
[fix][SCSS] NavSide moving when scrolling on IE11

### DIFF
--- a/packages/scss/CHANGELOG.md
+++ b/packages/scss/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
+## 2.1 - in dev
+### Fixes
+- Adding `.navSide-mainSection` to fix navSide scroll issue on IE11
 
-## 2.0 - in dev
+## 2.0
 ### New features
 - Adding `.radiosfield` & `.checkboxesfield`, the equivalent of `.textfield` for the corresponding inputs
 ### Fixes

--- a/packages/scss/demo/templates/compact-withBanner.html
+++ b/packages/scss/demo/templates/compact-withBanner.html
@@ -15,60 +15,62 @@
 	<div class="fake-banner"></div>
 	<main class="main">
 		<aside class="navSide mod-compact mod-withBottomSection mod-withBanner" id="navSide">
-			<nav class="navSide-scrollWrapper">
-				<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-					<a href="#" class="navSide-item-link">
-						<span class="navSide-item-link-title">Menu</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-				</div>
-				<div class="navSide-item-placeholder"></div>
-				<div class="navSide-item is-active" id="item1">
-					<a href="#" class="navSide-item-link is-active" onclick="w3.toggleClass('#item1', 'is-open')">
-						<i class="lucca-icon icon-heart"></i>
-						<span class="navSide-item-link-title">Section 1</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-					<nav class="navSide-item-subMenu">
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.1</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.2 with large name
-							<span class="navSide-item-alert">12</span></a>
-					</nav>
-				</div>
-				<div class="navSide-item" id="item2">
-					<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item2', 'is-open')">
-						<i class="lucca-icon icon-user"></i>
-						<span class="navSide-item-link-title">Section#2 with a larger name</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-					<nav class="navSide-item-subMenu">
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.1</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.2</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.3</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.4 <span class="navSide-item-alert">12</span></a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.5</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.6</a>
-					</nav>
-				</div>
-				<div class="navSide-item" id="item3">
-					<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
-						<i class="lucca-icon icon-analytics"></i>
-						<span class="navSide-item-link-title">Section #3</span>
-					</a>
-				</div>
-				<div class="navSide-item" id="item4">
-					<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item4', 'is-open')">
-						<i class="lucca-icon icon-sliders"></i>
-						<span class="navSide-item-link-title">Section #4</span>
-						<span class="navSide-item-alert">9</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-					<nav class="navSide-item-subMenu">
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.1</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.2</a>
-					</nav>
-				</div>
-			</nav>
+			<div class="navSide-mainSection">
+				<nav class="navSide-scrollWrapper">
+					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+						<a href="#" class="navSide-item-link">
+							<span class="navSide-item-link-title">Menu</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+					</div>
+					<div class="navSide-item-placeholder"></div>
+					<div class="navSide-item is-active" id="item1">
+						<a href="#" class="navSide-item-link is-active" onclick="w3.toggleClass('#item1', 'is-open')">
+							<i class="lucca-icon icon-heart"></i>
+							<span class="navSide-item-link-title">Section 1</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+						<nav class="navSide-item-subMenu">
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.1</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.2 with large name
+								<span class="navSide-item-alert">12</span></a>
+						</nav>
+					</div>
+					<div class="navSide-item" id="item2">
+						<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item2', 'is-open')">
+							<i class="lucca-icon icon-user"></i>
+							<span class="navSide-item-link-title">Section#2 with a larger name</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+						<nav class="navSide-item-subMenu">
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.1</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.2</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.3</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.4 <span class="navSide-item-alert">12</span></a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.5</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.6</a>
+						</nav>
+					</div>
+					<div class="navSide-item" id="item3">
+						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
+							<i class="lucca-icon icon-analytics"></i>
+							<span class="navSide-item-link-title">Section #3</span>
+						</a>
+					</div>
+					<div class="navSide-item" id="item4">
+						<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item4', 'is-open')">
+							<i class="lucca-icon icon-sliders"></i>
+							<span class="navSide-item-link-title">Section #4</span>
+							<span class="navSide-item-alert">9</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+						<nav class="navSide-item-subMenu">
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.1</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.2</a>
+						</nav>
+					</div>
+				</nav>
+			</div>
 			<div class="navSide-bottomSection">
 				<div class="navSide-item">
 					<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -82,38 +84,40 @@
 			<div class="container">
 				<h1>Markup</h1>
 				<code class="code mod-block">&lt;aside class=&quot;navSide&quot;&gt;
-	&lt;nav class=&quot;navSide-scrollWrapper&quot;&gt;
-	&lt;div class=&quot;navSide-item-placeholder&quot;&gt;&lt;/div&gt;
-	&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-		&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-			&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-			&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-		&lt;/a&gt;
-	&lt;/div&gt;
-	&lt;div class=&quot;navSide-item is-active&quot;&gt;
-			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link is-active&quot;&gt;
-				&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
-				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
-				&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-			&lt;/a&gt;
-			&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
-				[...]
-			&lt;/nav&gt;
-		&lt;/div&gt;
-		&lt;div class=&quot;navSide-item&quot;&gt;
+	&lt;div class=&quot;navSide-mainSection&quot;&gt;
+		&lt;nav class=&quot;navSide-scrollWrapper&quot;&gt;
+		&lt;div class=&quot;navSide-item-placeholder&quot;&gt;&lt;/div&gt;
+		&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
 			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-				&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
-				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
 				&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
 			&lt;/a&gt;
-			&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
-				[...]
-			&lt;/nav&gt;
 		&lt;/div&gt;
-		[...]
-	&lt;/nav&gt;
+		&lt;div class=&quot;navSide-item is-active&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link is-active&quot;&gt;
+					&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+				&lt;/a&gt;
+				&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
+					[...]
+				&lt;/nav&gt;
+			&lt;/div&gt;
+			&lt;div class=&quot;navSide-item&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+					&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+				&lt;/a&gt;
+				&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
+					[...]
+				&lt;/nav&gt;
+			&lt;/div&gt;
+			[...]
+		&lt;/nav&gt;
+	&lt;/div&gt;
 	&lt;div class=&quot;navSide-bottomSection&quot;&gt;
 		&lt;div class=&quot;navSide-item&quot;&gt;
 			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&quot;&gt;

--- a/packages/scss/demo/templates/full-withBanner.html
+++ b/packages/scss/demo/templates/full-withBanner.html
@@ -15,60 +15,62 @@
 	<div class="fake-banner"></div>
 	<main class="main">
 		<aside class="navSide mod-withBottomSection mod-withBanner" id="navSide">
-			<nav class="navSide-scrollWrapper">
-				<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-					<a href="#" class="navSide-item-link">
-						<span class="navSide-item-link-title">Menu</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-				</div>
-				<div class="navSide-item-placeholder"></div>
-				<div class="navSide-item is-active" id="item1">
-					<a href="#" class="navSide-item-link is-active" onclick="w3.toggleClass('#item1', 'is-open')">
-						<i class="lucca-icon icon-heart"></i>
-						<span class="navSide-item-link-title">Section 1</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-					<nav class="navSide-item-subMenu">
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.1</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.2 with large name
-							<span class="navSide-item-alert">12</span></a>
-					</nav>
-				</div>
-				<div class="navSide-item" id="item2">
-					<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item2', 'is-open')">
-						<i class="lucca-icon icon-user"></i>
-						<span class="navSide-item-link-title">Section#2 with a larger name</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-					<nav class="navSide-item-subMenu">
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.1</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.2</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.3</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.4 <span class="navSide-item-alert">12</span></a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.5</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.6</a>
-					</nav>
-				</div>
-				<div class="navSide-item" id="item3">
-					<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
-						<i class="lucca-icon icon-analytics"></i>
-						<span class="navSide-item-link-title">Section #3</span>
-					</a>
-				</div>
-				<div class="navSide-item" id="item4">
-					<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item4', 'is-open')">
-						<i class="lucca-icon icon-sliders"></i>
-						<span class="navSide-item-link-title">Section #4</span>
-						<span class="navSide-item-alert">9</span>
-						<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-					</a>
-					<nav class="navSide-item-subMenu">
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.1</a>
-						<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.2</a>
-					</nav>
-				</div>
-			</nav>
+			<div class="navSide-mainSection">
+				<nav class="navSide-scrollWrapper">
+					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+						<a href="#" class="navSide-item-link">
+							<span class="navSide-item-link-title">Menu</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+					</div>
+					<div class="navSide-item-placeholder"></div>
+					<div class="navSide-item is-active" id="item1">
+						<a href="#" class="navSide-item-link is-active" onclick="w3.toggleClass('#item1', 'is-open')">
+							<i class="lucca-icon icon-heart"></i>
+							<span class="navSide-item-link-title">Section 1</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+						<nav class="navSide-item-subMenu">
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.1</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.2 with large name
+								<span class="navSide-item-alert">12</span></a>
+						</nav>
+					</div>
+					<div class="navSide-item" id="item2">
+						<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item2', 'is-open')">
+							<i class="lucca-icon icon-user"></i>
+							<span class="navSide-item-link-title">Section#2 with a larger name</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+						<nav class="navSide-item-subMenu">
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.1</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.2</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.3</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.4 <span class="navSide-item-alert">12</span></a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.5</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.6</a>
+						</nav>
+					</div>
+					<div class="navSide-item" id="item3">
+						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
+							<i class="lucca-icon icon-analytics"></i>
+							<span class="navSide-item-link-title">Section #3</span>
+						</a>
+					</div>
+					<div class="navSide-item" id="item4">
+						<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item4', 'is-open')">
+							<i class="lucca-icon icon-sliders"></i>
+							<span class="navSide-item-link-title">Section #4</span>
+							<span class="navSide-item-alert">9</span>
+							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+						</a>
+						<nav class="navSide-item-subMenu">
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.1</a>
+							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.2</a>
+						</nav>
+					</div>
+				</nav>
+			</div>
 			<div class="navSide-bottomSection">
 				<div class="navSide-item">
 					<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -82,38 +84,40 @@
 			<div class="container">
 				<h1>Markup</h1>
 				<code class="code mod-block">&lt;aside class=&quot;navSide&quot;&gt;
-	&lt;nav class=&quot;navSide-scrollWrapper&quot;&gt;
-	&lt;div class=&quot;navSide-item-placeholder&quot;&gt;&lt;/div&gt;
-	&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-		&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-			&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-			&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-		&lt;/a&gt;
-	&lt;/div&gt;
-	&lt;div class=&quot;navSide-item is-active&quot;&gt;
-			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link is-active&quot;&gt;
-				&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
-				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
-				&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-			&lt;/a&gt;
-			&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
-				[...]
-			&lt;/nav&gt;
-		&lt;/div&gt;
-		&lt;div class=&quot;navSide-item&quot;&gt;
+	&lt;div class=&quot;navSide-mainSection&quot;&gt;
+		&lt;nav class=&quot;navSide-scrollWrapper&quot;&gt;
+		&lt;div class=&quot;navSide-item-placeholder&quot;&gt;&lt;/div&gt;
+		&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
 			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-				&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
-				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
 				&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
 			&lt;/a&gt;
-			&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
-				[...]
-			&lt;/nav&gt;
 		&lt;/div&gt;
-		[...]
-	&lt;/nav&gt;
+		&lt;div class=&quot;navSide-item is-active&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link is-active&quot;&gt;
+					&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+				&lt;/a&gt;
+				&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
+					[...]
+				&lt;/nav&gt;
+			&lt;/div&gt;
+			&lt;div class=&quot;navSide-item&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+					&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+				&lt;/a&gt;
+				&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
+					[...]
+				&lt;/nav&gt;
+			&lt;/div&gt;
+			[...]
+		&lt;/nav&gt;
+	&lt;/div&gt;
 	&lt;div class=&quot;navSide-bottomSection&quot;&gt;
 		&lt;div class=&quot;navSide-item&quot;&gt;
 			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&quot;&gt;

--- a/packages/scss/demo/templates/fullmenu.html
+++ b/packages/scss/demo/templates/fullmenu.html
@@ -12,59 +12,61 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-withBottomSection" id="navSide">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item is-active" id="item1">
-						<a href="#" class="navSide-item-link is-active" onclick="w3.toggleClass('#item1', 'is-open')">
-							<i class="lucca-icon icon-heart"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-						<nav class="navSide-item-subMenu">
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.1</a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.2 with large name <span class="navSide-item-alert">12</span></a>
-						</nav>
-					</div>
-					<div class="navSide-item" id="item2">
-						<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item2', 'is-open')">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section#2 with a larger name</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-						<nav class="navSide-item-subMenu">
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.1</a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.2</a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.3</a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.4 <span class="navSide-item-alert">12</span></a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.5</a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.6</a>
-						</nav>
-					</div>
-					<div class="navSide-item" id="item3">
-						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
-							<i class="lucca-icon icon-analytics"></i>
-							<span class="navSide-item-link-title">Section #3</span>
-						</a>
-					</div>
-					<div class="navSide-item" id="item4">
-						<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item4', 'is-open')">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section #4</span>
-							<span class="navSide-item-alert">9</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-						<nav class="navSide-item-subMenu">
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.1</a>
-							<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.2</a>
-						</nav>
-					</div>
-				</nav>
+				<div class="navSide-mainSection">
+					<nav class="navSide-scrollWrapper">
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item is-active" id="item1">
+							<a href="#" class="navSide-item-link is-active" onclick="w3.toggleClass('#item1', 'is-open')">
+								<i class="lucca-icon icon-heart"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+							<nav class="navSide-item-subMenu">
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.1</a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #1.2 with large name <span class="navSide-item-alert">12</span></a>
+							</nav>
+						</div>
+						<div class="navSide-item" id="item2">
+							<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item2', 'is-open')">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section#2 with a larger name</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+							<nav class="navSide-item-subMenu">
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.1</a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.2</a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.3</a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.4 <span class="navSide-item-alert">12</span></a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.5</a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Section #2.6</a>
+							</nav>
+						</div>
+						<div class="navSide-item" id="item3">
+							<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
+								<i class="lucca-icon icon-analytics"></i>
+								<span class="navSide-item-link-title">Section #3</span>
+							</a>
+						</div>
+						<div class="navSide-item" id="item4">
+							<a href="#" class="navSide-item-link" onclick="w3.toggleClass('#item4', 'is-open')">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section #4</span>
+								<span class="navSide-item-alert">9</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+							<nav class="navSide-item-subMenu">
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.1</a>
+								<a href="#" class="navSide-item-subMenu-link" onclick="setActive(event)">Subsection #4.2</a>
+							</nav>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -78,38 +80,40 @@
 				<div class="container">
 					<h1>Markup</h1>
 <code class="code mod-block">&lt;aside class=&quot;navSide&quot;&gt;
-	&lt;nav class=&quot;navSide-scrollWrapper&quot;&gt;
-	&lt;div class=&quot;navSide-item-placeholder&quot;&gt;&lt;/div&gt;
-	&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-		&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-			&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-			&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-		&lt;/a&gt;
-	&lt;/div&gt;
-	&lt;div class=&quot;navSide-item is-active&quot;&gt;
-			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link is-active&quot;&gt;
-				&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
-				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
-				&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-			&lt;/a&gt;
-			&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
-				[...]
-			&lt;/nav&gt;
-		&lt;/div&gt;
-		&lt;div class=&quot;navSide-item&quot;&gt;
+	&lt;div class=&quot;navSide-mainSection&quot;&gt;
+		&lt;nav class=&quot;navSide-scrollWrapper&quot;&gt;
+		&lt;div class=&quot;navSide-item-placeholder&quot;&gt;&lt;/div&gt;
+		&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
 			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-				&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
-				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+				&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
 				&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
 			&lt;/a&gt;
-			&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
-				[...]
-			&lt;/nav&gt;
 		&lt;/div&gt;
-		[...]
-	&lt;/nav&gt;
+		&lt;div class=&quot;navSide-item is-active&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link is-active&quot;&gt;
+					&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+				&lt;/a&gt;
+				&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
+					[...]
+				&lt;/nav&gt;
+			&lt;/div&gt;
+			&lt;div class=&quot;navSide-item&quot;&gt;
+				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+					&lt;i class=&quot;lucca-icon icon-heart&quot;&gt;&lt;/i&gt;
+					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Section #1&lt;/span&gt;
+					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+				&lt;/a&gt;
+				&lt;nav class=&quot;navSide-item-subMenu&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-subMenu-link&quot;&gt;Subsection #1.1&lt;/a&gt;
+					[...]
+				&lt;/nav&gt;
+			&lt;/div&gt;
+			[...]
+		&lt;/nav&gt;
+	&lt;/div&gt;
 	&lt;div class=&quot;navSide-bottomSection&quot;&gt;
 		&lt;div class=&quot;navSide-item&quot;&gt;
 			&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&quot;&gt;

--- a/packages/scss/demo/templates/side-cards.html
+++ b/packages/scss/demo/templates/side-cards.html
@@ -12,40 +12,42 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-compact">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item is-active">
-						<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
-							<i class="lucca-icon icon-tilesNine"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section 2</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-settings"></i>
-							<span class="navSide-item-link-title">Section 3</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section 4</span>
-							<span class="navSide-item-alert">9</span>
-						</a>
-					</div>
-				</nav>
+				<div class="navSide-mainSection">
+					<nav class="navSide-scrollWrapper">
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item is-active">
+							<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
+								<i class="lucca-icon icon-tilesNine"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section 2</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-settings"></i>
+								<span class="navSide-item-link-title">Section 3</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section 4</span>
+								<span class="navSide-item-alert">9</span>
+							</a>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -62,28 +64,30 @@
 							<h1>Side with cards</h1>
 <code class="code mod-block">&lt;main class="main"&gt;
 	&lt;aside class="navSide mod-compact"&gt;
-		&lt;nav class="navSide-scrollWrapper"&gt;
-			&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
-			&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item is-active"&gt;
-				&lt;a href="#" class="navSide-item-link is-active"&gt;
-					&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-					&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			...
-		&lt;/nav&gt;
+		&lt;div class="navSide-mainSection"&gt;
+			&lt;nav class="navSide-scrollWrapper"&gt;
+				&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
+				&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+						&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
+						&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item is-active"&gt;
+					&lt;a href="#" class="navSide-item-link is-active"&gt;
+						&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+						&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				...
+			&lt;/nav&gt;
+		&lt;/div&gt;
 		&lt;div class="navSide-bottomSection"&gt;
 			&lt;div class="navSide-item"&gt;
 				&lt;a href="#" class="navSide-item-link" onclick="setActive(event, true)"&gt;

--- a/packages/scss/demo/templates/side-filters.html
+++ b/packages/scss/demo/templates/side-filters.html
@@ -12,40 +12,42 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-compact">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item is-active">
-						<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
-							<i class="lucca-icon icon-tilesNine"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section 2</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-settings"></i>
-							<span class="navSide-item-link-title">Section 3</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section 4</span>
-							<span class="navSide-item-alert">9</span>
-						</a>
-					</div>
-				</nav>
+				<div class="navSide-mainSection">
+					<nav class="navSide-scrollWrapper">
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item is-active">
+							<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
+								<i class="lucca-icon icon-tilesNine"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section 2</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-settings"></i>
+								<span class="navSide-item-link-title">Section 3</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section 4</span>
+								<span class="navSide-item-alert">9</span>
+							</a>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -84,28 +86,30 @@
 					<h1>Side with filters</h1>
 <code class="code mod-block">&lt;main class="main"&gt;
 	&lt;aside class="navSide mod-compact"&gt;
-		&lt;nav class="navSide-scrollWrapper"&gt;
-			&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
-			&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item is-active"&gt;
-				&lt;a href="#" class="navSide-item-link is-active"&gt;
-					&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-					&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			...
-		&lt;/nav&gt;
+		&lt;div class="navSide-mainSection"&gt;
+			&lt;nav class="navSide-scrollWrapper"&gt;
+				&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
+				&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+						&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
+						&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item is-active"&gt;
+					&lt;a href="#" class="navSide-item-link is-active"&gt;
+						&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+						&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				...
+			&lt;/nav&gt;
+		&lt;/div&gt;
 		&lt;div class="navSide-bottomSection"&gt;
 			&lt;div class="navSide-item"&gt;
 				&lt;a href="#" class="navSide-item-link" onclick="setActive(event, true)"&gt;

--- a/packages/scss/demo/templates/side-header.html
+++ b/packages/scss/demo/templates/side-header.html
@@ -12,40 +12,42 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-compact">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item is-active">
-						<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
-							<i class="lucca-icon icon-tilesNine"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section 2</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-settings"></i>
-							<span class="navSide-item-link-title">Section 3</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section 4</span>
-							<span class="navSide-item-alert">9</span>
-						</a>
-					</div>
-				</nav>
+				<div class="navSide-mainSection">
+					<nav class="navSide-scrollWrapper">
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item is-active">
+							<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
+								<i class="lucca-icon icon-tilesNine"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section 2</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-settings"></i>
+								<span class="navSide-item-link-title">Section 3</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section 4</span>
+								<span class="navSide-item-alert">9</span>
+							</a>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -71,28 +73,30 @@
 					<h1>Side with header</h1>
 <code class="code mod-block">&lt;main class="main"&gt;
 	&lt;aside class="navSide mod-compact"&gt;
-		&lt;nav class="navSide-scrollWrapper"&gt;
-			&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
-			&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item is-active"&gt;
-				&lt;a href="#" class="navSide-item-link is-active"&gt;
-					&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-					&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			...
-		&lt;/nav&gt;
+		&lt;div class="navSide-mainSection"&gt;
+			&lt;nav class="navSide-scrollWrapper"&gt;
+				&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
+				&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+						&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
+						&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item is-active"&gt;
+					&lt;a href="#" class="navSide-item-link is-active"&gt;
+						&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+						&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				...
+			&lt;/nav&gt;
+		&lt;/div&gt;
 		&lt;div class="navSide-bottomSection"&gt;
 			&lt;div class="navSide-item"&gt;
 				&lt;a href="#" class="navSide-item-link" onclick="setActive(event, true)"&gt;

--- a/packages/scss/demo/templates/side-sections-header.html
+++ b/packages/scss/demo/templates/side-sections-header.html
@@ -12,40 +12,42 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-compact">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item is-active">
-						<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
-							<i class="lucca-icon icon-tilesNine"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section 2</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-settings"></i>
-							<span class="navSide-item-link-title">Section 3</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section 4</span>
-							<span class="navSide-item-alert">9</span>
-						</a>
-					</div>
-				</nav>
+				<div class="navSide-mainSection">
+					<nav class="navSide-scrollWrapper">
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item is-active">
+							<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
+								<i class="lucca-icon icon-tilesNine"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section 2</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-settings"></i>
+								<span class="navSide-item-link-title">Section 3</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section 4</span>
+								<span class="navSide-item-alert">9</span>
+							</a>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -71,28 +73,30 @@
 					<h1>Side with sections & header</h1>
 <code class="code mod-block">&lt;main class="main"&gt;
 	&lt;aside class="navSide mod-compact"&gt;
-		&lt;nav class="navSide-scrollWrapper"&gt;
-			&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
-			&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item is-active"&gt;
-				&lt;a href="#" class="navSide-item-link is-active"&gt;
-					&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-					&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			...
-		&lt;/nav&gt;
+		&lt;div class="navSide-mainSection"&gt;
+			&lt;nav class="navSide-scrollWrapper"&gt;
+				&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
+				&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+						&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
+						&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item is-active"&gt;
+					&lt;a href="#" class="navSide-item-link is-active"&gt;
+						&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+						&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				...
+			&lt;/nav&gt;
+		&lt;/div&gt;
 		&lt;div class="navSide-bottomSection"&gt;
 			&lt;div class="navSide-item"&gt;
 				&lt;a href="#" class="navSide-item-link" onclick="setActive(event, true)"&gt;

--- a/packages/scss/demo/templates/side-sections.html
+++ b/packages/scss/demo/templates/side-sections.html
@@ -12,40 +12,42 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-compact">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item is-active">
-						<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
-							<i class="lucca-icon icon-tilesNine"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section 2</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-settings"></i>
-							<span class="navSide-item-link-title">Section 3</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section 4</span>
-							<span class="navSide-item-alert">9</span>
-						</a>
-					</div>
-				</nav>
+				<<div class="navSide-mainSection">
+					nav class="navSide-scrollWrapper">
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item is-active">
+							<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
+								<i class="lucca-icon icon-tilesNine"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section 2</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-settings"></i>
+								<span class="navSide-item-link-title">Section 3</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section 4</span>
+								<span class="navSide-item-alert">9</span>
+							</a>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -60,28 +62,30 @@
 						<h1>Side with sections</h1>
 <code class="code mod-block">&lt;main class="main"&gt;
 	&lt;aside class="navSide mod-compact"&gt;
-		&lt;nav class="navSide-scrollWrapper"&gt;
-			&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
-			&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
-				&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
-					&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
-					&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item is-active"&gt;
-				&lt;a href="#" class="navSide-item-link is-active"&gt;
-					&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-					&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			...
-		&lt;/nav&gt;
+		&lt;div class="navSide-mainSection"&gt;
+			&lt;nav class="navSide-scrollWrapper"&gt;
+				&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
+				&lt;div class=&quot;navSide-item mod-mobileToggle&quot;&gt;
+					&lt;a href=&quot;#&quot; class=&quot;navSide-item-link&quot;&gt;
+						&lt;span class=&quot;navSide-item-link-title&quot;&gt;Menu&lt;/span&gt;
+						&lt;i class=&quot;navSide-item-arrow lucca-icon icon-arrowSouthThin&quot;&gt;&lt;/i&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item is-active"&gt;
+					&lt;a href="#" class="navSide-item-link is-active"&gt;
+						&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+						&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				...
+			&lt;/nav&gt;
+		&lt;/div&gt;
 		&lt;div class="navSide-bottomSection"&gt;
 			&lt;div class="navSide-item"&gt;
 				&lt;a href="#" class="navSide-item-link" onclick="setActive(event, true)"&gt;

--- a/packages/scss/demo/templates/side.html
+++ b/packages/scss/demo/templates/side.html
@@ -12,40 +12,42 @@
 	<body>
 		<main class="main">
 			<aside class="navSide mod-compact mod-withBottomSection">
-				<nav class="navSide-scrollWrapper">
-					<div class="navSide-item-placeholder"></div>
-					<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
-						<a href="#" class="navSide-item-link">
-							<span class="navSide-item-link-title">Menu</span>
-							<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
-						</a>
-					</div>
-					<div class="navSide-item is-active">
-						<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
-							<i class="lucca-icon icon-tilesNine"></i>
-							<span class="navSide-item-link-title">Section 1</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-user"></i>
-							<span class="navSide-item-link-title">Section 2</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-settings"></i>
-							<span class="navSide-item-link-title">Section 3</span>
-						</a>
-					</div>
-					<div class="navSide-item">
-						<a href="#" class="navSide-item-link" onclick="setActive(event)">
-							<i class="lucca-icon icon-sliders"></i>
-							<span class="navSide-item-link-title">Section 4</span>
-							<span class="navSide-item-alert">9</span>
-						</a>
-					</div>
-				</nav>
+				<div class="navSide-mainSection">
+					<nav class="navSide-scrollWrapper">
+						<div class="navSide-item-placeholder"></div>
+						<div class="navSide-item mod-mobileToggle" onclick="w3.toggleClass('#navSide', 'is-open')">
+							<a href="#" class="navSide-item-link">
+								<span class="navSide-item-link-title">Menu</span>
+								<i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"></i>
+							</a>
+						</div>
+						<div class="navSide-item is-active">
+							<a href="#" class="navSide-item-link is-active" onclick="setActive(event)">
+								<i class="lucca-icon icon-tilesNine"></i>
+								<span class="navSide-item-link-title">Section 1</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-user"></i>
+								<span class="navSide-item-link-title">Section 2</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-settings"></i>
+								<span class="navSide-item-link-title">Section 3</span>
+							</a>
+						</div>
+						<div class="navSide-item">
+							<a href="#" class="navSide-item-link" onclick="setActive(event)">
+								<i class="lucca-icon icon-sliders"></i>
+								<span class="navSide-item-link-title">Section 4</span>
+								<span class="navSide-item-alert">9</span>
+							</a>
+						</div>
+					</nav>
+				</div>
 				<div class="navSide-bottomSection">
 					<div class="navSide-item">
 						<a href="#" class="navSide-item-link" onclick="setActive(event, true)">
@@ -61,28 +63,30 @@
 					<h1>Side</h1>
 <code class="code mod-block">&lt;main class="main"&gt;
 	&lt;aside class="navSide mod-compact mod-withBottomSection"&gt;
-		&lt;nav class="navSide-scrollWrapper"&gt;
-			&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
-			&lt;div class="navSide-item mod-mobileToggle"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-						&lt;span class="navSide-item-link-title"&gt;Menu&lt;/span&gt;
-						&lt;i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"&gt;&lt;/i&gt;
-				&lt;/a&gt;
-			&lt;/div>
-			&lt;div class="navSide-item is-active"&gt;
-				&lt;a href="#" class="navSide-item-link is-active"&gt;
-					&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			&lt;div class="navSide-item"&gt;
-				&lt;a href="#" class="navSide-item-link"&gt;
-					&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
-					&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
-				&lt;/a&gt;
-			&lt;/div&gt;
-			...
-		&lt;/nav&gt;
+		&lt;div class="navSide-mainSection"&gt;
+			&lt;nav class="navSide-scrollWrapper"&gt;
+				&lt;div class="navSide-item-placeholder"&gt;&lt;/div&gt;
+				&lt;div class="navSide-item mod-mobileToggle"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+							&lt;span class="navSide-item-link-title"&gt;Menu&lt;/span&gt;
+							&lt;i class="navSide-item-arrow lucca-icon icon-arrowSouthThin"&gt;&lt;/i&gt;
+					&lt;/a&gt;
+				&lt;/div>
+				&lt;div class="navSide-item is-active"&gt;
+					&lt;a href="#" class="navSide-item-link is-active"&gt;
+						&lt;i class="lucca-icon icon-tilesNine"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 1&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				&lt;div class="navSide-item"&gt;
+					&lt;a href="#" class="navSide-item-link"&gt;
+						&lt;i class="lucca-icon icon-user"&gt;&lt;/i&gt;
+						&lt;span class="navSide-item-link-title"&gt;Section 2&lt;/span&gt;
+					&lt;/a&gt;
+				&lt;/div&gt;
+				...
+			&lt;/nav&gt;
+		&lt;/div&gt;
 		&lt;div class="navSide-bottomSection"&gt;
 			&lt;div class="navSide-item"&gt;
 				&lt;a href="#" class="navSide-item-link"&gt;

--- a/packages/scss/src/components/_main.scss
+++ b/packages/scss/src/components/_main.scss
@@ -30,5 +30,6 @@
 
 	.navSide.mod-withBanner ~ .main-content, .main-content.mod-withBanner {
 		height: calc(100vh - #{_theme("commons.banner-height")} - #{_component("navSide.mobile.toggle-height")});
+		margin-top: _component("navSide.mobile.toggle-height");
 	}
 }

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -376,9 +376,17 @@
 		background-color: _color("primary", "dark");
 		cursor: pointer;
 		overflow: hidden;
-		position: sticky;
+		position: fixed;
 		top: 0;
+		left: 0;
+		right: 0;
 		z-index: 1;
+	}
+
+	.navSide.mod-withBanner {
+		.navSide-item.mod-mobileToggle {
+			top: _theme("commons.banner-height");
+		}
 	}
 
 	.navSide-bottomSection {

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -3,14 +3,23 @@
 	bottom: 0;
 	display: block;
 	left: 0;
-	overflow-x: hidden;
-	overflow-y: auto;
 	padding-top: _component("navSide.padding-top");
 	position: fixed;
 	top: 0;
 	width: _component("navSide.width");
 	z-index: 2;
 
+	
+}
+
+// NECESSARY TO AVOID MOVEMENT WHEN THE SCROLLBAR APPEARS
+.navSide-mainSection {
+	display: block;
+	height: 100%;
+	position: relative;
+	width: _component("navSide.width");
+	overflow-x: hidden;
+	overflow-y: auto;
 	// SCROLLBAR
 	// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 	&::-webkit-scrollbar-track {
@@ -27,13 +36,9 @@
 	}
 }
 
-// NECESSARY TO AVOID MOVEMENT WHEN THE SCROLLBAR APPEARS
 .navSide-scrollWrapper {
-	display: block;
-	position: relative;
 	width: _component("navSide.width");
 }
-
 // MOBILE TOGGLE
 .navSide-item.mod-mobileToggle {
 	display: none;
@@ -118,10 +123,7 @@
 // BOTTOM MENU
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 .navSide-bottomSection {
-	bottom: 0;
 	height: _component("navSide.bottom-section-height");
-	left: 0;
-	position: fixed;
 	width: _component("navSide.width");
 	z-index: 1;
 
@@ -149,8 +151,9 @@
 }
 
 .navSide.mod-withBottomSection {
-	margin-bottom: 0;
-	padding-bottom: _component("navSide.bottom-section-height");
+	.navSide-mainSection {
+		height: calc(100% - #{_component("navSide.bottom-section-height")});
+	}
 }
 
 // ACTIVE & OPEN STATE
@@ -259,18 +262,10 @@
 		text-align: center;
 		width: _component("navSide.compact.width");
 
-		// SCROLLBAR
-		&::-webkit-scrollbar-track {
-			background-color: _component("navSide.scrollbar.bg-color");
-		}
-
-		&::-webkit-scrollbar-thumb {
-			background-color: _component("navSide.scrollbar.thumb-color");
-		}
-
-		.navSide-scrollWrapper {
+		.navSide-mainSection, .navSide-scrollWrapper {
 			width: _component("navSide.compact.width");
 		}
+
 		.navSide-item-link {
 			color: _component("navSide.compact-palette.text");
 			flex-direction: column;
@@ -348,11 +343,14 @@
 @include media_smaller_than("md") {
 	.navSide {
 		position: relative;
+		padding-top: _theme("commons.banner-height");
 		width: 100%;
-	}
-
-	.navSide-scrollWrapper {
-		width: 100%;
+		&, &.mod-withBottomSection {
+			.navSide-mainSection, .navSide-scrollWrapper {
+				width: 100%;
+				height: auto;
+			}
+		}
 	}
 
 	.navSide-item:not(.mod-mobileToggle), .navSide-item-placeholder {
@@ -378,7 +376,6 @@
 
 	.navSide-bottomSection {
 		background: transparent;
-		position: relative;
 		width: auto;
 		height: auto;
 
@@ -388,12 +385,10 @@
 		}
 	}
 
-	.navSide.mod-withBottomSection {
-		padding-bottom: 0;
-	}
-
 	.navSide.is-open {
 		height: 100vh;
+		overflow-x: hidden;
+		overflow-y: auto;
 		&.mod-withBanner {
 			height: calc(100vh - #{_theme("commons.banner-height")});
 		}

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -22,6 +22,13 @@
 	overflow-y: auto;
 	// SCROLLBAR
 	// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+	scrollbar-face-color: _component("navSide.scrollbar.thumb-color");
+	scrollbar-arrow-color:_component("navSide.scrollbar.arrow-color");
+	scrollbar-track-color: _component("navSide.scrollbar.bg-color");
+	scrollbar-shadow-color: _component("navSide.scrollbar.thumb-color");
+	scrollbar-3dlight-color:_component("navSide.scrollbar.thumb-color");
+
 	&::-webkit-scrollbar-track {
 		background-color: _component("navSide.scrollbar.bg-color");
 	}

--- a/packages/scss/src/theming/components/_nav-side.theme.scss
+++ b/packages/scss/src/theming/components/_nav-side.theme.scss
@@ -36,7 +36,8 @@ $navSide: (
 		width: .5rem,
 		border-radius: 10px,
 		bg-color: _color("primary", "dark"),
-		thumb-color: _color("primary")
+		thumb-color: _color("primary"),
+		arrow-color: _color("primary", "text"),
 	),
 	submenu: (
 		max-height: 33rem,


### PR DESCRIPTION
Fixes the issue where the navSide with a `navSide-bottomSection` was jumping when scrolling on IE.
We introduce a `navSide-mainSection` that wraps around the `navSide-scrollWrapper`.