### PR TITLE
modal-sidepanel - hide submit button

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -31,6 +31,7 @@ const routes: Routes = [
 	{ path: 'sidepanel', loadChildren: () => import('./sidepanel').then(m => m.SidepanelModule) },
 	{ path: 'node-sass-end', loadChildren: () => import('./node-sass-end').then(m => m.NodeSassEndModule) },
 	{ path: 'fix-modal', loadChildren: () => import('./fix-modal').then(m => m.FixModalModule) },
+	{ path: 'modals-no-submit', loadChildren: () => import('./modals-no-submit').then(m => m.ModalsNoSubmitModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/index.ts
@@ -1,0 +1,1 @@
+export * from './modals-no-submit.module';

--- a/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/modals-no-submit.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/modals-no-submit.component.html
@@ -1,0 +1,3 @@
+<h1>modals-no-submit</h1>
+<button class="button" (click)="openModal()">open modal</button>
+<button class="button" (click)="openSidepanel()">open sidepanel</button>

--- a/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/modals-no-submit.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/modals-no-submit.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { LuModal, LuSidepanel } from '@lucca-front/ng';
+
+@Component({
+	selector: 'lu-modals-no-submit',
+	templateUrl: './modals-no-submit.component.html'
+})
+export class ModalsNoSubmitComponent {
+	constructor(
+		private _modal: LuModal,
+		private _sidepanel: LuSidepanel,
+	) {}
+	openModal(data?) {
+		this._modal.open(BasicModalContent, data);
+	}
+	openSidepanel(data?) {
+		this._sidepanel.open(BasicModalContent, data);
+	}
+}
+@Component({
+	selector: 'lu-modal-content',
+	template: `content of the modal component
+	`
+})
+export class BasicModalContent {
+	title = 'title';
+
+	constructor(
+	) {}
+}

--- a/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/modals-no-submit.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/modals-no-submit/modals-no-submit.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { ModalsNoSubmitComponent, BasicModalContent } from './modals-no-submit.component';
+import { LuOverlayModule } from '@lucca-front/ng';
+
+
+
+@NgModule({
+	declarations: [
+		ModalsNoSubmitComponent,
+		BasicModalContent,
+	],
+	entryComponents: [
+		BasicModalContent,
+	],
+	imports: [
+		LuOverlayModule,
+
+		RouterModule.forChild([
+			{ path: '', component: ModalsNoSubmitComponent },
+		]),
+	],
+})
+export class ModalsNoSubmitModule {}

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.html
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.html
@@ -9,6 +9,6 @@
 	<!-- <ng-template [ngIf]="error$ | async as error"> -->
 		<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
 	<!-- </ng-template> -->
-	<button *ngIf="submiAction" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
+	<button *ngIf="!submitHidden" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
 	<button class="button mod-link" (click)="dismiss()">{{cancelLabel}}</button>
 </div>

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.html
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.html
@@ -9,6 +9,6 @@
 	<!-- <ng-template [ngIf]="error$ | async as error"> -->
 		<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
 	<!-- </ng-template> -->
-	<button *ngIf="submitLabel" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
+	<button *ngIf="submiAction" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
 	<button class="button mod-link" (click)="dismiss()">{{cancelLabel}}</button>
 </div>

--- a/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.ts
+++ b/packages/ng/libraries/core/src/lib/overlay/modal/modal-panel.component.ts
@@ -22,6 +22,9 @@ export abstract class ALuModalPanelComponent<T extends ILuModalContent = ILuModa
 	get submitDisabled() {
 		return this._componentInstance.submitDisabled;
 	}
+	get submitHidden() {
+		return !this._componentInstance.submitAction;
+	}
 	submitClass$ = new Subject();
 	error$ = new Subject();
 	constructor(

--- a/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel-panel.component.html
+++ b/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel-panel.component.html
@@ -9,6 +9,6 @@
 	<!-- <ng-template [ngIf]="error$ | async as error"> -->
 		<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
 	<!-- </ng-template> -->
-	<button *ngIf="submitLabel" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
+	<button *ngIf="submitAction" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
 	<button class="button mod-link" (click)="dismiss()">{{cancelLabel}}</button>
 </div>

--- a/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel-panel.component.html
+++ b/packages/ng/libraries/core/src/lib/overlay/sidepanel/sidepanel-panel.component.html
@@ -9,6 +9,6 @@
 	<!-- <ng-template [ngIf]="error$ | async as error"> -->
 		<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
 	<!-- </ng-template> -->
-	<button *ngIf="submitAction" class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
+	<button *ngIf="!submitHidden"  class="button palette-primary" [class.is-disabled]="submitDisabled" [ngClass]="submitClass$ | async" (click)="submit()">{{submitLabel}}</button>
 	<button class="button mod-link" (click)="dismiss()">{{cancelLabel}}</button>
 </div>


### PR DESCRIPTION
hides the submit button in modal/sp footer if the user hasnt provided a submit action

https://687-pr-lucca-front-luccasa.surge.sh/ng/#/modals-no-submit - modal/sp opens with no `ok` button
https://687-pr-lucca-front-luccasa.surge.sh/ng/#/fix-modal - modal/sp has a open button