### PR TITLE
[add] Scroll block and scroll in sidepanel

### DIFF
--- a/packages/ng/libraries/core/src/style/components/_popup.scss
+++ b/packages/ng/libraries/core/src/style/components/_popup.scss
@@ -10,6 +10,14 @@
 	max-height: calc(100vh - 80px);
 	background-color: _component("popup.panel.background-color");
 	border-radius: _theme("commons.border.radius");
+	width: _component("popup.sizes.small");
+	max-width: 100vw;
+
+	@each $panel-size, $size-obj in _getMap("components.popup.sizes") {
+		&.size-#{$panel-size} {
+			width: _component("popup.sizes."+$panel-size);
+		}
+	}
 	animation-name: popupAnimation;
 	animation-duration: 150ms;
 	animation-timing-function: cubic-bezier(0.25, 0.8, 0.25, 1);

--- a/packages/ng/libraries/core/src/style/components/_popup.scss
+++ b/packages/ng/libraries/core/src/style/components/_popup.scss
@@ -1,3 +1,7 @@
+.cdk-global-scrollblock {
+	overflow: hidden;
+}
+
 .cdk-overlay-backdrop.cdk-overlay-backdrop-showing.lu-popup-backdrop {
 	opacity: _component("popup.backdrop.opacity");
 	animation: fadeInBackdrop 100ms ease-out;

--- a/packages/ng/libraries/core/src/style/components/_sidepanel.scss
+++ b/packages/ng/libraries/core/src/style/components/_sidepanel.scss
@@ -1,7 +1,6 @@
 lu-sidepanel-panel {
-	display: flex;
-	flex-direction: column;
-	flex-wrap: nowrap;
+	display: block;
+	overflow: auto;
 	height: 100%;
 }
 
@@ -10,7 +9,7 @@ lu-sidepanel-panel {
 	top: 0;
 	right: 0;
 	bottom: 0;
-	width: _component("sidepanel.sizes.default");
+	width: _component("sidepanel.sizes.medium");
 	max-height: 100vh;
 	border-radius: 0;
 
@@ -23,15 +22,19 @@ lu-sidepanel-panel {
 	}
 }
 
-.lu-sidepanel-header, .lu-sidepanel-footer {
-	flex: 0 0 auto;
+.lu-sidepanel-footer {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	height: _component("sidepanel.footer-height");
+	background-color: _component("popup.panel.background-color");
 }
 
-.lu-sidepanel-content {
-	flex: 1 1 0px;
-	overflow-x: hidden;
-	overflow-y: auto;
+.lu-modal-content.lu-sidepanel-content {
+	padding-bottom: _component("sidepanel.content-padding-bottom")
 }
+
 
 @keyframes sidepanelAnimation {
 	from {

--- a/packages/ng/libraries/core/src/style/theme/_popup.theme.scss
+++ b/packages/ng/libraries/core/src/style/theme/_popup.theme.scss
@@ -19,6 +19,8 @@ $sidePanel: (
 		medium: 45rem,
 		large: 60rem,
 	),
+	footer-height: 50px,
+	content-padding-bottom: 66px
 );
 $theme: _set($theme, 'components.popup', $popup);
 $theme: _set($theme, 'components.sidepanel', $sidePanel);

--- a/packages/ng/libraries/core/src/style/theme/_popup.theme.scss
+++ b/packages/ng/libraries/core/src/style/theme/_popup.theme.scss
@@ -6,15 +6,19 @@ $popup: (
 	panel: (
 		background-color: #fff,
 	),
+	sizes: (
+		small: 25rem,
+		medium: 37rem,
+		large: 60rem,
+	)
 );
 
 $sidePanel: (
 	sizes: (
-		default: 39rem,
-		large: 45rem,
-		larger: 60rem,
-		largest: 80rem,
-	)
+		small: 39rem,
+		medium: 45rem,
+		large: 60rem,
+	),
 );
 $theme: _set($theme, 'components.popup', $popup);
 $theme: _set($theme, 'components.sidepanel', $sidePanel);


### PR DESCRIPTION
Adds sizing for modals/popup
Adds scrollblock from cdk
Changes scroll strategy in the sidepanel where the header scrolls with the content. It avoids craming the scroll between to heavy blocks.