### PR TITLE
[fix] typo in luTreeOptionItemTranslations

### DIFF
--- a/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.translate.ts
+++ b/packages/ng/libraries/core/src/lib/tree/option/item/tree-option-item.translate.ts
@@ -15,7 +15,7 @@ export const luTreeOptionItemTranslations = {
 		childrenOnly: 'Children only',
 	},
 	fr: {
-		parentOnly: 'seulement le parent',
+		parentOnly: 'Seulement le parent',
 		childrenOnly: 'Seulement les enfants',
 	},
 } as ILuTranslation<ILuTreeOptionItemLabel>;


### PR DESCRIPTION
Fixes a small typo in the default translations for `LU_TREE_OPTION_ITEM_TRANSLATIONS`