### PR TITLE
[628] improve button / textfield alignment & height

### DIFF
--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -3,6 +3,7 @@
 @include field("textfield");
 
 .textfield {
+	vertical-align: middle;
 	width: _component("field.sizes.default");
 }
 

--- a/packages/scss/src/theming/components/_button.theme.scss
+++ b/packages/scss/src/theming/components/_button.theme.scss
@@ -7,7 +7,7 @@ $button: (
 		dark: _theme("commons.background.darker"),
 		text: _color("text.default")
 	),
-	margin: .2rem,
+	margin: 0 .15rem,
 	line-height: 1.15,
 	font-weight: 600,
 	box-shadow: (

--- a/packages/scss/src/theming/components/_textfield.theme.scss
+++ b/packages/scss/src/theming/components/_textfield.theme.scss
@@ -4,7 +4,7 @@ $textfield: (
 
 	input: (
 		padding-horizontal: .5rem,
-		padding-vertical: .5rem,
+		padding-vertical: .45rem,
 		placeholder: desaturate(lighten(_color("primary", "color", true), 20%), 25%)
 	),
 


### PR DESCRIPTION
Improve buttons & textfield height/alignment to be perfectly aligned together by default. 

![image](https://user-images.githubusercontent.com/25581936/57229336-1bd44b80-7016-11e9-8eb9-b92dd813195e.png)

