### PR TITLE
formly-radio - always use radio fields

### DIFF
--- a/packages/ng/libraries/formly/src/lib/types/radios.html
+++ b/packages/ng/libraries/formly/src/lib/types/radios.html
@@ -1,16 +1,7 @@
-<div class="radiosfield-input" *ngIf="_options.length < 3; else buttonGroup">
+<div class="radiosfield-input">
 	<div *ngFor="let option of _options, let i = index" class="radio">
 		<input class="radio-input" type="radio" [value]="option.value" [id]="id + '_'+ i" [formControl]="formControl" [formlyAttributes]="field">
 		<label class="radio-label" [for]="id + '_'+ i">{{option.label}}</label>
 	</div>
 </div>
 <label class="radiosfield-label">{{to.label}}</label>
-
-<ng-template #buttonGroup>
-<div class="radioButtons">
-	<div class="radioButtons-item" *ngFor="let option of _options, let i = index">
-		<input class="radioButtons-item-input" type="radio" [value]="option.value" [id]="id + '_'+ i" [formControl]="formControl" [formlyAttributes]="field">
-		<label class="radioButtons-item-label" [for]="id + '_'+ i">{{option.label}}</label>
-	</div>
-</div>
-</ng-template>


### PR DESCRIPTION
i'll add an input type `button group` or something, but when the user want radio buttons, we should display radio buttons

alos what it did is display radios if less than 3 options, and display a button group for 3 or more option and i kinda feel it should be the orther way around