### PR TITLE
Poc.tree.picker

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/poc-tree-picker/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/poc-tree-picker/index.ts
@@ -1,1 +1,0 @@
-export * from './poc-tree-picker.module';

--- a/packages/ng/applications/sandbox/src/app/issues/poc-tree-picker/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/poc-tree-picker/index.ts
@@ -1,0 +1,1 @@
+export * from './poc-tree-picker.module';

--- a/packages/ng/applications/sandbox/src/app/issues/poc-tree/poc-tree.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/poc-tree/poc-tree.component.html
@@ -2,7 +2,7 @@
 <div class="textfield">
 	<lu-select class="textfield-input" [(ngModel)]="item">
 		<ng-container *luDisplayer="let value">{{ value.name }}</ng-container>
-		<lu-option-picker>
+		<lu-tree-option-picker>
 			<lu-tree-option [value]="node1">
 				{{node1.name}}
 				<lu-tree-option [value]="node11">
@@ -15,7 +15,7 @@
 					{{node12.name}}
 				</lu-tree-option>
 			</lu-tree-option>
-		</lu-option-picker>
+		</lu-tree-option-picker>
 	</lu-select>
 	<label for="" class="textfield-label">select single</label>
 </div>
@@ -23,7 +23,7 @@
 <div class="textfield">
 		<lu-select class="textfield-input" [(ngModel)]="collection" multiple>
 			<ng-container *luDisplayer="let values; multiple: true">{{ values.length }} items selected</ng-container>
-			<lu-option-picker>
+			<lu-tree-option-picker>
 				<lu-tree-option [value]="node1">
 					{{node1.name}}
 					<lu-tree-option [value]="node11">
@@ -36,7 +36,7 @@
 						{{node12.name}}
 					</lu-tree-option>
 				</lu-tree-option>
-			</lu-option-picker>
+			</lu-tree-option-picker>
 		</lu-select>
 		<label for="" class="textfield-label">select multiple</label>
 	</div>

--- a/packages/ng/applications/sandbox/src/app/issues/poc-tree/poc-tree.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/poc-tree/poc-tree.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 
 import { RouterModule } from '@angular/router';
 import { PocTreeComponent } from './poc-tree.component';
-import { LuSelectModule, LuTreeModule, LuOptionPickerModule, LuInputDisplayerModule } from '@lucca-front/ng';
+import { LuSelectModule, LuTreeModule, LuInputDisplayerModule } from '@lucca-front/ng';
 import { FormsModule } from '@angular/forms';
 
 
@@ -16,7 +16,7 @@ import { FormsModule } from '@angular/forms';
 		LuSelectModule,
 		LuTreeModule,
 		FormsModule,
-		LuOptionPickerModule,
+		// LuOptionPickerModule,
 		RouterModule.forChild([
 			{ path: '', component: PocTreeComponent },
 		]),

--- a/packages/ng/libraries/core/src/lib/option/item/option-item.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.component.ts
@@ -16,10 +16,10 @@ import { ILuOptionItem, ALuOptionItem } from './option-item.model';
 })
 export class LuOptionItemComponent<T = any> extends ALuOptionItem<T> implements ILuOptionItem<T> {
 	@Input() value: T;
-	@Output() onSelect = new EventEmitter<T>();
+	@Output() onSelect = new EventEmitter<this>();
 	@HostListener('click')
 	onclick() {
-		this.onSelect.emit(this.value);
+		this.onSelect.emit(this);
 	}
 	constructor(protected _vcr: ViewContainerRef) {
 		super();

--- a/packages/ng/libraries/core/src/lib/option/item/option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.model.ts
@@ -5,6 +5,6 @@ export interface ILuOptionItem<T = any> {
 	onSelect: Observable<this>;
 }
 export abstract class ALuOptionItem<T = any> implements ILuOptionItem<T> {
-	value: T;
-	onSelect: Observable<this>;
+	abstract value: T;
+	abstract onSelect: Observable<this>;
 }

--- a/packages/ng/libraries/core/src/lib/option/item/option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/item/option-item.model.ts
@@ -2,9 +2,9 @@ import { Observable } from 'rxjs';
 
 export interface ILuOptionItem<T = any> {
 	value: T;
-	onSelect: Observable<T>;
+	onSelect: Observable<this>;
 }
 export abstract class ALuOptionItem<T = any> implements ILuOptionItem<T> {
 	value: T;
-	onSelect: Observable<T>;
+	onSelect: Observable<this>;
 }

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker-advanced.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker-advanced.component.ts
@@ -18,27 +18,11 @@ import {
 	ALuOnCloseSubscriber,
 	ALuOnScrollBottomSubscriber,
 } from '../operator/index';
-import { LuOptionPickerComponent } from './option-picker.component';
+import { ALuOptionPickerComponent } from './option-picker.component';
+import { ILuOptionItem } from '../item/index';
 
-/**
-* advanced option picker panel
-*/
-@Component({
-	selector: 'lu-option-picker-advanced',
-	templateUrl: './option-picker-advanced.component.html',
-	styleUrls: ['./option-picker.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	animations: [luTransformPopover],
-	exportAs: 'LuOptionPicker',
-	providers: [
-		{
-			provide: ALuPickerPanel,
-			useExisting: forwardRef(() => LuOptionPickerAdvancedComponent),
-		},
-	]
-})
-export class LuOptionPickerAdvancedComponent<T = any>
-extends LuOptionPickerComponent<T> {
+export abstract class ALuOptionPickerAdvancedComponent<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>>
+extends ALuOptionPickerComponent<T, O> {
 	loading$: Observable<boolean>;
 
 	protected _operators = [];
@@ -104,5 +88,31 @@ extends LuOptionPickerComponent<T> {
 			o.onClose();
 		});
 		super.onClose();
+	}
+}
+
+/**
+* advanced option picker panel
+*/
+@Component({
+	selector: 'lu-option-picker-advanced',
+	templateUrl: './option-picker-advanced.component.html',
+	styleUrls: ['./option-picker.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	animations: [luTransformPopover],
+	exportAs: 'LuOptionPicker',
+	providers: [
+		{
+			provide: ALuPickerPanel,
+			useExisting: forwardRef(() => LuOptionPickerAdvancedComponent),
+		},
+	]
+})
+export class LuOptionPickerAdvancedComponent<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>> extends ALuOptionPickerAdvancedComponent<T, O> {
+	constructor(
+		_changeDetectorRef: ChangeDetectorRef,
+		_renderer: Renderer2,
+	) {
+		super(_changeDetectorRef, _renderer);
 	}
 }

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -23,26 +23,10 @@ import { map, delay } from 'rxjs/operators';
 import { ALuPickerPanel } from '../../input/index';
 import { UP_ARROW, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 
-/**
-* basic option picker panel
-*/
-@Component({
-	selector: 'lu-option-picker',
-	templateUrl: './option-picker.component.html',
-	styleUrls: ['./option-picker.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	animations: [luTransformPopover],
-	exportAs: 'LuOptionPicker',
-	providers: [
-		{
-			provide: ALuPickerPanel,
-			useExisting: forwardRef(() => LuOptionPickerComponent),
-		},
-	]
-})
-export class LuOptionPickerComponent<T = any, I extends ILuOptionItem<T> = ILuOptionItem<T>>
-extends ALuOptionPicker<T, I>
-implements ILuOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
+
+export abstract class ALuOptionPickerComponent<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>>
+extends ALuOptionPicker<T, O>
+implements ILuOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 
 
 	@Output() close = new EventEmitter<void>();
@@ -53,9 +37,9 @@ implements ILuOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 	protected _isOptionItemsInitialized: boolean;
 	protected _defaultOverlayPaneClasses = ['mod-optionPicker'];
 
-	protected _options: I[] = [];
-	protected _optionsQL: QueryList<I>;
-	@ContentChildren(ALuOptionItem, { descendants: true }) set optionsQL(ql: QueryList<I>) {
+	protected _options: O[] = [];
+	protected _optionsQL: QueryList<O>;
+	@ContentChildren(ALuOptionItem, { descendants: true }) set optionsQL(ql: QueryList<O>) {
 		this._optionsQL = ql;
 		this.initOptionItemsObservable();
 	}
@@ -237,10 +221,35 @@ implements ILuOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 
 		const items$ = merge(of(this._optionsQL), this._optionsQL.changes)
 			.pipe(
-				map<QueryList<I>, I[]>(q => q.toArray()),
+				map<QueryList<O>, O[]>(q => q.toArray()),
 				delay(0),
 			);
 		items$.subscribe(o => this._options = o || []);
 		this._optionItems$ = items$;
+	}
+}
+/**
+* basic option picker panel
+*/
+@Component({
+	selector: 'lu-option-picker',
+	templateUrl: './option-picker.component.html',
+	styleUrls: ['./option-picker.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	animations: [luTransformPopover],
+	exportAs: 'LuOptionPicker',
+	providers: [
+		{
+			provide: ALuPickerPanel,
+			useExisting: forwardRef(() => LuOptionPickerComponent),
+		},
+	]
+})
+export class LuOptionPickerComponent<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>> extends ALuOptionPickerComponent<T, O> {
+	constructor(
+		_changeDetectorRef: ChangeDetectorRef,
+		_renderer: Renderer2,
+	) {
+		super(_changeDetectorRef, _renderer);
 	}
 }

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -40,9 +40,9 @@ import { UP_ARROW, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 		},
 	]
 })
-export class LuOptionPickerComponent<T = any>
-extends ALuOptionPicker<T>
-implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
+export class LuOptionPickerComponent<T = any, I extends ILuOptionItem<T> = ILuOptionItem<T>>
+extends ALuOptionPicker<T, I>
+implements ILuOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 
 
 	@Output() close = new EventEmitter<void>();
@@ -53,9 +53,9 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 	protected _isOptionItemsInitialized: boolean;
 	protected _defaultOverlayPaneClasses = ['mod-optionPicker'];
 
-	protected _options: ILuOptionItem<T>[] = [];
-	protected _optionsQL: QueryList<ILuOptionItem<T>>;
-	@ContentChildren(ALuOptionItem, { descendants: true }) set optionsQL(ql: QueryList<ILuOptionItem<T>>) {
+	protected _options: I[] = [];
+	protected _optionsQL: QueryList<I>;
+	@ContentChildren(ALuOptionItem, { descendants: true }) set optionsQL(ql: QueryList<I>) {
 		this._optionsQL = ql;
 		this.initOptionItemsObservable();
 	}
@@ -190,7 +190,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 		const options = this._optionsQL ? this._optionsQL.toArray() : [];
 		const highlightedOption = options[this.highlightIndex];
 		if (!!highlightedOption) {
-			this._updateValue(highlightedOption.value);
+			this._updateValue(highlightedOption);
 		}
 	}
 	protected _initSelected() {
@@ -237,7 +237,7 @@ implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit {
 
 		const items$ = merge(of(this._optionsQL), this._optionsQL.changes)
 			.pipe(
-				map<QueryList<ILuOptionItem<T>>, ILuOptionItem<T>[]>(q => q.toArray()),
+				map<QueryList<I>, I[]>(q => q.toArray()),
 				delay(0),
 			);
 		items$.subscribe(o => this._options = o || []);

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -190,7 +190,7 @@ implements ILuOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 		const options = this._optionsQL ? this._optionsQL.toArray() : [];
 		const highlightedOption = options[this.highlightIndex];
 		if (!!highlightedOption) {
-			this._updateValue(highlightedOption);
+			this._toggle(highlightedOption);
 		}
 	}
 	protected _initSelected() {

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
@@ -4,9 +4,9 @@ import { switchMap } from 'rxjs/operators';
 import { ILuOptionItem } from '../item/index';
 import { ESCAPE, TAB } from '@angular/cdk/keycodes';
 
-export interface ILuOptionPickerPanel<T = any> extends ILuPickerPanel<T> {}
+export interface ILuOptionPickerPanel<T = any, I extends ILuOptionItem<T> = ILuOptionItem<T>> extends ILuPickerPanel<T> {}
 
-export abstract class ALuOptionPicker<T = any> extends ALuPickerPanel<T> implements ILuOptionPickerPanel<T> {
+export abstract class ALuOptionPicker<T = any, I extends ILuOptionItem<T> = ILuOptionItem<T>> extends ALuPickerPanel<T> implements ILuOptionPickerPanel<T, I> {
 	protected _subs = new Subscription();
 	onSelectValue: Observable<T | T[]>;
 	protected _value: T | T[];
@@ -14,7 +14,7 @@ export abstract class ALuOptionPicker<T = any> extends ALuPickerPanel<T> impleme
 		this._value = value;
 		this._applySelected();
 	}
-	protected set _optionItems$(optionItems$: Observable<ILuOptionItem<T>[]>) {
+	protected set _optionItems$(optionItems$: Observable<I[]>) {
 		// reapply selected when the options change
 		this._subs.add(
 			optionItems$
@@ -25,10 +25,11 @@ export abstract class ALuOptionPicker<T = any> extends ALuPickerPanel<T> impleme
 			items => merge(...items.map(i => i.onSelect))
 		));
 		this._subs.add(
-			singleFlow$.subscribe(option => this._updateValue(option.value)),
+			singleFlow$.subscribe(option => this._updateValue(option))
 		);
 	}
-	protected _updateValue(value: T) {
+	protected _updateValue(option: I) {
+		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);
 		} else {

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
@@ -25,10 +25,10 @@ export abstract class ALuOptionPicker<T = any, I extends ILuOptionItem<T> = ILuO
 			items => merge(...items.map(i => i.onSelect))
 		));
 		this._subs.add(
-			singleFlow$.subscribe(option => this._updateValue(option))
+			singleFlow$.subscribe(option => this._toggle(option))
 		);
 	}
-	protected _updateValue(option: I) {
+	protected _toggle(option: I) {
 		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
@@ -25,8 +25,7 @@ export abstract class ALuOptionPicker<T = any> extends ALuPickerPanel<T> impleme
 			items => merge(...items.map(i => i.onSelect))
 		));
 		this._subs.add(
-			singleFlow$
-			.subscribe((value: T) => this._updateValue(value))
+			singleFlow$.subscribe(option => this._updateValue(option.value)),
 		);
 	}
 	protected _updateValue(value: T) {

--- a/packages/ng/libraries/core/src/lib/tree/option/index.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/index.ts
@@ -1,2 +1,3 @@
 export * from './item/index';
+export * from './picker/index';
 export * from './tree-option.module';

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.html
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.html
@@ -1,4 +1,5 @@
 <div class="node" (click)="select()">
 	<ng-content></ng-content>
 </div>
+<i class="icon" (click)="selectSelf()">self</i><i class="icon" (click)="selectChildren()">children</i>
 <div #children class="children"></div>

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, Output, Input, EventEmitter, forwardRef, ContentChildren, ElementRef, ViewChild, QueryList, Renderer2 } from '@angular/core';
 import { ILuOptionItem, ALuOptionItem } from '../../../option/index';
-import { ALuTreeOptionItem } from './tree-option-item.model';
+import { ALuTreeOptionItem, ILuTreeOptionItem } from './tree-option-item.model';
 
 @Component({
 	selector: 'lu-tree-option',
@@ -26,12 +26,12 @@ export class LuTreeOptionItemComponent<T = any> extends ALuTreeOptionItem<T> imp
 	select() {
 		this.onSelect.emit(this);
 	}
-	childrenOptionItems: ILuOptionItem<T>[] = [];
+	children: ILuTreeOptionItem<T>[] = [];
 	@ContentChildren(ALuTreeOptionItem, { descendants: false, read: ALuTreeOptionItem }) set _childrenItems(ql: QueryList<ALuTreeOptionItem>) {
 		const children = ql.toArray();
 		// need to remove item at index 0 cuz its this LuTreeOptionItemComponent
 		children.shift();
-		this.childrenOptionItems = children;
+		this.children = children;
 		// TODO - plug ql.changes to refresh if children changes
 	}
 

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
@@ -22,15 +22,25 @@ import { ALuTreeOptionItem } from './tree-option-item.model';
 })
 export class LuTreeOptionItemComponent<T = any> extends ALuTreeOptionItem<T> implements ILuOptionItem<T> {
 	@Input() value: T;
-	@Output() onSelect = new EventEmitter<T>();
+	@Output() onSelect = new EventEmitter<this>();
 	select() {
-		this.onSelect.emit(this.value);
+		this.onSelect.emit(this);
 	}
+	childrenOptionItems: ILuOptionItem<T>[] = [];
+	@ContentChildren(ALuTreeOptionItem, { descendants: false, read: ALuTreeOptionItem }) set _childrenItems(ql: QueryList<ALuTreeOptionItem>) {
+		const children = ql.toArray();
+		// need to remove item at index 0 cuz its this LuTreeOptionItemComponent
+		children.shift();
+		this.childrenOptionItems = children;
+		// TODO - plug ql.changes to refresh if children changes
+	}
+
 	@ContentChildren(ALuTreeOptionItem, { descendants: false, read: ElementRef }) set _childrenElts(ql: QueryList<ElementRef>) {
 		const children = ql.toArray();
-		// need to remove item at index 0 cuz its this one
+		// need to remove item at index 0 cuz its this LuTreeOptionItemComponent
 		children.shift();
 		this.displayChildren(children);
+		// TODO - plug ql.changes to refresh if children changes
 	}
 	@ViewChild('children', { read: ElementRef, static: true }) _childrenContainer: ElementRef;
 	constructor(

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
@@ -8,11 +8,11 @@ import { ALuTreeOptionItem } from './tree-option-item.model';
 	styleUrls: ['./tree-option-item.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	providers: [
-		{
-			provide: ALuOptionItem,
-			useExisting: forwardRef(() => LuTreeOptionItemComponent),
-			multi: true,
-		},
+		// {
+		// 	provide: ALuOptionItem,
+		// 	useExisting: forwardRef(() => LuTreeOptionItemComponent),
+		// 	multi: true,
+		// },
 		{
 			provide: ALuTreeOptionItem,
 			useExisting: forwardRef(() => LuTreeOptionItemComponent),

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.component.ts
@@ -23,8 +23,16 @@ import { ALuTreeOptionItem, ILuTreeOptionItem } from './tree-option-item.model';
 export class LuTreeOptionItemComponent<T = any> extends ALuTreeOptionItem<T> implements ILuOptionItem<T> {
 	@Input() value: T;
 	@Output() onSelect = new EventEmitter<this>();
+	@Output() onSelectSelf = new EventEmitter<this>();
+	@Output() onSelectChildren = new EventEmitter<this>();
 	select() {
 		this.onSelect.emit(this);
+	}
+	selectSelf() {
+		this.onSelectSelf.emit(this);
+	}
+	selectChildren() {
+		this.onSelectChildren.emit(this);
 	}
 	children: ILuTreeOptionItem<T>[] = [];
 	@ContentChildren(ALuTreeOptionItem, { descendants: false, read: ALuTreeOptionItem }) set _childrenItems(ql: QueryList<ALuTreeOptionItem>) {

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
@@ -1,8 +1,14 @@
 import { ILuOptionItem, ALuOptionItem } from '../../../option/index';
 
 export interface ILuTreeOptionItem<T = any> extends ILuOptionItem<T> {
-	childrenOptionItems: ILuOptionItem<T>[];
+	children: ILuTreeOptionItem<T>[];
+	allChildren: ILuTreeOptionItem<T>[];
 }
 export abstract class ALuTreeOptionItem<T = any>extends ALuOptionItem<T> implements ILuTreeOptionItem<T> {
-	abstract childrenOptionItems: ILuOptionItem<T>[];
+	abstract children: ILuTreeOptionItem<T>[];
+	get allChildren(): ILuTreeOptionItem<T>[] {
+		return this.children
+		.map(c => [c, ...c.children])
+		.reduce((aggr, val) => [...aggr, ...val], []);
+	}
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
@@ -1,8 +1,12 @@
 import { ILuOptionItem, ALuOptionItem } from '../../../option/index';
+import { Observable } from 'rxjs';
 
 export interface ILuTreeOptionItem<T = any> extends ILuOptionItem<T> {
 	children: ILuTreeOptionItem<T>[];
 	allChildren: ILuTreeOptionItem<T>[];
+
+	onSelectSelf: Observable<this>;
+	onSelectChildren: Observable<this>;
 }
 export abstract class ALuTreeOptionItem<T = any>extends ALuOptionItem<T> implements ILuTreeOptionItem<T> {
 	abstract children: ILuTreeOptionItem<T>[];
@@ -11,4 +15,6 @@ export abstract class ALuTreeOptionItem<T = any>extends ALuOptionItem<T> impleme
 		.map(c => [c, ...c.children])
 		.reduce((aggr, val) => [...aggr, ...val], []);
 	}
+	abstract onSelectSelf: Observable<this>;
+	abstract onSelectChildren: Observable<this>;
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
@@ -1,6 +1,8 @@
 import { ILuOptionItem, ALuOptionItem } from '../../../option/index';
 
 export interface ILuTreeOptionItem<T = any> extends ILuOptionItem<T> {
+	childrenOptionItems: ILuOptionItem<T>[];
 }
 export abstract class ALuTreeOptionItem<T = any>extends ALuOptionItem<T> implements ILuTreeOptionItem<T> {
+	abstract childrenOptionItems: ILuOptionItem<T>[];
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/index.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/index.ts
@@ -1,0 +1,1 @@
+export * from './tree-option-picker.module';

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.html
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.html
@@ -1,0 +1,9 @@
+<ng-template>
+	<div class="lu-popover-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
+	 (keydown)="_handleKeydown($event)" (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)"
+	 [@transformPopover]="'enter'">
+		<div class="lu-popover-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus">
+			<ng-content></ng-content>
+		</div>
+	</div>
+</ng-template>

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.scss
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.scss
@@ -1,0 +1,2 @@
+@import '_definitions';
+@include optionPickerStyle;

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -4,8 +4,8 @@ import { ALuPickerPanel } from '../../../input/index';
 import { LuOptionPickerComponent } from '../../../option/index';
 import { ILuTreeOptionPickerPanel } from './tree-option-picker.model';
 import { ILuTreeOptionItem, ALuTreeOptionItem } from '../item';
-import { Observable } from 'rxjs';
-import { switchMap, merge } from 'rxjs/operators';
+import { Observable, merge } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
 
 /**
 * basic option picker panel

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -3,7 +3,7 @@ import { luTransformPopover } from '../../../overlay/index';
 import { ALuPickerPanel } from '../../../input/index';
 import { LuOptionPickerComponent } from '../../../option/index';
 import { ILuTreeOptionPickerPanel } from './tree-option-picker.model';
-import { ILuTreeOptionItem, ALuTreeOptionItem } from '../item';
+import { ILuTreeOptionItem, ALuTreeOptionItem } from '../item/index';
 import { Observable, merge } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -29,15 +29,15 @@ enum ToggleMode {
 		},
 	]
 })
-export class LuTreeOptionPickerComponent<T = any, I extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>>
-extends LuOptionPickerComponent<T, I>
-implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
-	@ContentChildren(ALuTreeOptionItem, { descendants: true }) set optionsQL(ql: QueryList<I>) {
+export class LuTreeOptionPickerComponent<T = any, O extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>>
+extends LuOptionPickerComponent<T, O>
+implements ILuTreeOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
+	@ContentChildren(ALuTreeOptionItem, { descendants: true }) set optionsQL(ql: QueryList<O>) {
 		this._optionsQL = ql;
 		this.initOptionItemsObservable();
 	}
 	@ContentChildren(ALuTreeOptionItem, { descendants: true, read: ViewContainerRef }) optionsQLVR: QueryList<ViewContainerRef>;
-	protected set _optionItems$(optionItems$: Observable<I[]>) {
+	protected set _optionItems$(optionItems$: Observable<O[]>) {
 		// reapply selected when the options change
 		this._subs.add(
 			optionItems$
@@ -67,7 +67,7 @@ implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 			.subscribe(option => this._toggle(option, ToggleMode.children))
 		);
 	}
-	protected _toggle(option: I, mod = ToggleMode.all) {
+	protected _toggle(option: O, mod = ToggleMode.all) {
 		switch (mod) {
 			case ToggleMode.self:
 				return this._toggleSelf(option);
@@ -78,7 +78,7 @@ implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 				return this._toggleAll(option);
 		}
 	}
-	protected _toggleAll(option: I) {
+	protected _toggleAll(option: O) {
 		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);
@@ -96,7 +96,7 @@ implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 		}
 		this._select(newValues);
 	}
-	protected _toggleSelf(option: I) {
+	protected _toggleSelf(option: O) {
 		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);
@@ -114,7 +114,7 @@ implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 		}
 		this._select(newValues);
 	}
-	protected _toggleChildren(option: I) {
+	protected _toggleChildren(option: O) {
 		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -123,9 +123,9 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 		}
 		const allChildren = option.allChildren.map(i => i.value);
 		const values = <T[]>this._value || [];
+		const parentSelected = values.some(v => JSON.stringify(v) === JSON.stringify(value));
 		let newValues = this._remove(values, [value]);
 		const allChildrenSelected = allChildren.every(child => values.some(v => JSON.stringify(v) === JSON.stringify(child)));
-		const parentSelected = values.some(v => JSON.stringify(v) === JSON.stringify(value));
 		if (allChildrenSelected && !parentSelected) {
 			newValues = this._remove(newValues, allChildren);
 		} else {

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -1,0 +1,62 @@
+import { ChangeDetectionStrategy, Component, forwardRef, OnDestroy, AfterViewInit, ContentChildren, ViewContainerRef, QueryList } from '@angular/core';
+import { luTransformPopover } from '../../../overlay/index';
+import { ALuPickerPanel } from '../../../input/index';
+import { LuOptionPickerComponent } from '../../../option/index';
+import { ILuTreeOptionPickerPanel } from './tree-option-picker.model';
+import { ILuTreeOptionItem, ALuTreeOptionItem } from '../item';
+import { Observable } from 'rxjs';
+import { switchMap, merge } from 'rxjs/operators';
+
+/**
+* basic option picker panel
+*/
+@Component({
+	selector: 'lu-tree-option-picker',
+	templateUrl: './tree-option-picker.component.html',
+	styleUrls: ['./tree-option-picker.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	animations: [luTransformPopover],
+	exportAs: 'LuTreeOptionPicker',
+	providers: [
+		{
+			provide: ALuPickerPanel,
+			useExisting: forwardRef(() => LuTreeOptionPickerComponent),
+		},
+	]
+})
+export class LuTreeOptionPickerComponent<T = any, I extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>>
+extends LuOptionPickerComponent<T, I>
+implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
+	@ContentChildren(ALuTreeOptionItem, { descendants: true }) set optionsQL(ql: QueryList<I>) {
+		this._optionsQL = ql;
+		this.initOptionItemsObservable();
+	}
+	@ContentChildren(ALuTreeOptionItem, { descendants: true, read: ViewContainerRef }) optionsQLVR: QueryList<ViewContainerRef>;
+	protected set _optionItems$(optionItems$: Observable<I[]>) {
+		// reapply selected when the options change
+		this._subs.add(
+			optionItems$
+			.subscribe(o => this._applySelected())
+		);
+		// subscribe to any option.onSelect
+		const singleFlowSelect$ = optionItems$.pipe(switchMap(
+			items => merge(...items.map(i => i.onSelect))
+		));
+		this._subs.add(
+			singleFlowSelect$
+			.subscribe(option => this._updateValue(option))
+		);
+	}
+	protected _updateValue(option: I) {
+		const value = option.value;
+		if (!this.multiple) {
+			this._select(value);
+			return;
+		}
+		const children = option.childrenOptionItems.map(i => i.value);
+		const values = <T[]>this._value || [];
+		if (values.some(v => JSON.stringify(v) === JSON.stringify(value))) {
+			
+		}
+	}
+}

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -44,19 +44,33 @@ implements ILuTreeOptionPickerPanel<T, I>, OnDestroy, AfterViewInit {
 		));
 		this._subs.add(
 			singleFlowSelect$
-			.subscribe(option => this._updateValue(option))
+			.subscribe(option => this._toggle(option))
 		);
 	}
-	protected _updateValue(option: I) {
+	protected _toggle(option: I) {
 		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);
 			return;
 		}
-		const children = option.childrenOptionItems.map(i => i.value);
+		const allChildren = option.allChildren.map(i => i.value);
 		const values = <T[]>this._value || [];
+		let newValues;
 		if (values.some(v => JSON.stringify(v) === JSON.stringify(value))) {
-			
+			// remove option and its children
+			newValues = this._remove(values, [value, ...allChildren]);
+		} else {
+			// add option and its children
+			newValues = this._add(values, [value, ...allChildren]);
 		}
+		this._select(newValues);
+	}
+	protected _add(values: T[], entries: T[]): T[] {
+		const newEntries = entries.filter(entry => !values.some(v => JSON.stringify(v) === JSON.stringify(entry)));
+		return [...values, ...newEntries];
+	}
+	protected _remove(values: T[], entries: T[]): T[] {
+		const entriesToKeep = values.filter(value => !entries.some(e => JSON.stringify(e) === JSON.stringify(value)));
+		return [...entriesToKeep];
 	}
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.model.ts
@@ -1,0 +1,24 @@
+import { ILuOptionPickerPanel, ALuOptionPicker } from '../../../option/index';
+import { Observable } from 'rxjs';
+import { ILuTreeOptionItem } from '../item/index';
+import { switchMap, merge } from 'rxjs/operators';
+
+export interface ILuTreeOptionPickerPanel<T = any> extends ILuOptionPickerPanel<T> {}
+
+export abstract class ALuTreeOptionPicker<T = any> extends ALuOptionPicker<T> implements ILuOptionPickerPanel<T> {
+	protected set _optionItems$(optionItems$: Observable<ILuTreeOptionItem<T>[]>) {
+		// reapply selected when the options change
+		this._subs.add(
+			optionItems$
+			.subscribe(o => this._applySelected())
+		);
+		// subscribe to any option.onSelect
+		const singleFlow$ = optionItems$.pipe(switchMap(
+			items => merge(...items.map(i => i.onSelect))
+		));
+		this._subs.add(
+			singleFlow$
+			.subscribe((value: T) => this._updateValue(value))
+		);
+	}
+}

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.model.ts
@@ -6,22 +6,5 @@ import { switchMap, merge } from 'rxjs/operators';
 export interface ILuTreeOptionPickerPanel<T = any, I extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>> extends ILuOptionPickerPanel<T, I> {}
 
 export abstract class ALuTreeOptionPicker<T = any, I extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>> extends ALuOptionPicker<T, I> implements ILuTreeOptionPickerPanel<T, I> {
-	protected set _optionItems$(optionItems$: Observable<I[]>) {
-		// reapply selected when the options change
-		this._subs.add(
-			optionItems$
-			.subscribe(o => this._applySelected())
-		);
-		// subscribe to any option.onSelect
-		const singleFlowSelect$ = optionItems$.pipe(switchMap(
-			items => merge(...items.map(i => i.onSelect))
-		));
-		this._subs.add(
-			singleFlowSelect$
-			.subscribe(option => this._updateValue(option))
-		);
-	}
-	protected _updateValue(option: I) {
 
-	}
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.model.ts
@@ -3,22 +3,25 @@ import { Observable } from 'rxjs';
 import { ILuTreeOptionItem } from '../item/index';
 import { switchMap, merge } from 'rxjs/operators';
 
-export interface ILuTreeOptionPickerPanel<T = any> extends ILuOptionPickerPanel<T> {}
+export interface ILuTreeOptionPickerPanel<T = any, I extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>> extends ILuOptionPickerPanel<T, I> {}
 
-export abstract class ALuTreeOptionPicker<T = any> extends ALuOptionPicker<T> implements ILuOptionPickerPanel<T> {
-	protected set _optionItems$(optionItems$: Observable<ILuTreeOptionItem<T>[]>) {
+export abstract class ALuTreeOptionPicker<T = any, I extends ILuTreeOptionItem<T> = ILuTreeOptionItem<T>> extends ALuOptionPicker<T, I> implements ILuTreeOptionPickerPanel<T, I> {
+	protected set _optionItems$(optionItems$: Observable<I[]>) {
 		// reapply selected when the options change
 		this._subs.add(
 			optionItems$
 			.subscribe(o => this._applySelected())
 		);
 		// subscribe to any option.onSelect
-		const singleFlow$ = optionItems$.pipe(switchMap(
+		const singleFlowSelect$ = optionItems$.pipe(switchMap(
 			items => merge(...items.map(i => i.onSelect))
 		));
 		this._subs.add(
-			singleFlow$
-			.subscribe((value: T) => this._updateValue(value))
+			singleFlowSelect$
+			.subscribe(option => this._updateValue(option))
 		);
+	}
+	protected _updateValue(option: I) {
+
 	}
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.module.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+
+@NgModule({
+	declarations: [
+	],
+	exports: [
+	],
+})
+export class LuTreeOptionPickerModule {}

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.module.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.module.ts
@@ -1,9 +1,22 @@
 import { NgModule } from '@angular/core';
+import { LuTreeOptionPickerComponent } from './tree-option-picker.component';
+import { CommonModule } from '@angular/common';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { LuScrollModule } from '../../../scroll/index';
+import { A11yModule } from '@angular/cdk/a11y';
 
 @NgModule({
+	imports: [
+		CommonModule,
+		OverlayModule,
+		LuScrollModule,
+		A11yModule,
+	],
 	declarations: [
+		LuTreeOptionPickerComponent,
 	],
 	exports: [
+		LuTreeOptionPickerComponent,
 	],
 })
 export class LuTreeOptionPickerModule {}

--- a/packages/ng/libraries/core/src/lib/tree/option/tree-option.module.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/tree-option.module.ts
@@ -1,12 +1,15 @@
 import { NgModule } from '@angular/core';
 import { LuTreeOptionItemModule } from './item/index';
+import { LuTreeOptionPickerModule } from './picker/index';
 
 @NgModule({
 	imports: [
 		LuTreeOptionItemModule,
+		LuTreeOptionPickerModule,
 	],
 	exports: [
 		LuTreeOptionItemModule,
+		LuTreeOptionPickerModule,
 	],
 })
 export class LuTreeOptionModule {}


### PR DESCRIPTION
- added tree-picker component to handle all the different methods of selection on a tree
- tree-option-item does not preovide a `ALuOptionItem`, so you cant use it in an option picker - i did that so that you dont have a different comportment when you embedded tree options in option picker and in tree picker (in an option picker, selecting a node would only select the node, not all the children too)
