### PR TITLE
fix textfield mod white focus style

### DIFF
--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -138,6 +138,8 @@
 			}
 
 			&:focus {
+				box-shadow: 0 0 0 2px _color("primary", "light");
+				
 				&::placeholder {
 					color: _component("textfield.focus.placeholder");
 				}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25581936/68306119-33fe5380-00a9-11ea-952c-bd463ee960f0.png)

fixes #822 