### PR TITLE
[Fix] Calendar style on IE11

### DIFF
--- a/packages/ng/.angular.json
+++ b/packages/ng/.angular.json
@@ -219,6 +219,9 @@
                   "maximumError": "5mb"
                 }
               ]
+            },
+            "es5": {
+              "tsConfig": "applications/sandbox/tsconfig.es5.json"
             }
           }
         },
@@ -230,6 +233,9 @@
           "configurations": {
             "production": {
               "browserTarget": "sandbox:build:production"
+						},
+						"es5": {
+              "browserTarget": "sandbox:build:es5"
             }
           }
         },

--- a/packages/ng/applications/sandbox/tsconfig.es5.json
+++ b/packages/ng/applications/sandbox/tsconfig.es5.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.app.json",
+	"compilerOptions": {
+		"target": "es5"
+	}
+}

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.scss
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.scss
@@ -2,8 +2,17 @@
 
 .calendar {
 	background: white;
-	width: 17.8rem;
+	width: _component("calendar.width", true);
+	width: _component("calendar.width");
+	padding: _theme("spacings.smaller", true);
 	padding: _theme("spacings.smaller");
+}
+:host-context(.mod-block) {
+	.calendar {
+		width: auto;
+		max-width: _component("calendar.width", true);
+		max-width: _component("calendar.width");
+	}
 }
 
 .calendar-header {
@@ -20,13 +29,16 @@
 
 	.lucca-icon {
 		font-size: .9rem;
+		color: _color("text.dark", "color", true);
 		color: _color("text.dark");
 	}
 }
 
 .calendar-header-date {
 	font-weight: 600;
+	color: _color("text.dark", "color", true);
 	color: _color("text.dark");
+	font-size: _theme("sizes.big.font-size", true);
 	font-size: _theme("sizes.big.font-size");
 	padding: 0;
 	background: transparent;
@@ -38,29 +50,39 @@
 	display: none;
 
 	&.mod-dailyView {
-		display: grid;
-		grid-template-columns: repeat(7, 2.4rem);
+		display: flex;
+		align-items: stretch;
+		flex-wrap: wrap;
+		.calendar-labels-item {
+			width: calc(99% / 7);
+		}
 		text-align: center;
+		font-size: _theme("sizes.small.font-size", true);
 		font-size: _theme("sizes.small.font-size");
+		color: _color("text.light", "color", true);
 		color: _color("text.light");
+		margin-bottom: _theme("spacings.smaller", true);
 		margin-bottom: _theme("spacings.smaller");
 	}
 }
 
 .calendar-grid {
-	display: grid;
+	display: flex;
 	text-align: center;
+	align-self: stretch;
+	flex-wrap: wrap;
 
 	&.mod-dailyView {
-		grid-template-columns: repeat(7, 2.4rem);
+		.calendar-grid-item {
+			width: calc(99% / 7);
+		}
 	}
 
-	&.mod-monthlyView {
-		grid-template-columns: repeat(3, 5.6rem);
-	}
-
+	&.mod-monthlyView,
 	&.mod-yearlyView {
-		grid-template-columns: repeat(3, 5.6rem);
+		.calendar-grid-item {
+			width: calc(99% / 3);
+		}
 	}
 }
 
@@ -74,15 +96,18 @@
 	outline: none;
 
 	&.is-previousMonth, &.is-nextMonth {
+		color: _color("text.placeholder", "color", true);
 		color: _color("text.placeholder");
 	}
 
 	&.is-today {
+		color: _color("primary", "color", true);
 		color: _color("primary");
 
 		&:before {
 			content: "";
 			z-index: 2;
+			box-shadow: inset 0 0 0 2px _color("primary", "lighter", true);
 			box-shadow: inset 0 0 0 2px _color("primary", "lighter");
 			position: absolute;
 			top: 0;
@@ -95,13 +120,16 @@
 
 	&:hover {
 		.calendar-grid-item-content {
+			background: _color("primary", "lighter", true);
 			background: _color("primary", "lighter");
 		}
 	}
 
 	&.is-active {
 		.calendar-grid-item-content {
+			background: _color("primary", "color", true);
 			background: _color("primary");
+			color: _color("primary", "text", true);
 			color: _color("primary", "text");
 		}
 
@@ -110,6 +138,7 @@
 				&:after {
 					content: "";
 					z-index: 1;
+					color: _color("primary", "color", true);
 					color: _color("primary");
 					box-shadow: inset 0 0 0 4px white;
 					position: absolute;

--- a/packages/ng/libraries/root/src/style/_theming.overridable.scss
+++ b/packages/ng/libraries/root/src/style/_theming.overridable.scss
@@ -3,6 +3,9 @@
 @import 'theme/user-picture.theme';
 @import 'user-picture.override';
 
+@import 'theme/calendar.theme';
+@import 'calendar.override';
+
 @import 'theme/options.theme';
 @import 'options.override';
 

--- a/packages/ng/libraries/root/src/style/_theming.scss
+++ b/packages/ng/libraries/root/src/style/_theming.scss
@@ -1,6 +1,7 @@
 $useCssVar: true !default;
 @import '~@lucca-front/scss/src/_theming';
 @import 'theme/user-picture.theme';
+@import 'theme/calendar.theme';
 @import 'theme/options.theme';
 @import 'theme/popup.theme';
 @import 'theme/select.theme';

--- a/packages/ng/libraries/root/src/style/theme/_calendar.theme.scss
+++ b/packages/ng/libraries/root/src/style/theme/_calendar.theme.scss
@@ -1,0 +1,4 @@
+$calendar: (
+	width: 17.8rem
+);
+$theme: _set($theme, 'components.calendar', $calendar);

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -22,6 +22,7 @@
 		"cpx": "cpx",
 		"tsc": "tsc",
 		"start": "ng serve sandbox",
+		"ie11": "ng serve sandbox --configuration es5",
 		"build": "npm run build:lib",
 		"test": "ng test core",
 		"test:sr": "ng test core --watch=false",


### PR DESCRIPTION
Leaves out grid for a flex display to make it usable on IE11.
Fixes #995 