### PR TITLE
[fix] ng-formly api without filters

### DIFF
--- a/packages/ng/libraries/formly/src/lib/types/api.ts
+++ b/packages/ng/libraries/formly/src/lib/types/api.ts
@@ -11,7 +11,7 @@ export class LuFormlyFieldApi extends FieldType {
 		return this.to.api;
 	}
 	get _filters() {
-		return this.to.filters;
+		return this.to.filters || [];
 	}
 	focus() {
 		this.to._isFocused = true;


### PR DESCRIPTION
[ng-formly] fix nullrefex on apiselect when templateoptions.filters wasnt specified

fixes #529 