### PR TITLE
[FIX][SCSS] Mobile menu height should be toggle size.

### DIFF
--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -350,7 +350,7 @@
 @include media_smaller_than("md") {
 	.navSide {
 		position: relative;
-		padding-top: _theme("commons.banner-height");
+		padding-top: _component("navSide.mobile.toggle-height");
 		width: 100%;
 		&, &.mod-withBottomSection {
 			.navSide-mainSection, .navSide-scrollWrapper {


### PR DESCRIPTION
Padding-top on mobile menu must be toggle size and not banner size.