### PR TITLE
[fix] select - custom displayer

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/ivy-option-picker/ivy-option-picker.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/ivy-option-picker/ivy-option-picker.module.ts
@@ -6,6 +6,7 @@ import { LuSelectModule } from '@lucca-front/ng/select';
 import { LuInputModule } from '@lucca-front/ng/input';
 import { LuOptionModule } from '@lucca-front/ng/option';
 import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
 
 
 
@@ -18,6 +19,7 @@ import { FormsModule } from '@angular/forms';
 		LuInputModule,
 		FormsModule,
 		LuOptionModule,
+		CommonModule,
 		RouterModule.forChild([
 			{ path: '', component: IvyOptionPickerComponent },
 		]),

--- a/packages/ng/libraries/api/src/lib/select/input/api-select-input.component.ts
+++ b/packages/ng/libraries/api/src/lib/select/input/api-select-input.component.ts
@@ -8,7 +8,8 @@ import {
 	ViewChild,
 	Input,
 	Renderer2,
-	AfterContentInit
+	AfterContentInit,
+	AfterViewInit
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -39,7 +40,7 @@ import { LuOptionComparer } from '@lucca-front/ng/option';
 })
 export class LuApiSelectInputComponent<T extends IApiItem = IApiItem>
 extends ALuSelectInputComponent<T>
-implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
+implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit {
 
 	@Input() set api(api: string) { this._service.api = api; }
 	@Input() set fields(fields: string) { this._service.fields = fields; }
@@ -65,16 +66,16 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit {
 		);
 	}
 
-	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: ILuPickerPanel<T>) {
-		if (!picker) { return; }
-		this._picker = picker;
-	}
-	@ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
-		if (!clearer) { return; }
-		this._clearer = clearer;
-	}
-	@ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<T>) {
-		if (!displayer) { return; }
-		this.displayer = displayer;
-	}
+	// @ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: ILuPickerPanel<T>) {
+	// 	if (!picker) { return; }
+	// 	this._picker = picker;
+	// }
+	// @ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
+	// 	if (!clearer) { return; }
+	// 	this._clearer = clearer;
+	// }
+	// @ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<T>) {
+	// 	if (!displayer) { return; }
+	// 	this.displayer = displayer;
+	// }
 }

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
@@ -9,6 +9,7 @@ import {
 	Input,
 	Renderer2,
 	AfterContentInit,
+	AfterViewInit,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, NG_VALIDATORS, Validator, AbstractControl, ValidationErrors } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -37,7 +38,7 @@ import { ALuDateAdapter, DateGranularity } from '../adapter/index';
 })
 export class LuDateSelectInputComponent<D>
 extends ALuSelectInputComponent<D>
-implements ControlValueAccessor, ILuInputWithPicker<D>, AfterContentInit, Validator {
+implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit, Validator {
 	@Input() min?: D;
 	@Input() max?: D;
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }

--- a/packages/ng/libraries/department/src/lib/select/input/department-select-input.component.ts
+++ b/packages/ng/libraries/department/src/lib/select/input/department-select-input.component.ts
@@ -8,7 +8,8 @@ import {
 	ViewChild,
 	Renderer2,
 	AfterContentInit,
-	Inject
+	Inject,
+	AfterViewInit
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -36,7 +37,7 @@ import { LuOptionComparer } from '@lucca-front/ng/option';
 })
 export class LuDepartmentSelectInputComponent<D extends ILuDepartment = ILuDepartment, P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>>
 extends ALuSelectInputComponent<D, P>
-implements ControlValueAccessor, ILuInputWithPicker<D>, AfterContentInit {
+implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit {
 	byId: LuOptionComparer<D> = (option1: D, option2: D) => option1 && option2 && option1.id === option2.id;
 
 	constructor(
@@ -56,18 +57,18 @@ implements ControlValueAccessor, ILuInputWithPicker<D>, AfterContentInit {
 		);
 	}
 
-	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: P) {
-		if (!picker) { return; }
-		this._picker = picker;
-	}
-	@ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
-		if (!clearer) { return; }
-		this._clearer = clearer;
-	}
-	@ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<D>) {
-		if (!displayer) { return; }
-		this.displayer = displayer;
-	}
+	// @ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: P) {
+	// 	if (!picker) { return; }
+	// 	this._picker = picker;
+	// }
+	// @ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
+	// 	if (!clearer) { return; }
+	// 	this._clearer = clearer;
+	// }
+	// @ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<D>) {
+	// 	if (!displayer) { return; }
+	// 	this.displayer = displayer;
+	// }
 
 	searchFn(o, c) {
 		return o.name.toLowerCase().startsWith(c.toLowerCase());

--- a/packages/ng/libraries/select/src/lib/input/select-input.component.ts
+++ b/packages/ng/libraries/select/src/lib/input/select-input.component.ts
@@ -13,6 +13,7 @@ import {
 	Input,
 	HostBinding,
 	OnDestroy,
+	AfterViewInit,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -31,7 +32,7 @@ import { ALuSelectInput } from './select-input.model';
 
 export abstract class ALuSelectInputComponent<T = any, TPicker extends ILuPickerPanel<T> = ILuPickerPanel<T>>
 extends ALuSelectInput<T, TPicker>
-implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDestroy {
+implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit, OnDestroy {
 	@ViewChild('display', { read: ViewContainerRef, static: true }) protected set _vcDisplayContainer(vcr: ViewContainerRef) {
 		this.displayContainer = vcr;
 	}
@@ -79,15 +80,20 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 	/**
 	 * popover trigger class extension
 	 */
-	@ContentChild(ALuPickerPanel, { static: true }) set _contentChildPicker(picker: TPicker) {
-		if (!picker) { return; }
-		this._picker = picker;
-	}
+	@ContentChild(ALuPickerPanel, { static: true }) ccPicker: TPicker;
+	@ViewChild(ALuPickerPanel, { static: true }) vcPicker: TPicker;
 
-	@ContentChild(ALuInputDisplayer, { static: true }) set _contentChildDisplayer(displayer: ILuInputDisplayer<T>) {
-		if (!displayer) { return; }
-		this.displayer = displayer;
-	}
+	@ContentChild(ALuInputDisplayer, { static: true }) ccDisplayer: ILuInputDisplayer<T>;
+	@ViewChild(ALuInputDisplayer, { static: true }) vcDisplayer: ILuInputDisplayer<T>;
+	// @ContentChild(ALuPickerPanel, { static: true }) set _contentChildPicker(picker: TPicker) {
+	// 	if (!picker) { return; }
+	// 	this._picker = picker;
+	// }
+
+	// @ContentChild(ALuInputDisplayer, { static: true }) set _contentChildDisplayer(displayer: ILuInputDisplayer<T>) {
+	// 	if (!displayer) { return; }
+	// 	this.displayer = displayer;
+	// }
 
 	@HostListener('click')
 	onClick() {
@@ -119,12 +125,23 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterContentInit, OnDest
 		}
 	}
 
-
-	ngAfterContentInit() {
+	ngAfterViewInit() {
 		this._isContentInitialized = true;
+
+		// init picker and displayer
+		const picker = this.ccPicker || this.vcPicker;
+		if (!!picker) {
+			this._picker = picker;
+		}
+		const displayer = this.ccDisplayer || this.vcDisplayer;
+		if (!!displayer) {
+			this._displayer = displayer;
+		}
+
 		this.render();
 		this._picker.setValue(this.value);
 	}
+
 	ngOnDestroy() {
 		this.closePopover();
 		this.destroyPopover();
@@ -179,8 +196,8 @@ export class LuSelectInputComponent<T = any> extends ALuSelectInputComponent<T> 
 		}
 	}
 
-	ngAfterContentInit() {
-		super.ngAfterContentInit();
+	ngAfterViewInit() {
+		super.ngAfterViewInit();
 		this.displayClearer(); // dont keep
 	}
 }

--- a/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.ts
@@ -12,7 +12,8 @@ import {
 	Renderer2,
 	HostBinding,
 	AfterContentInit,
-	Inject
+	Inject,
+	AfterViewInit
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -49,7 +50,7 @@ import { LuOptionComparer } from '@lucca-front/ng/option';
 })
 export class LuUserSelectInputComponent<U extends ILuUser = ILuUser>
 extends ALuSelectInputComponent<U>
-implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
+implements ControlValueAccessor, ILuInputWithPicker<U>, AfterViewInit {
 	searchFormat = LuDisplayFullname.lastfirst;
 
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
@@ -80,16 +81,16 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterContentInit {
 		);
 	}
 
-	@ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: ILuPickerPanel<U>) {
-		if (!picker) { return; }
-		this._picker = picker;
-	}
-	@ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
-		if (!clearer) { return; }
-		this._clearer = clearer;
-	}
-	@ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<U>) {
-		if (!displayer) { return; }
-		this.displayer = displayer;
-	}
+	// @ViewChild(ALuPickerPanel, { static: true }) set _vcPicker(picker: ILuPickerPanel<U>) {
+	// 	if (!picker) { return; }
+	// 	this._picker = picker;
+	// }
+	// @ViewChild(ALuClearer, { static: true }) set _vcClearer(clearer: ILuClearer) {
+	// 	if (!clearer) { return; }
+	// 	this._clearer = clearer;
+	// }
+	// @ViewChild(ALuInputDisplayer, { static: true }) set _vcDisplayer(displayer: ILuInputDisplayer<U>) {
+	// 	if (!displayer) { return; }
+	// 	this.displayer = displayer;
+	// }
 }


### PR DESCRIPTION
depending on if ivy is enabled or not, the order in which `@contenChild` and `@ViewChild` query are executed changes and it is source of bug because i over relied on `get/set` (fyi - it was the source of the bugs that caused me to panicked when i tried to migrate to ng 9 + ivy)

now i rely on _official_ life-cycle hooks to initialise my components

----

[ici](http://lucca-front.lucca.local/rc/ng/#/split-select) on peut voir que le custom displayer est ignore alors que [la](http://lucca-front.lucca.local/PR-966/ng/#/split-select) il remarche