### PR TITLE
[bug][ng] Select padding and picker minwidth

### DIFF
--- a/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.scss
+++ b/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.scss
@@ -1,2 +1,6 @@
 @import '_definitions';
 @include selectInputStyle;
+
+.lu-select-value {
+	padding-right: 2.5rem;
+}

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.model.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.model.ts
@@ -111,7 +111,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, ILuInput<T> {
 	protected _getOverlayConfig(): OverlayConfig {
 		const config = super._getOverlayConfig();
 		const clientRect = this._elementRef.nativeElement.getBoundingClientRect();
-		config.width = `${clientRect.width}px`; // might become min/maxWidth
+		config.minWidth = `${Math.max(185, clientRect.width)}px`; // might become min/maxWidth
 		return config;
 	}
 

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.scss
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.scss
@@ -1,2 +1,6 @@
 @import '_definitions';
 @include selectInputStyle;
+
+.lu-select-value {
+	padding-right: 2.5rem;
+}

--- a/packages/ng/libraries/core/src/style/components/_overlay.scss
+++ b/packages/ng/libraries/core/src/style/components/_overlay.scss
@@ -73,9 +73,8 @@
 
 	/* Option picker */
 
-  &.mod-optionPicker {
-		width: auto !important;
-    min-width: 13rem;
+	&.mod-optionPicker {
+		min-width: 13rem;
 		max-width: 30rem;
-  }
+	}
 }


### PR DESCRIPTION
Fixes #610
`api-select` and `user-select` are always clearable. Therefor, we are adding a similar padding as on the `is-clearable` state .
#601 broke the fact that the picker should at least be as wide as its input. It is now the case, yet we force it to be at least 185px wide.