### PR TITLE
[table] table-body-row-cell alignment

### DIFF
--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -40,6 +40,7 @@
 	border-top: _theme("commons.divider.width") solid _theme("commons.divider.color");
 	display: table-cell;
 	padding: _component("table.padding");
+	vertical-align: middle;
 }
 
 


### PR DESCRIPTION
fix #850 
A vertical align middle should be defined (for a div / a structure)
