### PR TITLE
buttons, button-groups & iconAction should have a vertical-align: mid…

### DIFF
--- a/packages/scss/src/components/_action-icon.scss
+++ b/packages/scss/src/components/_action-icon.scss
@@ -8,6 +8,7 @@
 	margin-left: .1rem;
 	transition: all _theme("commons.animations.durations.fast") ease;
 	width: 2rem;
+	vertical-align: middle;
 
 	&:hover {
 		&:not([disabled]) {


### PR DESCRIPTION
fixes #853 
add a vertical align middle on actionIcon class
