### PR TITLE
[fix] minor - textfield* and callout bg

### DIFF
--- a/packages/scss/CHANGELOG.md
+++ b/packages/scss/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## In dev
 ### Fixes
 - `textfield` is-required character is visible again
+- `callout` background can be edited in theme
 
 ## 2.1
 ### Fixes
@@ -11,7 +12,7 @@
 ### New features
 - Adding `.radiosfield` & `.checkboxesfield`, the equivalent of `.textfield` for the corresponding inputs
 ### Fixes
-- `.form` now supports `.mod-compact`, `.mod-framedt`, `.mod-material` to stylised the whole form
+- `.form` now supports `.mod-compact`, `.mod-framed`, `.mod-material` to stylised the whole form
 
 ### Breaking changes
 - `transparent` key in palettes is now `see-through`

--- a/packages/scss/CHANGELOG.md
+++ b/packages/scss/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
-## 2.1 - in dev
+## In dev
+### Fixes
+- `textfield` is-required character is visible again
+
+## 2.1
 ### Fixes
 - Adding `.navSide-mainSection` to fix navSide scroll issue on IE11
 

--- a/packages/scss/src/components/_callout.scss
+++ b/packages/scss/src/components/_callout.scss
@@ -1,5 +1,5 @@
 .callout {
-	background: _theme("commons.background.base");
+	background: _component("callout.background");
 	border-radius: _theme("commons.border.radius");
 	margin: _component("callout.margin");
 	padding: _component("callout.padding");

--- a/packages/scss/src/mixins/_forms.scss
+++ b/packages/scss/src/mixins/_forms.scss
@@ -60,5 +60,4 @@
 	content: "*";
 	display: inline-block;
 	margin-left: .2em;
-	position: absolute;
 }

--- a/packages/scss/src/theming/components/_callout.theme.scss
+++ b/packages/scss/src/theming/components/_callout.theme.scss
@@ -1,5 +1,6 @@
 $callout: (
-  margin: 0 0 1rem,
-  padding: 1rem 1.5rem
+  margin: 0 0 _theme("spacings.small"),
+  padding: _theme("spacings.small") 1.5rem,
+  background: _theme("commons.background.base")
 );
 $theme: _set($theme, "components.callout", $callout);


### PR DESCRIPTION
- textfield is-required character is visible again
- callout background is editable in theme

--------

fixes #533 
fixes #535 