### PR TITLE
department select

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
@@ -1,0 +1,1 @@
+<h1>department-select</h1>

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
@@ -16,8 +16,13 @@
 </div>
 <h2>all in one directive</h2>
 <div class="textfield">
-	<lu-department-select class="textfield-input" [(ngModel)]="collection" multiple></lu-department-select>
+	<lu-department-select class="textfield-input" [(ngModel)]="item"></lu-department-select>
 	<label for="" class="textfield-label">departments select</label>
+</div>
+<code>{{item | json }}</code>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [(ngModel)]="collection" multiple></lu-department-select>
+	<label for="" class="textfield-label">departments select multiple</label>
 </div>
 <code>{{collection | json }}</code>
 

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
@@ -6,6 +6,7 @@
 		<lu-tree-option-picker-advanced>
 			<lu-department-feeder></lu-department-feeder>
 			<lu-tree-option-searcher [searchFn]="searchFn"></lu-tree-option-searcher>
+			<lu-tree-option-pager></lu-tree-option-pager>
 			<lu-tree-option *luForTreeOptions="let option" [tree]="option">
 				<ng-container *luDisplayer="let value">{{ value.name }}</ng-container>
 			</lu-tree-option>

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
@@ -13,5 +13,6 @@
 		</lu-tree-option-picker-advanced>
 	</lu-select>
 	<label for="" class="textfield-label">departments</label>
+	<code>{{collection | json }}</code>
 </div>
 

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
@@ -1,5 +1,5 @@
 <h1>department-select</h1>
-<p>with just the department feeder</p>
+<h2>via tree picker advanced and department feeder</h2>
 <div class="textfield">
 	<lu-select class="textfield-input" [(ngModel)]="collection" multiple>
 		<ng-container *luDisplayer="let values; multiple: true">{{ values.length }} departments selected</ng-container>
@@ -12,7 +12,12 @@
 			</lu-tree-option>
 		</lu-tree-option-picker-advanced>
 	</lu-select>
-	<label for="" class="textfield-label">departments</label>
-	<code>{{collection | json }}</code>
+	<label for="" class="textfield-label">departments feeder</label>
 </div>
+<h2>all in one directive</h2>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [(ngModel)]="collection" multiple></lu-department-select>
+	<label for="" class="textfield-label">departments select</label>
+</div>
+<code>{{collection | json }}</code>
 

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.html
@@ -1,1 +1,16 @@
 <h1>department-select</h1>
+<p>with just the department feeder</p>
+<div class="textfield">
+	<lu-select class="textfield-input" [(ngModel)]="collection" multiple>
+		<ng-container *luDisplayer="let values; multiple: true">{{ values.length }} departments selected</ng-container>
+		<lu-tree-option-picker-advanced>
+			<lu-department-feeder></lu-department-feeder>
+			<lu-tree-option-searcher [searchFn]="searchFn"></lu-tree-option-searcher>
+			<lu-tree-option *luForTreeOptions="let option" [tree]="option">
+				<ng-container *luDisplayer="let value">{{ value.name }}</ng-container>
+			</lu-tree-option>
+		</lu-tree-option-picker-advanced>
+	</lu-select>
+	<label for="" class="textfield-label">departments</label>
+</div>
+

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
@@ -6,6 +6,7 @@ import { Component } from '@angular/core';
 })
 export class DepartmentSelectComponent {
 	collection = [];
+	item;
 	searchFn(o, c) {
 		return o.name.toLowerCase().startsWith(c.toLowerCase());
 	}

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
@@ -5,4 +5,8 @@ import { Component } from '@angular/core';
 	templateUrl: './department-select.component.html'
 })
 export class DepartmentSelectComponent {
+	collection = [];
+	searchFn(o, c) {
+		return o.name.toLowerCase().startsWith(c.toLowerCase());
+	}
 }

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-department-select',
+	templateUrl: './department-select.component.html'
+})
+export class DepartmentSelectComponent {
+}

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 
 @Component({
-	selector: 'lu-department-select',
+	selector: 'lu-department-select-issue',
 	templateUrl: './department-select.component.html'
 })
 export class DepartmentSelectComponent {

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, LOCALE_ID } from '@angular/core';
 
 import { RouterModule } from '@angular/router';
 import { DepartmentSelectComponent } from './department-select.component';
@@ -28,5 +28,9 @@ import { CommonModule } from '@angular/common';
 			{ path: '', component: DepartmentSelectComponent },
 		]),
 	],
+	providers: [
+		{ provide: LOCALE_ID, useValue: 'fr-FR' },
+	]
+
 })
 export class DepartmentSelectModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { DepartmentSelectComponent } from './department-select.component';
+
+// needed to reroute api calls to prisme-proxy
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+
+
+@NgModule({
+	declarations: [
+		DepartmentSelectComponent,
+	],
+	imports: [
+		HttpClientModule,
+		RedirectModule,
+		RouterModule.forChild([
+			{ path: '', component: DepartmentSelectComponent },
+		]),
+	],
+})
+export class DepartmentSelectModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/department-select.module.ts
@@ -7,6 +7,9 @@ import { DepartmentSelectComponent } from './department-select.component';
 import { HttpClientModule } from '@angular/common/http';
 import { RedirectModule } from '../../redirect';
 
+import { FormsModule } from '@angular/forms';
+import { LuSelectModule, LuTreeModule, LuDepartmentModule, LuInputDisplayerModule } from '@lucca-front/ng';
+import { CommonModule } from '@angular/common';
 
 @NgModule({
 	declarations: [
@@ -15,6 +18,12 @@ import { RedirectModule } from '../../redirect';
 	imports: [
 		HttpClientModule,
 		RedirectModule,
+		LuDepartmentModule,
+		LuInputDisplayerModule,
+		LuSelectModule,
+		LuTreeModule,
+		FormsModule,
+		CommonModule,
 		RouterModule.forChild([
 			{ path: '', component: DepartmentSelectComponent },
 		]),

--- a/packages/ng/applications/sandbox/src/app/issues/department-select/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/department-select/index.ts
@@ -1,0 +1,1 @@
+export * from './department-select.module';

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -25,6 +25,7 @@ const routes: Routes = [
 	{ path: 'fix-472', loadChildren: () => import('./fix-472').then(m => m.Fix472Module) },
 	{ path: 'poc-tree', loadChildren: () => import('./poc-tree').then(m => m.PocTreeModule) },
 	{ path: 'tree-picker-advanced', loadChildren: () => import('./tree-picker-advanced').then(m => m.TreePickerAdvancedModule) },
+	{ path: 'department-select', loadChildren: () => import('./department-select').then(m => m.DepartmentSelectModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -26,6 +26,7 @@ const routes: Routes = [
 	{ path: 'poc-tree', loadChildren: () => import('./poc-tree').then(m => m.PocTreeModule) },
 	{ path: 'tree-picker-advanced', loadChildren: () => import('./tree-picker-advanced').then(m => m.TreePickerAdvancedModule) },
 	{ path: 'department-select', loadChildren: () => import('./department-select').then(m => m.DepartmentSelectModule) },
+	{ path: 'split-select', loadChildren: () => import('./split-select').then(m => m.SplitSelectModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -27,6 +27,7 @@ const routes: Routes = [
 	{ path: 'tree-picker-advanced', loadChildren: () => import('./tree-picker-advanced').then(m => m.TreePickerAdvancedModule) },
 	{ path: 'department-select', loadChildren: () => import('./department-select').then(m => m.DepartmentSelectModule) },
 	{ path: 'split-select', loadChildren: () => import('./split-select').then(m => m.SplitSelectModule) },
+	{ path: 'user-select-translate', loadChildren: () => import('./user-select-translate').then(m => m.UserSelectTranslateModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/split-select/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/split-select/index.ts
@@ -1,0 +1,1 @@
+export * from './split-select.module';

--- a/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.component.html
@@ -1,0 +1,24 @@
+<h1>split-select</h1>
+<h2>classic select</h2>
+<div class="textfield">
+	<lu-select class="textfield-input" [(ngModel)]="item">
+		<ng-container *luDisplayer="let value">{{ value.name }}</ng-container>
+		<lu-option-picker>
+			<lu-option [value]="option">{{option.name}}</lu-option>
+		</lu-option-picker>
+		<lu-select-clearer></lu-select-clearer>
+	</lu-select>
+	<label class="textfield-label">select basic</label>
+</div>
+<h2>api select</h2>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments">
+	</lu-api-select>
+	<label class="textfield-label">api select basic</label>
+</div>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments">
+		<ng-container *luDisplayer="let value">{{ value | json }}</ng-container>
+	</lu-api-select>
+	<label class="textfield-label">api select with custom displayer</label>
+</div>

--- a/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.component.html
@@ -12,8 +12,7 @@
 </div>
 <h2>api select</h2>
 <div class="textfield">
-	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments">
-	</lu-api-select>
+	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments"></lu-api-select>
 	<label class="textfield-label">api select basic</label>
 </div>
 <div class="textfield">
@@ -21,4 +20,16 @@
 		<ng-container *luDisplayer="let value">{{ value | json }}</ng-container>
 	</lu-api-select>
 	<label class="textfield-label">api select with custom displayer</label>
+</div>
+<h2>user select</h2>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="item">
+	</lu-user-select>
+	<label class="textfield-label">user select basic</label>
+</div>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="item">
+		<ng-container *luDisplayer="let value">{{ value | json }}</ng-container>
+	</lu-user-select>
+	<label class="textfield-label">user select with custom displayer</label>
 </div>

--- a/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-split-select',
+	templateUrl: './split-select.component.html'
+})
+export class SplitSelectComponent {
+	item = { id: 1, name: 'initial value' };
+	option = { id: 2, name: 'option' };
+}

--- a/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/split-select/split-select.module.ts
@@ -1,0 +1,29 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { SplitSelectComponent } from './split-select.component';
+
+// needed to reroute api calls to prisme-proxy
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { LuModule } from '@lucca-front/ng';
+
+
+@NgModule({
+	declarations: [
+		SplitSelectComponent,
+	],
+	imports: [
+		LuModule,
+		CommonModule,
+		FormsModule,
+		HttpClientModule,
+		RedirectModule,
+		RouterModule.forChild([
+			{ path: '', component: SplitSelectComponent },
+		]),
+	],
+})
+export class SplitSelectModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/index.ts
@@ -1,0 +1,1 @@
+export * from './user-select-translate.module';

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.html
@@ -1,0 +1,1 @@
+<h1>user-select-translate</h1>

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.html
@@ -1,1 +1,13 @@
 <h1>user-select-translate</h1>
+<h2>Single</h2>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="item"></lu-user-select>
+	<label for="" class="textfield-label">user select</label>
+</div>
+<code>{{item | json }}</code>
+<h2>Multiple</h2>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="collection" multiple></lu-user-select>
+	<label for="" class="textfield-label">users select multiple</label>
+</div>
+<code>{{collection | json }}</code>

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.ts
@@ -5,4 +5,6 @@ import { Component } from '@angular/core';
 	templateUrl: './user-select-translate.component.html'
 })
 export class UserSelectTranslateComponent {
+	item;
+	collection = [];
 }

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-user-select-translate',
+	templateUrl: './user-select-translate.component.html'
+})
+export class UserSelectTranslateComponent {
+}

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { NgModule, LOCALE_ID } from '@angular/core';
 
 import { RouterModule } from '@angular/router';
 import { UserSelectTranslateComponent } from './user-select-translate.component';
@@ -6,6 +6,9 @@ import { UserSelectTranslateComponent } from './user-select-translate.component'
 // needed to reroute api calls to prisme-proxy
 import { HttpClientModule } from '@angular/common/http';
 import { RedirectModule } from '../../redirect';
+import { FormsModule } from '@angular/forms';
+import { LuUserModule } from '@lucca-front/ng';
+import { CommonModule } from '@angular/common';
 
 
 @NgModule({
@@ -15,9 +18,15 @@ import { RedirectModule } from '../../redirect';
 	imports: [
 		HttpClientModule,
 		RedirectModule,
+		FormsModule,
+		LuUserModule,
+		CommonModule,
 		RouterModule.forChild([
 			{ path: '', component: UserSelectTranslateComponent },
 		]),
 	],
+	providers: [
+		{ provide: LOCALE_ID, useValue: 'fr-FR' },
+	]
 })
 export class UserSelectTranslateModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-translate/user-select-translate.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { UserSelectTranslateComponent } from './user-select-translate.component';
+
+// needed to reroute api calls to prisme-proxy
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+
+
+@NgModule({
+	declarations: [
+		UserSelectTranslateComponent,
+	],
+	imports: [
+		HttpClientModule,
+		RedirectModule,
+		RouterModule.forChild([
+			{ path: '', component: UserSelectTranslateComponent },
+		]),
+	],
+})
+export class UserSelectTranslateModule {}

--- a/packages/ng/libraries/core/src/lib/api/select/api-select.module.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/api-select.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { LuApiFeederModule } from './feeder/index';
 import { LuApiSearcherModule } from './searcher/index';
 import { LuApiPagerModule } from './pager/index';
-import { LuApiSelectInputModule } from './input/api-select-input.module';
+import { LuApiSelectInputModule } from './input/index';
 
 @NgModule({
 	imports: [

--- a/packages/ng/libraries/core/src/lib/api/select/index.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/index.ts
@@ -2,3 +2,4 @@ export * from './api-select.module';
 export * from './feeder/index';
 export * from './searcher/index';
 export * from './pager/index';
+export * from './input/index';

--- a/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.ts
@@ -15,7 +15,7 @@ import {
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
 import { ILuInputWithPicker, ALuPickerPanel, ALuClearer, ILuClearer, ALuInputDisplayer, ILuInputDisplayer } from '../../../input/index';
-import { ALuSelectInput } from '../../../select/index';
+import { ALuSelectInputComponent } from '../../../select/index';
 import { ILuOptionPickerPanel } from '../../../option/index';
 import { IApiItem } from '../../api.model';
 import { ALuApiPagedSearcherService, LuApiPagedSearcherService } from '../searcher/index';
@@ -38,17 +38,8 @@ import { ALuApiPagedSearcherService, LuApiPagedSearcherService } from '../search
 	],
 })
 export class LuApiSelectInputComponent<T extends IApiItem = IApiItem, P extends ILuOptionPickerPanel<T> = ILuOptionPickerPanel<T>>
-extends ALuSelectInput<T, P>
+extends ALuSelectInputComponent<T, P>
 implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
-	@ViewChild('display', { read: ViewContainerRef, static: true }) protected set _vcDisplayContainer(vcr: ViewContainerRef) {
-		this.displayContainer = vcr;
-	}
-	@HostBinding('tabindex') tabindex = 0;
-	@HostBinding('class.mod-multiple')
-	get modMultiple() { return this._multiple; }
-	@HostBinding('class.mod-multipleView')
-	get modMultipleView() { return this.useMultipleViews(); }
-	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 
 	@Input() set api(api: string) { this._service.api = api; }
 	@Input() set fields(fields: string) { this._service.fields = fields; }
@@ -56,15 +47,6 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	@Input() set orderBy(orderBy: string) { this._service.orderBy = orderBy; }
 	@Input() set transformFn(transformFn: (item: any) => T) { this._service.transformFn = transformFn; }
 
-	@Input('multiple') set inputMultiple(m: boolean | string) {
-		if (m === '') {
-			// allows to have multiple = true when writing
-			// <lu-api-select multiple>
-			this.multiple = true;
-		} else {
-			this.multiple = !!m;
-		}
-	}
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,
@@ -81,55 +63,19 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 			_renderer,
 		);
 	}
-	// @HostBinding('attr.disabled')
-	// get isDisabled() { return this.disabled; }
-	@HostBinding('class.is-focused')
-	get isFocused() { return this._popoverOpen; }
 	/**
 	 * popover trigger class extension
 	 */
 	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: P) {
+		if (!picker) { return; }
 		this._picker = picker;
 	}
-	@ViewChild(ALuClearer, { static: true }) set _contentChildClearer(clearer: ILuClearer) {
+	@ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
+		if (!clearer) { return; }
 		this._clearer = clearer;
 	}
-	@ViewChild(ALuInputDisplayer, { static: true }) set _contentChildDisplayer(displayer: ILuInputDisplayer<T>) {
+	@ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<T>) {
+		if (!displayer) { return; }
 		this.displayer = displayer;
-	}
-	/**
-	 * bind to dom events
-	 */
-	@HostListener('click')
-	onClick() {
-		super.onClick();
-	}
-	@HostListener('mouseenter')
-	onMouseEnter() {
-		super.onMouseEnter();
-	}
-	@HostListener('mouseleave')
-	onMouseLeave() {
-		super.onMouseLeave();
-	}
-	@HostListener('focus')
-	onFocus() {
-		super.onFocus();
-	}
-	@HostListener('blur')
-	onBlur() {
-		super.onBlur();
-	}
-	@HostListener('keydown.space', ['$event'])
-	@HostListener('keydown.enter', ['$event'])
-	onKeydown($event: KeyboardEvent) {
-		this.openPopover();
-		$event.stopPropagation();
-		$event.preventDefault();
-	}
-	ngAfterContentInit() {
-		this._isContentInitialized = true;
-		this.render();
-		this._picker.setValue(this.value);
 	}
 }

--- a/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/input/api-select-input.component.ts
@@ -63,9 +63,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 			_renderer,
 		);
 	}
-	/**
-	 * popover trigger class extension
-	 */
+
 	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: P) {
 		if (!picker) { return; }
 		this._picker = picker;

--- a/packages/ng/libraries/core/src/lib/api/select/input/index.ts
+++ b/packages/ng/libraries/core/src/lib/api/select/input/index.ts
@@ -1,2 +1,2 @@
-export * from './api-select.module';
-export * from './api-select.component';
+export * from './api-select-input.module';
+export * from './api-select-input.component';

--- a/packages/ng/libraries/core/src/lib/department/department.model.ts
+++ b/packages/ng/libraries/core/src/lib/department/department.model.ts
@@ -1,0 +1,3 @@
+import { IApiItem } from '../api/index';
+
+export interface ILuDepartment extends IApiItem {}

--- a/packages/ng/libraries/core/src/lib/department/department.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/department.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { LuDepartmentSelectModule } from './select/index';
+
+@NgModule({
+	imports: [
+		LuDepartmentSelectModule,
+	],
+	exports: [
+		LuDepartmentSelectModule,
+	],
+})
+export class LuDepartmentModule {}

--- a/packages/ng/libraries/core/src/lib/department/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/index.ts
@@ -1,0 +1,4 @@
+export * from './department.model';
+export * from './department.module';
+
+export * from './select/index';

--- a/packages/ng/libraries/core/src/lib/department/select/department-select.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/department-select.module.ts
@@ -1,12 +1,15 @@
 import { NgModule } from '@angular/core';
 import { LuDepartmentFeederModule } from './feeder/index';
+import { LuDepartmentSelectInputModule } from './input/index';
 
 @NgModule({
 	imports: [
 		LuDepartmentFeederModule,
+		LuDepartmentSelectInputModule,
 	],
 	exports: [
 		LuDepartmentFeederModule,
+		LuDepartmentSelectInputModule,
 	],
 })
 export class LuDepartmentSelectModule {}

--- a/packages/ng/libraries/core/src/lib/department/select/department-select.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/department-select.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+
+@NgModule({
+	imports: [
+	],
+	exports: [
+	],
+})
+export class LuDepartmentSelectModule {}

--- a/packages/ng/libraries/core/src/lib/department/select/department-select.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/department-select.module.ts
@@ -1,9 +1,12 @@
 import { NgModule } from '@angular/core';
+import { LuDepartmentFeederModule } from './feeder/index';
 
 @NgModule({
 	imports: [
+		LuDepartmentFeederModule,
 	],
 	exports: [
+		LuDepartmentFeederModule,
 	],
 })
 export class LuDepartmentSelectModule {}

--- a/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.component.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, forwardRef, Input, Optional, SkipSelf, Inject, Self } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ALuDepartmentFeederService, ILuDepartmentFeederService } from './department-feeder.model';
+import { LuDepartmentFeederService } from './department-feeder.service';
+import { ALuTreeOptionOperator, ILuTreeOptionOperator, ILuTree } from '../../../tree/index';
+import { ILuDepartment } from '../../department.model';
+import { ALuOnOpenSubscriber, ILuOnOpenSubscriber } from '../../../option/index';
+
+@Component({
+	selector: 'lu-department-feeder',
+	template: '',
+	styleUrls: [],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuTreeOptionOperator,
+			useExisting: forwardRef(() => LuDepartmentFeederComponent),
+			multi: true,
+		},
+		{
+			provide: ALuDepartmentFeederService,
+			useClass: LuDepartmentFeederService,
+		},
+		{
+			provide: ALuOnOpenSubscriber,
+			useExisting: forwardRef(() => LuDepartmentFeederComponent),
+			multi: true,
+		},
+	],
+})
+export class LuDepartmentFeederComponent extends ALuTreeOptionOperator<ILuDepartment>
+implements ILuTreeOptionOperator<ILuDepartment>, ILuOnOpenSubscriber {
+	outOptions$ = new BehaviorSubject<ILuTree<ILuDepartment>[]>([]);
+	protected _service: ILuDepartmentFeederService;
+	constructor(
+		@Inject(ALuDepartmentFeederService) @Optional() @SkipSelf() hostService: ILuDepartmentFeederService,
+		@Inject(ALuDepartmentFeederService) @Self() selfService: ILuDepartmentFeederService,
+	) {
+		super();
+		this._service = hostService || selfService;
+	}
+	onOpen() {
+		this._service.getTrees().subscribe(trees => this.outOptions$.next(trees))
+	}
+}

--- a/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.component.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, forwardRef, Input, Optional, SkipSelf, Inject, Self } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { Observable, Subject } from 'rxjs';
 import { ALuDepartmentFeederService, ILuDepartmentFeederService } from './department-feeder.model';
 import { LuDepartmentFeederService } from './department-feeder.service';
 import { ALuTreeOptionOperator, ILuTreeOptionOperator, ILuTree } from '../../../tree/index';
@@ -30,7 +30,8 @@ import { ALuOnOpenSubscriber, ILuOnOpenSubscriber } from '../../../option/index'
 })
 export class LuDepartmentFeederComponent extends ALuTreeOptionOperator<ILuDepartment>
 implements ILuTreeOptionOperator<ILuDepartment>, ILuOnOpenSubscriber {
-	outOptions$ = new BehaviorSubject<ILuTree<ILuDepartment>[]>([]);
+	outOptions$: Observable<ILuTree<ILuDepartment>[]>;
+	protected _out$ = new Subject<ILuTree<ILuDepartment>[]>();
 	protected _service: ILuDepartmentFeederService;
 	constructor(
 		@Inject(ALuDepartmentFeederService) @Optional() @SkipSelf() hostService: ILuDepartmentFeederService,
@@ -38,8 +39,9 @@ implements ILuTreeOptionOperator<ILuDepartment>, ILuOnOpenSubscriber {
 	) {
 		super();
 		this._service = hostService || selfService;
+		this.outOptions$ = this._out$.asObservable();
 	}
 	onOpen() {
-		this._service.getTrees().subscribe(trees => this.outOptions$.next(trees))
+		this._service.getTrees().subscribe(trees => this._out$.next(trees));
 	}
 }

--- a/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.model.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.model.ts
@@ -1,0 +1,10 @@
+import { ILuTree } from '../../../tree/index';
+import { ILuDepartment } from '../../department.model';
+import { Observable } from 'rxjs';
+
+export interface ILuDepartmentFeederService {
+	getTrees(): Observable<ILuTree<ILuDepartment>[]>;
+}
+export abstract class ALuDepartmentFeederService implements ILuDepartmentFeederService {
+	abstract getTrees(): Observable<ILuTree<ILuDepartment>[]>;
+}

--- a/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { LuDepartmentFeederComponent } from './department-feeder.component';
+
+@NgModule({
+	imports: [
+		HttpClientModule,
+	],
+	declarations: [
+		LuDepartmentFeederComponent,
+	],
+	exports: [
+		LuDepartmentFeederComponent,
+	],
+})
+export class LuDepartmentFeederModule {}

--- a/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.service.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/feeder/department-feeder.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { ALuDepartmentFeederService, ILuDepartmentFeederService } from './department-feeder.model';
+import { map } from 'rxjs/operators';
+import { ILuTree } from '../../../tree/index';
+import { ILuDepartment } from '../../department.model';
+
+@Injectable()
+export class LuDepartmentFeederService extends ALuDepartmentFeederService implements ILuDepartmentFeederService {
+	constructor(protected _http: HttpClient) { super(); }
+	getTrees() {
+		return this._http.get('/api/v3/departments/tree?fields=id,name').pipe(
+			map((response: any): ILuTree<ILuDepartment>[] => {
+				const tree = response.data;
+				return tree.children.map(c => this.format(c));
+			})
+		);
+	}
+	private format(t): ILuTree<ILuDepartment> {
+		return { value: t.node, children: t.children.map(c => this.format(c)) };
+	}
+}

--- a/packages/ng/libraries/core/src/lib/department/select/feeder/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/feeder/index.ts
@@ -1,0 +1,2 @@
+export * from './department-feeder.model';
+export * from './department-feeder.module';

--- a/packages/ng/libraries/core/src/lib/department/select/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/index.ts
@@ -1,0 +1,1 @@
+export * from './department-select.module';

--- a/packages/ng/libraries/core/src/lib/department/select/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/index.ts
@@ -1,2 +1,3 @@
 export * from './department-select.module';
 export * from './feeder/index';
+export * from './input/index';

--- a/packages/ng/libraries/core/src/lib/department/select/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/index.ts
@@ -1,1 +1,2 @@
 export * from './department-select.module';
+export * from './feeder/index';

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.html
@@ -1,0 +1,18 @@
+<div class="lu-select-placeholder">{{placeholder}}</div>
+<div class="lu-select-value">
+	<div class="lu-select-display-wrapper">
+		<ng-container #display></ng-container>
+	</div>
+</div>
+<div class="lu-select-suffix">
+	<lu-select-clearer></lu-select-clearer>
+</div>
+<span [class.chip]="multiple" *luDisplayer="let option">{{option.name}}</span>
+<lu-tree-option-picker-advanced>
+	<lu-department-feeder></lu-department-feeder>
+	<lu-tree-option-searcher [searchFn]="searchFn"></lu-tree-option-searcher>
+	<lu-tree-option-pager></lu-tree-option-pager>
+	<lu-tree-option *luForTreeOptions="let option" [tree]="option">
+		<ng-container *luDisplayer="let value">{{ value.name }}</ng-container>
+	</lu-tree-option>
+</lu-tree-option-picker-advanced>

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.html
@@ -7,7 +7,12 @@
 <div class="lu-select-suffix">
 	<lu-select-clearer></lu-select-clearer>
 </div>
-<span [class.chip]="multiple" *luDisplayer="let option">{{option.name}}</span>
+
+<ng-template luDisplayer [luDisplayerMultiple]="true" let-values>
+	<span *ngIf="multiple && values?.length > 1; else: singleView"><span class="label">{{values.length}}</span> {{intl.departments}}</span>
+	<ng-template #singleView>{{(values[0] || values).name}}</ng-template>
+</ng-template>
+
 <lu-tree-option-picker-advanced>
 	<lu-department-feeder></lu-department-feeder>
 	<lu-tree-option-searcher [searchFn]="searchFn"></lu-tree-option-searcher>

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.scss
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.scss
@@ -1,0 +1,6 @@
+@import '_definitions';
+@include selectInputStyle;
+
+.lu-select-value {
+	padding-right: 2.5rem;
+}

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.ts
@@ -7,7 +7,8 @@ import {
 	ElementRef,
 	ViewChild,
 	Renderer2,
-	AfterContentInit
+	AfterContentInit,
+	Inject
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -15,6 +16,8 @@ import { ILuInputWithPicker, ALuPickerPanel, ALuClearer, ILuClearer, ALuInputDis
 import { ALuSelectInputComponent } from '../../../select/index';
 import { ILuOptionPickerPanel } from '../../../option/index';
 import { ILuDepartment } from '../../department.model';
+import { LuDepartmentSelectInputIntl } from './department-select-input.intl';
+import { ILuDepartmentSelectInputLabel } from './department-select-input.translate';
 
 @Component({
 	selector: 'lu-department-select',
@@ -39,6 +42,7 @@ implements ControlValueAccessor, ILuInputWithPicker<D>, AfterContentInit {
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
 		protected _renderer: Renderer2,
+		@Inject(LuDepartmentSelectInputIntl) public intl: ILuDepartmentSelectInputLabel,
 	) {
 		super(
 			_changeDetectorRef,

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.component.ts
@@ -1,0 +1,68 @@
+import {
+	ChangeDetectionStrategy,
+	Component,
+	ChangeDetectorRef,
+	forwardRef,
+	ViewContainerRef,
+	ElementRef,
+	ViewChild,
+	Renderer2,
+	AfterContentInit
+} from '@angular/core';
+import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
+import { Overlay } from '@angular/cdk/overlay';
+import { ILuInputWithPicker, ALuPickerPanel, ALuClearer, ILuClearer, ALuInputDisplayer, ILuInputDisplayer } from '../../../input/index';
+import { ALuSelectInputComponent } from '../../../select/index';
+import { ILuOptionPickerPanel } from '../../../option/index';
+import { ILuDepartment } from '../../department.model';
+
+@Component({
+	selector: 'lu-department-select',
+	templateUrl: './department-select-input.component.html',
+	styleUrls: ['./department-select-input.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => LuDepartmentSelectInputComponent),
+			multi: true,
+		},
+	],
+})
+export class LuDepartmentSelectInputComponent<D extends ILuDepartment = ILuDepartment, P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>>
+extends ALuSelectInputComponent<D, P>
+implements ControlValueAccessor, ILuInputWithPicker<D>, AfterContentInit {
+
+	constructor(
+		protected _changeDetectorRef: ChangeDetectorRef,
+		protected _overlay: Overlay,
+		protected _elementRef: ElementRef,
+		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
+	) {
+		super(
+			_changeDetectorRef,
+			_overlay,
+			_elementRef,
+			_viewContainerRef,
+			_renderer,
+		);
+	}
+
+	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: P) {
+		if (!picker) { return; }
+		this._picker = picker;
+	}
+	@ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
+		if (!clearer) { return; }
+		this._clearer = clearer;
+	}
+	@ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<D>) {
+		if (!displayer) { return; }
+		this.displayer = displayer;
+	}
+
+	searchFn(o, c) {
+		return o.name.toLowerCase().startsWith(c.toLowerCase());
+	}
+}

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.intl.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.intl.ts
@@ -1,0 +1,11 @@
+import { Injectable, LOCALE_ID, Inject } from '@angular/core';
+import { LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS } from './department-select-input.token';
+import { ILuDepartmentSelectInputLabel } from './department-select-input.translate';
+import { ALuIntl } from '../../../translate/index';
+
+@Injectable()
+export class LuDepartmentSelectInputIntl extends ALuIntl<ILuDepartmentSelectInputLabel> {
+	constructor(@Inject(LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS) translations, @Inject(LOCALE_ID) locale) {
+		super(translations, locale);
+	}
+}

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { LuDepartmentSelectInputComponent } from './department-select-input.component';
+import { CommonModule } from '@angular/common';
+import { LuSelectClearerModule } from '../../../select/index';
+import { LuInputDisplayerModule } from '../../../input/index';
+import { LuTreeOptionPickerModule, LuTreeOptionPagerModule, LuTreeOptionSearcherModule, LuTreeOptionItemModule, LuForTreeOptionsModule } from '../../../tree/index';
+import { LuDepartmentFeederModule } from '../feeder/index';
+
+@NgModule({
+	imports: [
+		CommonModule,
+		LuSelectClearerModule,
+		LuInputDisplayerModule,
+		LuTreeOptionPickerModule,
+		LuTreeOptionPagerModule,
+		LuTreeOptionSearcherModule,
+		LuTreeOptionItemModule,
+		LuForTreeOptionsModule,
+		LuDepartmentFeederModule,
+	],
+	declarations: [
+		LuDepartmentSelectInputComponent,
+	],
+	exports: [
+		LuDepartmentSelectInputComponent,
+	],
+})
+export class LuDepartmentSelectInputModule {}

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.module.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.module.ts
@@ -5,6 +5,9 @@ import { LuSelectClearerModule } from '../../../select/index';
 import { LuInputDisplayerModule } from '../../../input/index';
 import { LuTreeOptionPickerModule, LuTreeOptionPagerModule, LuTreeOptionSearcherModule, LuTreeOptionItemModule, LuForTreeOptionsModule } from '../../../tree/index';
 import { LuDepartmentFeederModule } from '../feeder/index';
+import { LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS } from './department-select-input.token';
+import { luDepartmentSelectInputTranslations } from './department-select-input.translate';
+import { LuDepartmentSelectInputIntl } from './department-select-input.intl';
 
 @NgModule({
 	imports: [
@@ -23,6 +26,10 @@ import { LuDepartmentFeederModule } from '../feeder/index';
 	],
 	exports: [
 		LuDepartmentSelectInputComponent,
+	],
+	providers: [
+		{ provide: LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS, useValue: luDepartmentSelectInputTranslations },
+		LuDepartmentSelectInputIntl,
 	],
 })
 export class LuDepartmentSelectInputModule {}

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.token.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS = new InjectionToken('LuDepartmentSelectTranslationsTranslations');

--- a/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.translate.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/department-select-input.translate.ts
@@ -1,0 +1,17 @@
+import { ILuTranslation } from '../../../translate/index';
+
+export interface ILuDepartmentSelectInputLabel {
+	departments: string;
+}
+export abstract class ALuDepartmentSelectInputLabel {
+	departments: string;
+}
+
+export const luDepartmentSelectInputTranslations = {
+	en: {
+		departments: 'departments',
+	},
+	fr: {
+		departments: 'départements',
+	},
+} as ILuTranslation<ILuDepartmentSelectInputLabel>;

--- a/packages/ng/libraries/core/src/lib/department/select/input/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/index.ts
@@ -1,0 +1,2 @@
+export * from './department-select-input.module';
+export * from './department-select-input.component';

--- a/packages/ng/libraries/core/src/lib/department/select/input/index.ts
+++ b/packages/ng/libraries/core/src/lib/department/select/input/index.ts
@@ -1,2 +1,4 @@
 export * from './department-select-input.module';
 export * from './department-select-input.component';
+export * from './department-select-input.token';
+export * from './department-select-input.translate';

--- a/packages/ng/libraries/core/src/lib/index.ts
+++ b/packages/ng/libraries/core/src/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './animation/index';
 export * from './api/index';
+export * from './department/index';
 export * from './input/index';
 export * from './number/index';
 export * from './option/index';

--- a/packages/ng/libraries/core/src/lib/module.ts
+++ b/packages/ng/libraries/core/src/lib/module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { LuApiModule } from './api/index';
+import { LuDepartmentModule } from './department/index';
 import { LuInputModule } from './input/index';
 import { LuNumberModule } from './number/index';
 import { LuOptionModule } from './option/index';
@@ -13,6 +14,7 @@ import { LuTreeModule } from './tree/index';
 @NgModule({
 	imports: [
 		LuApiModule,
+		LuDepartmentModule,
 		LuInputModule,
 		LuNumberModule,
 		LuOptionModule,
@@ -25,6 +27,7 @@ import { LuTreeModule } from './tree/index';
 	],
 	exports: [
 		LuApiModule,
+		LuDepartmentModule,
 		LuInputModule,
 		LuNumberModule,
 		LuOptionModule,

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.ts
@@ -19,7 +19,7 @@ import { luTransformPopover } from '../../overlay/index';
 import { ILuOptionItem, ALuOptionItem } from '../item/index';
 import { ILuOptionPickerPanel, ALuOptionPicker } from './option-picker.model';
 import { merge, of } from 'rxjs';
-import { map, delay } from 'rxjs/operators';
+import { map, delay, share } from 'rxjs/operators';
 import { ALuPickerPanel } from '../../input/index';
 import { UP_ARROW, DOWN_ARROW, ENTER } from '@angular/cdk/keycodes';
 
@@ -110,7 +110,7 @@ implements ILuOptionPickerPanel<T, O>, OnDestroy {
 		this._applyHighlight(true);
 	}
 	protected _initHighlight() {
-		this._subs.add(this._optionItems$.subscribe(options => {
+		this._subs.add(this._options$.subscribe(options => {
 			const optionCount = options.length;
 			const newHighlight =  Math.max(Math.min(this.highlightIndex, optionCount - 1), -1);
 			if (newHighlight !== this.highlightIndex) {
@@ -173,7 +173,7 @@ implements ILuOptionPickerPanel<T, O>, OnDestroy {
 		}
 	}
 	protected _initSelected() {
-		this._subs.add(this._optionItems$.subscribe(() => {
+		this._subs.add(this._options$.subscribe(() => {
 			this._applySelected();
 		}));
 	}
@@ -218,9 +218,10 @@ implements ILuOptionPickerPanel<T, O>, OnDestroy {
 			.pipe(
 				map<QueryList<O>, O[]>(q => q.toArray()),
 				delay(0),
+				share(),
 			);
 		items$.subscribe(o => this._options = o || []);
-		this._optionItems$ = items$;
+		this._options$ = items$;
 		this._initHighlight();
 		this._initSelected();
 	}

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.model.ts
@@ -4,9 +4,9 @@ import { switchMap } from 'rxjs/operators';
 import { ILuOptionItem } from '../item/index';
 import { ESCAPE, TAB } from '@angular/cdk/keycodes';
 
-export interface ILuOptionPickerPanel<T = any, I extends ILuOptionItem<T> = ILuOptionItem<T>> extends ILuPickerPanel<T> {}
+export interface ILuOptionPickerPanel<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>> extends ILuPickerPanel<T> {}
 
-export abstract class ALuOptionPicker<T = any, I extends ILuOptionItem<T> = ILuOptionItem<T>> extends ALuPickerPanel<T> implements ILuOptionPickerPanel<T, I> {
+export abstract class ALuOptionPicker<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>> extends ALuPickerPanel<T> implements ILuOptionPickerPanel<T, O> {
 	protected _subs = new Subscription();
 	onSelectValue: Observable<T | T[]>;
 	protected _value: T | T[];
@@ -14,21 +14,24 @@ export abstract class ALuOptionPicker<T = any, I extends ILuOptionItem<T> = ILuO
 		this._value = value;
 		this._applySelected();
 	}
-	protected set _optionItems$(optionItems$: Observable<I[]>) {
+	private __options$: Observable<O[]>;
+	protected get _options$() { return this.__options$; }
+	protected set _options$(options$: Observable<O[]>) {
+		this.__options$ = options$;
 		// reapply selected when the options change
 		this._subs.add(
-			optionItems$
+			options$
 			.subscribe(o => this._applySelected())
 		);
 		// subscribe to any option.onSelect
-		const singleFlow$ = optionItems$.pipe(switchMap(
+		const singleFlow$ = options$.pipe(switchMap(
 			items => merge(...items.map(i => i.onSelect))
 		));
 		this._subs.add(
 			singleFlow$.subscribe(option => this._toggle(option))
 		);
 	}
-	protected _toggle(option: I) {
+	protected _toggle(option: O) {
 		const value = option.value;
 		if (!this.multiple) {
 			this._select(value);

--- a/packages/ng/libraries/core/src/lib/overlay/modal/index.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/index.ts
@@ -4,3 +4,4 @@ export * from './modal-ref.model';
 // export * from './modal-ref.factory';
 export * from './modal.service';
 export * from './modal.token';
+export * from './modal.translate';

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -76,10 +76,12 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	 * popover trigger class extension
 	 */
 	@ContentChild(ALuPickerPanel, { static: true }) set _contentChildPicker(picker: P) {
+		if (!picker) { return; }
 		this._picker = picker;
 	}
 
 	@ContentChild(ALuInputDisplayer, { static: true }) set _contentChildDisplayer(displayer: ILuInputDisplayer<T>) {
+		if (!displayer) { return; }
 		this.displayer = displayer;
 	}
 
@@ -140,6 +142,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 })
 export class LuSelectInputComponent<T = any, P extends ILuPickerPanel<T> = ILuPickerPanel<T>> extends ALuSelectInputComponent<T, P> {
 	@ContentChild(ALuClearer, { static: true }) set _contentChildClearer(clearer: ILuClearer) {
+		if (!clearer) { return; }
 		this._clearer = clearer;
 	}
 

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -28,23 +28,7 @@ import {
 } from '../../input/index';
 import { ALuSelectInput } from './select-input.model';
 
-/**
-* Displays user'picture or a placeholder with his/her initials and random bg color'
-*/
-@Component({
-	selector: 'lu-select',
-	templateUrl: './select-input.component.html',
-	styleUrls: ['./select-input.component.scss'],
-	changeDetection: ChangeDetectionStrategy.OnPush,
-	providers: [
-		{
-			provide: NG_VALUE_ACCESSOR,
-			useExisting: forwardRef(() => LuSelectInputComponent),
-			multi: true,
-		},
-	],
-})
-export class LuSelectInputComponent<T = any, P extends ILuPickerPanel<T> = ILuPickerPanel<T>>
+export abstract class ALuSelectInputComponent<T = any, P extends ILuPickerPanel<T> = ILuPickerPanel<T>>
 extends ALuSelectInput<T, P>
 implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	@ViewChild('display', { read: ViewContainerRef, static: true }) protected set _vcDisplayContainer(vcr: ViewContainerRef) {
@@ -64,11 +48,11 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 		}
 	}
 	constructor(
-		protected _renderer: Renderer2,
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
 	) {
 		super(
 			_changeDetectorRef,
@@ -82,21 +66,19 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	get isDisabled() { return this.disabled; }
 	@HostBinding('class.is-focused')
 	get isFocused() { return this._popoverOpen; }
-	@HostBinding('class.is-clearable')
-	get isClearable() { return !!this.clearerEltRef; }
 	@HostBinding('class.mod-multiple')
 	get modMultiple() { return this._multiple; }
 	@HostBinding('class.mod-multipleView')
 	get modMultipleView() { return this.useMultipleViews(); }
+	@HostBinding('class.is-clearable')
+	get isClearable() { return !!this._clearer; }
 	/**
 	 * popover trigger class extension
 	 */
 	@ContentChild(ALuPickerPanel, { static: true }) set _contentChildPicker(picker: P) {
 		this._picker = picker;
 	}
-	@ContentChild(ALuClearer, { static: true }) set _contentChildClearer(clearer: ILuClearer) {
-		this._clearer = clearer;
-	}
+
 	@ContentChild(ALuInputDisplayer, { static: true }) set _contentChildDisplayer(displayer: ILuInputDisplayer<T>) {
 		this.displayer = displayer;
 	}
@@ -133,10 +115,49 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	ngAfterContentInit() {
 		this._isContentInitialized = true;
 		this.render();
-		this.displayClearer();
 		this._picker.setValue(this.value);
 	}
 
+
+}
+
+
+/**
+* select input
+*/
+@Component({
+	selector: 'lu-select',
+	templateUrl: './select-input.component.html',
+	styleUrls: ['./select-input.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => LuSelectInputComponent),
+			multi: true,
+		},
+	],
+})
+export class LuSelectInputComponent<T = any, P extends ILuPickerPanel<T> = ILuPickerPanel<T>> extends ALuSelectInputComponent<T, P> {
+	@ContentChild(ALuClearer, { static: true }) set _contentChildClearer(clearer: ILuClearer) {
+		this._clearer = clearer;
+	}
+
+	constructor(
+		protected _changeDetectorRef: ChangeDetectorRef,
+		protected _overlay: Overlay,
+		protected _elementRef: ElementRef,
+		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
+	) {
+		super(
+			_changeDetectorRef,
+			_overlay,
+			_elementRef,
+			_viewContainerRef,
+			_renderer,
+		);
+	}
 	// display clearer
 	@ContentChild(ALuClearer, { read: ElementRef, static: true }) clearerEltRef: ElementRef;
 	@ViewChild('suffix', { read: ElementRef, static: true }) suffixEltRef: ElementRef;
@@ -144,5 +165,10 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 		if (!!this.clearerEltRef) {
 			this._renderer.appendChild(this.suffixEltRef.nativeElement, this.clearerEltRef.nativeElement);
 		}
+	}
+
+	ngAfterContentInit() {
+		super.ngAfterContentInit();
+		this.displayClearer(); // dont keep
 	}
 }

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -68,8 +68,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	get isFocused() { return this._popoverOpen; }
 	@HostBinding('class.mod-multiple')
 	get modMultiple() { return this._multiple; }
-	@HostBinding('class.mod-multipleView')
-	get modMultipleView() { return this.useMultipleViews(); }
+
 	@HostBinding('class.is-clearable')
 	get isClearable() { return !!this._clearer; }
 	/**
@@ -145,7 +144,8 @@ export class LuSelectInputComponent<T = any, P extends ILuPickerPanel<T> = ILuPi
 		if (!clearer) { return; }
 		this._clearer = clearer;
 	}
-
+	@HostBinding('class.mod-multipleView')
+	get modMultipleView() { return this.useMultipleViews(); }
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,

--- a/packages/ng/libraries/core/src/lib/tree/option/index.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/index.ts
@@ -1,4 +1,5 @@
 export * from './item/index';
 export * from './picker/index';
 export * from './operator/index';
+
 export * from './tree-option.module';

--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.model.ts
@@ -12,7 +12,7 @@ export abstract class ALuTreeOptionItem<T = any>extends ALuOptionItem<T> impleme
 	abstract children: this[];
 	get allChildren(): this[] {
 		return this.children
-		.map(c => [c, ...c.children])
+		.map(c => [c, ...c.allChildren])
 		.reduce((aggr, val) => [...aggr, ...val], []);
 	}
 	abstract onSelectSelf: Observable<this>;

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/index.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/index.ts
@@ -3,3 +3,4 @@ export * from './tree-option-operator.module';
 
 export * from './feeder/index';
 export * from './for-tree-options/index';
+export * from './searcher/index';

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/index.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/index.ts
@@ -3,4 +3,5 @@ export * from './tree-option-operator.module';
 
 export * from './feeder/index';
 export * from './for-tree-options/index';
+export * from './pager/index';
 export * from './searcher/index';

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/pager/index.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/pager/index.ts
@@ -1,0 +1,2 @@
+export * from './tree-option-pager.component';
+export * from './tree-option-pager.module';

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.component.ts
@@ -40,6 +40,20 @@ export class LuTreeOptionPagerComponent<T = any> extends ALuTreeOptionOperator<T
 		this.next();
 	}
 	trim(trees: ILuTree<T>[] = [], paging: number = MAGIC_STEP): ILuTree<T>[] {
-		return trees;
+		const flat = this.flatten(trees);
+		const flatTrimmed = flat.slice(0, paging);
+
+		return this.filter(trees, flatTrimmed);
+	}
+	flatten(trees: ILuTree<T>[] = []): T[] {
+		return trees.map(t => [t.value, ...this.flatten(t.children)]).reduce((a, v) => [...a, ...v], []);
+	}
+	filter(trees: ILuTree<T>[] = [], values: T[]): ILuTree<T>[] {
+		return trees.map(t => {
+			if (!values.includes(t.value)) {
+				return undefined;
+			}
+			return { ...t, children: this.filter(t.children, values) }
+		}).filter(t => !!t);
 	}
 }

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.component.ts
@@ -50,7 +50,7 @@ export class LuTreeOptionPagerComponent<T = any> extends ALuTreeOptionOperator<T
 	}
 	filter(trees: ILuTree<T>[] = [], values: T[]): ILuTree<T>[] {
 		return trees.map(t => {
-			if (!values.includes(t.value)) {
+			if (!values.some(v => v === t.value)) {
 				return undefined;
 			}
 			return { ...t, children: this.filter(t.children, values) }

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.component.ts
@@ -1,0 +1,45 @@
+import { ChangeDetectionStrategy, Component, forwardRef } from '@angular/core';
+import { ILuOnScrollBottomSubscriber, ALuOnScrollBottomSubscriber } from '../../../../option/index';
+import { Observable, BehaviorSubject, combineLatest } from 'rxjs';
+import { ALuTreeOptionOperator, ILuTreeOptionOperator } from '../tree-option-operator.model';
+import { ILuTree } from '../../../tree.model';
+const MAGIC_STEP = 10;
+@Component({
+	selector: 'lu-tree-option-pager',
+	template: '',
+	styleUrls: [],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuTreeOptionOperator,
+			useExisting: forwardRef(() => LuTreeOptionPagerComponent),
+			multi: true,
+		},
+		{
+			provide: ALuOnScrollBottomSubscriber,
+			useExisting: forwardRef(() => LuTreeOptionPagerComponent),
+			multi: true,
+		},
+	],
+})
+export class LuTreeOptionPagerComponent<T = any> extends ALuTreeOptionOperator<T> implements ILuTreeOptionOperator<T>, ILuOnScrollBottomSubscriber {
+	set inOptions$(in$: Observable<ILuTree<T>[]>) {
+		this.outOptions$ = combineLatest(
+			in$,
+			this.paging$,
+			(options, paging) => {
+				return this.trim(options, paging);
+			}
+		);
+	}
+	paging$ = new BehaviorSubject<number>(MAGIC_STEP);
+	next() {
+		this.paging$.next(this.paging$.value + MAGIC_STEP);
+	}
+	onScrollBottom() {
+		this.next();
+	}
+	trim(trees: ILuTree<T>[] = [], paging: number = MAGIC_STEP): ILuTree<T>[] {
+		return trees;
+	}
+}

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.module.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/pager/tree-option-pager.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { LuTreeOptionPagerComponent } from './tree-option-pager.component';
+
+@NgModule({
+	imports: [
+	],
+	declarations: [
+		LuTreeOptionPagerComponent,
+	],
+	exports: [
+		LuTreeOptionPagerComponent,
+	],
+})
+export class LuTreeOptionPagerModule {}

--- a/packages/ng/libraries/core/src/lib/tree/option/operator/tree-option-operator.module.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/operator/tree-option-operator.module.ts
@@ -2,16 +2,19 @@ import { NgModule } from '@angular/core';
 import { LuTreeOptionFeederModule } from './feeder/index';
 import { LuForTreeOptionsModule } from './for-tree-options/index';
 import { LuTreeOptionSearcherModule } from './searcher/index';
+import { LuTreeOptionPagerModule } from './pager/index';
 
 @NgModule({
 	imports: [
 		LuTreeOptionFeederModule,
 		LuForTreeOptionsModule,
+		LuTreeOptionPagerModule,
 		LuTreeOptionSearcherModule,
 	],
 	exports: [
 		LuTreeOptionFeederModule,
 		LuForTreeOptionsModule,
+		LuTreeOptionPagerModule,
 		LuTreeOptionSearcherModule,
 	],
 })

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -31,7 +31,7 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy {
 		this.initOptionItemsObservable();
 	}
 	@ContentChildren(ALuTreeOptionItem, { descendants: true, read: ViewContainerRef }) optionsQLVR: QueryList<ViewContainerRef>;
-	protected set _optionItems$(optionItems$: Observable<O[]>) {
+	protected set _options$(optionItems$: Observable<O[]>) {
 		// reapply selected when the options change
 		this._subs.add(
 			optionItems$
@@ -160,7 +160,7 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy {
 				delay(0),
 			);
 		items$.subscribe(o => this._options = o || []);
-		this._optionItems$ = items$;
+		this._options$ = items$;
 	}
 }
 /**

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.ts
@@ -87,7 +87,9 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy {
 		const allChildren = option.allChildren.map(i => i.value);
 		const values = <T[]>this._value || [];
 		let newValues;
-		if (values.some(v => JSON.stringify(v) === JSON.stringify(value))) {
+		const selfSelected = values.some(v => JSON.stringify(v) === JSON.stringify(value));
+		const allChildrenSelected = allChildren.every(child => values.some(v => JSON.stringify(v) === JSON.stringify(child)));
+		if (selfSelected && allChildrenSelected) {
 			// remove option and its children
 			newValues = this._remove(values, [value, ...allChildren]);
 		} else {

--- a/packages/ng/libraries/core/src/lib/user/select/input/index.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/index.ts
@@ -1,2 +1,4 @@
 export * from './user-select-input.component';
 export * from './user-select-input.module';
+export * from './user-select-input.token';
+export * from './user-select-input.translate';

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
@@ -7,7 +7,10 @@
 <div class="lu-select-suffix">
 	<lu-select-clearer></lu-select-clearer>
 </div>
-<span [class.chip]="multiple" *luDisplayer="let user">{{user | luUserDisplay}}</span>
+<ng-template luDisplayer [luDisplayerMultiple]="true" let-values>
+	<span *ngIf="multiple && values?.length > 1; else: singleView"><span class="label">{{values.length}}</span> {{intl.users}}</span>
+	<ng-template #singleView>{{(values[0] || values) | luUserDisplay}}</ng-template>
+</ng-template>
 <lu-option-picker-advanced>
 	<lu-user-paged-searcher></lu-user-paged-searcher>
 	<lu-option *luForOptions="let user" [value]="user">{{ user | luUserDisplay: searchFormat }}</lu-option>

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.ts
@@ -11,7 +11,8 @@ import {
 	Input,
 	Renderer2,
 	HostBinding,
-	AfterContentInit
+	AfterContentInit,
+	Inject
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -21,6 +22,8 @@ import { ALuSelectInputComponent } from '../../../select/index';
 import { ILuOptionPickerPanel } from '../../../option/index';
 import { LuDisplayFullname } from '../../display/index';
 import { ALuUserPagedSearcherService, LuUserPagedSearcherService } from '../searcher/index';
+import { LuUserSelectInputIntl } from './user-select-input.intl';
+import { ILuUserSelectInputLabel } from './user-select-input.translate';
 
 /**
 * Displays user'picture or a placeholder with his/her initials and random bg color'
@@ -62,7 +65,8 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
 		protected _viewContainerRef: ViewContainerRef,
 		protected _renderer: Renderer2,
 		protected _service: ALuUserPagedSearcherService<U>,
-	) {
+		@Inject(LuUserSelectInputIntl) public intl: ILuUserSelectInputLabel,
+		) {
 		super(
 			_changeDetectorRef,
 			_overlay,

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.ts
@@ -17,7 +17,7 @@ import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
 import { ILuInputWithPicker, ALuPickerPanel, ALuClearer, ILuClearer, ILuInputDisplayer, ALuInputDisplayer } from '../../../input/index';
 import { IUser } from '../../user.model';
-import { ALuSelectInput } from '../../../select/index';
+import { ALuSelectInputComponent } from '../../../select/index';
 import { ILuOptionPickerPanel } from '../../../option/index';
 import { LuDisplayFullname } from '../../display/index';
 import { ALuUserPagedSearcherService, LuUserPagedSearcherService } from '../searcher/index';
@@ -43,17 +43,9 @@ import { ALuUserPagedSearcherService, LuUserPagedSearcherService } from '../sear
 	],
 })
 export class LuUserSelectInputComponent<U extends IUser = IUser, P extends ILuOptionPickerPanel<U> = ILuOptionPickerPanel<U>>
-extends ALuSelectInput<U, P>
+extends ALuSelectInputComponent<U, P>
 implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
-	@ViewChild('display', { read: ViewContainerRef, static: true }) protected set _vcDisplayContainer(vcr: ViewContainerRef) {
-		this.displayContainer = vcr;
-	}
 	searchFormat = LuDisplayFullname.lastfirst;
-	@HostBinding('tabindex') tabindex = 0;
-	@HostBinding('class.mod-multiple')
-	get modMultiple() { return this._multiple; }
-	@HostBinding('class.mod-multipleView')
-	get modMultipleView() { return this.useMultipleViews(); }
 
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 	@Input() set fields(fields: string) { this._service.fields = fields; }
@@ -63,15 +55,6 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
 	@Input() set appInstanceId(appInstanceId: number | string) { this._service.appInstanceId = appInstanceId; }
 	@Input() set operations(operations: number[]) { this._service.operations = operations; }
 
-	@Input('multiple') set inputMultiple(m: boolean | string) {
-		if (m === '') {
-			// allows to have multiple = true when writing
-			// <lu-api-select multiple>
-			this.multiple = true;
-		} else {
-			this.multiple = !!m;
-		}
-	}
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,
@@ -88,59 +71,17 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
 			_renderer,
 		);
 	}
-	// @HostBinding('attr.disabled')
-	// get isDisabled() { return this.disabled; }
-	@HostBinding('class.is-focused')
-	get isFocused() { return this._popoverOpen; }
 
-	/**
-	 * popover trigger class extension
-	 */
 	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: P) {
+		if (!picker) { return; }
 		this._picker = picker;
 	}
 	@ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
+		if (!clearer) { return; }
 		this._clearer = clearer;
 	}
 	@ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<U>) {
+		if (!displayer) { return; }
 		this.displayer = displayer;
-		this.render();
 	}
-	/**
-	 * bind to dom events
-	 */
-	@HostListener('click')
-	onClick() {
-		super.onClick();
-	}
-	@HostListener('mouseenter')
-	onMouseEnter() {
-		super.onMouseEnter();
-	}
-	@HostListener('mouseleave')
-	onMouseLeave() {
-		super.onMouseLeave();
-	}
-	@HostListener('focus')
-	onFocus() {
-		super.onFocus();
-	}
-	@HostListener('blur')
-	onBlur() {
-		super.onBlur();
-	}
-	@HostListener('keydown.space', ['$event'])
-	@HostListener('keydown.enter', ['$event'])
-	onKeydown($event: KeyboardEvent) {
-		this.openPopover();
-		$event.stopPropagation();
-		$event.preventDefault();
-	}
-
-	ngAfterContentInit() {
-		this._isContentInitialized = true;
-		this.render();
-		this._picker.setValue(this.value);
-	}
-
 }

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.intl.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.intl.ts
@@ -1,0 +1,11 @@
+import { Injectable, LOCALE_ID, Inject } from '@angular/core';
+import { LU_USER_SELECT_INPUT_TRANSLATIONS } from './user-select-input.token';
+import { ILuUserSelectInputLabel } from './user-select-input.translate';
+import { ALuIntl } from '../../../translate/index';
+
+@Injectable()
+export class LuUserSelectInputIntl extends ALuIntl<ILuUserSelectInputLabel> {
+	constructor(@Inject(LU_USER_SELECT_INPUT_TRANSLATIONS) translations, @Inject(LOCALE_ID) locale) {
+		super(translations, locale);
+	}
+}

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.module.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.module.ts
@@ -6,6 +6,9 @@ import { LuOptionOperatorModule, LuOptionItemModule, LuOptionPickerModule } from
 import { LuSelectClearerModule } from '../../../select/index';
 import { LuUserSearcherModule } from '../searcher/index';
 import { LuInputDisplayerModule } from '../../../input/index';
+import { LU_USER_SELECT_INPUT_TRANSLATIONS } from './user-select-input.token';
+import { luUserSelectInputTranslations } from './user-select-input.translate';
+import { LuUserSelectInputIntl } from './user-select-input.intl';
 
 @NgModule({
 	imports: [
@@ -24,5 +27,9 @@ import { LuInputDisplayerModule } from '../../../input/index';
 	exports: [
 		LuUserSelectInputComponent,
 	],
+	providers: [
+		{ provide: LU_USER_SELECT_INPUT_TRANSLATIONS, useValue: luUserSelectInputTranslations },
+		LuUserSelectInputIntl,
+	]
 })
 export class LuUserSelectInputModule {}

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.token.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_USER_SELECT_INPUT_TRANSLATIONS = new InjectionToken('LuUserSelectTranslationsTranslations');

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.translate.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.translate.ts
@@ -1,0 +1,17 @@
+import { ILuTranslation } from '../../../translate/index';
+
+export interface ILuUserSelectInputLabel {
+	users: string;
+}
+export abstract class ALuUserSelectInputLabel {
+	users: string;
+}
+
+export const luUserSelectInputTranslations = {
+	en: {
+		users: 'users',
+	},
+	fr: {
+		users: 'utilisateurs',
+	},
+} as ILuTranslation<ILuUserSelectInputLabel>;

--- a/packages/ng/libraries/formly/src/lib/formly.config.ts
+++ b/packages/ng/libraries/formly/src/lib/formly.config.ts
@@ -6,6 +6,7 @@ import { LuFormlyFieldTextarea } from './types/textarea';
 import { LuFormlyFieldSelect } from './types/select';
 import { LuFormlyFieldUser } from './types/user';
 import { LuFormlyFieldApi } from './types/api';
+import { LuFormlyFieldDepartment } from './types/department';
 import { LuFormlyFieldRadios } from './types/radios';
 // wrappers
 import { LuFormlyWrapperHelper, TemplateHelper } from './wrappers/helper';
@@ -31,6 +32,7 @@ export const LU_FORMLY_COMPONENTS = [
 	LuFormlyFieldSelect,
 	LuFormlyFieldUser,
 	LuFormlyFieldApi,
+	LuFormlyFieldDepartment,
 	LuFormlyFieldRadios,
 	LuFormlyFieldCheckboxes,
 
@@ -83,6 +85,11 @@ export const LU_FORMLY_CONFIG = {
 		{
 			name: 'api',
 			component: LuFormlyFieldApi,
+			wrappers: ['textfield-layout'],
+		},
+		{
+			name: 'department',
+			component: LuFormlyFieldDepartment,
 			wrappers: ['textfield-layout'],
 		},
 	],

--- a/packages/ng/libraries/formly/src/lib/formly.module.ts
+++ b/packages/ng/libraries/formly/src/lib/formly.module.ts
@@ -13,7 +13,8 @@ import {
 	LuUserSelectModule,
 	LuOptionModule,
 	LuSelectClearerModule,
-	LuApiSelectModule
+	LuApiSelectModule,
+	LuDepartmentSelectModule
 } from '@lucca-front/ng';
 
 @NgModule({
@@ -31,6 +32,7 @@ import {
 		LuUserSelectModule,
 		LuInputModule,
 		LuApiSelectModule,
+		LuDepartmentSelectModule,
 
 		FormlyModule.forChild(LU_FORMLY_CONFIG),
 	],

--- a/packages/ng/libraries/formly/src/lib/types/department.html
+++ b/packages/ng/libraries/formly/src/lib/types/department.html
@@ -1,0 +1,4 @@
+<lu-department-select class="textfield-input" [formControl]="formControl" [formlyAttributes]="field" [multiple]="to.multiple"
+ (focus)="focus()" (blur)="blur()" [placeholder]="to.placeholder">
+</lu-department-select>
+<label [attr.for]="id" class="textfield-label">{{ to.label }}</label>

--- a/packages/ng/libraries/formly/src/lib/types/department.ts
+++ b/packages/ng/libraries/formly/src/lib/types/department.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core';
+import { FieldType } from '@ngx-formly/core';
+
+@Component({
+	selector: 'lu-formly-field-department',
+	styleUrls: ['formly-field.common.scss', 'select.scss'],
+	templateUrl: './department.html',
+})
+export class LuFormlyFieldDepartment extends FieldType {
+	focus() {
+		this.to._isFocused = true;
+	}
+	blur() {
+		this.to._isFocused = false;
+	}
+}


### PR DESCRIPTION
contains
- `department-feeder` tree option operator
- refacto of `ALuSelectInputComponent` and factorisation of code between select, api-select, user-select
- department-select input component
- formly type `department`

still needed
- the style for tree-option-item, and icons for select self and selectchildren
