### PR TITLE
picker rescroll shenanigans

### DIFF
--- a/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.model.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.model.ts
@@ -2,7 +2,7 @@ import { ILuOptionOperator } from '../../../option/index';
 import { IApiItem } from '../../api.model';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, merge, Subject } from 'rxjs';
-import { switchMap, catchError, mapTo, tap, debounceTime, map, distinctUntilChanged } from 'rxjs/operators';
+import { switchMap, catchError, mapTo, tap, map, distinctUntilChanged } from 'rxjs/operators';
 import { ALuApiFeederService } from '../feeder/index';
 
 enum Strategy {

--- a/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.model.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/pager/api-pager.model.ts
@@ -2,7 +2,7 @@ import { ILuOptionOperator } from '../../../option/index';
 import { IApiItem } from '../../api.model';
 import { HttpClient } from '@angular/common/http';
 import { Observable, of, merge, Subject } from 'rxjs';
-import { switchMap, catchError, mapTo, tap, debounceTime, map } from 'rxjs/operators';
+import { switchMap, catchError, mapTo, tap, debounceTime, map, distinctUntilChanged } from 'rxjs/operators';
 import { ALuApiFeederService } from '../feeder/index';
 
 enum Strategy {
@@ -34,7 +34,7 @@ implements ILuApiOptionPager<T> {
 		this._page$.next(0);
 	}
 	onClose() {
-		this._page$.next(undefined);
+		this._page$.next(0);
 	}
 	onScrollBottom() {
 		if (!this._loading) {
@@ -44,6 +44,7 @@ implements ILuApiOptionPager<T> {
 	protected initObservables() {
 		const _results$: Observable<{ items: T[], strategy: Strategy }> = this._page$
 		.pipe(
+			distinctUntilChanged(),
 			tap(p => this._page = p),
 			switchMap<number, { items: T[], strategy: Strategy }>(page => {
 				if (page === undefined) {

--- a/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.model.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/searcher/api-searcher.model.ts
@@ -109,7 +109,7 @@ implements ILuApiOptionPagedSearcher<T> {
 	constructor(service: S) {
 		super(service);
 	}
-	onOpen() {
+	onClose() {
 		this.resetClue();
 		this.resetPage();
 	}


### PR DESCRIPTION
fixes #577 

-----

after some debug it seemed that the rescroll was triggered by the fact that at the time of the opening of the picker, old options were still there, so it could find the highlighted option and it tried to scroll to it. it was due to option list reinitialization was made on the onOpen event, add some debouncetime and you have this

- i have 80 options and select the 77th
- i close the picker
- i reopen the picker, all 80 options are available
- it highlights the 77th, and try to scroll to it
- at the same time onOpen is called in the api-pager
- it reinits with just 20 options
- it tries to scroll to the 77th of the 20 options
- all hell breaks loose

so the fix was to reinit the option list on close