### PR TITLE
[bug][ng] Adds a loader when opening an option-picker

### DIFF
--- a/packages/ng/libraries/core/src/lib/option/operator/for-options/for-options.directive.ts
+++ b/packages/ng/libraries/core/src/lib/option/operator/for-options/for-options.directive.ts
@@ -25,6 +25,7 @@ import { ALuOptionOperator, ILuOptionOperator } from '../option-operator.model';
 })
 export class LuForOptionsDirective<T> extends NgForOf<T>
 	implements ILuOptionOperator<T>, OnDestroy {
+	outOptions$;
 	protected _subs = new Subscription();
 	set inOptions$(options$: Observable<T[]>) {
 		this._subs.add(
@@ -33,6 +34,7 @@ export class LuForOptionsDirective<T> extends NgForOf<T>
 				this._changeDetectionRef.markForCheck();
 			}),
 		);
+		this.outOptions$ = options$;
 	}
 	@Input()
 	set luForOptionsTrackBy(fn: TrackByFunction<T>) {

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.html
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.html
@@ -3,7 +3,11 @@
 	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)"
 	 [@transformPopover]="'enter'">
 		<div class="lu-popover-content" [ngStyle]="popoverContentStyles" cdkTrapFocus="focusTrapEnabled" luScroll (onScrollBottom)="onScrollBottom()">
-			<ng-content></ng-content>
+			<ng-content *ngIf="!(loading$ | async); else loading"></ng-content>
 		</div>
 	</div>
+</ng-template>
+
+<ng-template #loading>
+	<div class="loading mod-block"></div>
 </ng-template>

--- a/packages/ng/libraries/core/src/style/definitions/option/_option-picker.scss
+++ b/packages/ng/libraries/core/src/style/definitions/option/_option-picker.scss
@@ -4,5 +4,11 @@
 		max-height: 280px;
 		overflow-y: auto;
 		display: block;
+
+		.loading {
+			height: 280px;
+			margin: 0;
+			overflow: hidden;
+		}
 	}
 }


### PR DESCRIPTION
Fixes #609 
It adds a loader when opening an option-picker that takes 100% of the picker max-height. Therefor, the initial height of the select is more accurate and the dropdown is correctly placed by the overlay service.