### PR TITLE
Fix/705.option picker.keyboard.selection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ after_success:
   - cd ../
   - chmod ugo+x ./deploy.sh
   - ./deploy.sh
+

--- a/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/fix-705-select-enter.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/fix-705-select-enter.component.html
@@ -1,0 +1,14 @@
+<h1>fix-705-select-enter</h1>
+<div class="textfield">
+	<lu-select class="textfield-input" [(ngModel)]="model">
+		<span *luDisplayer="let value">{{value}}</span>
+		<lu-select-clearer *ngIf="true"></lu-select-clearer>
+		<lu-option-picker>
+			<lu-option value="1">1</lu-option>
+			<lu-option value="2">2</lu-option>
+		</lu-option-picker>
+	</lu-select>
+</div>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="model" api="/api/v3/departments"></lu-api-select>
+</div>

--- a/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/fix-705-select-enter.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/fix-705-select-enter.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-fix-705-select-enter',
+	templateUrl: './fix-705-select-enter.component.html'
+})
+export class Fix705SelectEnterComponent {
+	model = 1;
+
+}

--- a/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/fix-705-select-enter.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/fix-705-select-enter.module.ts
@@ -1,0 +1,32 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { Fix705SelectEnterComponent } from './fix-705-select-enter.component';
+
+// needed to reroute api calls to prisme-proxy
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+import { LuApiModule, LuSelectModule, LuInputDisplayerModule, LuOptionModule } from '@lucca-front/ng';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+
+@NgModule({
+	declarations: [
+		Fix705SelectEnterComponent,
+	],
+	imports: [
+		LuSelectModule,
+		LuApiModule,
+		LuInputDisplayerModule,
+		LuOptionModule,
+		FormsModule,
+		CommonModule,
+		HttpClientModule,
+		RedirectModule,
+		RouterModule.forChild([
+			{ path: '', component: Fix705SelectEnterComponent },
+		]),
+	],
+})
+export class Fix705SelectEnterModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/fix-705-select-enter/index.ts
@@ -1,0 +1,1 @@
+export * from './fix-705-select-enter.module';

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -31,6 +31,7 @@ const routes: Routes = [
 	{ path: 'sidepanel', loadChildren: () => import('./sidepanel').then(m => m.SidepanelModule) },
 	{ path: 'node-sass-end', loadChildren: () => import('./node-sass-end').then(m => m.NodeSassEndModule) },
 	{ path: 'fix-modal', loadChildren: () => import('./fix-modal').then(m => m.FixModalModule) },
+	{ path: 'fix-705-select-enter', loadChildren: () => import('./fix-705-select-enter').then(m => m.Fix705SelectEnterModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker-advanced.component.html
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker-advanced.component.html
@@ -1,6 +1,6 @@
 <ng-template>
 	<div class="lu-popover-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
-	 (keydown)="_handleKeydown($event)" (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
+	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-popover-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
 			<ng-content *ngIf="!(loading$ | async); else loading"></ng-content>
 		</div>

--- a/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.html
+++ b/packages/ng/libraries/core/src/lib/option/picker/option-picker.component.html
@@ -1,6 +1,6 @@
 <ng-template>
 	<div class="lu-popover-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
-	 (keydown)="_handleKeydown($event)" (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
+	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-popover-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus">
 			<ng-content></ng-content>
 		</div>

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -106,7 +106,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 		super.onBlur();
 	}
 	@HostListener('keydown.space', ['$event'])
-	@HostListener('keydown.enter', ['$event'])
+	// @HostListener('keydown.enter', ['$event'])
 	onKeydown($event: KeyboardEvent) {
 		this.openPopover();
 		$event.stopPropagation();

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -106,11 +106,13 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 		super.onBlur();
 	}
 	@HostListener('keydown.space', ['$event'])
-	// @HostListener('keydown.enter', ['$event'])
+	@HostListener('keydown.enter', ['$event'])
 	onKeydown($event: KeyboardEvent) {
-		this.openPopover();
-		$event.stopPropagation();
-		$event.preventDefault();
+		if (!this._popoverOpen) {
+			this.openPopover();
+			$event.stopPropagation();
+			$event.preventDefault();
+		}
 	}
 
 

--- a/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
+++ b/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts
@@ -128,7 +128,6 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 
 }
 
-
 /**
 * select input
 */

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker-advanced.component.html
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker-advanced.component.html
@@ -1,6 +1,6 @@
 <ng-template>
 	<div class="lu-popover-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
-	 (keydown)="_handleKeydown($event)" (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
+	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-popover-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
 			<ng-content *ngIf="!(loading$ | async); else loading"></ng-content>
 		</div>

--- a/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.html
+++ b/packages/ng/libraries/core/src/lib/tree/option/picker/tree-option-picker.component.html
@@ -1,6 +1,6 @@
 <ng-template>
 	<div class="lu-popover-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
-	 (keydown)="_handleKeydown($event)" (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
+	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-popover-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus">
 			<ng-content></ng-content>
 		</div>


### PR DESCRIPTION
as stated in the issue, the problem was that the select-input stopped propagation of event `keydown.enter`.

solution was to stop propagation only when the picker wasnt already opened

> due to the fact that the select-input opens on `enter` and stops propagation - [see code](https://github.com/LuccaSA/lucca-front/blob/master/packages/ng/libraries/core/src/lib/select/input/select-input.component.ts#L109)
>
> and when a basic option picker is opened, the select-input stays focuesd, so the `keydown.enter` event is stopped.
>
> but when you open an advanced option picker with a searcher, the focus is passed to the search input, so the `keydown.enter` is caught by the overlay



----

fixes #705 

