### PR TITLE
Feat - homonyms

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -39,6 +39,7 @@ const routes: Routes = [
 	{ path: 'fix-modal', loadChildren: () => import('./fix-modal').then(m => m.FixModalModule) },
 	{ path: 'modals-no-submit', loadChildren: () => import('./modals-no-submit').then(m => m.ModalsNoSubmitModule) },
 	{ path: 'select-overlap', loadChildren: () => import('./select-overlap').then(m => m.SelectOverlapModule) },
+	{ path: 'user-select-homonyms', loadChildren: () => import('./user-select-homonyms').then(m => m.UserSelectHomonymsModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/index.ts
@@ -1,0 +1,1 @@
+export * from './user-select-homonyms.module';

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.html
@@ -1,0 +1,1 @@
+<h1>user-select-homonyms</h1>

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.html
@@ -1,1 +1,6 @@
 <h1>user-select-homonyms</h1>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="item"></lu-user-select>
+	<label for="" class="textfield-label">user select</label>
+</div>
+<code>{{item | json }}</code>

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.ts
@@ -5,4 +5,5 @@ import { Component } from '@angular/core';
 	templateUrl: './user-select-homonyms.component.html'
 })
 export class UserSelectHomonymsComponent {
+	item;
 }

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-user-select-homonyms',
+	templateUrl: './user-select-homonyms.component.html'
+})
+export class UserSelectHomonymsComponent {
+}

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.module.ts
@@ -7,6 +7,8 @@ import { LuUserModule } from '@lucca-front/ng';
 // needed to reroute api calls to prisme-proxy
 import { HttpClientModule } from '@angular/common/http';
 import { RedirectModule } from '../../redirect';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 
 
 @NgModule({
@@ -14,6 +16,8 @@ import { RedirectModule } from '../../redirect';
 		UserSelectHomonymsComponent,
 	],
 	imports: [
+		FormsModule,
+		CommonModule,
 		LuUserModule,
 		HttpClientModule,
 		RedirectModule,

--- a/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-select-homonyms/user-select-homonyms.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { UserSelectHomonymsComponent } from './user-select-homonyms.component';
+import { LuUserModule } from '@lucca-front/ng';
+
+// needed to reroute api calls to prisme-proxy
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+
+
+@NgModule({
+	declarations: [
+		UserSelectHomonymsComponent,
+	],
+	imports: [
+		LuUserModule,
+		HttpClientModule,
+		RedirectModule,
+		RouterModule.forChild([
+			{ path: '', component: UserSelectHomonymsComponent },
+		]),
+	],
+})
+export class UserSelectHomonymsModule {}

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/index.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/index.ts
@@ -1,0 +1,1 @@
+export * from './user-homonyms.module';

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/index.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/index.ts
@@ -1,1 +1,2 @@
 export * from './user-homonyms.module';
+export * from './user-homonyms.service';

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.component.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, forwardRef, SkipSelf, Self, Optional, Inject, OnInit } from '@angular/core';
+import { ALuOptionOperator, ILuOptionOperator} from '../../../option/index';
+import { IUser } from '../../user.model';
+import { merge } from 'rxjs/operators';
+
+@Component({
+	selector: 'lu-user-homonyms',
+	template: '',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: ALuOptionOperator,
+			useExisting: forwardRef(() => LuUserHomonymsComponent),
+			multi: true,
+		},
+		// {
+		// 	provide: ALuUserPagedSearcherService,
+		// 	useClass: LuUserPagedSearcherService,
+		// },
+	],
+})
+export class LuUserHomonymsComponent<U extends IUser = IUser> implements ILuOptionOperator<U> {
+	set inOptions$(in$) {
+		this._rawIn$ = in$;
+		this._outOptions$ = merge(
+			this._rawIn$,
+			// this._rawIn$.pipe()
+		);
+	}
+	private _rawIn$;
+	private _outOptions$;
+	get outOptions$() {
+		return this._outOptions$;
+	}
+	constructor(
+		// @Inject(ALuUserPagedSearcherService) @Optional() @SkipSelf() hostService: ALuUserPagedSearcherService,
+		// @Inject(ALuUserPagedSearcherService) @Self() selfService: ALuUserPagedSearcherService,
+	) {
+	}
+}
+

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.module.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { HttpClientModule } from '@angular/common/http';
+import { LuUserHomonymsComponent } from './user-homonyms.component';
+
+@NgModule({
+	imports: [
+		HttpClientModule,
+	],
+	declarations: [
+		LuUserHomonymsComponent,
+	],
+	exports: [
+		LuUserHomonymsComponent,
+	],
+})
+export class LuUserHomonymsModule {}

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.module.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.module.ts
@@ -1,10 +1,12 @@
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
 import { LuUserHomonymsComponent } from './user-homonyms.component';
+import { LuUserDisplayModule } from '../../display/index';
 
 @NgModule({
 	imports: [
 		HttpClientModule,
+		LuUserDisplayModule,
 	],
 	declarations: [
 		LuUserHomonymsComponent,

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.service.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.service.ts
@@ -1,0 +1,65 @@
+import { IUser } from '../../user.model';
+import { Observable, of } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { LuUserDisplayPipe, LuDisplayFullname, LuDisplayInitials } from '../../display/index';
+import { delay, map, catchError } from 'rxjs/operators';
+
+interface IHomonyms<U extends IUser = IUser> {
+	[key: string]: U[];
+}
+
+export interface ILuUserHomonymsService<U extends IUser = IUser> {
+	extractHomonyms(users: U[]): U[];
+	enrichHomonyms(homonyms: U[]): Observable<U[]>;
+}
+
+export abstract class ALuUserHomonymsService<U extends IUser = IUser> implements ILuUserHomonymsService<U> {
+	abstract extractHomonyms(users: U[]): U[];
+	abstract enrichHomonyms(homonyms: U[]): Observable<U[]>;
+}
+export class LuUserHomonymsService<U extends IUser = IUser> extends ALuUserHomonymsService<U> implements ILuUserHomonymsService<U> {
+	//  temp - match homonyms on initials to get more homonyms match in dev mode
+	// private _format = LuDisplayFullname.lastfirst;
+	private _format = LuDisplayInitials.lastfirst;
+	extractHomonyms(users: U[]): U[] {
+		const namesCount = {} as { [key: string]: number};
+		users.forEach(user => {
+			const name = this._pipe.transform(user, this._format);
+			const count = namesCount[name] || 0;
+			namesCount[name] = count + 1;
+		});
+
+		const nonUniqNames = Object.keys(namesCount)
+		.filter(key => namesCount[key] > 1);
+
+		const homonymsByname = {} as IHomonyms<U>;
+		nonUniqNames.forEach(name => {
+			homonymsByname[name] = users.filter(u => name === this._pipe.transform(u, this._format));
+		});
+		const homonyms = [] as U[];
+		Object.keys(homonymsByname).forEach(name => homonyms.push(...homonymsByname[name]));
+		return homonyms;
+	}
+
+	enrichHomonyms(homonyms: U[]): Observable<U[]> {
+		if (!homonyms || homonyms.length === 0) { return of([]); }
+		return this._http.get<any>(`/api/v3/users`, { params: {
+			'id': homonyms.map(u => u.id).join(','),
+			'fields': 'id,department.name',
+		}}).pipe(
+			map(res => res.data.items as { id: number, department?: { name: string }}[]),
+			map(infos => infos.map(info => {
+					const homonym = homonyms.find(h => h.id === info.id);
+					return { ...homonym, additionalInformation: info.department ? info.department.name : '' } as U;
+				}) as U[]
+			),
+			catchError(err => of([])),
+		);
+	}
+	constructor(
+		private _pipe: LuUserDisplayPipe,
+		private _http: HttpClient,
+	) {
+		super();
+	}
+}

--- a/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.service.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/homonyms/user-homonyms.service.ts
@@ -18,9 +18,7 @@ export abstract class ALuUserHomonymsService<U extends IUser = IUser> implements
 	abstract enrichHomonyms(homonyms: U[]): Observable<U[]>;
 }
 export class LuUserHomonymsService<U extends IUser = IUser> extends ALuUserHomonymsService<U> implements ILuUserHomonymsService<U> {
-	//  temp - match homonyms on initials to get more homonyms match in dev mode
-	// private _format = LuDisplayFullname.lastfirst;
-	private _format = LuDisplayInitials.lastfirst;
+	private _format = LuDisplayFullname.lastfirst;
 	extractHomonyms(users: U[]): U[] {
 		const namesCount = {} as { [key: string]: number};
 		users.forEach(user => {

--- a/packages/ng/libraries/core/src/lib/user/select/index.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/index.ts
@@ -2,3 +2,4 @@ export * from './user-select.module';
 
 export * from './input/index';
 export * from './searcher/index';
+export * from './homonyms/index';

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
@@ -16,6 +16,6 @@
 	<lu-user-homonyms></lu-user-homonyms>
 	<lu-option *luForOptions="let user" [value]="user">
 		<div>{{ user | luUserDisplay: searchFormat }}</div>
-		<div *ngIf="user.additionalInfo"><i>{{user.additionalInfo}}</i></div>
+		<div *ngIf="user.additionalInformation"><i>{{user.additionalInformation}}</i></div>
 	</lu-option>
 </lu-option-picker-advanced>

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
@@ -16,6 +16,8 @@
 	<lu-user-homonyms></lu-user-homonyms>
 	<lu-option *luForOptions="let user" [value]="user">
 		<div>{{ user | luUserDisplay: searchFormat }}</div>
-		<div *ngIf="user.additionalInformation"><i>{{user.additionalInformation}}</i></div>
+		<div class="lu-select-additionalInformation" *ngIf="user.additionalInformation">
+			({{user.additionalInformation}})
+		</div>
 	</lu-option>
 </lu-option-picker-advanced>

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.html
@@ -13,5 +13,9 @@
 </ng-template>
 <lu-option-picker-advanced>
 	<lu-user-paged-searcher></lu-user-paged-searcher>
-	<lu-option *luForOptions="let user" [value]="user">{{ user | luUserDisplay: searchFormat }}</lu-option>
+	<lu-user-homonyms></lu-user-homonyms>
+	<lu-option *luForOptions="let user" [value]="user">
+		<div>{{ user | luUserDisplay: searchFormat }}</div>
+		<div *ngIf="user.additionalInfo"><i>{{user.additionalInfo}}</i></div>
+	</lu-option>
 </lu-option-picker-advanced>

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.scss
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.component.scss
@@ -4,3 +4,9 @@
 .lu-select-value {
 	padding-right: 2.5rem;
 }
+
+.lu-select-additionalInformation {
+	font-size: 80%;
+	font-style: italic;
+	margin-top: -.25em;
+}

--- a/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.module.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/input/user-select-input.module.ts
@@ -9,6 +9,7 @@ import { LuInputDisplayerModule } from '../../../input/index';
 import { LU_USER_SELECT_INPUT_TRANSLATIONS } from './user-select-input.token';
 import { luUserSelectInputTranslations } from './user-select-input.translate';
 import { LuUserSelectInputIntl } from './user-select-input.intl';
+import { LuUserHomonymsModule } from '../homonyms/index';
 
 @NgModule({
 	imports: [
@@ -20,6 +21,7 @@ import { LuUserSelectInputIntl } from './user-select-input.intl';
 		LuSelectClearerModule,
 		LuUserSearcherModule,
 		LuInputDisplayerModule,
+		LuUserHomonymsModule,
 	],
 	declarations: [
 		LuUserSelectInputComponent,

--- a/packages/ng/libraries/core/src/lib/user/select/user-select.module.ts
+++ b/packages/ng/libraries/core/src/lib/user/select/user-select.module.ts
@@ -1,15 +1,18 @@
 import { NgModule } from '@angular/core';
 import { LuUserSelectInputModule } from './input/index';
 import { LuUserSearcherModule } from './searcher/index';
+import { LuUserHomonymsModule } from './homonyms/index';
 
 @NgModule({
 	imports: [
 		LuUserSelectInputModule,
 		LuUserSearcherModule,
+		LuUserHomonymsModule,
 	],
 	exports: [
 		LuUserSelectInputModule,
 		LuUserSearcherModule,
+		LuUserHomonymsModule,
 	],
 })
 export class LuUserSelectModule {}

--- a/packages/ng/libraries/core/src/lib/user/user.model.ts
+++ b/packages/ng/libraries/core/src/lib/user/user.model.ts
@@ -5,4 +5,5 @@ export interface IUser extends IApiItem<number> {
 	lastName: string;
 	picture?: { href: string };
 	jobTitle?: string;
+	additionalInformation?: string;
 }


### PR DESCRIPTION
fixes #413 

when the user-select must displays 2 homonyms, it'll display an additional information to differentiate them

@sanlucca i need some polish on it

![image](https://user-images.githubusercontent.com/10089239/63779343-af43cc00-c8e6-11e9-9e15-a6d65f0326c2.png)

before merging, must replace this dev lines

https://github.com/LuccaSA/lucca-front/compare/rc...feat/homonyms?expand=1#diff-28d9955c4f0b225b531ef382c7a83f84R21
```ts
	//  temp - match homonyms on initials to get more homonyms match in dev mode
	// private _format = LuDisplayFullname.lastfirst;
	private _format = LuDisplayInitials.lastfirst;
```
