### PR TITLE
Feat/datepicker placeholder

### DIFF
--- a/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
@@ -1,7 +1,9 @@
-import { Directive, ElementRef, Renderer2, ChangeDetectorRef, forwardRef, HostListener, Input } from '@angular/core';
+import { Directive, ElementRef, Renderer2, ChangeDetectorRef, forwardRef, HostListener, Input, Inject } from '@angular/core';
 import { ALuInput } from '@lucca-front/ng/input';
 import { NG_VALUE_ACCESSOR, Validator, NG_VALIDATORS, ValidationErrors, AbstractControl } from '@angular/forms';
 import { ALuDateAdapter, DateGranularity } from '../adapter/index';
+import { ILuDateInputLabel } from './date-input.translate';
+import { LuDateInputIntl } from './date-input.intl';
 
 @Directive({
 	selector: 'input[luDateInput]',
@@ -22,13 +24,18 @@ export class LuDateInputDirective<D> extends ALuInput<D> implements Validator {
 	private _focused = false;
 	@Input() min?: D;
 	@Input() max?: D;
+	@Input() set placeholder(p: string) {
+		this._elementRef.nativeElement.placeholder = p;
+	}
 	constructor(
 		_changeDetectorRef: ChangeDetectorRef,
 		_elementRef: ElementRef<HTMLInputElement>,
 		_renderer: Renderer2,
 		private _adapter: ALuDateAdapter<D>,
+		@Inject(LuDateInputIntl) private _intl: ILuDateInputLabel,
 	) {
 		super(_changeDetectorRef, _elementRef, _renderer);
+		this.placeholder = this._intl.placeholder;
 	}
 	protected render() {
 		if (this._focused) { return; }

--- a/packages/ng/libraries/date/src/lib/input/date-input.intl.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.intl.ts
@@ -1,0 +1,11 @@
+import { Injectable, LOCALE_ID, Inject } from '@angular/core';
+import { LU_DATE_INPUT_TRANSLATIONS } from './date-input.token';
+import { ILuDateInputLabel } from './date-input.translate';
+import { ALuIntl } from '@lucca-front/ng/core';
+
+@Injectable()
+export class LuDateInputIntl extends ALuIntl<ILuDateInputLabel> {
+	constructor(@Inject(LU_DATE_INPUT_TRANSLATIONS) translations, @Inject(LOCALE_ID) locale) {
+		super(translations, locale);
+	}
+}

--- a/packages/ng/libraries/date/src/lib/input/date-input.module.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.module.ts
@@ -1,5 +1,8 @@
 import { NgModule } from '@angular/core';
 import { LuDateInputDirective } from './date-input.directive';
+import { LuDateInputIntl } from './date-input.intl';
+import { luDateInputTranslations } from './date-input.translate';
+import { LU_DATE_INPUT_TRANSLATIONS } from './date-input.token';
 
 @NgModule({
 	imports: [
@@ -10,5 +13,9 @@ import { LuDateInputDirective } from './date-input.directive';
 	declarations: [
 		LuDateInputDirective,
 	],
+	providers: [
+		LuDateInputIntl,
+		{ provide: LU_DATE_INPUT_TRANSLATIONS, useValue: luDateInputTranslations },
+	]
 })
 export class LuDateInputModule {}

--- a/packages/ng/libraries/date/src/lib/input/date-input.token.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_DATE_INPUT_TRANSLATIONS = new InjectionToken('LuDateInputtranslations');

--- a/packages/ng/libraries/date/src/lib/input/date-input.translate.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.translate.ts
@@ -1,0 +1,20 @@
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+export interface ILuDateInputLabel {
+	placeholder: string;
+}
+export abstract class ALuDateInputLabel {
+	placeholder: string;
+}
+
+export const luDateInputTranslations = {
+	en: {
+		placeholder: 'dd/mm/yyyy',
+	},
+	'en-US': {
+		placeholder: 'mm/dd/yyyy',
+	},
+	fr: {
+		placeholder: 'jj/mm/aaaa',
+	},
+} as ILuTranslation<ILuDateInputLabel>;

--- a/packages/ng/libraries/date/src/lib/input/index.ts
+++ b/packages/ng/libraries/date/src/lib/input/index.ts
@@ -1,2 +1,5 @@
 export * from './date-input.directive';
 export * from './date-input.module';
+export * from './date-input.token';
+export * from './date-input.translate';
+export * from './date-input.intl';

--- a/packages/ng/libraries/date/src/lib/picker/date-picker.component.html
+++ b/packages/ng/libraries/date/src/lib/picker/date-picker.component.html
@@ -3,7 +3,7 @@
 	(click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-picker-content" [ngClass]="contentClassesMap" cdkTrapFocus="false" cdkTrapFocusAutoCapture="true">
 			<div class="textfield lu-picker-textfield">
-				<input luDateInput class="textfield-input" [ngModel]="_value" (ngModelChange)="_onInput($event)" (keydown.enter)="_onEnter()"[min]="min" [max]="max" placeholder="%%jj/mm/aaaa%%">
+				<input luDateInput class="textfield-input" [ngModel]="_value" (ngModelChange)="_onInput($event)" (keydown.enter)="_onEnter()"[min]="min" [max]="max">
 			</div>
 			<lu-calendar [ngModel]="_value" (ngModelChange)="_onCalendar($event)"[min]="min" [max]="max"></lu-calendar>
 		</div>

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
@@ -7,7 +7,7 @@
 <div class="lu-select-suffix">
 	<lu-input-clearer></lu-input-clearer>
 </div>
-<ng-template luDisplayer let-values>
+<ng-template luDisplayer let-value>
 	{{ value | luDate }}
 </ng-template>
 <lu-date-picker [min]="min" [max]="max"></lu-date-picker>

--- a/packages/ng/libraries/select/src/lib/input/select-input.component.ts
+++ b/packages/ng/libraries/select/src/lib/input/select-input.component.ts
@@ -70,7 +70,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 	@HostBinding('class.is-disabled')
 	get isDisabled() { return this.disabled; }
 	@HostBinding('class.is-focused')
-	get isFocused() { return this._popoverOpen; }
+	get isFocused() { return this._popoverOpen && !this.target.overlap; }
 	@HostBinding('class.mod-multiple')
 	get modMultiple() { return this._multiple; }
 


### PR DESCRIPTION
- default placeholder for date-input directive, gives insight as to what is expected to be inputed and follows locale_id
- selects (all of them) removed class `is-focused` when the picker overlaps the select