### PR TITLE
[Fix] ng popover events

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -61,6 +61,7 @@ const routes: Routes = [
 	{ path: 'option-groupby', loadChildren: () => import('./option-groupby').then(m => m.OptionGroupbyModule) },
 	{ path: 'select-option-placeholder', loadChildren: () => import('./select-option-placeholder').then(m => m.SelectOptionPlaceholderModule) },
 	{ path: 'date-picker-width', loadChildren: () => import('./date-picker-width').then(m => m.DatePickerWidthModule) },
+	{ path: 'overlays-events', loadChildren: () => import('./overlays-events').then(m => m.OverlaysEventsModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/overlays-events/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/overlays-events/index.ts
@@ -1,0 +1,1 @@
+export * from './overlays-events.module';

--- a/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.component.html
@@ -1,0 +1,61 @@
+<h1>overlays-events</h1>
+<h2>Popover</h2>
+<button class="button" [luPopover]="thePopover" (luPopoverOnOpen)="onOpen()" (luPopoverOnClose)="onClose()">click me</button>
+<lu-popover #thePopover>content</lu-popover>
+
+<h2>Tooltip</h2>
+<label class="label" luTooltip="tooltip" (luTooltipOnOpen)="onOpen()" (luTooltipOnClose)="onClose()">hover me</label>
+
+<h2>Dropdown</h2>
+
+<div class="button-group">
+	<button class="button">Main action</button>
+	<button class="button mod-more" [luDropdown]="dropdown" (luDropdownOnOpen)="onOpen()" (luDropdownOnClose)="onClose()">
+		<span class="cdk-visually-hidden">
+			More actions
+		</span>
+	</button>
+</div>
+<lu-dropdown #dropdown>
+	<li class="lu-dropdown-options-item" >
+		<a routerLink="." fragment="link1" class="lu-dropdown-options-item-action" luDropdownItem>Link 1</a>
+	</li>
+	<li class="lu-dropdown-options-item" >
+		<button class="lu-dropdown-options-item-action" luDropdownItem (click)="debug()">Button 2</button>
+	</li>
+</lu-dropdown>
+
+<h2>Select</h2>
+<h3>Basic</h3>
+<div class="textfield">
+	<lu-select class="textfield-input" [(ngModel)]="item" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()">
+		<span *luDisplayer="let value">{{value}}</span>
+		<lu-input-clearer *ngIf="true"></lu-input-clearer>
+		<lu-option-picker>
+			<lu-option value="1">1</lu-option>
+			<lu-option value="2">2</lu-option>
+		</lu-option-picker>
+	</lu-select>
+	<label class="textfield-label">Textfield label</label>
+</div>
+<h3>Api</h3>
+<div class="textfield">
+	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments" placeholder="Everything" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-api-select>
+	<label class="textfield-label">Woobwoob</label>
+</div>
+
+<h3>User</h3>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="user" placeholder="Everything" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-user-select>
+	<label class="textfield-label">Woobwoob</label>
+</div>
+<h3>Department</h3>
+<div class="textfield">
+	<lu-department-select class="textfield-input" [(ngModel)]="department" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-department-select>
+	<label for="" class="textfield-label">departments select</label>
+</div>
+<h3>Date</h3>
+<div class="textfield">
+	<lu-date-select class="textfield-input" [(ngModel)]="date" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-date-select>
+	<label for="" class="textfield-label">date select</label>
+</div>

--- a/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.component.html
@@ -40,22 +40,22 @@
 </div>
 <h3>Api</h3>
 <div class="textfield">
-	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments" placeholder="Everything" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-api-select>
+	<lu-api-select class="textfield-input" [(ngModel)]="item" api="/api/v3/departments" placeholder="Everything" (onOpen)="onOpen()" (onClose)="onClose()"></lu-api-select>
 	<label class="textfield-label">Woobwoob</label>
 </div>
 
 <h3>User</h3>
 <div class="textfield">
-	<lu-user-select class="textfield-input" [(ngModel)]="user" placeholder="Everything" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-user-select>
+	<lu-user-select class="textfield-input" [(ngModel)]="user" placeholder="Everything" (onOpen)="onOpen()" (onClose)="onClose()"></lu-user-select>
 	<label class="textfield-label">Woobwoob</label>
 </div>
 <h3>Department</h3>
 <div class="textfield">
-	<lu-department-select class="textfield-input" [(ngModel)]="department" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-department-select>
+	<lu-department-select class="textfield-input" [(ngModel)]="department" (onOpen)="onOpen()" (onClose)="onClose()"></lu-department-select>
 	<label for="" class="textfield-label">departments select</label>
 </div>
 <h3>Date</h3>
 <div class="textfield">
-	<lu-date-select class="textfield-input" [(ngModel)]="date" (onPickerOpen)="onOpen()" (onPickerClose)="onClose()"></lu-date-select>
+	<lu-date-select class="textfield-input" [(ngModel)]="date" (onOpen)="onOpen()" (onClose)="onClose()"></lu-date-select>
 	<label for="" class="textfield-label">date select</label>
 </div>

--- a/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.component.ts
@@ -1,0 +1,21 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'sand-overlays-events',
+	templateUrl: './overlays-events.component.html'
+})
+export class OverlaysEventsComponent {
+	item;
+	user;
+	department;
+	date;
+	onOpen() {
+		console.log('on open')
+	}
+	onClose() {
+		console.log('on close')
+	}
+	debug() {
+		console.log('debug');
+	}
+}

--- a/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/overlays-events/overlays-events.module.ts
@@ -1,0 +1,50 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { OverlaysEventsComponent } from './overlays-events.component';
+import { LuPopoverModule } from '@lucca-front/ng/popover';
+import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+import { LuDropdownModule } from '@lucca-front/ng/dropdown';
+import { LuDepartmentModule } from '@lucca-front/ng/department';
+import { LuUserModule } from '@lucca-front/ng/user';
+import { LuApiModule } from '@lucca-front/ng/api';
+import { LuDateModule } from '@lucca-front/ng/date';
+import { LuSelectModule } from '@lucca-front/ng/select';
+import { LuOptionModule } from '@lucca-front/ng/option';
+import { LuInputModule } from '@lucca-front/ng/input';
+
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+import { FormsModule } from '@angular/forms';
+import { CommonModule } from '@angular/common';
+import { ALuDateAdapter, LuNativeDateAdapter } from '@lucca-front/ng/core';
+
+@NgModule({
+	declarations: [
+		OverlaysEventsComponent,
+	],
+	imports: [
+		LuPopoverModule,
+		LuTooltipModule,
+		LuDropdownModule,
+		LuDepartmentModule,
+		LuUserModule,
+		LuApiModule,
+		LuDateModule,
+		LuSelectModule,
+		LuOptionModule,
+		LuInputModule,
+
+		HttpClientModule,
+		RedirectModule,
+		FormsModule,
+		CommonModule,
+		RouterModule.forChild([
+			{ path: '', component: OverlaysEventsComponent },
+		]),
+	],
+	providers: [
+		{ provide: ALuDateAdapter, useClass: LuNativeDateAdapter },
+	]
+})
+export class OverlaysEventsModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/refacto-overlay-advanced/refacto-overlay-advanced.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/refacto-overlay-advanced/refacto-overlay-advanced.component.html
@@ -39,12 +39,12 @@
 <p>
 	i cant trigger hover or click if there's no pointer event :'(
 </p>
-<button class="button" luTooltip="tooltip enabled">enabled tooltip</button>
+<button class="button" luTooltip="tooltip enabled" (luTooltipOnClose)="onClose()"  (luTooltipOnOpen)="onOpen()">enabled tooltip</button>
 <button class="button" luTooltip="ttooltip disabled" luTooltipDisabled="true">disabled tooltip</button>
 <button class="button" luTooltip="disabled button" disabled="disabled">disabled button</button>
 <br />
 <h2>focus trap</h2>
-<button class="button" [luPopover]="trapped">click me</button>
+<button class="button" [luPopover]="trapped" (luPopoverOnClose)="onClose()"  (luPopoverOnOpen)="onOpen()">click me</button>
 <lu-popover #trapped trap-focus="true">
 	<div class="textfiled">
 		<input type="text" class="textfield-input">

--- a/packages/ng/applications/sandbox/src/app/issues/refacto-overlay-advanced/refacto-overlay-advanced.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/refacto-overlay-advanced/refacto-overlay-advanced.component.ts
@@ -5,4 +5,10 @@ import { Component } from '@angular/core';
 	templateUrl: './refacto-overlay-advanced.component.html'
 })
 export class RefactoOverlayAdvancedComponent {
+	onOpen() {
+		console.log('onopen')
+	}
+	onClose() {
+		console.log('onclose')
+	}
 }

--- a/packages/ng/libraries/dropdown/src/lib/trigger/dropdown-trigger.directive.ts
+++ b/packages/ng/libraries/dropdown/src/lib/trigger/dropdown-trigger.directive.ts
@@ -1,5 +1,5 @@
 import { ILuDropdownPanel } from '../panel/index';
-import { AfterViewInit, OnDestroy, Input, HostBinding, ElementRef, ViewContainerRef, HostListener, Directive } from '@angular/core';
+import { AfterViewInit, OnDestroy, Input, HostBinding, ElementRef, ViewContainerRef, HostListener, Directive, Output, EventEmitter } from '@angular/core';
 import { ALuPopoverTrigger, ILuPopoverTarget, ILuPopoverTrigger, LuPopoverTarget, LuPopoverPosition, LuPopoverAlignment } from '@lucca-front/ng/popover';
 import { Overlay } from '@angular/cdk/overlay';
 
@@ -25,6 +25,11 @@ implements ILuPopoverTrigger<TPanel, ILuPopoverTarget>, AfterViewInit, OnDestroy
 	@Input('luDropdownDisabled') set inputDisabled(d: boolean) { this.disabled = d; }
 	/** set to true if you want the panel to appear on top of the target */
 	@Input('luDropdownOverlap') set inputOverlap(ov: boolean) { this.target.overlap = ov; }
+
+	/** Event emitted when the associated popover is opened. */
+	@Output('luDropdownOnOpen') onOpen = new EventEmitter<void>();
+	/** Event emitted when the associated popover is closed. */
+	@Output('luDropdownOnClose') onClose = new EventEmitter<void>();
 
 	/** accessibility attribute - dont override */
 	@HostBinding('attr.aria-expanded') get _attrAriaExpanded() { return this._popoverOpen; }
@@ -59,5 +64,11 @@ implements ILuPopoverTrigger<TPanel, ILuPopoverTarget>, AfterViewInit, OnDestroy
 	ngOnDestroy() {
 		this.closePopover();
 		this.destroyPopover();
+	}
+	protected _emitOpen(): void {
+		this.onOpen.emit();
+	}
+	protected _emitClose(): void {
+		this.onClose.emit();
 	}
 }

--- a/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.directive.ts
+++ b/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.directive.ts
@@ -39,6 +39,7 @@ export class LuPopoverTriggerDirective<TPanel extends ILuPopoverPanel = ILuPopov
 extends ALuPopoverTrigger<TPanel, TTarget>
 implements ILuPopoverTrigger<TPanel, TTarget>, AfterViewInit, OnDestroy {
 
+
 	/** References the popover instance that the trigger is associated with. */
 	@Input('luPopover') set inputPanel(p: TPanel) { this.panel = p; }
 
@@ -49,10 +50,10 @@ implements ILuPopoverTrigger<TPanel, TTarget>, AfterViewInit, OnDestroy {
 	@Input('luPopoverTrigger') set inputTriggerEvent(te: LuPopoverTriggerEvent) { this.triggerEvent = te; }
 
 	/** Event emitted when the associated popover is opened. */
-	@Output() onPopoverOpen = new EventEmitter<void>();
+	@Output('luPopoverOnOpen') onOpen = new EventEmitter<void>();
 
 	/** Event emitted when the associated popover is closed. */
-	@Output() onPopoverClose = new EventEmitter<void>();
+	@Output('luPopoverOnClose') onClose = new EventEmitter<void>();
 
 	/** how you want to position the panel relative to the target, allowed values: above, below, before, after */
 	@Input('luPopoverPosition') set inputPosition(pos: LuPopoverPosition) { this.target.position = pos; }
@@ -121,5 +122,11 @@ implements ILuPopoverTrigger<TPanel, TTarget>, AfterViewInit, OnDestroy {
 	ngOnDestroy() {
 		this.closePopover();
 		this.destroyPopover();
+	}
+	protected _emitOpen(): void {
+		this.onOpen.emit();
+	}
+	protected _emitClose(): void {
+		this.onClose.emit();
 	}
 }

--- a/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.model.ts
+++ b/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.model.ts
@@ -1,6 +1,5 @@
 import {
 	ElementRef,
-	EventEmitter,
 	ViewContainerRef,
 } from '@angular/core';
 
@@ -18,7 +17,7 @@ import {
 } from '@angular/cdk/overlay';
 import { TemplatePortal, ComponentPortal } from '@angular/cdk/portal';
 
-import { Subscription, Subject, timer } from 'rxjs';
+import { Subscription, Subject, timer, Observable } from 'rxjs';
 import { generateId } from '@lucca-front/ng/core';
 
 import {
@@ -50,6 +49,10 @@ export declare interface ILuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuP
 
 	/** disable popover apparition */
 	disabled: boolean;
+	/** Event emitted when the associated popover is opened. */
+	onOpen: Observable<void>;
+	/** Event emitted when the associated popover is closed. */
+	onClose: Observable<void>;
 
 	openPopover();
 	closePopover();
@@ -114,6 +117,15 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 	protected _triggerId: string;
 	protected _panelId: string;
 
+
+	/** Event emitted when the associated popover is opened. */
+	abstract onOpen: Observable<void>;
+	/** Event emitted when the associated popover is closed. */
+	abstract onClose: Observable<void>;
+
+	protected abstract _emitOpen(): void;
+	protected abstract _emitClose(): void;
+
 	constructor(
 		protected _overlay: Overlay,
 		protected _elementRef: ElementRef,
@@ -170,6 +182,7 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 			/** Only subscribe to mouse enter/leave of the panel if trigger = hover */
 
 			this._initPopover();
+			this._emitOpen();
 		}
 	}
 
@@ -185,6 +198,7 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 			}
 
 			this._resetPopover();
+			this._emitClose();
 		}
 	}
 

--- a/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.model.ts
+++ b/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.model.ts
@@ -188,7 +188,7 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 
 	/** Closes the popover. */
 	closePopover(): void {
-		if (this._overlayRef) {
+		if (this._overlayRef && this._overlayRef.hasAttached()) {
 			this._overlayRef.detach();
 
 			/** unsubscribe to backdrop click if it was defined */

--- a/packages/ng/libraries/select/src/lib/input/select-input.component.ts
+++ b/packages/ng/libraries/select/src/lib/input/select-input.component.ts
@@ -55,9 +55,9 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit, OnDestroy
 		}
 	}
 	/** Event emitted when the associated popover is opened. */
-	@Output('onPickerOpen') onOpen = new EventEmitter<void>();
+	@Output() onOpen = new EventEmitter<void>();
 	/** Event emitted when the associated popover is closed. */
-	@Output('onPickerClose') onClose = new EventEmitter<void>();
+	@Output() onClose = new EventEmitter<void>();
 
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,

--- a/packages/ng/libraries/select/src/lib/input/select-input.component.ts
+++ b/packages/ng/libraries/select/src/lib/input/select-input.component.ts
@@ -8,12 +8,13 @@ import {
 	ContentChild,
 	HostListener,
 	ViewChild,
-	AfterContentInit,
 	Renderer2,
 	Input,
 	HostBinding,
 	OnDestroy,
 	AfterViewInit,
+	Output,
+	EventEmitter,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -53,6 +54,11 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit, OnDestroy
 			this.multiple = !!m;
 		}
 	}
+	/** Event emitted when the associated popover is opened. */
+	@Output('onPickerOpen') onOpen = new EventEmitter<void>();
+	/** Event emitted when the associated popover is closed. */
+	@Output('onPickerClose') onClose = new EventEmitter<void>();
+
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,
@@ -152,7 +158,12 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit, OnDestroy
 		this.closePopover();
 		this.destroyPopover();
 	}
-
+	protected _emitOpen(): void {
+		this.onOpen.emit();
+	}
+	protected _emitClose(): void {
+		this.onClose.emit();
+	}
 }
 
 /**

--- a/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
@@ -8,6 +8,8 @@ import {
 	HostListener,
 	Injector,
 	OnDestroy,
+	Output,
+	EventEmitter,
 } from '@angular/core';
 	import { Overlay } from '@angular/cdk/overlay';
 	import { ALuPopoverTrigger, LuPopoverPosition, LuPopoverTarget } from '@lucca-front/ng/popover';
@@ -30,6 +32,10 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 
 	@Input('luTooltipPosition') set inputPosition(pos: LuPopoverPosition) { this.target.position = pos; }
 
+	/** Event emitted when the associated popover is opened. */
+	@Output('luTooltipOnOpen') onOpen = new EventEmitter<void>();
+	/** Event emitted when the associated popover is closed. */
+	@Output('luTooltipOnClose') onClose = new EventEmitter<void>();
 	@HostListener('mouseenter')
 	onMouseEnter() {
 		super.onMouseEnter();
@@ -65,5 +71,11 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 	ngOnDestroy() {
 		this.closePopover();
 		this.destroyPopover();
+	}
+	protected _emitOpen(): void {
+		this.onOpen.emit();
+	}
+	protected _emitClose(): void {
+		this.onClose.emit();
 	}
 }


### PR DESCRIPTION
added outputs on popover _triggers_ that emits when the panel opens or closes

popover trigger
```ts
@Directive({
	selector: '[luPopover]',
})
export class LuPopoverTriggerDirective {
	@Output('luPopoverOnOpen') onOpen = new EventEmitter<void>();
	@Output('luPopoverOnClose') onClose = new EventEmitter<void>();
```
```html
<button [luPopover]="asdas" (luPopoverOnOpen)="onOpen()" (luPopoverOnClose)="onClose()">click me</button>
```

dropdown trigger
```ts
@Directive({
	selector: '[luDropdown]',
})
export class LuDropdownTriggerDirective {
	@Output('luDropdownOnOpen') onOpen = new EventEmitter<void>();
	@Output('luDropdownOnClose') onClose = new EventEmitter<void>();
```

tooltip-trigger
```ts
@Directive({
	selector: '[luTooltip]',
})
export class LuTooltipTriggerDirective {
	@Output('luTooltipOnOpen') onOpen = new EventEmitter<void>();
	@Output('luTooltipOnClose') onClose = new EventEmitter<void>();
```

any select (normal, api, user, department, date, ...)
```ts
@Directive({
	selector: 'lu-xxx-select',
})
export class LuXxxSelectInputComponent {
	@Output() onOpen = new EventEmitter<void>();
	@Output() onClose = new EventEmitter<void>();
```

-------

@t8g 

closes #987 
closes #912 