### PR TITLE
[fix] Select picker overlap

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -32,6 +32,7 @@ const routes: Routes = [
 	{ path: 'node-sass-end', loadChildren: () => import('./node-sass-end').then(m => m.NodeSassEndModule) },
 	{ path: 'fix-modal', loadChildren: () => import('./fix-modal').then(m => m.FixModalModule) },
 	{ path: 'modals-no-submit', loadChildren: () => import('./modals-no-submit').then(m => m.ModalsNoSubmitModule) },
+	{ path: 'select-overlap', loadChildren: () => import('./select-overlap').then(m => m.SelectOverlapModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/index.ts
@@ -1,0 +1,1 @@
+export * from './select-overlap.module';

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.html
@@ -9,3 +9,15 @@
 		</lu-option-picker>
 	</lu-select>
 </div>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="model" api="/api/v3/departments" pickerOverlap="true"></lu-api-select>
+	<label for="" class="textfield-label">api select</label>
+</div>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="user" pickerOverlap="true"></lu-user-select>
+	<label for="" class="textfield-label">user select</label>
+</div>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [(ngModel)]="item" pickerOverlap="true"></lu-department-select>
+	<label for="" class="textfield-label">department select</label>
+</div>

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.html
@@ -1,0 +1,11 @@
+<h1>select-overlap</h1>
+<div class="textfield">
+	<lu-select class="textfield-input" [(ngModel)]="model" pickerOverlap="true">
+		<span *luDisplayer="let value">{{value}}</span>
+		<lu-select-clearer *ngIf="true"></lu-select-clearer>
+		<lu-option-picker>
+			<lu-option value="1">1</lu-option>
+			<lu-option value="2">2</lu-option>
+		</lu-option-picker>
+	</lu-select>
+</div>

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.ts
@@ -6,4 +6,6 @@ import { Component } from '@angular/core';
 })
 export class SelectOverlapComponent {
 	model = 1;
+	item;
+	user;
 }

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-select-overlap',
+	templateUrl: './select-overlap.component.html'
+})
+export class SelectOverlapComponent {
+	model = 1;
+}

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.module.ts
@@ -2,9 +2,11 @@ import { NgModule } from '@angular/core';
 
 import { RouterModule } from '@angular/router';
 import { SelectOverlapComponent } from './select-overlap.component';
-import { LuSelectModule, LuOptionModule, LuInputModule } from '@lucca-front/ng';
+import { LuSelectModule, LuOptionModule, LuInputModule, LuApiModule, LuUserModule, LuDepartmentModule } from '@lucca-front/ng';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
 
 
 
@@ -21,6 +23,11 @@ import { CommonModule } from '@angular/common';
 		RouterModule.forChild([
 			{ path: '', component: SelectOverlapComponent },
 		]),
+		HttpClientModule,
+		RedirectModule,
+		LuApiModule,
+		LuUserModule,
+		LuDepartmentModule,
 	],
 })
 export class SelectOverlapModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/select-overlap/select-overlap.module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { SelectOverlapComponent } from './select-overlap.component';
+import { LuSelectModule, LuOptionModule, LuInputModule } from '@lucca-front/ng';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+
+
+@NgModule({
+	declarations: [
+		SelectOverlapComponent,
+	],
+	imports: [
+		LuSelectModule,
+		LuOptionModule,
+		FormsModule,
+		LuInputModule,
+		CommonModule,
+		RouterModule.forChild([
+			{ path: '', component: SelectOverlapComponent },
+		]),
+	],
+})
+export class SelectOverlapModule {}

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -38,6 +38,10 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 
 	@HostBinding('tabindex') tabindex = 0;
 
+	@Input('pickerOverlap') set overlapInput(o: boolean) {
+		this.target.overlap = o;
+	}
+
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 	@Input('multiple') set inputMultiple(m: boolean | string) {
 		if (m === '') {


### PR DESCRIPTION
with the refactor of the popovers, it was not possible anymore to make  the picker of a select overlap its input. now its possible again

was used in [prisme](http://prisme.lucca.io/home) for the search bar