### PR TITLE
Modal.some.enhancements

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/poc-modal/poc-modal.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/poc-modal/poc-modal.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { LuModal, ALuModalRef, ILuModalContent } from '@lucca-front/ng';
-import { timer, Subject, throwError } from 'rxjs';
-import { mapTo, catchError } from 'rxjs/operators';
+import { timer, Subject, throwError, of } from 'rxjs';
+import { mapTo, catchError, delay } from 'rxjs/operators';
 
 @Component({
 	selector: 'lu-poc-modal',
@@ -20,7 +20,7 @@ export class PocModalComponent {
 		<p>only the content in this injected component</p>
 		<label class="label">{{error}}</label>
 		<div class="textfield">
-			<input class="textfield-input" [(ngModel)]="result">
+			<input class="textfield-input" type="number" [(ngModel)]="result">
 			<label class="textfield-label">result</label>
 		</div>
 		<div class="checkbox">
@@ -32,13 +32,20 @@ export class PocModalComponent {
 export class PocModalInsideComponent implements ILuModalContent {
 	title = 'title of the component';
 	submitLabel = 'submit';
+	cancelLabel = 'dismiss';
 	submitDisabled = false;
 
 	result = 0;
 	error;
 	// submitAction = () => timer(1500).pipe(mapTo(this.result));
 	submitAction = () => {
-		const obs$ = throwError(`error with result ${this.result}`);
+		let obs$;
+		if (this.result % 2 === 0) {
+			obs$ = throwError(`error with result ${this.result}`);
+		} else {
+			obs$ = of(this.result).pipe(delay(2000));
+
+		}
 
 		return obs$.pipe(
 			catchError(err => { this.error = err; return throwError(`error message`); })

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.html
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.html
@@ -10,5 +10,5 @@
 		<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
 	<!-- </ng-template> -->
 	<button *ngIf="submitLabel" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
-	<button class="button mod-link" (click)="dismiss()">{{intl.cancel}}</button>
+	<button class="button mod-link" (click)="dismiss()">{{cancelLabel}}</button>
 </div>

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.ts
@@ -21,7 +21,10 @@ export class LuModalPanelComponent<T extends ILuModalContent = ILuModalContent> 
 		return this._componentInstance.title;
 	}
 	get submitLabel() {
-		return this._componentInstance.submitLabel;
+		return this._componentInstance.submitLabel || this.intl.submit;
+	}
+	get cancelLabel() {
+		return this._componentInstance.cancelLabel || this.intl.cancel;
 	}
 	get submitDisabled() {
 		return this._componentInstance.submitDisabled;

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal.model.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal.model.ts
@@ -6,4 +6,5 @@ export interface ILuModalContent<T = any> extends ILuPopupContent {
 	submitAction?: () => Observable<T>;
 	submitLabel?: string;
 	submitDisabled?: boolean;
+	cancelLabel?: string;
 }

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal.translate.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal.translate.ts
@@ -1,17 +1,21 @@
 import { ILuTranslation } from '../../translate/index';
 
 export interface ILuModalLabel {
+	submit: string;
 	cancel: string;
 }
 export abstract class ALuModalLabel {
+	submit: string;
 	cancel: string;
 }
 
 export const luModalTranslations = {
 	en: {
+		submit: 'Ok',
 		cancel: 'Cancel',
 	},
 	fr: {
+		submit: 'Ok',
 		cancel: 'Annuler',
 	},
 } as ILuTranslation<ILuModalLabel>;

--- a/packages/ng/tsconfig.json
+++ b/packages/ng/tsconfig.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es5",
+    "target": "es2015",
+    "module": "esnext",
     "typeRoots": [
       "node_modules/@types"
     ],


### PR DESCRIPTION
@GuillaumeNury - i did what you said about the labels for the buttons in the modal footer

- there's a default for each one, linked to a trad key so you can override it by providing your own trad
- or you can specify a `submitLabel` and `cancelLabel` for the component you want to inject in the modal
