### PR TITLE
[add] optionComparer input on option-pickers

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -27,6 +27,7 @@ const routes: Routes = [
 	{ path: 'modal-synched', loadChildren: () => import('./modal-synched').then(m => m.ModalSynchedModule) },
 	{ path: 'modals-no-submit', loadChildren: () => import('./modals-no-submit').then(m => m.ModalsNoSubmitModule) },
 	{ path: 'node-sass-end', loadChildren: () => import('./node-sass-end').then(m => m.NodeSassEndModule) },
+	{ path: 'option-comparer', loadChildren: () => import('./option-comparer').then(m => m.OptionComparerModule) },
 	{ path: 'option-selector', loadChildren: () => import('./option-selector').then(m => m.OptionSelectorModule) },
 	{ path: 'picker-structure', loadChildren: () => import('./picker-structure').then(m => m.PickerStructureModule) },
 	{ path: 'poc-modal', loadChildren: () => import('./poc-modal').then(m => m.PocModalModule) },

--- a/packages/ng/applications/sandbox/src/app/issues/option-comparer/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/option-comparer/index.ts
@@ -1,0 +1,1 @@
+export * from './option-comparer.module';

--- a/packages/ng/applications/sandbox/src/app/issues/option-comparer/option-comparer.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/option-comparer/option-comparer.component.html
@@ -1,0 +1,46 @@
+<h1>option-comparer</h1>
+<h2>Api</h2>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [ngModel]="empty" api="/api/v3/axissections"></lu-api-select>
+	<label for="" class="textfield-label">empty</label>
+</div>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/axissections"></lu-api-select>
+	<label for="" class="textfield-label">section</label>
+</div>
+<pre>{{ item | json }}</pre>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="items" api="/api/v3/axissections" multiple></lu-api-select>
+	<label for="" class="textfield-label">sections</label>
+</div>
+<pre>{{ items | json }}</pre>
+<h2>User</h2>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [ngModel]="empty"></lu-user-select>
+	<label class="textfield-label">user</label>
+</div>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="user"></lu-user-select>
+	<label class="textfield-label">user</label>
+</div>
+<pre>{{ user | json }}</pre>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="users" multiple></lu-user-select>
+	<label class="textfield-label">users</label>
+</div>
+<pre>{{ users | json }}</pre>
+<h2>Department</h2>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [ngModel]="empty"></lu-department-select>
+	<label for="" class="textfield-label">empty</label>
+</div>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [(ngModel)]="department"></lu-department-select>
+	<label for="" class="textfield-label">department</label>
+</div>
+<pre>{{ department | json }}</pre>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [(ngModel)]="departments" multiple></lu-department-select>
+	<label for="" class="textfield-label">departments</label>
+</div>
+<pre>{{ departments | json }}</pre>

--- a/packages/ng/applications/sandbox/src/app/issues/option-comparer/option-comparer.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/option-comparer/option-comparer.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'sand-option-comparer',
+	templateUrl: './option-comparer.component.html'
+})
+export class OptionComparerComponent {
+	empty = undefined;
+	user = { id: 8, lastName: 'Not', firstName: 'my real name' };
+	users = [this.user];
+	department = { id: 13, name: 'placeholder name' };
+	departments = [this.department];
+	item = { id: 27, name: 'placeholder name' };
+	items = [this.item];
+}

--- a/packages/ng/applications/sandbox/src/app/issues/option-comparer/option-comparer.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/option-comparer/option-comparer.module.ts
@@ -1,0 +1,31 @@
+import { NgModule } from '@angular/core';
+// needed to reroute api calls to prisme-proxy
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+import { RouterModule } from '@angular/router';
+import { OptionComparerComponent } from './option-comparer.component';
+import { LuApiModule } from '@lucca-front/ng/api';
+import { LuUserModule } from '@lucca-front/ng/user';
+import { LuDepartmentModule } from '@lucca-front/ng/department';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+
+
+@NgModule({
+	declarations: [
+		OptionComparerComponent,
+	],
+	imports: [
+		LuApiModule,
+		LuUserModule,
+		LuDepartmentModule,
+		FormsModule,
+		CommonModule,
+		RouterModule.forChild([
+			{ path: '', component: OptionComparerComponent },
+		]),
+		HttpClientModule,
+		RedirectModule,
+	],
+})
+export class OptionComparerModule {}

--- a/packages/ng/libraries/api/src/lib/select/input/api-select-input.component.html
+++ b/packages/ng/libraries/api/src/lib/select/input/api-select-input.component.html
@@ -8,7 +8,7 @@
 	<lu-input-clearer></lu-input-clearer>
 </div>
 <span [class.chip]="multiple" *luDisplayer="let option">{{option.name}}</span>
-<lu-option-picker-advanced>
+<lu-option-picker-advanced [option-comparer]="byId">
 	<header class="lu-picker-header">
 		<lu-api-paged-searcher></lu-api-paged-searcher>
 	</header>

--- a/packages/ng/libraries/api/src/lib/select/input/api-select-input.component.ts
+++ b/packages/ng/libraries/api/src/lib/select/input/api-select-input.component.ts
@@ -18,6 +18,7 @@ import { ALuSelectInputComponent } from '@lucca-front/ng/select';
 import { IApiItem } from '../../api.model';
 import { ALuApiPagedSearcherService, LuApiPagedSearcherService } from '../searcher/index';
 import { ILuPickerPanel } from '@lucca-front/ng/picker';
+import { LuOptionComparer } from '@lucca-front/ng/option';
 
 @Component({
 	selector: 'lu-api-select',
@@ -46,6 +47,7 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 	@Input() set orderBy(orderBy: string) { this._service.orderBy = orderBy; }
 	@Input() set transformFn(transformFn: (item: any) => T) { this._service.transformFn = transformFn; }
 
+	byId: LuOptionComparer<T> = (option1: T, option2: T) => option1 && option2 && option1.id === option2.id;
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,

--- a/packages/ng/libraries/department/src/lib/select/input/department-select-input.component.html
+++ b/packages/ng/libraries/department/src/lib/select/input/department-select-input.component.html
@@ -13,7 +13,7 @@
 	<ng-template #singleView>{{(values[0] || values).name}}</ng-template>
 </ng-template>
 
-<lu-tree-option-picker-advanced>
+<lu-tree-option-picker-advanced [option-comparer]="byId">
 	<header class="lu-picker-header" [class.mod-multiple]="multiple">
 		<lu-department-feeder></lu-department-feeder>
 		<lu-tree-option-searcher [searchFn]="searchFn"></lu-tree-option-searcher>

--- a/packages/ng/libraries/department/src/lib/select/input/department-select-input.component.ts
+++ b/packages/ng/libraries/department/src/lib/select/input/department-select-input.component.ts
@@ -19,6 +19,7 @@ import { ILuOptionPickerPanel } from '@lucca-front/ng/option';
 import { ILuDepartment } from '../../department.model';
 import { LuDepartmentSelectInputIntl } from './department-select-input.intl';
 import { ILuDepartmentSelectInputLabel } from './department-select-input.translate';
+import { LuOptionComparer } from '@lucca-front/ng/option';
 
 @Component({
 	selector: 'lu-department-select',
@@ -36,6 +37,7 @@ import { ILuDepartmentSelectInputLabel } from './department-select-input.transla
 export class LuDepartmentSelectInputComponent<D extends ILuDepartment = ILuDepartment, P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>>
 extends ALuSelectInputComponent<D, P>
 implements ControlValueAccessor, ILuInputWithPicker<D>, AfterContentInit {
+	byId: LuOptionComparer<D> = (option1: D, option2: D) => option1 && option2 && option1.id === option2.id;
 
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,

--- a/packages/ng/libraries/option/src/lib/picker/option-picker.component.ts
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { luTransformPopover } from '@lucca-front/ng/popover';
 import { ILuOptionItem, ALuOptionItem } from '../item/index';
-import { ILuOptionPickerPanel, ALuOptionPicker } from './option-picker.model';
+import { ILuOptionPickerPanel, ALuOptionPicker, LuOptionComparer } from './option-picker.model';
 import { merge, of } from 'rxjs';
 import { map, delay, share } from 'rxjs/operators';
 import { ALuPickerPanel } from '@lucca-front/ng/picker';
@@ -44,6 +44,15 @@ implements ILuOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 	@Input('content-classes')
 	set inputContentClasses(classes: string) {
 		this.contentClasses = classes;
+	}
+
+	/**
+	 * This method take a function that compare options from feeder and options from form value.
+	 * By default, compare JSON values.
+	 */
+	@Input('option-comparer')
+	set inputOptionComparer(comparer: LuOptionComparer<T>) {
+		this.optionComparer = comparer;
 	}
 
 
@@ -203,14 +212,14 @@ implements ILuOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 		// add `is-selected` to all selected indexes
 		const selectedIndexes = [];
 		if (!this.multiple) {
-			const selectedIndex = this._options.findIndex(o => JSON.stringify(o.value) === JSON.stringify(this._value));
+			const selectedIndex = this._options.findIndex(o => this.optionComparer(o.value, this._value as T));
 			if (selectedIndex !== -1) { selectedIndexes.push(selectedIndex); }
 			if (selectedIndex !== -1 && this.highlightIndex === -1) { this.highlightIndex = selectedIndex; }
 		} else {
 			const values = <T[]> this._value || [];
 			selectedIndexes.push(
 				...values
-				.map(v => this._options.findIndex(o => JSON.stringify(o.value) === JSON.stringify(v)))
+				.map(v => this._options.findIndex(o => this.optionComparer(o.value, v)))
 				.filter(i => i !== -1)
 			);
 		}

--- a/packages/ng/libraries/option/src/lib/picker/option-picker.model.ts
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker.model.ts
@@ -6,6 +6,8 @@ import { ESCAPE, TAB } from '@angular/cdk/keycodes';
 
 export interface ILuOptionPickerPanel<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>> extends ILuPickerPanel<T> {}
 
+export type LuOptionComparer<T> = (option1: T, option2: T) => boolean;
+
 export abstract class ALuOptionPicker<T = any, O extends ILuOptionItem<T> = ILuOptionItem<T>> extends ALuPickerPanel<T> implements ILuOptionPickerPanel<T, O> {
 	protected _subs = new Subscription();
 	onSelectValue: Observable<T | T[]>;
@@ -34,6 +36,8 @@ export abstract class ALuOptionPicker<T = any, O extends ILuOptionItem<T> = ILuO
 			singleFlow$.subscribe(option => this._toggle(option))
 		);
 	}
+	protected optionComparer: LuOptionComparer<T> =
+		(option1: T, option2: T) => JSON.stringify(option1) === JSON.stringify(option2)
 	protected _toggle(option: O) {
 		const value = option.value;
 		if (!this.multiple) {
@@ -41,9 +45,9 @@ export abstract class ALuOptionPicker<T = any, O extends ILuOptionItem<T> = ILuO
 		} else {
 			const values = <T[]>this._value || [];
 			let newValues;
-			if (values.some(v => JSON.stringify(v) === JSON.stringify(value))) {
+			if (values.some(v => this.optionComparer(v, value))) {
 				// value was present, we remove it
-				newValues = values.filter(v => JSON.stringify(v) !== JSON.stringify(value));
+				newValues = values.filter(v => !this.optionComparer(v, value));
 			} else {
 				// value was absent, we add it
 				newValues = [...values, value];

--- a/packages/ng/libraries/option/src/lib/picker/tree-option-picker.component.ts
+++ b/packages/ng/libraries/option/src/lib/picker/tree-option-picker.component.ts
@@ -87,8 +87,8 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 		const allChildren = option.allChildren.map(i => i.value);
 		const values = <T[]>this._value || [];
 		let newValues;
-		const selfSelected = values.some(v => JSON.stringify(v) === JSON.stringify(value));
-		const allChildrenSelected = allChildren.every(child => values.some(v => JSON.stringify(v) === JSON.stringify(child)));
+		const selfSelected = values.some(v => this.optionComparer(v, value));
+		const allChildrenSelected = allChildren.every(child => values.some(v => this.optionComparer(v, child)));
 		if (selfSelected && allChildrenSelected) {
 			// remove option and its children
 			newValues = this._remove(values, [value, ...allChildren]);
@@ -106,8 +106,8 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 		}
 		const allChildren = option.allChildren.map(i => i.value);
 		const values = <T[]>this._value || [];
-		const selfSelected = values.some(v => JSON.stringify(v) === JSON.stringify(value));
-		const someChildSelected = allChildren.some(child => values.some(v => JSON.stringify(v) === JSON.stringify(child)));
+		const selfSelected = values.some(v => this.optionComparer(v, value));
+		const someChildSelected = allChildren.some(child => values.some(v => this.optionComparer(v, child)));
 
 		let newValues = this._remove(values, [...allChildren]);
 		if (selfSelected && !someChildSelected) {
@@ -127,9 +127,9 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 		}
 		const allChildren = option.allChildren.map(i => i.value);
 		const values = <T[]>this._value || [];
-		const selfSelected = values.some(v => JSON.stringify(v) === JSON.stringify(value));
+		const selfSelected = values.some(v => this.optionComparer(v, value));
 		let newValues = this._remove(values, [value]);
-		const allChildrenSelected = allChildren.every(child => values.some(v => JSON.stringify(v) === JSON.stringify(child)));
+		const allChildrenSelected = allChildren.every(child => values.some(v => this.optionComparer(v, child)));
 		if (allChildrenSelected && !selfSelected) {
 			newValues = this._remove(newValues, allChildren);
 		} else {
@@ -138,11 +138,11 @@ implements ILuTreeOptionPickerPanel<T, O>, OnDestroy, AfterViewInit {
 		this._select(newValues);
 	}
 	protected _add(values: T[], entries: T[]): T[] {
-		const newEntries = entries.filter(entry => !values.some(v => JSON.stringify(v) === JSON.stringify(entry)));
+		const newEntries = entries.filter(entry => !values.some(v => this.optionComparer(v, entry)));
 		return [...values, ...newEntries];
 	}
 	protected _remove(values: T[], entries: T[]): T[] {
-		const entriesToKeep = values.filter(value => !entries.some(e => JSON.stringify(e) === JSON.stringify(value)));
+		const entriesToKeep = values.filter(value => !entries.some(e => this.optionComparer(e, value)));
 		return [...entriesToKeep];
 	}
 

--- a/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.html
@@ -11,7 +11,7 @@
 	<span *ngIf="multiple && values?.length > 1; else: singleView"><span class="chip mod-unkillable">{{values.length}}</span> {{intl.users}}</span>
 	<ng-template #singleView>{{(values[0] || values) | luUserDisplay}}</ng-template>
 </ng-template>
-<lu-option-picker-advanced>
+<lu-option-picker-advanced [option-comparer]="byId">
 	<header class="lu-picker-header">
 		<lu-user-paged-searcher></lu-user-paged-searcher>
 	</header>

--- a/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.ts
@@ -25,6 +25,7 @@ import { LuDisplayFullname } from '../../display/index';
 import { ALuUserPagedSearcherService, LuUserPagedSearcherService } from '../searcher/index';
 import { LuUserSelectInputIntl } from './user-select-input.intl';
 import { ILuUserSelectInputLabel } from './user-select-input.translate';
+import { LuOptionComparer } from '@lucca-front/ng/option';
 
 /**
 * Displays user'picture or a placeholder with his/her initials and random bg color'
@@ -58,6 +59,8 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
 	@Input() set transformFn(transformFn: (item: any) => U) { this._service.transformFn = transformFn; }
 	@Input() set appInstanceId(appInstanceId: number | string) { this._service.appInstanceId = appInstanceId; }
 	@Input() set operations(operations: number[]) { this._service.operations = operations; }
+
+	byId: LuOptionComparer<U> = (option1: U, option2: U) => option1 && option2 && option1.id === option2.id;
 
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,


### PR DESCRIPTION
To detect which option are selected, there is a comparison of JSON values. When using API/User Select, it is more safe to compare options by id.

This PR add a new input to pass something like `(o1, o2) => o1.id === o2.id`.

If we want to go further, feeders could provide a comparer that would be used by picker.
API/Users feeder could provide a ByIdOptionComparer. When no comparer are provided, we can stick to the JSON comparer.