### PR TITLE
[fix] [SCSS] Checkboxesfield mod-row was not properly defined

### DIFF
--- a/packages/scss/src/components/inputs/checkbox/_checkboxesfield.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkboxesfield.scss
@@ -34,6 +34,6 @@
 		margin-bottom: 0;
 	}
 	.checkbox {
-		margin-right: 1.5rem;
+		margin-right: _component("field.horizontal-spacing");
 	}
 }

--- a/packages/scss/src/components/inputs/checkbox/_checkboxesfield.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkboxesfield.scss
@@ -29,11 +29,11 @@
 %checkboxesfield-row {
 	display: flex;
 	flex-wrap: wrap;
-	.radio {
+	.checkbox {
 		margin-top: 0;
 		margin-bottom: 0;
 	}
-	.radio {
+	.checkbox {
 		margin-right: 1.5rem;
 	}
 }

--- a/packages/scss/src/components/inputs/radio/_radiosfield.scss
+++ b/packages/scss/src/components/inputs/radio/_radiosfield.scss
@@ -37,6 +37,6 @@
 		margin-bottom: 0;
 	}
 	.radio {
-		margin-right: 1.5rem;
+		margin-right: _component("field.horizontal-spacing");
 	}
 }

--- a/packages/scss/src/theming/components/_field.theme.scss
+++ b/packages/scss/src/theming/components/_field.theme.scss
@@ -1,5 +1,6 @@
 $field: (
 	font-size: _theme("sizes.standard.font-size"),
+	horizontal-spacing: 1.5rem,
 
 	input: (
 		color: _color("text.default"),


### PR DESCRIPTION
Checkboxesfield mod-row used `.radio` instead of `.checkbox`
Both checkboxesfield & radiosfield now uses a common variable for horizontal-spacing