### PR TITLE
[feat] tooltip positioning

### DIFF
--- a/packages/ng/docs/demo/src/app/tooltip/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/tooltip/basic/basic.html
@@ -1,3 +1,5 @@
 <span luTooltip="LOL">That tooltip</span><br>
 <span [luTooltip]="tooltipContent">Bold tooltip</span><br>
-<span [luTooltip]="tooltipContent" [luTooltipDisabled]="true">Disabled tooltip</span>
+<span [luTooltip]="tooltipContent" [luTooltipDisabled]="true">Disabled tooltip</span><br>
+<span luTooltip="LOL" [luTooltipPosition]="'below'">That tooltip on bottom</span><br>
+

--- a/packages/ng/docs/demo/src/app/tooltip/basic/basic.html
+++ b/packages/ng/docs/demo/src/app/tooltip/basic/basic.html
@@ -2,4 +2,5 @@
 <span [luTooltip]="tooltipContent">Bold tooltip</span><br>
 <span [luTooltip]="tooltipContent" [luTooltipDisabled]="true">Disabled tooltip</span><br>
 <span luTooltip="LOL" [luTooltipPosition]="'below'">That tooltip on bottom</span><br>
-
+<span luTooltip="LOL" [luTooltipPosition]="'after'">That tooltip after</span><br>
+<span luTooltip="LOL" [luTooltipPosition]="'before'">That tooltip before</span><br>

--- a/packages/ng/libraries/core/src/lib/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/libraries/core/src/lib/popover/trigger/popover-trigger.model.ts
@@ -328,7 +328,6 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 				change.connectionPair.overlayX === 'end' ? 'before' : 'after';
 			const posY: LuPopoverPosition =
 				change.connectionPair.overlayY === 'bottom' ? 'above' : 'below';
-
 			this.popover.setPositionClassesChanges(posX, posY);
 		});
 	}

--- a/packages/ng/libraries/core/src/lib/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/libraries/core/src/lib/popover/trigger/popover-trigger.model.ts
@@ -25,6 +25,9 @@ import { Subscription } from 'rxjs';
 import {
 	ILuPopoverPanel,
 	LuPopoverPosition,
+	LuPopoverTriggerEvent,
+	LuPopoverAlignment,
+	LuPopoverScrollStrategy,
 } from '../panel/popover-panel.model';
 import {
 	ILuPopoverTarget,
@@ -53,6 +56,14 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 
 	/** References the popover instance that the trigger is associated with. */
 	popover: T;
+	position: LuPopoverPosition = 'above';
+	alignment: LuPopoverAlignment;
+	scrollStrategy: LuPopoverScrollStrategy = 'close';
+	containerPositioning: boolean;
+	overlapTrigger: boolean;
+	triggerEvent: LuPopoverTriggerEvent = 'click';
+	targetOffsetX: number;
+	targetOffsetY: number;
 
 	/** References the popover target instance that the trigger is associated with. */
 	targetElement: ILuPopoverTarget;
@@ -191,8 +202,9 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 
 	/** Return if the popover main positionning is vertical */
 	get isVerticallyPositionned(): boolean {
+		const position = this.popover ? this.popover.position : this.position;
 		return (
-			this.popover.position === 'below' || this.popover.position === 'above'
+			position === 'below' || position === 'above'
 		);
 	}
 
@@ -280,15 +292,16 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 	protected _getOverlayConfig(): OverlayConfig {
 		const overlayState = new OverlayConfig();
 		overlayState.positionStrategy = this._getPosition().withDirection(this.dir);
-
+		const triggerEvent = this.popover ? this.popover.triggerEvent : this.triggerEvent;
 		/** Display overlay backdrop if trigger event is click */
-		if (this.popover.triggerEvent === 'click') {
+		if (triggerEvent === 'click') {
 			overlayState.hasBackdrop = true;
 			overlayState.backdropClass = 'cdk-overlay-transparent-backdrop';
 		}
 
 		overlayState.direction = this.dir;
-		switch (this.popover.scrollStrategy) {
+		const scrollStrategy = this.popover ? this.popover.scrollStrategy : this.scrollStrategy;
+		switch (scrollStrategy) {
 			case 'block':
 				overlayState.scrollStrategy = this._overlay.scrollStrategies.block();
 				break;
@@ -326,38 +339,42 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 	 * @returns ConnectedPositionStrategy
 	 */
 	protected _getPosition(): ConnectedPositionStrategy {
-		const position: OriginConnectionPosition = {
+		const connectionPosition: OriginConnectionPosition = {
 			originX: 'start',
 			originY: 'top',
 		};
 
 		// Position
-		if (this.popover.position === 'above') {
-			position.originY = this.popover.overlapTrigger ? 'bottom' : 'top';
-		} else if (this.popover.position === 'below') {
-			position.originY = this.popover.overlapTrigger ? 'top' : 'bottom';
-		} else if (this.popover.position === 'before') {
-			position.originX = this.popover.overlapTrigger ? 'end' : 'start';
-		} else if (this.popover.position === 'after') {
-			position.originX = this.popover.overlapTrigger ? 'start' : 'end';
+		const position = this.popover ? this.popover.position : this.position;
+		const popoverOverlapTrigger = this.popover ? this.popover.overlapTrigger : false;
+		const overlapTrigger = popoverOverlapTrigger || this.overlapTrigger;
+		if (position === 'above') {
+			connectionPosition.originY = overlapTrigger ? 'bottom' : 'top';
+		} else if (position === 'below') {
+			connectionPosition.originY = overlapTrigger ? 'top' : 'bottom';
+		} else if (position === 'before') {
+			connectionPosition.originX = overlapTrigger ? 'end' : 'start';
+		} else if (position === 'after') {
+			connectionPosition.originX = overlapTrigger ? 'start' : 'end';
 		}
 
 		// Alignment
+		const alignment = this.popover ? this.popover.alignment : this.alignment;
 		if (this.isVerticallyPositionned) {
-			if (this.popover.alignment === 'left') {
-				position.originX = 'start';
-			} else if (this.popover.alignment === 'right') {
-				position.originX = 'end';
+			if (alignment === 'left') {
+				connectionPosition.originX = 'start';
+			} else if (alignment === 'right') {
+				connectionPosition.originX = 'end';
 			} else {
-				position.originX = 'center';
+				connectionPosition.originX = 'center';
 			}
 		} else {
-			if (this.popover.alignment === 'top') {
-				position.originY = 'top';
-			} else if (this.popover.alignment === 'bottom') {
-				position.originY = 'bottom';
+			if (alignment === 'top') {
+				connectionPosition.originY = 'top';
+			} else if (alignment === 'bottom') {
+				connectionPosition.originY = 'bottom';
 			} else {
-				position.originY = 'center';
+				connectionPosition.originY = 'center';
 			}
 		}
 
@@ -366,44 +383,47 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 			overlayY: 'top',
 		};
 
-		if (this.popover.overlapTrigger) {
-			overlayPosition.overlayX = position.originX;
-			overlayPosition.overlayY = position.originY;
+		if (overlapTrigger) {
+			overlayPosition.overlayX = connectionPosition.originX;
+			overlayPosition.overlayY = connectionPosition.originY;
 		} else if (this.isVerticallyPositionned) {
-			overlayPosition.overlayX = position.originX;
+			overlayPosition.overlayX = connectionPosition.originX;
 			overlayPosition.overlayY =
-				this.popover.position === 'above' ? 'bottom' : 'top';
+				position === 'above' ? 'bottom' : 'top';
 		} else {
 			overlayPosition.overlayX =
-				this.popover.position === 'before' ? 'end' : 'start';
-			overlayPosition.overlayY = position.originY;
+				position === 'before' ? 'end' : 'start';
+			overlayPosition.overlayY = connectionPosition.originY;
 		}
 
 		let offsetX = 0;
 		let offsetY = 0;
 
+		const targetOffsetX = this.popover ? this.popover.targetOffsetX : this.targetOffsetX;
+		const targetOffsetY = this.popover ? this.popover.targetOffsetY : this.targetOffsetY;
+
 		if (
-			this.popover.overlapTrigger &&
+			overlapTrigger &&
 			!this.isVerticallyPositionned &&
-			this.popover.targetOffsetX &&
-			!isNaN(Number(this.popover.targetOffsetX))
+			targetOffsetX &&
+			!isNaN(Number(targetOffsetX))
 		) {
 			if (overlayPosition.overlayX === 'end') {
-				offsetX = -Number(this.popover.targetOffsetX);
+				offsetX = -Number(targetOffsetX);
 			} else if (overlayPosition.overlayX === 'start') {
-				offsetX = Number(this.popover.targetOffsetX);
+				offsetX = Number(targetOffsetX);
 			}
 		}
 
 		if (
 			this.isVerticallyPositionned &&
-			this.popover.targetOffsetY &&
-			!isNaN(Number(this.popover.targetOffsetY))
+			targetOffsetY &&
+			!isNaN(Number(targetOffsetY))
 		) {
 			if (overlayPosition.overlayY === 'top') {
-				offsetY = Number(this.popover.targetOffsetY);
+				offsetY = Number(targetOffsetY);
 			} else if (overlayPosition.overlayY === 'bottom') {
-				offsetY = -Number(this.popover.targetOffsetY);
+				offsetY = -Number(targetOffsetY);
 			}
 		}
 
@@ -413,7 +433,7 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 		 * If undefined defaults to the trigger element reference.
 		 */
 		let element = this._elementRef;
-		if (typeof this.targetElement !== 'undefined') {
+		if (typeof this.targetElement !== 'undefined' && this.popover) {
 			this.popover.containerPositioning = true;
 			element = this.targetElement._elementRef;
 		}
@@ -424,11 +444,11 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 
 		return this._overlay
 			.position()
-			.connectedTo(element, position, overlayPosition)
+			.connectedTo(element, connectionPosition, overlayPosition)
 			.withFallbackPosition(
 				{
-					originX: position.originX,
-					originY: this._invertVerticalPos(position.originY),
+					originX: connectionPosition.originX,
+					originY: this._invertVerticalPos(connectionPosition.originY),
 				},
 				{
 					overlayX: overlayPosition.overlayX,
@@ -437,8 +457,8 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 			)
 			.withFallbackPosition(
 				{
-					originX: this._invertHorizontalPos(position.originX),
-					originY: position.originY,
+					originX: this._invertHorizontalPos(connectionPosition.originX),
+					originY: connectionPosition.originY,
 				},
 				{
 					overlayX: this._invertHorizontalPos(overlayPosition.overlayX),
@@ -447,8 +467,8 @@ implements ILuPopoverTrigger<T>, AfterViewInit, OnDestroy {
 			)
 			.withFallbackPosition(
 				{
-					originX: this._invertHorizontalPos(position.originX),
-					originY: this._invertVerticalPos(position.originY),
+					originX: this._invertHorizontalPos(connectionPosition.originX),
+					originY: this._invertVerticalPos(connectionPosition.originY),
 				},
 				{
 					overlayX: this._invertHorizontalPos(overlayPosition.overlayX),

--- a/packages/ng/libraries/core/src/lib/tooltip/panel/tooltip-panel.component.ts
+++ b/packages/ng/libraries/core/src/lib/tooltip/panel/tooltip-panel.component.ts
@@ -10,6 +10,21 @@ import { ALuPopoverPanel, ILuPopoverPanel, luTransformPopover } from '../../popo
 export class LuTooltipPanelComponent extends ALuPopoverPanel implements ILuPopoverPanel, OnInit {
 
 	@HostBinding('@transformPopover') animationState = 'enter';
+	@HostBinding('class') get classes() {
+		if (this._classList['lu-popover-above']) {
+			return 'lu-tooltip-above';
+		}
+		if (this._classList['lu-popover-below']) {
+			return 'lu-tooltip-below';
+		}
+		if (this._classList['lu-popover-before']) {
+			return 'lu-tooltip-before';
+		}
+		if (this._classList['lu-popover-after']) {
+			return 'lu-tooltip-after';
+		}
+		return '';
+	}
 
 	@Input() content;
 

--- a/packages/ng/libraries/core/src/lib/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/libraries/core/src/lib/tooltip/trigger/tooltip-trigger.directive.ts
@@ -9,7 +9,7 @@ import {
 	HostListener } from '@angular/core';
 	import { Overlay, OverlayRef, OverlayConfig } from '@angular/cdk/overlay';
 	import { ComponentPortal } from '@angular/cdk/portal';
-	import { ALuPopoverTrigger } from '../../popover/index';
+	import { ALuPopoverTrigger, LuPopoverPosition } from '../../popover/index';
 	import { LuTooltipPanelComponent } from '../panel/tooltip-panel.component';
 
 @Directive({
@@ -20,6 +20,7 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 	@Input('luTooltip') tooltipContent;
 	@Input() enterDelay = 300;
 	@Input() leaveDelay = 100;
+	@Input('luTooltipPosition') position: LuPopoverPosition = 'above';
 	@Input('luTooltipDisabled')
 	get disabled(): boolean {
 		return this._disabled;
@@ -106,6 +107,7 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 		this._createOverlay();
 		this.popover = this._overlayRef.attach(this._portal).instance;
 		this.popover.content = this.tooltipContent;
+		this.popover.position = this.position;
 		this.popover.markForChange();
 		this.popover.close.subscribe(() => {
 			this.closePopover();

--- a/packages/ng/libraries/core/src/lib/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/libraries/core/src/lib/tooltip/trigger/tooltip-trigger.directive.ts
@@ -76,17 +76,7 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 
 	_getOverlayConfig(): OverlayConfig {
 		const overlayState = new OverlayConfig();
-		overlayState.positionStrategy = this._overlay.position()
-			.connectedTo(this._elementRef, {
-				originX: 'center',
-				originY: 'top',
-			}, {
-				overlayX: 'center',
-				overlayY: 'bottom',
-			});
-
-		overlayState.hasBackdrop = false;
-		overlayState.direction = this.dir;
+		overlayState.positionStrategy = this._getPosition().withDirection(this.dir);
 		overlayState.scrollStrategy = this._overlay.scrollStrategies.close();
 		return overlayState;
 	}

--- a/packages/ng/libraries/core/src/style/definitions/tooltip/_tooltip.scss
+++ b/packages/ng/libraries/core/src/style/definitions/tooltip/_tooltip.scss
@@ -10,21 +10,24 @@
 		color: _component("tooltip.color");
 		padding: _component("tooltip.padding", true);
 		padding: _component("tooltip.padding");
-		position: relative;
 
-		&::after {
-			content: '';
-			display: block;
-			position: absolute;
-			width: 0;
-			height: 0;
-			border-left: 5px solid transparent;
-			border-right: 5px solid transparent;
-			border-top: 5px solid _component("tooltip.background", true);
-			border-top: 5px solid _component("tooltip.background");
-			bottom: -4px;
-			left: 50%;
-			transform: translateX(-50%);
+		&.lu-tooltip-above {
+			transform-origin: bottom center;
+		}
+
+		&.lu-tooltip-below {
+			transform-origin: top center;
+			margin-top: 2px;
+		}
+
+		&.lu-tooltip-before {
+			transform-origin: center right;
+			margin-right: 5px;
+		}
+
+		&.lu-tooltip-after {
+			transform-origin: center left;
+			margin-left: 5px;
 		}
 	}
 }


### PR DESCRIPTION
added input on tooltip trigger directive to allow custom positionning

@sanlucca right now it has no impact, cuz tooltip doesn't support classes `lu-popover-below`, so i think you need to patch [this file](https://github.com/LuccaSA/lucca-front/blob/feat.tooltip.position/packages/ng/libraries/core/src/style/definitions/tooltip/_tooltip.scss) with [this](https://github.com/LuccaSA/lucca-front/blob/feat.tooltip.position/packages/ng/libraries/core/src/style/components/_popover.scss#L17)

-----

fixes #432 