### PR TITLE
Fix modal/sidepanel

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
@@ -1,2 +1,4 @@
 <h1>fix-modal</h1>
-<button class="button" (click)="open()">click me</button>
+<button class="button" (click)="openPopup()">open popup</button>
+<button class="button" (click)="openModal()">open modal</button>
+<button class="button" (click)="openSidepanel()">open sidepanel</button>

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
@@ -1,0 +1,2 @@
+<h1>fix-modal</h1>
+<button class="button" (click)="open()">click me</button>

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
@@ -2,3 +2,5 @@
 <button class="button" (click)="openPopup()">open popup</button>
 <button class="button" (click)="openModal()">open modal</button>
 <button class="button" (click)="openSidepanel()">open sidepanel</button>
+
+<button class="button" (click)="openModal('data')">open modal with data</button>

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.html
@@ -2,5 +2,7 @@
 <button class="button" (click)="openPopup()">open popup</button>
 <button class="button" (click)="openModal()">open modal</button>
 <button class="button" (click)="openSidepanel()">open sidepanel</button>
-
-<button class="button" (click)="openModal('data')">open modal with data</button>
+<br />
+<button class="button" (click)="openPopup('popup')">open popup with data</button>
+<button class="button" (click)="openModal('modal')">open modal with data</button>
+<button class="button" (click)="openSidepanel('sidepanel')">open modal with data</button>

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
@@ -1,0 +1,20 @@
+import { Component } from '@angular/core';
+import { LuModal } from '@lucca-front/ng';
+
+@Component({
+	selector: 'lu-fix-modal',
+	templateUrl: './fix-modal.component.html'
+})
+export class FixModalComponent {
+	constructor(private _modal: LuModal) {}
+	open() {
+		this._modal.open(BasicModalContent);
+	}
+}
+@Component({
+	selector: 'lu-modal-content',
+	template: 'content'
+})
+export class BasicModalContent {
+	title = 'title';
+}

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
@@ -1,14 +1,25 @@
 import { Component } from '@angular/core';
-import { LuModal } from '@lucca-front/ng';
+import { LuModal, LuPopup, LuSidepanel } from '@lucca-front/ng';
+import { of } from 'rxjs';
 
 @Component({
 	selector: 'lu-fix-modal',
 	templateUrl: './fix-modal.component.html'
 })
 export class FixModalComponent {
-	constructor(private _modal: LuModal) {}
-	open() {
+	constructor(
+		private _popup: LuPopup,
+		private _modal: LuModal,
+		private _sidepanel: LuSidepanel,
+	) {}
+	openPopup() {
+		this._popup.open(BasicModalContent);
+	}
+	openModal() {
 		this._modal.open(BasicModalContent);
+	}
+	openSidepanel() {
+		this._sidepanel.open(BasicModalContent);
 	}
 }
 @Component({
@@ -17,4 +28,5 @@ export class FixModalComponent {
 })
 export class BasicModalContent {
 	title = 'title';
+	submitAction = () => of(true);
 }

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
@@ -1,5 +1,5 @@
-import { Component, Inject } from '@angular/core';
-import { LuModal, LuPopup, LuSidepanel, LU_MODAL_DATA } from '@lucca-front/ng';
+import { Component, Inject, Optional } from '@angular/core';
+import { LuModal, LuPopup, LuSidepanel, LU_MODAL_DATA, LU_POPUP_DATA, LU_SIDEPANEL_DATA } from '@lucca-front/ng';
 import { of } from 'rxjs';
 
 @Component({
@@ -24,13 +24,19 @@ export class FixModalComponent {
 }
 @Component({
 	selector: 'lu-modal-content',
-	template: 'content {{data}}'
+	template: `content of the modal component <br />
+	popup data: {{popupData}}<br />
+	modal data: {{modalData}}<br />
+	sidepanel data: {{sidepanelData}}<br />
+	`
 })
 export class BasicModalContent {
 	title = 'title';
 	submitAction = () => of(true);
 
 	constructor(
-		@Inject(LU_MODAL_DATA) public data,
+		@Optional()@Inject(LU_POPUP_DATA) public popupData,
+		@Optional()@Inject(LU_MODAL_DATA) public modalData,
+		@Optional()@Inject(LU_SIDEPANEL_DATA) public sidepanelData,
 	) {}
 }

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { LuModal, LuPopup, LuSidepanel } from '@lucca-front/ng';
+import { Component, Inject } from '@angular/core';
+import { LuModal, LuPopup, LuSidepanel, LU_MODAL_DATA } from '@lucca-front/ng';
 import { of } from 'rxjs';
 
 @Component({
@@ -12,21 +12,25 @@ export class FixModalComponent {
 		private _modal: LuModal,
 		private _sidepanel: LuSidepanel,
 	) {}
-	openPopup() {
-		this._popup.open(BasicModalContent);
+	openPopup(data?) {
+		this._popup.open(BasicModalContent, data);
 	}
-	openModal() {
-		this._modal.open(BasicModalContent);
+	openModal(data?) {
+		this._modal.open(BasicModalContent, data);
 	}
-	openSidepanel() {
-		this._sidepanel.open(BasicModalContent);
+	openSidepanel(data?) {
+		this._sidepanel.open(BasicModalContent, data);
 	}
 }
 @Component({
 	selector: 'lu-modal-content',
-	template: 'content'
+	template: 'content {{data}}'
 })
 export class BasicModalContent {
 	title = 'title';
 	submitAction = () => of(true);
+
+	constructor(
+		@Inject(LU_MODAL_DATA) public data,
+	) {}
 }

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/fix-modal.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { FixModalComponent, BasicModalContent } from './fix-modal.component';
+import { LuOverlayModule } from '@lucca-front/ng';
+
+@NgModule({
+	declarations: [
+		FixModalComponent,
+		BasicModalContent,
+	],
+	imports: [
+		LuOverlayModule,
+
+		RouterModule.forChild([
+			{ path: '', component: FixModalComponent },
+		]),
+	],
+	entryComponents: [
+		BasicModalContent,
+	]
+})
+export class FixModalModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/fix-modal/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './fix-modal.module';

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -30,6 +30,7 @@ const routes: Routes = [
 	{ path: 'user-select-translate', loadChildren: () => import('./user-select-translate').then(m => m.UserSelectTranslateModule) },
 	{ path: 'sidepanel', loadChildren: () => import('./sidepanel').then(m => m.SidepanelModule) },
 	{ path: 'node-sass-end', loadChildren: () => import('./node-sass-end').then(m => m.NodeSassEndModule) },
+	{ path: 'fix-modal', loadChildren: () => import('./fix-modal').then(m => m.FixModalModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal.module.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal.module.ts
@@ -1,11 +1,10 @@
 import { NgModule } from '@angular/core';
 import { LuModal } from './modal.service';
-import { LU_MODAL_CONFIG, LU_MODAL_TRANSLATIONS } from './modal.token';
+import { LU_MODAL_CONFIG, LU_MODAL_TRANSLATIONS, LU_MODAL_REF_FACTORY } from './modal.token';
 import { luDefaultModalConfig } from './modal-config.default';
 import { LuModalPanelComponent } from './modal-panel.component';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
-import { LU_POPUP_REF_FACTORY, LU_POPUP_CONFIG } from '../popup/index';
 import { LuModalRefFactory } from './modal-ref.factory';
 import { LuModalIntl } from './modal.intl';
 import { luModalTranslations } from './modal.translate';
@@ -24,9 +23,8 @@ import { CommonModule } from '@angular/common';
 	providers: [
 		LuModal,
 		LuModalIntl,
-		{ provide: LU_POPUP_CONFIG, useValue: luDefaultModalConfig },
 		{ provide: LU_MODAL_CONFIG, useValue: luDefaultModalConfig },
-		{ provide: LU_POPUP_REF_FACTORY, useClass: LuModalRefFactory },
+		{ provide: LU_MODAL_REF_FACTORY, useClass: LuModalRefFactory },
 		{ provide: LU_MODAL_TRANSLATIONS, useValue: luModalTranslations },
 	]
 })

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal.service.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal.service.ts
@@ -1,5 +1,14 @@
-import { Injectable } from '@angular/core';
-import { LuPopup } from '../popup/index';
+import { Injectable, Inject } from '@angular/core';
+import { LuPopup, ILuPopupRefFactory } from '../popup/index';
+import { ILuModalConfig } from './modal-config.model';
+import { LU_MODAL_CONFIG, LU_MODAL_REF_FACTORY } from './modal.token';
 
 @Injectable()
-export class LuModal extends LuPopup {}
+export class LuModal extends LuPopup {
+	constructor(
+		@Inject(LU_MODAL_REF_FACTORY) protected _factory: ILuPopupRefFactory,
+		@Inject(LU_MODAL_CONFIG) protected _config: ILuModalConfig,
+	) {
+		super(_factory, _config);
+	}
+}

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal.token.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal.token.ts
@@ -3,4 +3,5 @@ import { InjectionToken } from '@angular/core';
 /** Injection token that can be used to access the data that was passed in to a dialog. */
 export const LU_MODAL_DATA = new InjectionToken<any>('LuModalData');
 export const LU_MODAL_CONFIG = new InjectionToken<any>('LuModalDefaultConfig');
+export const LU_MODAL_REF_FACTORY = new InjectionToken<any>('LuModalRefFactory');
 export const LU_MODAL_TRANSLATIONS = new InjectionToken('LuModalTranslations');

--- a/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel.module.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel.module.ts
@@ -1,10 +1,9 @@
 import { NgModule } from '@angular/core';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
-import { LU_POPUP_REF_FACTORY, LU_POPUP_CONFIG } from '../popup/index';
 import { CommonModule } from '@angular/common';
 import { LuSidepanel } from './sidepanel.service';
-import { LU_SIDEPANEL_CONFIG, LU_SIDEPANEL_TRANSLATIONS } from './sidepanel.token';
+import { LU_SIDEPANEL_CONFIG, LU_SIDEPANEL_TRANSLATIONS, LU_SIDEPANEL_REF_FACTORY } from './sidepanel.token';
 import { luSidepanelTranslations } from './sidepanel.translate';
 import { LuSidepanelIntl } from './sidepanel.intl';
 import { LuSidepanelPanelComponent } from './sidepanel-panel.component';
@@ -24,9 +23,8 @@ import { LuSidepanelRefFactory } from './sidepanel-ref.factory';
 	providers: [
 		LuSidepanel,
 		LuSidepanelIntl,
-		{ provide: LU_POPUP_CONFIG, useValue: luDefaultSidepanelConfig },
 		{ provide: LU_SIDEPANEL_CONFIG, useValue: luDefaultSidepanelConfig },
-		{ provide: LU_POPUP_REF_FACTORY, useClass: LuSidepanelRefFactory },
+		{ provide: LU_SIDEPANEL_REF_FACTORY, useClass: LuSidepanelRefFactory },
 		{ provide: LU_SIDEPANEL_TRANSLATIONS, useValue: luSidepanelTranslations },
 	]
 })

--- a/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel.service.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel.service.ts
@@ -1,5 +1,15 @@
-import { Injectable } from '@angular/core';
+import { Injectable, Inject } from '@angular/core';
 import { LuModal } from '../modal/index';
+import { ILuSidepanelConfig } from './sidepanel-config.model';
+import { LU_SIDEPANEL_CONFIG, LU_SIDEPANEL_REF_FACTORY } from './sidepanel.token';
+import { ILuPopupRefFactory } from '../popup/index';
 
 @Injectable()
-export class LuSidepanel extends LuModal {}
+export class LuSidepanel extends LuModal {
+	constructor(
+		@Inject(LU_SIDEPANEL_REF_FACTORY) protected _factory: ILuPopupRefFactory,
+		@Inject(LU_SIDEPANEL_CONFIG) protected _config: ILuSidepanelConfig,
+	) {
+		super(_factory, _config);
+	}
+}

--- a/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel.token.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel.token.ts
@@ -4,3 +4,4 @@ import { InjectionToken } from '@angular/core';
 export const LU_SIDEPANEL_DATA = new InjectionToken<any>('LuSidepanelData');
 export const LU_SIDEPANEL_CONFIG = new InjectionToken<any>('LuSidepanelDefaultConfig');
 export const LU_SIDEPANEL_TRANSLATIONS = new InjectionToken('LuSidepanelTranslations');
+export const LU_SIDEPANEL_REF_FACTORY = new InjectionToken<any>('LuSidepanelRefFactory');


### PR DESCRIPTION
the way the injection was handled, the factory creating modalRef depended on what module you imported

- if you imported `LuModalModule` then `LuModal.open(...)` opened modals :+1:
- if you imported `LuOverlayModule` then `LuModal.open(...)` opened sidepanels :-1: