### PR TITLE
[fix] dropdown focus comportment

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/dropdown/dropdown.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/dropdown/dropdown.component.html
@@ -6,7 +6,16 @@
 		</span>
 	</button>
 </div>
-
+<button class="button">other buttons</button>
+<div class="textfield">
+	<input type="text" class="textfield-input">
+	<label for="" class="textfield-label">and inputs</label>
+</div>
+<button class="button">to check if the focus</button>
+<div class="textfield">
+	<input type="text" class="textfield-input">
+	<label for="" class="textfield-label">handles properly</label>
+</div>
 <lu-dropdown #dropdown>
 	<li class="lu-dropdown-options-item" >
 		<a routerLink="." fragment="link1" class="lu-dropdown-options-item-action" luDropdownItem>Link 1</a>

--- a/packages/ng/libraries/dropdown/src/lib/item/dropdown-item.directive.ts
+++ b/packages/ng/libraries/dropdown/src/lib/item/dropdown-item.directive.ts
@@ -27,9 +27,9 @@ export class LuDropdownItemDirective extends ALuDropdownItem implements OnDestro
 		// $event.stopPropagation();
 		this.onSelect.emit(true);
 	}
-	// focus() {
-	// 	this._eltRef.nativeElement.focus();
-	// }
+	focus() {
+		this._eltRef.nativeElement.focus();
+	}
 	ngOnDestroy() {
 		this.onSelect.complete();
 	}

--- a/packages/ng/libraries/dropdown/src/lib/item/dropdown-item.model.ts
+++ b/packages/ng/libraries/dropdown/src/lib/item/dropdown-item.model.ts
@@ -2,9 +2,9 @@ import { Observable } from 'rxjs';
 
 export interface ILuDropdownItem {
 	onSelect: Observable<boolean>;
-	// focus(): void;
+	focus(): void;
 }
 export abstract class ALuDropdownItem implements ILuDropdownItem {
 	abstract onSelect: Observable<boolean>;
-	// abstract focus(): void;
+	abstract focus(): void;
 }

--- a/packages/ng/libraries/dropdown/src/lib/panel/dropdown-panel.component.ts
+++ b/packages/ng/libraries/dropdown/src/lib/panel/dropdown-panel.component.ts
@@ -9,6 +9,7 @@ import {
 	ChangeDetectionStrategy,
 	QueryList,
 	ContentChildren,
+	HostListener,
 } from '@angular/core';
 
 import {
@@ -119,9 +120,19 @@ export class LuDropdownPanelComponent extends ALuPopoverPanel implements ILuPopo
 		this.hovered.emit(hovered);
 	}
 
+	onOpen() {
+		this.focusFirstItem();
+	}
+	private focusFirstItem() {
+		const firstItem = this._items[0];
+		if (firstItem) {
+			firstItem.focus()
+		}
+	}
+
 	// keydown
-	_handleKeydown(event: KeyboardEvent) {
-		super._handleKeydown(event);
+	// _handleKeydown(event: KeyboardEvent) {
+	// 	super._handleKeydown(event);
 		// switch (event.keyCode) {
 		// 	case UP_ARROW:
 		// 		this._decrHighlight();
@@ -149,7 +160,7 @@ export class LuDropdownPanelComponent extends ALuPopoverPanel implements ILuPopo
 		// 		}
 		// 		break;
 		// }
-	}
+	// }
 	// protected _incrHighlight() {
 	// 	this.highlightIndex++;
 	// }


### PR DESCRIPTION
- focus first dropdown item at dropdown opening to allow the user to navigate it via `tab` without having to go through the rest of the page
- refocus trigger button on dropdown close