### PR TITLE
[fix] some bugs with api pager and paged searcher

### DIFF
--- a/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component, forwardRef, Input, Inject, Optional, SkipSelf, Self, OnInit } from '@angular/core';
 import { ILuOptionOperator, ALuOptionOperator } from '../../../option/index';
-import { BehaviorSubject } from 'rxjs';
 import { LuApiPagerService } from './api-pager.service';
 import { IApiItem } from '../../api.model';
 import { ALuApiOptionPager, ALuApiPagerService } from './api-pager.model';

--- a/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.component.ts
@@ -25,7 +25,6 @@ import { ALuApiOptionPager, ALuApiPagerService } from './api-pager.model';
 export class LuApiPagerComponent<T extends IApiItem = IApiItem, S extends ALuApiPagerService<T> = ALuApiPagerService<T>>
 extends ALuApiOptionPager<T, S>
 implements ILuOptionOperator<T>, OnInit {
-	// outOptions$ = new BehaviorSubject<T[]>([]);
 	constructor(
 		@Inject(ALuApiPagerService) @Optional() @SkipSelf() hostService: ALuApiPagerService,
 		@Inject(ALuApiPagerService) @Self() selfService: ALuApiPagerService,

--- a/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, forwardRef, Input, Inject, Optional, SkipSelf, Self } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, Inject, Optional, SkipSelf, Self, OnInit } from '@angular/core';
 import { ILuOptionOperator, ALuOptionOperator } from '../../../option/index';
 import { BehaviorSubject } from 'rxjs';
 import { LuApiPagerService } from './api-pager.service';
@@ -24,8 +24,8 @@ import { ALuApiOptionPager, ALuApiPagerService } from './api-pager.model';
 })
 export class LuApiPagerComponent<T extends IApiItem = IApiItem, S extends ALuApiPagerService<T> = ALuApiPagerService<T>>
 extends ALuApiOptionPager<T, S>
-implements ILuOptionOperator<T> {
-	outOptions$ = new BehaviorSubject<T[]>([]);
+implements ILuOptionOperator<T>, OnInit {
+	// outOptions$ = new BehaviorSubject<T[]>([]);
 	constructor(
 		@Inject(ALuApiPagerService) @Optional() @SkipSelf() hostService: ALuApiPagerService,
 		@Inject(ALuApiPagerService) @Self() selfService: ALuApiPagerService,
@@ -43,4 +43,7 @@ implements ILuOptionOperator<T> {
 	 * if you wnat to cast dates into moments for example
 	 */
 	@Input() set transformFn(transformFn: (item: any) => T) { this._service.transformFn = transformFn; }
+	ngOnInit() {
+		super.init();
+	}
 }

--- a/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.model.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.model.ts
@@ -1,10 +1,14 @@
 import { ILuOptionOperator } from '../../../option/index';
 import { IApiItem } from '../../api.model';
 import { HttpClient } from '@angular/common/http';
-import { Observable, BehaviorSubject, of, merge } from 'rxjs';
-import { switchMap, catchError, mapTo } from 'rxjs/operators';
+import { Observable, of, merge, Subject } from 'rxjs';
+import { switchMap, catchError, mapTo, tap, debounceTime, map } from 'rxjs/operators';
 import { ALuApiFeederService } from '../feeder/index';
 
+enum Strategy {
+	append,
+	replace,
+}
 const MAGIC_PAGE_SIZE = 20;
 export interface ILuApiOptionPager<T extends IApiItem = IApiItem> extends ILuOptionOperator<T> {}
 export interface ILuApiPagerService<T extends IApiItem = IApiItem> {
@@ -13,13 +17,17 @@ export interface ILuApiPagerService<T extends IApiItem = IApiItem> {
 
 export abstract class ALuApiOptionPager<T extends IApiItem = IApiItem, S extends ILuApiPagerService<T> = ILuApiPagerService<T>>
 implements ILuApiOptionPager<T> {
-	outOptions$ = new BehaviorSubject<T[]>([]);
+	outOptions$ = new Subject<T[]>();
 	loading$: Observable<boolean>;
 
 	protected _loading = false;
-	protected _results$: Observable<T[]>;
-	protected _page$ = new BehaviorSubject<number>(undefined);
+	protected _results$: Observable<{ items: T[], strategy: Strategy }>;
+	protected _options: T[] = [];
+	protected _page$ = new Subject<number>();
+	protected _page: number;
 	constructor(protected _service: S) {
+	}
+	protected init() {
 		this.initObservables();
 	}
 	onOpen() {
@@ -30,31 +38,35 @@ implements ILuApiOptionPager<T> {
 	}
 	onScrollBottom() {
 		if (!this._loading) {
-			this._page$.next(this._page$.value + 1);
+			this._page$.next(this._page + 1);
 		}
 	}
 	protected initObservables() {
-		this._results$ = this._page$
+		const _results$: Observable<{ items: T[], strategy: Strategy }> = this._page$
 		.pipe(
-			switchMap(page => {
+			tap(p => this._page = p),
+			switchMap<number, { items: T[], strategy: Strategy }>(page => {
 				if (page === undefined) {
-					return of([]);
+					return of({ items: [], strategy: Strategy.replace });
 				}
-				return this._service.getPaged(page);
-			})),
-			catchError(err => of([])
+				return this._service.getPaged(page).pipe(
+					map(items => ({ items: items, strategy: page === 0 ? Strategy.replace : Strategy.append }))
+				);
+			}),
+			catchError(err => of({ items: [], strategy: Strategy.replace })),
+			tap(results => {
+				if (results.strategy === Strategy.replace) {
+					this._options = [...results.items];
+				} else {
+					this._options.push(...results.items);
+				}
+				this.outOptions$.next([...this._options]);
+			}),
 		);
 
-		this._results$.subscribe(items => {
-			if (this._page$.value === 0) {
-				this.outOptions$.next([...items]);
-			} else {
-				this.outOptions$.next([...this.outOptions$.value, ...items]);
-			}
-		});
 		this.loading$ = merge(
 			this._page$.pipe(mapTo(true)),
-			this._results$.pipe(mapTo(false)),
+			_results$.pipe(mapTo(false)),
 		);
 		this.loading$.subscribe(l => this._loading = l);
 	}

--- a/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.model.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.model.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 
-import { Observable, BehaviorSubject, Subject, combineLatest, merge, of } from 'rxjs';
+import { Observable, Subject, combineLatest, merge, of } from 'rxjs';
 
 import {
 	mapTo,

--- a/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.model.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.model.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 
-import { Observable, BehaviorSubject, combineLatest, merge, of } from 'rxjs';
+import { Observable, BehaviorSubject, Subject, combineLatest, merge, of } from 'rxjs';
 
 import {
 	mapTo,
@@ -23,10 +23,9 @@ export interface ILuApiSearcherService<T extends IApiItem = IApiItem> extends IL
 
 export abstract class ALuApiOptionSearcher<T extends IApiItem = IApiItem, S extends ILuApiSearcherService<T> = ILuApiSearcherService<T>>
 implements ILuApiOptionFeeder<T> {
-	outOptions$ = new BehaviorSubject<T[]>([]);
+	outOptions$ = new Subject<T[]>();
 	loading$: Observable<boolean>;
 
-	protected _results$: Observable<T[]>;
 	protected _clue$: Observable<string>;
 
 	set clue$(clue$: Observable<string>) {
@@ -38,17 +37,17 @@ implements ILuApiOptionFeeder<T> {
 	}
 	protected initObservables(clue$) {
 		this._clue$ = clue$.pipe(share());
-		this._results$ = this._clue$
+		const results$ = this._clue$
 		.pipe(
 			switchMap(clue => this._service.searchAll(clue)),
 			catchError(err => of([])),
 			share(),
 		);
 
-		this._results$.subscribe(items => this.outOptions$.next(items));
+		results$.subscribe(items => this.outOptions$.next(items));
 		this.loading$ = merge(
 			this._clue$.pipe(mapTo(true)),
-			this._results$.pipe(mapTo(false)),
+			results$.pipe(mapTo(false)),
 		);
 	}
 	abstract resetClue();
@@ -100,10 +99,12 @@ implements ILuApiPagedSearcherService<T> {
 export abstract class ALuApiOptionPagedSearcher<T extends IApiItem = IApiItem, S extends ILuApiPagedSearcherService<T> = ILuApiPagedSearcherService<T>>
 extends ALuApiOptionSearcher<T, S>
 implements ILuApiOptionPagedSearcher<T> {
-	outOptions$ = new BehaviorSubject<T[]>([]);
+	outOptions$ = new Subject<T[]>();
 	loading$: Observable<boolean>;
 	protected _loading = false;
-	protected _page$ = new BehaviorSubject<number>(undefined);
+	protected _page$ = new Subject<number>();
+	protected _page: number;
+	protected _options: T[] = [];
 
 	constructor(service: S) {
 		super(service);
@@ -114,18 +115,18 @@ implements ILuApiOptionPagedSearcher<T> {
 	}
 	onScrollBottom() {
 		if (!this._loading) {
-			this._page$.next(this._page$.value + 1);
+			this._page$.next(this._page + 1);
 		}
 	}
 	protected initObservables(clue$) {
-		const distinctPage$ = this._page$.pipe(distinctUntilChanged());
+		const distinctPage$ = this._page$.pipe(distinctUntilChanged(), tap(p => this._page = p));
 
 		this._clue$ = clue$.pipe(
 			tap(() => this._page$.next(0)),
 			distinctUntilChanged(),
 			share()
 		);
-		this._results$ = combineLatest(
+		const results$ = combineLatest(
 			distinctPage$,
 			this._clue$,
 		).pipe(
@@ -134,18 +135,19 @@ implements ILuApiOptionPagedSearcher<T> {
 			share(),
 		);
 
-		this._results$
+		results$
 		.pipe(withLatestFrom(distinctPage$))
 		.subscribe(([items, page]) => {
 			if (page === 0) {
-				this.outOptions$.next([...items]);
+				this._options = [...items];
 			} else {
-				this.outOptions$.next([...this.outOptions$.value, ...items]);
+				this._options.push(...items);
 			}
+			this.outOptions$.next([...this._options]);
 		});
 		this.loading$ = merge(
 			this._clue$.pipe(mapTo(true)),
-			this._results$.pipe(mapTo(false)),
+			results$.pipe(mapTo(false)),
 		);
 		this.loading$.subscribe(l => this._loading = l);
 	}

--- a/packages/ng/libraries/core/src/lib/option/operator/for-options/for-options.directive.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/for-options/for-options.directive.ts
@@ -30,6 +30,7 @@ export class LuForOptionsDirective<T> extends NgForOf<T>
 		this._subs.add(
 			options$.subscribe(options => {
 				this.ngForOf = options;
+				this._changeDetectionRef.markForCheck();
 			}),
 		);
 	}


### PR DESCRIPTION
fixes #572 
maybe fixes #541 

--------

- added a markforcheck in foroptions directive that seemed to not update since the optimizations from PR #550 
- also rewrote api pager and api paged searcher to use `Subject` instead of `BehaviorSubject` that seemed to emit twice when .next was called once, resulting in multiple http.get