### PR TITLE
[NG][SCSS] Fix textarea disabled on mod-framed

### DIFF
--- a/packages/ng/docs/demo/src/app/formly/fieldgroup/fieldgroup.ts
+++ b/packages/ng/docs/demo/src/app/formly/fieldgroup/fieldgroup.ts
@@ -56,6 +56,7 @@ export class FieldgroupComponent {
 							templateOptions: {
 								type: 'text',
 								label: 'Street Name',
+								disabled: true,
 							},
 						},
 					],
@@ -69,6 +70,7 @@ export class FieldgroupComponent {
 							templateOptions: {
 								label: 'comments',
 								mod: 'textarea',
+								disabled: true
 							},
 						},
 					],

--- a/packages/ng/libraries/formly/src/lib/wrappers/textfield-layout.html
+++ b/packages/ng/libraries/formly/src/lib/wrappers/textfield-layout.html
@@ -1,3 +1,3 @@
-<div class="textfield" [ngClass]="[mod, modWithSuffix, modMultiline, isRequired, isFocused, isError]">
+<div class="textfield" [ngClass]="[mod, modWithSuffix, modMultiline, isRequired, isFocused, isError, isDisabled]">
 	<ng-container #fieldComponent></ng-container>
 </div>

--- a/packages/ng/libraries/formly/src/lib/wrappers/textfield-layout.ts
+++ b/packages/ng/libraries/formly/src/lib/wrappers/textfield-layout.ts
@@ -35,6 +35,10 @@ export class LuFormlyWrapperTextfieldLayout extends FieldWrapper {
 		return !!this.to && !!this.to.required ? 'is-required' : '';
 	}
 
+	get isDisabled() {
+		return !!this.to && !!this.to.disabled ? 'is-disabled' : '';
+	}
+
 	get isFocused() {
 		return !!this.to && this.to._isFocused ? 'is-focused' : '';
 	}

--- a/packages/scss/src/components/inputs/field/_field.framed.scss
+++ b/packages/scss/src/components/inputs/field/_field.framed.scss
@@ -129,7 +129,8 @@
 
 	.#{$fieldname}-input {
 		&[disabled], &[readonly] {
-			background-color: _theme("commons.background.dark");
+			background-color: _theme("commons.disabled.background");
+			color: _theme("commons.disabled.color");
 			background-image: none;
 			opacity: .6;
 

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -74,6 +74,12 @@
 		&.is-error {
 			background-color: _color("error", "see-through");
 		}
+
+		&[disabled], &[readonly], &.is-disabled, &.is-readonly {
+			background-color: _theme("commons.disabled.background");
+			color: _theme("commons.disabled.color");
+			pointer-events: not-allowed;
+		}
 	}
 
 	&.mod-withSuffix {

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -41,9 +41,11 @@
 
 		@mixin inputColoring($palette) {
 			&:hover, &:focus {
-				@include fakeBorder(1px, _color($palette));
-				background-color: _color($palette, "see-through");
-				z-index: 2;
+				&:not([disabled]):not([readonly]):not(.is-disabled):not(.is-readonly) {
+					@include fakeBorder(1px, _color($palette));
+					background-color: _color($palette, "see-through");
+					z-index: 2;
+				}
 			}
 
 			textarea.textfield-input {
@@ -76,9 +78,12 @@
 		}
 
 		&[disabled], &[readonly], &.is-disabled, &.is-readonly {
-			background-color: _theme("commons.disabled.background");
-			color: _theme("commons.disabled.color");
-			pointer-events: not-allowed;
+			&, &:hover, &:focus {
+				background-color: _theme("commons.disabled.background");
+				color: _theme("commons.disabled.color");
+				opacity: .6;
+				cursor: not-allowed;
+			}
 		}
 	}
 

--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -251,7 +251,7 @@
 	&[disabled], &[readonly], &.is-disabled, &.is-readonly {
 		background: _theme("commons.disabled.background");
 		color: _theme("commons.disabled.color");
-		pointer-events: not-allowed;
+		cursor: not-allowed;
 
 		&::placeholder {
 			color: _theme("commons.disabled.placeholder");


### PR DESCRIPTION
Textarea disabled wasn't working on mod-framed because in this mod, the `textfield` needs to be the one disabled, not the input. 
Therefore, I adapted the style in the `scss` package and added a `is-disabled` on the `textfield-layout` for formly 