### PR TITLE
[ENH] Add mod-withMenu and mod-withMenuCompact

### DIFF
--- a/packages/scss/src/components/_container.scss
+++ b/packages/scss/src/components/_container.scss
@@ -50,7 +50,7 @@
 	}
 }
 
-.navSide.mod-compact ~ .main-content {
+.navSide.mod-compact ~ .main-content, .mod-withMenuCompact .main-content {
 	.container {
 		@each $bp-name, $bp-obj in $breakpoints {
 			@include media_larger_than($bp-name) {

--- a/packages/scss/src/components/_main.scss
+++ b/packages/scss/src/components/_main.scss
@@ -2,15 +2,15 @@
 	position: relative;
 }
 
-.navSide ~ .main-content {
+.navSide ~ .main-content, .mod-withMenu .main-content {
 	margin-left: _theme("components.navSide.width");
 }
 
-.navSide.mod-compact ~ .main-content {
+.navSide.mod-compact ~ .main-content, .mod-withMenuCompact .main-content {
 	margin-left: _theme("components.navSide.compact.width");
 }
 
-.navSide.mod-withBanner ~ .main-content, .main-content.mod-withBanner {
+.navSide.mod-withBanner ~ .main-content, .mod-withBanner .main-content, .main-content.mod-withBanner {
 	height: calc(100vh - #{_theme("commons.banner-height")});
 	overflow-y: auto;
 	margin-top: _theme("commons.banner-height");
@@ -28,7 +28,7 @@
 		overflow: hidden;
 	}
 
-	.navSide.mod-withBanner ~ .main-content, .main-content.mod-withBanner {
+	.navSide.mod-withBanner ~ .main-content, .main-content.mod-withBanner, .mod-withBanner .main-content {
 		height: calc(100vh - #{_theme("commons.banner-height")} - #{_component("navSide.mobile.toggle-height")});
 		margin-top: _component("navSide.mobile.toggle-height");
 	}


### PR DESCRIPTION
Adds `mod-withMenu` and `mod-withMenuCompact` to handle layout without using proxy selectors.
Might be a patch or a feature in 2.5