### PR TITLE
Fix/utc.date.picker

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.html
@@ -1,0 +1,16 @@
+<h1>date-utc</h1>
+<h2>to string</h2>
+<pre>
+	utc valentine's day: {{ utcValentine }}
+	valentine's day: {{ valentine }}
+</pre>
+<h2>to isostring</h2>
+<pre>
+	utc valentine's day: {{ utcValentine.toISOString() }}
+	valentine's day: {{ valentine.toISOString() }}
+</pre>
+<h2>luDate pipe 'long'</h2>
+<pre>
+	utc valentine's day: {{ utcValentine | luDate: 'long' }}
+	valentine's day: {{ valentine | luDate: 'long' }}
+</pre>

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.html
@@ -14,3 +14,11 @@
 	utc valentine's day: {{ utcValentine | luDate: 'long' }}
 	valentine's day: {{ valentine | luDate: 'long' }}
 </pre>
+<h2>date adapter</h2>
+<pre>
+	today iso string: {{ today.toISOString() }}
+</pre>
+<h2>lu-date-calendar</h2>
+<p>
+	<lu-calendar [(ngModel)]="utcValentine"></lu-calendar>
+</p>

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.html
@@ -2,23 +2,38 @@
 <h2>to string</h2>
 <pre>
 	utc valentine's day: {{ utcValentine }}
-	valentine's day: {{ valentine }}
+	local valentine's day: {{ valentine }}
 </pre>
 <h2>to isostring</h2>
 <pre>
 	utc valentine's day: {{ utcValentine.toISOString() }}
-	valentine's day: {{ valentine.toISOString() }}
+	local valentine's day: {{ valentine.toISOString() }}
 </pre>
 <h2>luDate pipe 'long'</h2>
 <pre>
 	utc valentine's day: {{ utcValentine | luDate: 'long' }}
-	valentine's day: {{ valentine | luDate: 'long' }}
+	local valentine's day: {{ valentine | luDate: 'long' }}
 </pre>
 <h2>date adapter</h2>
 <pre>
+	today string: {{ today }}
 	today iso string: {{ today.toISOString() }}
 </pre>
 <h2>lu-date-calendar</h2>
 <p>
+	utc valentine's
 	<lu-calendar [(ngModel)]="utcValentine"></lu-calendar>
 </p>
+<p>
+	local valentine's
+	<lu-calendar [(ngModel)]="valentine"></lu-calendar>
+</p>
+<h2>lu-date-select</h2>
+<div class="textfield">
+	<lu-date-select class="textfield-input" name="utcValentine" [(ngModel)]="utcValentine"></lu-date-select>
+	<label for="utcValentine" class="textfield-label">utc valentine's</label>
+</div>
+<div class="textfield">
+	<lu-date-select class="textfield-input" name="valentine" [(ngModel)]="valentine"></lu-date-select>
+	<label for="valentine" class="textfield-label">local valentine's</label>
+</div>

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ALuDateAdapter } from '@lucca-front/ng/date';
 
 @Component({
 	selector: 'sand-date-utc',
@@ -7,4 +8,11 @@ import { Component } from '@angular/core';
 export class DateUtcComponent {
 	utcValentine = new Date(Date.UTC(2020, 1, 14));
 	valentine = new Date(2020, 1, 14);
+	today;
+
+	constructor(
+		private _adapter: ALuDateAdapter<Date>,
+	) {
+		this.today = _adapter.forgeToday();
+	}
 }

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'sand-date-utc',
+	templateUrl: './date-utc.component.html'
+})
+export class DateUtcComponent {
+	utcValentine = new Date(Date.UTC(2020, 1, 14));
+	valentine = new Date(2020, 1, 14);
+}

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.module.ts
@@ -26,8 +26,8 @@ registerLocaleData(localeGb);
 		]),
 	],
 	providers: [
-		{ provide: LOCALE_ID, useValue: 'fr-FR' },
-		// { provide: LOCALE_ID, useValue: 'en-GB' },
+		// { provide: LOCALE_ID, useValue: 'fr-FR' },
+		{ provide: LOCALE_ID, useValue: 'en-GB' },
 		// { provide: LOCALE_ID, useValue: 'en-US' },
 	]
 })

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.module.ts
@@ -1,0 +1,32 @@
+import { NgModule, LOCALE_ID } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { DateUtcComponent } from './date-utc.component';
+import { LuDateModule, LuNativeUTCDateModule, LuNativeDateModule } from '@lucca-front/ng/date';
+
+import { registerLocaleData } from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
+import localeGb from '@angular/common/locales/en-GB';
+
+registerLocaleData(localeFr);
+registerLocaleData(localeGb);
+
+@NgModule({
+	declarations: [
+		DateUtcComponent,
+	],
+	imports: [
+		LuDateModule,
+		// LuNativeDateModule,
+		LuNativeUTCDateModule,
+		RouterModule.forChild([
+			{ path: '', component: DateUtcComponent },
+		]),
+	],
+	providers: [
+		// { provide: LOCALE_ID, useValue: 'fr-FR' },
+		// { provide: LOCALE_ID, useValue: 'en-GB' },
+		{ provide: LOCALE_ID, useValue: 'en-US' },
+	]
+})
+export class DateUtcModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/date-utc.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { DateUtcComponent } from './date-utc.component';
 import { LuDateModule, LuNativeUTCDateModule, LuNativeDateModule } from '@lucca-front/ng/date';
 
+import { FormsModule } from '@angular/forms';
 import { registerLocaleData } from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
 import localeGb from '@angular/common/locales/en-GB';
@@ -17,16 +18,17 @@ registerLocaleData(localeGb);
 	],
 	imports: [
 		LuDateModule,
-		// LuNativeDateModule,
-		LuNativeUTCDateModule,
+		LuNativeDateModule,
+		// LuNativeUTCDateModule,
+		FormsModule,
 		RouterModule.forChild([
 			{ path: '', component: DateUtcComponent },
 		]),
 	],
 	providers: [
-		// { provide: LOCALE_ID, useValue: 'fr-FR' },
+		{ provide: LOCALE_ID, useValue: 'fr-FR' },
 		// { provide: LOCALE_ID, useValue: 'en-GB' },
-		{ provide: LOCALE_ID, useValue: 'en-US' },
+		// { provide: LOCALE_ID, useValue: 'en-US' },
 	]
 })
 export class DateUtcModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/date-utc/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-utc/index.ts
@@ -1,0 +1,1 @@
+export * from './date-utc.module';

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -13,6 +13,7 @@ const routes: Routes = [
 	{ path: 'date-minmax', loadChildren: () => import('./date-minmax').then(m => m.DateMinmaxModule) },
 	{ path: 'date-picker', loadChildren: () => import('./date-picker').then(m => m.DatePickerModule) },
 	{ path: 'date-select', loadChildren: () => import('./date-select').then(m => m.DateSelectModule) },
+	{ path: 'date-utc', loadChildren: () => import('./date-utc').then(m => m.DateUtcModule) },
 	{ path: 'department-select', loadChildren: () => import('./department-select').then(m => m.DepartmentSelectModule) },
 	{ path: 'fix-472', loadChildren: () => import('./fix-472').then(m => m.Fix472Module) },
 	{ path: 'fix-705-select-enter', loadChildren: () => import('./fix-705-select-enter').then(m => m.Fix705SelectEnterModule) },

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
@@ -6,7 +6,36 @@ export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 	abstract forgeToday(): D;
 	abstract forgeInvalid(): D;
 	abstract isValid(d: D): boolean;
-	abstract compare(a: D, b: D, granularity: DateGranularity): number;
+	compare(a: D, b: D, granularity: DateGranularity): number {
+		if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
+			throw new Error('you must provide valid and not null dates to be compared');
+		}
+		const aDecade = Math.floor(this.getYear(a) / 10);
+		const bDecade = Math.floor(this.getYear(b) / 10);
+		if (aDecade < bDecade) { return -1; }
+		if (aDecade > bDecade) { return 1; }
+		if (granularity === DateGranularity.decade) { return 0; }
+
+		const aYear = this.getYear(a);
+		const bYear = this.getYear(b);
+		if (aYear < bYear) { return -1; }
+		if (aYear > bYear) { return 1; }
+		if (granularity === DateGranularity.year) { return 0; }
+
+		const aMonth = this.getMonth(a);
+		const bMonth = this.getMonth(b);
+		if (aMonth < bMonth) { return -1; }
+		if (aMonth > bMonth) { return 1; }
+		if (granularity === DateGranularity.month) { return 0; }
+
+		const aDate = this.getDate(a);
+		const bDate = this.getDate(b);
+		if (aDate < bDate) { return -1; }
+		if (aDate > bDate) { return 1; }
+		if (granularity === DateGranularity.day) { return 0; }
+
+		return 0;
+	}
 	abstract isParsable(text: string): boolean;
 	abstract parse(text: string): D;
 	abstract format(d: D, format: string): string;

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
@@ -46,4 +46,5 @@ export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 	abstract getDate(d: D): number;
 	abstract getDay(d: D): number;
 
+	abstract add(d: D, count: number, granularity: DateGranularity): D;
 }

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
@@ -44,4 +44,6 @@ export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 	abstract getYear(d: D): number;
 	abstract getMonth(d: D): number;
 	abstract getDate(d: D): number;
+	abstract getDay(d: D): number;
+
 }

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.class.ts
@@ -3,7 +3,7 @@ import { DateGranularity } from './date-granularity.enum';
 
 export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 	abstract forge(year: number, month: number, date: number): D;
-	abstract forge(year: number, month: number, date: number): D;
+	abstract forgeToday(): D;
 	abstract forgeInvalid(): D;
 	abstract isValid(d: D): boolean;
 	abstract compare(a: D, b: D, granularity: DateGranularity): number;

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.interface.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.interface.ts
@@ -15,4 +15,6 @@ export interface ILuDateAdapter<D> {
 	getMonth(d: D): number;
 	getDate(d: D): number;
 	getDay(d: D): number;
+
+	add(d: D, count: number, granularity: DateGranularity): D;
 }

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.interface.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.interface.ts
@@ -14,4 +14,5 @@ export interface ILuDateAdapter<D> {
 	getYear(d: D): number;
 	getMonth(d: D): number;
 	getDate(d: D): number;
+	getDay(d: D): number;
 }

--- a/packages/ng/libraries/date/src/lib/adapter/date-adapter.interface.ts
+++ b/packages/ng/libraries/date/src/lib/adapter/date-adapter.interface.ts
@@ -2,6 +2,7 @@ import { DateGranularity } from './date-granularity.enum';
 
 export interface ILuDateAdapter<D> {
 	forge(year: number, month: number, date: number): D;
+	forgeToday(): D;
 	forgeInvalid(): D;
 	isValid(d: D): boolean;
 	compare(a: D, b: D, granularity: DateGranularity): number;

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -66,7 +66,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		super.writeValue(value);
 	}
 	initDayLabels() {
-		this.labels = getLocaleDayNames(this._locale, FormStyle.Standalone, TranslationWidth.Narrow);
+		this.labels = [...getLocaleDayNames(this._locale, FormStyle.Standalone, TranslationWidth.Narrow)];
 		if (getLocaleFirstDayOfWeek(this._locale) === 1) {
 			this.labels.push(this.labels.shift());
 		}
@@ -93,7 +93,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		const isFirstDayOfWeek = this._adapter.getDay(start) === getLocaleFirstDayOfWeek(this._locale);
 		this.header = this._factory.forgeMonth(month, 'MMMM y');
 		if (!isFirstDayOfWeek) {
-			const offset = (this._adapter.getDay(start) - getLocaleFirstDayOfWeek(this._locale) - 1 + 7) % 7;
+			const offset = (this._adapter.getDay(start) - getLocaleFirstDayOfWeek(this._locale) + 7) % 7;
 			index = -1 * offset;
 		}
 		while (true) {

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -58,8 +58,9 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		this.initDayLabels();
 	}
 	writeValue(value?: D) {
-		const t = new Date();
-		const today = this._adapter.forge(t.getFullYear(), t.getMonth(), t.getDate());
+		// const t = new Date();
+		// const today = this._adapter.forge(t.getFullYear(), t.getMonth(), t.getDate());
+		const today = this._adapter.forgeToday();
 		const date = value && this._adapter.isValid(value) ? this._adapter.clone(value) : today;
 		this.header = this._factory.forgeMonth(date);
 		super.writeValue(value);
@@ -86,28 +87,24 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 	}
 
 	protected renderDailyView(month: D = this.header.date) {
-		// todo - add class is-disabled to prevent selecting date over min/max
 		this.items = [];
-		const start = new Date(this._adapter.getYear(month), this._adapter.getMonth(month) - 1, 1);
-		let index = 1;
-		const t = new Date();
-		const today = this._adapter.forge(t.getFullYear(), t.getMonth() + 1, t.getDate());
-		const isFirstDayOfWeek = start.getDay() === getLocaleFirstDayOfWeek(this._locale);
+		const start = this._adapter.forge(this._adapter.getYear(month), this._adapter.getMonth(month), 1);
+		let index = 0;
+		const isFirstDayOfWeek = this._adapter.getDay(start) === getLocaleFirstDayOfWeek(this._locale);
 		this.header = this._factory.forgeMonth(month, 'MMMM y');
-		const min = this.min && this._adapter.isValid(this.min) ? this.min : undefined;
-		const max = this.max && this._adapter.isValid(this.max) ? this.max : undefined;
 		if (!isFirstDayOfWeek) {
-			const offset = (start.getDay() - getLocaleFirstDayOfWeek(this._locale) - 1 + 7) % 7;
+			const offset = (this._adapter.getDay(start) - getLocaleFirstDayOfWeek(this._locale) - 1 + 7) % 7;
 			index = -1 * offset;
-			start.setDate(-1 * offset);
 		}
 		while (true) {
-			const date = new Date(this._adapter.getYear(month), this._adapter.getMonth(month) - 1, 1);
-			date.setDate(index++);
-			const d = this._adapter.forge(date.getFullYear(), date.getMonth() + 1, date.getDate());
+			// const date = new Date(this._adapter.getYear(month), this._adapter.getMonth(month) - 1, 1);
+			// date.setDate(index++);
+			// const d = this._adapter.forge(date.getFullYear(), date.getMonth() + 1, date.getDate());
+			const d = this._adapter.add(start, index++, DateGranularity.day);
 			const day = this._factory.forgeDay(d);
 			const isNextMonth = this._adapter.compare(d, month, DateGranularity.month) > 0;
-			const isFDOW = date.getDay() === getLocaleFirstDayOfWeek(this._locale);
+			// const isFDOW = date.getDay() === getLocaleFirstDayOfWeek(this._locale);
+			const isFDOW = this._adapter.getDay(d) === getLocaleFirstDayOfWeek(this._locale);
 			if (isFDOW && isNextMonth) {
 				break;
 			} else {
@@ -136,8 +133,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 	}
 	protected applyDailyMods() {
 		const month = this.header.date;
-		const t = new Date();
-		const today = this._adapter.forge(t.getFullYear(), t.getMonth() + 1, t.getDate());
+		const today = this._adapter.forgeToday();
 		const min = this.min && this._adapter.isValid(this.min) ? this.min : undefined;
 		const max = this.max && this._adapter.isValid(this.max) ? this.max : undefined;
 		this.items.forEach(item => {
@@ -163,8 +159,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		});
 	}
 	protected applyMonthlyMods() {
-		const t = new Date();
-		const today = this._adapter.forge(t.getFullYear(), t.getMonth() + 1, t.getDate());
+		const today = this._adapter.forgeToday();
 		const min = this.min && this._adapter.isValid(this.min) ? this.min : undefined;
 		const max = this.max && this._adapter.isValid(this.max) ? this.max : undefined;
 		this.items.forEach(item => {
@@ -184,8 +179,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		});
 	}
 	protected applyYearlyMods() {
-		const t = new Date();
-		const today = this._adapter.forge(t.getFullYear(), t.getMonth() + 1, t.getDate());
+		const today = this._adapter.forgeToday();
 		const min = this.min && this._adapter.isValid(this.min) ? this.min : undefined;
 		const max = this.max && this._adapter.isValid(this.max) ? this.max : undefined;
 		this.items.forEach(item => {
@@ -275,45 +269,51 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 	}
 	// TODO - fix
 	protected nextMonth() {
-		const year = this._adapter.getYear(this.header.date);
-		const month = this._adapter.getMonth(this.header.date);
-		const date = this._adapter.getDate(this.header.date);
-		const temp = new Date(year, month - 1, date);
-		temp.setDate(32);
-		temp.setDate(1);
+		// const year = this._adapter.getYear(this.header.date);
+		// const month = this._adapter.getMonth(this.header.date);
+		// const date = this._adapter.getDate(this.header.date);
+		// const temp = new Date(year, month - 1, date);
+		// temp.setDate(32);
+		// temp.setDate(1);
 
-		const d = this._adapter.forge(temp.getFullYear(), temp.getMonth() + 1, 1);
+		// const d = this._adapter.forge(temp.getFullYear(), temp.getMonth() + 1, 1);
+		const d = this._adapter.add(this.header.date, 1, DateGranularity.month);
 		this.header = this._factory.forgeMonth(d);
 	}
 	protected nextYear() {
-		const year = this._adapter.getYear(this.header.date) + 1;
-		const d = this._adapter.forge(year, 1, 1);
+		// const year = this._adapter.getYear(this.header.date) + 1;
+		// const d = this._adapter.forge(year, 1, 1);
+		const d = this._adapter.add(this.header.date, 1, DateGranularity.year);
 		this.header = this._factory.forgeYear(d);
 	}
 	protected nextDecade() {
-		const year = this._adapter.getYear(this.header.date) + 10;
-		const d = this._adapter.forge(year, 1, 1);
+		// const year = this._adapter.getYear(this.header.date) + 10;
+		// const d = this._adapter.forge(year, 1, 1);
+		const d = this._adapter.add(this.header.date, 1, DateGranularity.decade);
 		this.header = this._factory.forgeDecade(d);
 	}
 	protected previousMonth() {
-		const year = this._adapter.getYear(this.header.date);
-		const month = this._adapter.getMonth(this.header.date);
-		const date = this._adapter.getDate(this.header.date);
-		const temp = new Date(year, month - 1, date);
-		temp.setDate(-10);
-		temp.setDate(1);
+		// const year = this._adapter.getYear(this.header.date);
+		// const month = this._adapter.getMonth(this.header.date);
+		// const date = this._adapter.getDate(this.header.date);
+		// const temp = new Date(year, month - 1, date);
+		// temp.setDate(-10);
+		// temp.setDate(1);
 
-		const d = this._adapter.forge(temp.getFullYear(), temp.getMonth() + 1, 1);
+		// const d = this._adapter.forge(temp.getFullYear(), temp.getMonth() + 1, 1);
+		const d = this._adapter.add(this.header.date, -1, DateGranularity.month);
 		this.header = this._factory.forgeMonth(d);
 	}
 	protected previousYear() {
-		const year = this._adapter.getYear(this.header.date) - 1;
-		const d = this._adapter.forge(year, 1, 1);
+		// const year = this._adapter.getYear(this.header.date) - 1;
+		// const d = this._adapter.forge(year, 1, 1);
+		const d = this._adapter.add(this.header.date, -1, DateGranularity.year);
 		this.header = this._factory.forgeYear(d);
 	}
 	protected previousDecade() {
-		const year = this._adapter.getYear(this.header.date) - 10;
-		const d = this._adapter.forge(year, 1, 1);
+		// const year = this._adapter.getYear(this.header.date) - 10;
+		// const d = this._adapter.forge(year, 1, 1);
+		const d = this._adapter.add(this.header.date, -1, DateGranularity.decade);
 		this.header = this._factory.forgeDecade(d);
 	}
 

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -58,8 +58,6 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		this.initDayLabels();
 	}
 	writeValue(value?: D) {
-		// const t = new Date();
-		// const today = this._adapter.forge(t.getFullYear(), t.getMonth(), t.getDate());
 		const today = this._adapter.forgeToday();
 		const date = value && this._adapter.isValid(value) ? this._adapter.clone(value) : today;
 		this.header = this._factory.forgeMonth(date);
@@ -97,13 +95,9 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 			index = -1 * offset;
 		}
 		while (true) {
-			// const date = new Date(this._adapter.getYear(month), this._adapter.getMonth(month) - 1, 1);
-			// date.setDate(index++);
-			// const d = this._adapter.forge(date.getFullYear(), date.getMonth() + 1, date.getDate());
 			const d = this._adapter.add(start, index++, DateGranularity.day);
 			const day = this._factory.forgeDay(d);
 			const isNextMonth = this._adapter.compare(d, month, DateGranularity.month) > 0;
-			// const isFDOW = date.getDay() === getLocaleFirstDayOfWeek(this._locale);
 			const isFDOW = this._adapter.getDay(d) === getLocaleFirstDayOfWeek(this._locale);
 			if (isFDOW && isNextMonth) {
 				break;
@@ -213,8 +207,6 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		}
 	}
 	protected selectDay(item: ICalendarItem<D>) {
-		// const date = item.date ? new Date(item.date) : new Date();
-		// date.setDate(1);
 		const year = this._adapter.getYear(item.date);
 		const month = this._adapter.getMonth(item.date);
 		const d = this._adapter.forge(year, month, 1);
@@ -267,52 +259,27 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		this.granularity = this.header.granularity;
 		this.render();
 	}
-	// TODO - fix
 	protected nextMonth() {
-		// const year = this._adapter.getYear(this.header.date);
-		// const month = this._adapter.getMonth(this.header.date);
-		// const date = this._adapter.getDate(this.header.date);
-		// const temp = new Date(year, month - 1, date);
-		// temp.setDate(32);
-		// temp.setDate(1);
-
-		// const d = this._adapter.forge(temp.getFullYear(), temp.getMonth() + 1, 1);
 		const d = this._adapter.add(this.header.date, 1, DateGranularity.month);
 		this.header = this._factory.forgeMonth(d);
 	}
 	protected nextYear() {
-		// const year = this._adapter.getYear(this.header.date) + 1;
-		// const d = this._adapter.forge(year, 1, 1);
 		const d = this._adapter.add(this.header.date, 1, DateGranularity.year);
 		this.header = this._factory.forgeYear(d);
 	}
 	protected nextDecade() {
-		// const year = this._adapter.getYear(this.header.date) + 10;
-		// const d = this._adapter.forge(year, 1, 1);
 		const d = this._adapter.add(this.header.date, 1, DateGranularity.decade);
 		this.header = this._factory.forgeDecade(d);
 	}
 	protected previousMonth() {
-		// const year = this._adapter.getYear(this.header.date);
-		// const month = this._adapter.getMonth(this.header.date);
-		// const date = this._adapter.getDate(this.header.date);
-		// const temp = new Date(year, month - 1, date);
-		// temp.setDate(-10);
-		// temp.setDate(1);
-
-		// const d = this._adapter.forge(temp.getFullYear(), temp.getMonth() + 1, 1);
 		const d = this._adapter.add(this.header.date, -1, DateGranularity.month);
 		this.header = this._factory.forgeMonth(d);
 	}
 	protected previousYear() {
-		// const year = this._adapter.getYear(this.header.date) - 1;
-		// const d = this._adapter.forge(year, 1, 1);
 		const d = this._adapter.add(this.header.date, -1, DateGranularity.year);
 		this.header = this._factory.forgeYear(d);
 	}
 	protected previousDecade() {
-		// const year = this._adapter.getYear(this.header.date) - 10;
-		// const d = this._adapter.forge(year, 1, 1);
 		const d = this._adapter.add(this.header.date, -1, DateGranularity.decade);
 		this.header = this._factory.forgeDecade(d);
 	}

--- a/packages/ng/libraries/date/src/lib/index.ts
+++ b/packages/ng/libraries/date/src/lib/index.ts
@@ -4,4 +4,5 @@ export * from './input/index';
 export * from './picker/index';
 export * from './adapter/index';
 export * from './native/index';
+export * from './native-utc/index';
 export * from './select/index';

--- a/packages/ng/libraries/date/src/lib/native-utc/index.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/index.ts
@@ -1,0 +1,2 @@
+export * from './native-utc-date.adapter';
+export * from './native-utc-date.module';

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
@@ -98,4 +98,26 @@ export class LuNativeUTCDateAdapter extends ALuDateAdapter<Date> implements ILuD
 	getDay(d: Date): number {
 		return d.getUTCDay();
 	}
+
+	add(d: Date, count: number, granularity: DateGranularity): Date {
+		let year = this.getYear(d);
+		let month = this.getMonth(d);
+		let date = this.getDate(d);
+		switch (granularity) {
+			case DateGranularity.decade:
+				year += 10 * count;
+				break;
+			case DateGranularity.year:
+				year += count;
+				break;
+			case DateGranularity.month:
+				month += count;
+				break;
+			case DateGranularity.day:
+				date += count;
+				break;
+		}
+		return this.forge(year, month, date);
+	}
+
 }

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
@@ -3,7 +3,7 @@ import { LOCALE_ID, Inject, Injectable } from '@angular/core';
 import { getLocaleDateFormat, FormatWidth, formatDate } from '@angular/common';
 
 @Injectable()
-export class LuNativelUTCDateAdapter extends ALuDateAdapter<Date> implements ILuDateAdapter<Date> {
+export class LuNativeUTCDateAdapter extends ALuDateAdapter<Date> implements ILuDateAdapter<Date> {
 
 	private _regex = /[\/\,\.\-\s]/i;
 	private _order = {
@@ -42,9 +42,9 @@ export class LuNativelUTCDateAdapter extends ALuDateAdapter<Date> implements ILu
 			// d is a valid date, but
 			// as i can write new Date(1234, 56, 78) and mr javascript accepts it
 			// i check now that the generated date has the same year/month/date as what i entered
-			// if (d.getFullYear() !== year && d.getYear() !== year) { return false; } // getYear doesn't exist anymore
-			if (d.getMonth() !== month - 1) { return false; }
-			if (d.getDate() !== date) { return false; }
+			if (d.getUTCFullYear() !== year) { return false; }
+			if (d.getUTCMonth() !== month - 1) { return false; }
+			if (d.getUTCDate() !== date) { return false; }
 			return true;
 		} catch {
 			return false;
@@ -68,6 +68,10 @@ export class LuNativelUTCDateAdapter extends ALuDateAdapter<Date> implements ILu
 	}
 	forge(year: number, month: number, date: number): Date {
 		return new Date(Date.UTC(year, month - 1, date)); // month-1 cuz 0 -> january
+	}
+	forgeToday(): Date {
+		const nonUTCToday = new Date();
+		return new Date(Date.UTC(nonUTCToday.getFullYear(), nonUTCToday.getMonth(), nonUTCToday.getDate()));
 	}
 	forgeInvalid(): Date {
 		return new Date('Invalid Date');

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
@@ -81,36 +81,36 @@ export class LuNativeUTCDateAdapter extends ALuDateAdapter<Date> implements ILuD
 		if (isNaN(d.getTime())) { return false; }
 		return true;
 	}
-	compare(a: Date, b: Date, granularity: DateGranularity): number {
-		if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
-			throw new Error('you must provide valid and not null dates to be compared');
-		}
-		const aDecade = Math.floor(a.getFullYear() / 10);
-		const bDecade = Math.floor(b.getFullYear() / 10);
-		if (aDecade < bDecade) { return -1; }
-		if (aDecade > bDecade) { return 1; }
-		if (granularity === DateGranularity.decade) { return 0; }
+	// compare(a: Date, b: Date, granularity: DateGranularity): number {
+	// 	if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
+	// 		throw new Error('you must provide valid and not null dates to be compared');
+	// 	}
+	// 	const aDecade = Math.floor(this.getYear(a) / 10);
+	// 	const bDecade = Math.floor(this.getYear(b) / 10);
+	// 	if (aDecade < bDecade) { return -1; }
+	// 	if (aDecade > bDecade) { return 1; }
+	// 	if (granularity === DateGranularity.decade) { return 0; }
 
-		const aYear = a.getFullYear();
-		const bYear = b.getFullYear();
-		if (aYear < bYear) { return -1; }
-		if (aYear > bYear) { return 1; }
-		if (granularity === DateGranularity.year) { return 0; }
+	// 	const aYear = this.getYear(a);
+	// 	const bYear = this.getYear(b);
+	// 	if (aYear < bYear) { return -1; }
+	// 	if (aYear > bYear) { return 1; }
+	// 	if (granularity === DateGranularity.year) { return 0; }
 
-		const aMonth = a.getMonth();
-		const bMonth = b.getMonth();
-		if (aMonth < bMonth) { return -1; }
-		if (aMonth > bMonth) { return 1; }
-		if (granularity === DateGranularity.month) { return 0; }
+	// 	const aMonth = this.getMonth(a);
+	// 	const bMonth = this.getMonth(b);
+	// 	if (aMonth < bMonth) { return -1; }
+	// 	if (aMonth > bMonth) { return 1; }
+	// 	if (granularity === DateGranularity.month) { return 0; }
 
-		const aDate = a.getDate();
-		const bDate = b.getDate();
-		if (aDate < bDate) { return -1; }
-		if (aDate > bDate) { return 1; }
-		if (granularity === DateGranularity.day) { return 0; }
+	// 	const aDate = this.getDate(a);
+	// 	const bDate = this.getDate(b);
+	// 	if (aDate < bDate) { return -1; }
+	// 	if (aDate > bDate) { return 1; }
+	// 	if (granularity === DateGranularity.day) { return 0; }
 
-		return 0;
-	}
+	// 	return 0;
+	// }
 	clone(d: Date): Date {
 		return new Date(d);
 	}

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
@@ -1,0 +1,123 @@
+import { ILuDateAdapter, ALuDateAdapter, DateGranularity } from '../adapter/index';
+import { LOCALE_ID, Inject, Injectable } from '@angular/core';
+import { getLocaleDateFormat, FormatWidth, formatDate } from '@angular/common';
+
+@Injectable()
+export class LuNativelUTCDateAdapter extends ALuDateAdapter<Date> implements ILuDateAdapter<Date> {
+
+	private _regex = /[\/\,\.\-\s]/i;
+	private _order = {
+		date: 0,
+		month: 1,
+		year: 2,
+	};
+	constructor(
+		@Inject(LOCALE_ID) private _locale: string,
+	) {
+		super();
+		this.initOrder();
+	}
+	private initOrder() {
+		const format = getLocaleDateFormat(this._locale, FormatWidth.Short);
+		const groups = format.split(this._regex);
+		groups.forEach((g, i) => {
+			if (g.indexOf('d') !== -1) { return this._order.date = i; }
+			if (g.indexOf('M') !== -1) { return this._order.month = i; }
+			if (g.indexOf('y') !== -1) { return this._order.year = i; }
+		});
+	}
+	isParsable(text: string): boolean {
+		if (!text) { return false; }
+		const groups = text.split(this._regex);
+		if (groups.length !== 3) { return false; }
+		try {
+			const date = parseInt(groups[this._order.date], 10);
+			const month = parseInt(groups[this._order.month], 10);
+			const year = parseInt(groups[this._order.year], 10);
+			const d = new Date(Date.UTC(year, month - 1, date));
+			// checking if its a valid date
+			// https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript
+			if (!(d instanceof Date)) { return false; }
+			if (isNaN(d.getTime())) { return false; }
+			// d is a valid date, but
+			// as i can write new Date(1234, 56, 78) and mr javascript accepts it
+			// i check now that the generated date has the same year/month/date as what i entered
+			// if (d.getFullYear() !== year && d.getYear() !== year) { return false; } // getYear doesn't exist anymore
+			if (d.getMonth() !== month - 1) { return false; }
+			if (d.getDate() !== date) { return false; }
+			return true;
+		} catch {
+			return false;
+		}
+	}
+	parse(text: string): Date {
+		if (!text) { return undefined; }
+		if (!this.isParsable(text)) {
+			this.forgeInvalid();
+		}
+
+		const groups = text.split(this._regex);
+		const date = parseInt(groups[this._order.date], 10);
+		const month = parseInt(groups[this._order.month], 10);
+		const year = parseInt(groups[this._order.year], 10);
+
+		return this.forge(year, month, date);
+	}
+	format(d: Date, format: string): string {
+		return formatDate(d, format, this._locale, 'UTC');
+	}
+	forge(year: number, month: number, date: number): Date {
+		return new Date(Date.UTC(year, month - 1, date)); // month-1 cuz 0 -> january
+	}
+	forgeInvalid(): Date {
+		return new Date('Invalid Date');
+	}
+	isValid(d: Date): boolean {
+		if (!(d instanceof Date)) { return false; }
+		if (isNaN(d.getTime())) { return false; }
+		return true;
+	}
+	compare(a: Date, b: Date, granularity: DateGranularity): number {
+		if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
+			throw new Error('you must provide valid and not null dates to be compared');
+		}
+		const aDecade = Math.floor(a.getFullYear() / 10);
+		const bDecade = Math.floor(b.getFullYear() / 10);
+		if (aDecade < bDecade) { return -1; }
+		if (aDecade > bDecade) { return 1; }
+		if (granularity === DateGranularity.decade) { return 0; }
+
+		const aYear = a.getFullYear();
+		const bYear = b.getFullYear();
+		if (aYear < bYear) { return -1; }
+		if (aYear > bYear) { return 1; }
+		if (granularity === DateGranularity.year) { return 0; }
+
+		const aMonth = a.getMonth();
+		const bMonth = b.getMonth();
+		if (aMonth < bMonth) { return -1; }
+		if (aMonth > bMonth) { return 1; }
+		if (granularity === DateGranularity.month) { return 0; }
+
+		const aDate = a.getDate();
+		const bDate = b.getDate();
+		if (aDate < bDate) { return -1; }
+		if (aDate > bDate) { return 1; }
+		if (granularity === DateGranularity.day) { return 0; }
+
+		return 0;
+	}
+	clone(d: Date): Date {
+		return new Date(d);
+	}
+
+	getYear(d: Date): number {
+		return d.getUTCFullYear();
+	}
+	getMonth(d: Date): number {
+		return d.getUTCMonth() + 1;
+	}
+	getDate(d: Date): number {
+		return d.getUTCDate();
+	}
+}

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.adapter.ts
@@ -81,36 +81,7 @@ export class LuNativeUTCDateAdapter extends ALuDateAdapter<Date> implements ILuD
 		if (isNaN(d.getTime())) { return false; }
 		return true;
 	}
-	// compare(a: Date, b: Date, granularity: DateGranularity): number {
-	// 	if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
-	// 		throw new Error('you must provide valid and not null dates to be compared');
-	// 	}
-	// 	const aDecade = Math.floor(this.getYear(a) / 10);
-	// 	const bDecade = Math.floor(this.getYear(b) / 10);
-	// 	if (aDecade < bDecade) { return -1; }
-	// 	if (aDecade > bDecade) { return 1; }
-	// 	if (granularity === DateGranularity.decade) { return 0; }
 
-	// 	const aYear = this.getYear(a);
-	// 	const bYear = this.getYear(b);
-	// 	if (aYear < bYear) { return -1; }
-	// 	if (aYear > bYear) { return 1; }
-	// 	if (granularity === DateGranularity.year) { return 0; }
-
-	// 	const aMonth = this.getMonth(a);
-	// 	const bMonth = this.getMonth(b);
-	// 	if (aMonth < bMonth) { return -1; }
-	// 	if (aMonth > bMonth) { return 1; }
-	// 	if (granularity === DateGranularity.month) { return 0; }
-
-	// 	const aDate = this.getDate(a);
-	// 	const bDate = this.getDate(b);
-	// 	if (aDate < bDate) { return -1; }
-	// 	if (aDate > bDate) { return 1; }
-	// 	if (granularity === DateGranularity.day) { return 0; }
-
-	// 	return 0;
-	// }
 	clone(d: Date): Date {
 		return new Date(d);
 	}
@@ -123,5 +94,8 @@ export class LuNativeUTCDateAdapter extends ALuDateAdapter<Date> implements ILuD
 	}
 	getDate(d: Date): number {
 		return d.getUTCDate();
+	}
+	getDay(d: Date): number {
+		return d.getUTCDay();
 	}
 }

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.module.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { ALuDateAdapter } from '../adapter/index';
+import { LuNativelUTCDateAdapter } from './native-utc-date.adapter';
+
+@NgModule({
+	providers: [
+		LuNativelUTCDateAdapter,
+		{ provide: ALuDateAdapter, useClass: LuNativelUTCDateAdapter },
+	]
+})
+export class LuNativeUTCDateModule {}

--- a/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.module.ts
+++ b/packages/ng/libraries/date/src/lib/native-utc/native-utc-date.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { ALuDateAdapter } from '../adapter/index';
-import { LuNativelUTCDateAdapter } from './native-utc-date.adapter';
+import { LuNativeUTCDateAdapter } from './native-utc-date.adapter';
 
 @NgModule({
 	providers: [
-		LuNativelUTCDateAdapter,
-		{ provide: ALuDateAdapter, useClass: LuNativelUTCDateAdapter },
+		LuNativeUTCDateAdapter,
+		{ provide: ALuDateAdapter, useClass: LuNativeUTCDateAdapter },
 	]
 })
 export class LuNativeUTCDateModule {}

--- a/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
@@ -81,36 +81,36 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 		if (isNaN(d.getTime())) { return false; }
 		return true;
 	}
-	compare(a: Date, b: Date, granularity: DateGranularity): number {
-		if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
-			throw new Error('you must provide valid and not null dates to be compared');
-		}
-		const aDecade = Math.floor(a.getFullYear() / 10);
-		const bDecade = Math.floor(b.getFullYear() / 10);
-		if (aDecade < bDecade) { return -1; }
-		if (aDecade > bDecade) { return 1; }
-		if (granularity === DateGranularity.decade) { return 0; }
+	// compare(a: Date, b: Date, granularity: DateGranularity): number {
+	// 	if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
+	// 		throw new Error('you must provide valid and not null dates to be compared');
+	// 	}
+	// 	const aDecade = Math.floor(a.getFullYear() / 10);
+	// 	const bDecade = Math.floor(b.getFullYear() / 10);
+	// 	if (aDecade < bDecade) { return -1; }
+	// 	if (aDecade > bDecade) { return 1; }
+	// 	if (granularity === DateGranularity.decade) { return 0; }
 
-		const aYear = a.getFullYear();
-		const bYear = b.getFullYear();
-		if (aYear < bYear) { return -1; }
-		if (aYear > bYear) { return 1; }
-		if (granularity === DateGranularity.year) { return 0; }
+	// 	const aYear = a.getFullYear();
+	// 	const bYear = b.getFullYear();
+	// 	if (aYear < bYear) { return -1; }
+	// 	if (aYear > bYear) { return 1; }
+	// 	if (granularity === DateGranularity.year) { return 0; }
 
-		const aMonth = a.getMonth();
-		const bMonth = b.getMonth();
-		if (aMonth < bMonth) { return -1; }
-		if (aMonth > bMonth) { return 1; }
-		if (granularity === DateGranularity.month) { return 0; }
+	// 	const aMonth = a.getMonth();
+	// 	const bMonth = b.getMonth();
+	// 	if (aMonth < bMonth) { return -1; }
+	// 	if (aMonth > bMonth) { return 1; }
+	// 	if (granularity === DateGranularity.month) { return 0; }
 
-		const aDate = a.getDate();
-		const bDate = b.getDate();
-		if (aDate < bDate) { return -1; }
-		if (aDate > bDate) { return 1; }
-		if (granularity === DateGranularity.day) { return 0; }
+	// 	const aDate = a.getDate();
+	// 	const bDate = b.getDate();
+	// 	if (aDate < bDate) { return -1; }
+	// 	if (aDate > bDate) { return 1; }
+	// 	if (granularity === DateGranularity.day) { return 0; }
 
-		return 0;
-	}
+	// 	return 0;
+	// }
 	clone(d: Date): Date {
 		return new Date(d);
 	}

--- a/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
@@ -69,6 +69,10 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 	forge(year: number, month: number, date: number): Date {
 		return new Date(year, month - 1, date); // month-1 cuz 0 -> january
 	}
+	forgeToday(): Date {
+		const today = new Date();
+		return new Date(today.getFullYear(), today.getMonth(), today.getDate());
+	}
 	forgeInvalid(): Date {
 		return new Date('Invalid Date');
 	}

--- a/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
@@ -81,36 +81,6 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 		if (isNaN(d.getTime())) { return false; }
 		return true;
 	}
-	// compare(a: Date, b: Date, granularity: DateGranularity): number {
-	// 	if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
-	// 		throw new Error('you must provide valid and not null dates to be compared');
-	// 	}
-	// 	const aDecade = Math.floor(a.getFullYear() / 10);
-	// 	const bDecade = Math.floor(b.getFullYear() / 10);
-	// 	if (aDecade < bDecade) { return -1; }
-	// 	if (aDecade > bDecade) { return 1; }
-	// 	if (granularity === DateGranularity.decade) { return 0; }
-
-	// 	const aYear = a.getFullYear();
-	// 	const bYear = b.getFullYear();
-	// 	if (aYear < bYear) { return -1; }
-	// 	if (aYear > bYear) { return 1; }
-	// 	if (granularity === DateGranularity.year) { return 0; }
-
-	// 	const aMonth = a.getMonth();
-	// 	const bMonth = b.getMonth();
-	// 	if (aMonth < bMonth) { return -1; }
-	// 	if (aMonth > bMonth) { return 1; }
-	// 	if (granularity === DateGranularity.month) { return 0; }
-
-	// 	const aDate = a.getDate();
-	// 	const bDate = b.getDate();
-	// 	if (aDate < bDate) { return -1; }
-	// 	if (aDate > bDate) { return 1; }
-	// 	if (granularity === DateGranularity.day) { return 0; }
-
-	// 	return 0;
-	// }
 	clone(d: Date): Date {
 		return new Date(d);
 	}
@@ -123,5 +93,8 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 	}
 	getDate(d: Date): number {
 		return d.getDate();
+	}
+	getDay(d: Date): number {
+		return d.getDay();
 	}
 }

--- a/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
+++ b/packages/ng/libraries/date/src/lib/native/native-date.adapter.ts
@@ -97,4 +97,26 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 	getDay(d: Date): number {
 		return d.getDay();
 	}
+
+	add(d: Date, count: number, granularity: DateGranularity): Date {
+		let year = this.getYear(d);
+		let month = this.getMonth(d);
+		let date = this.getDate(d);
+		switch (granularity) {
+			case DateGranularity.decade:
+				year += 10 * count;
+				break;
+			case DateGranularity.year:
+				year += count;
+				break;
+			case DateGranularity.month:
+				month += count;
+				break;
+			case DateGranularity.day:
+				date += count;
+				break;
+		}
+		return this.forge(year, month, date);
+	}
+
 }

--- a/packages/ng/libraries/date/src/lib/native/native-date.module.ts
+++ b/packages/ng/libraries/date/src/lib/native/native-date.module.ts
@@ -4,6 +4,7 @@ import { LuNativeDateAdapter } from './native-date.adapter';
 
 @NgModule({
 	providers: [
+		LuNativeDateAdapter,
 		{ provide: ALuDateAdapter, useClass: LuNativeDateAdapter },
 	]
 })

--- a/packages/ng/schematics/issue/index.ts
+++ b/packages/ng/schematics/issue/index.ts
@@ -105,11 +105,11 @@ function addRoute(source: SourceFile, routerPath: string, issueName: string, iss
 	return changes;
 }
 function findRoutesNode(source: SourceFile): Node | null {
-	const constNode = findNodes(source, SyntaxKind.ConstKeyword)[0];
+	const constNode = findNodes(source as any as import('D:/lucca-front/packages/ng/node_modules/@schematics/angular/third_party/github.com/Microsoft/TypeScript/lib/typescript').Node, SyntaxKind.ConstKeyword)[0];
 	if (!constNode) { return null; }
 	const routesNode = constNode.parent.getChildAt(1).getChildAt(0).getChildAt(4);
 
-	return routesNode;
+	return routesNode as any as Node;
 }
 
 export function readIntoSourceFile(host: Tree, modulePath: string) {


### PR DESCRIPTION
a lot of bugs in the date-select due to the fact that the `lu-calendar` was using both js dates and the dateadapter for its operations.

also added a utc native date adapter to bind your datepicker to utc dates and not local dates