### PR TITLE
[ng] date inputs - add granularity option

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.html
@@ -1,4 +1,18 @@
 <h1>date-granularity</h1>
+granularity: <code>{{ gran }}</code>
+<h2>calendar-input</h2>
 <lu-calendar [(ngModel)]="date" [granularity]="gran"></lu-calendar>
 
-{{ date | luDate: 'full' }}
+<h2>date-input</h2>
+<div class="textfield">
+	<input  class="textfield-input" luDateInput [(ngModel)]="date" [granularity]="gran">
+	<label class="textfield-label">date input</label>
+</div>
+
+<h2>date-select</h2>
+<div class="textfield">
+	<lu-date-select class="textfield-input" [(ngModel)]="date" [granularity]="gran"></lu-date-select>
+	<label for="" class="textfield-label">date select</label>
+</div>
+
+<pre>{{ date | luDate: 'full' }}</pre>

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.html
@@ -1,4 +1,4 @@
 <h1>date-granularity</h1>
-<lu-calendar [(ngModel)]="date"></lu-calendar>
+<lu-calendar [(ngModel)]="date" [granularity]="gran"></lu-calendar>
 
 {{ date | luDate: 'full' }}

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.html
@@ -1,0 +1,4 @@
+<h1>date-granularity</h1>
+<lu-calendar [(ngModel)]="date"></lu-calendar>
+
+{{ date | luDate: 'full' }}

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.ts
@@ -7,5 +7,5 @@ import { ELuDateGranularity } from '@lucca-front/ng/core';
 })
 export class DateGranularityComponent {
 	date = new Date();
-	gran = ELuDateGranularity.year;
+	gran = ELuDateGranularity.month;
 }

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'sand-date-granularity',
+	templateUrl: './date-granularity.component.html'
+})
+export class DateGranularityComponent {
+	date = new Date();
+}

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ELuDateGranularity } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'sand-date-granularity',
@@ -6,4 +7,5 @@ import { Component } from '@angular/core';
 })
 export class DateGranularityComponent {
 	date = new Date();
+	gran = ELuDateGranularity.year;
 }

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/date-granularity.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { DateGranularityComponent } from './date-granularity.component';
+import { LuDateModule } from '@lucca-front/ng/date';
+import { FormsModule } from '@angular/forms';
+import { ALuDateAdapter, LuNativeDateAdapter } from '@lucca-front/ng/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+	declarations: [
+		DateGranularityComponent,
+	],
+	imports: [
+		LuDateModule,
+		FormsModule,
+		CommonModule,
+
+		RouterModule.forChild([
+			{ path: '', component: DateGranularityComponent },
+		]),
+	],
+	providers: [
+		{ provide: ALuDateAdapter, useClass: LuNativeDateAdapter },
+	]
+})
+export class DateGranularityModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/date-granularity/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-granularity/index.ts
@@ -1,0 +1,1 @@
+export * from './date-granularity.module';

--- a/packages/ng/applications/sandbox/src/app/issues/date-input/date-input.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-input/date-input.component.html
@@ -16,3 +16,4 @@
 	</div>
 </form>
 <button class="button" (click)="submit()" [class.is-disabled]="form.invalid">submit</button>
+<pre>{{ date | luDate: 'shortDate' }}</pre>

--- a/packages/ng/applications/sandbox/src/app/issues/date-input/date-input.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-input/date-input.module.ts
@@ -29,10 +29,10 @@ registerLocaleData(localeDe);
 		]),
 	],
 	providers: [
-		// { provide: LOCALE_ID, useValue: 'fr-FR' },
+		{ provide: LOCALE_ID, useValue: 'fr-FR' },
 		// { provide: LOCALE_ID, useValue: 'de-DE' },
 		// { provide: LOCALE_ID, useValue: 'en-GB' },
-		{ provide: LOCALE_ID, useValue: 'en-US' },
+		// { provide: LOCALE_ID, useValue: 'en-US' },
 		{ provide: ALuDateAdapter, useClass: LuNativeDateAdapter },
 	]
 })

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -61,6 +61,7 @@ const routes: Routes = [
 	{ path: 'option-groupby', loadChildren: () => import('./option-groupby').then(m => m.OptionGroupbyModule) },
 	{ path: 'select-option-placeholder', loadChildren: () => import('./select-option-placeholder').then(m => m.SelectOptionPlaceholderModule) },
 	{ path: 'date-picker-width', loadChildren: () => import('./date-picker-width').then(m => m.DatePickerWidthModule) },
+	{ path: 'date-granularity', loadChildren: () => import('./date-granularity').then(m => m.DateGranularityModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/libraries/core/src/lib/date/date-adapter.class.ts
+++ b/packages/ng/libraries/core/src/lib/date/date-adapter.class.ts
@@ -36,8 +36,8 @@ export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 
 		return 0;
 	}
-	abstract isParsable(text: string): boolean;
-	abstract parse(text: string): D;
+	abstract isParsable(text: string, granularity?: ELuDateGranularity): boolean;
+	abstract parse(text: string, granularity?: ELuDateGranularity): D;
 	abstract format(d: D, format: string): string;
 	abstract clone(d: D): D;
 

--- a/packages/ng/libraries/core/src/lib/date/date-adapter.interface.ts
+++ b/packages/ng/libraries/core/src/lib/date/date-adapter.interface.ts
@@ -6,8 +6,8 @@ export interface ILuDateAdapter<D> {
 	forgeInvalid(): D;
 	isValid(d: D): boolean;
 	compare(a: D, b: D, granularity: ELuDateGranularity): number;
-	isParsable(text: string): boolean;
-	parse(text: string): D;
+	isParsable(text: string, granularity?: ELuDateGranularity): boolean;
+	parse(text: string, granularity?: ELuDateGranularity): D;
 	format(d: D, format: string): string;
 	clone(d: D): D;
 

--- a/packages/ng/libraries/core/src/lib/date/native/native-date.adapter.ts
+++ b/packages/ng/libraries/core/src/lib/date/native/native-date.adapter.ts
@@ -31,14 +31,34 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 			if (g.indexOf('y') !== -1) { return this._order.year = i; }
 		});
 	}
-	isParsable(text: string): boolean {
+	private extract(text: string, granularity: ELuDateGranularity = ELuDateGranularity.day): { date: number, month: number, year: number } {
+		const groups = text.split(this._regex);
+		let date = 1, month = 1, year = 1;
+		switch(granularity) {
+			case ELuDateGranularity.year:
+				year = parseInt(groups[Math.max(this._order.year - 2, 0)], 10);
+				break;
+			case ELuDateGranularity.month:
+				month = parseInt(groups[Math.max(this._order.month - 1, 0)], 10);
+				year = parseInt(groups[Math.max(this._order.year - 1, 0)], 10) || new Date().getFullYear();
+				break;
+			case ELuDateGranularity.day:
+			default:
+				date = parseInt(groups[this._order.date], 10);
+				month = parseInt(groups[this._order.month], 10);
+				year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
+		}
+		return { date, month, year };
+	}
+	isParsable(text: string, granularity = ELuDateGranularity.day): boolean {
 		if (!text) { return false; }
 		const groups = text.split(this._regex);
 		if (groups.length !== 3 && groups.length !== 2) { return false; }
 		try {
-			const date = parseInt(groups[this._order.date], 10);
-			const month = parseInt(groups[this._order.month], 10);
-			const year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
+			const { date, month, year } = this.extract(text, granularity);
+			// const date = parseInt(groups[this._order.date], 10);
+			// const month = parseInt(groups[this._order.month], 10);
+			// const year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
 			let d : Date;
 			if (this._options.useUtc) {
 				d = new Date(Date.UTC(year, month - 1, date));
@@ -73,10 +93,11 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 			this.forgeInvalid();
 		}
 
-		const groups = text.split(this._regex);
-		const date = parseInt(groups[this._order.date], 10);
-		const month = parseInt(groups[this._order.month], 10);
-		const year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
+		const { date, month, year } = this.extract(text, granularity);
+		// const groups = text.split(this._regex);
+		// const date = parseInt(groups[this._order.date], 10);
+		// const month = parseInt(groups[this._order.month], 10);
+		// const year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
 
 		return this.forge(year, month, date);
 	}

--- a/packages/ng/libraries/core/src/lib/date/native/native-date.adapter.ts
+++ b/packages/ng/libraries/core/src/lib/date/native/native-date.adapter.ts
@@ -67,7 +67,7 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 			return false;
 		}
 	}
-	parse(text: string): Date {
+	parse(text: string, granularity = ELuDateGranularity.day): Date {
 		if (!text) { return undefined; }
 		if (!this.isParsable(text)) {
 			this.forgeInvalid();

--- a/packages/ng/libraries/core/src/lib/date/native/native-date.adapter.ts
+++ b/packages/ng/libraries/core/src/lib/date/native/native-date.adapter.ts
@@ -55,10 +55,9 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 		const groups = text.split(this._regex);
 		if (groups.length !== 3 && groups.length !== 2) { return false; }
 		try {
+
 			const { date, month, year } = this.extract(text, granularity);
-			// const date = parseInt(groups[this._order.date], 10);
-			// const month = parseInt(groups[this._order.month], 10);
-			// const year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
+
 			let d : Date;
 			if (this._options.useUtc) {
 				d = new Date(Date.UTC(year, month - 1, date));
@@ -94,10 +93,6 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 		}
 
 		const { date, month, year } = this.extract(text, granularity);
-		// const groups = text.split(this._regex);
-		// const date = parseInt(groups[this._order.date], 10);
-		// const month = parseInt(groups[this._order.month], 10);
-		// const year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
 
 		return this.forge(year, month, date);
 	}

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -27,12 +27,13 @@ import { ALuDateAdapter, ELuDateGranularity } from '@lucca-front/ng/core';
 export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlValueAccessor, OnInit, Validator {
 	@Input() min?: D;
 	@Input() max?: D;
+	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
 
-	granularity: ELuDateGranularity;
+	viewGranularity: ELuDateGranularity;
 	header: ICalendarItem<D>;
 	items: ICalendarItem<D>[] = [];
 	get mod() {
-		switch (this.granularity) {
+		switch (this.viewGranularity) {
 			case ELuDateGranularity.year:
 				return 'mod-yearlyView';
 			case ELuDateGranularity.month:
@@ -54,7 +55,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		super(_changeDetectorRef, _elementRef, _renderer);
 	}
 	ngOnInit() {
-		this.granularity = ELuDateGranularity.day;
+		this.viewGranularity = this.granularity;
 		this.initDayLabels();
 	}
 	writeValue(value?: D) {
@@ -70,7 +71,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		}
 	}
 	protected render() {
-		switch (this.granularity) {
+		switch (this.viewGranularity) {
 			case ELuDateGranularity.year:
 				this.renderYearlyView();
 				break;
@@ -193,7 +194,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		});
 	}
 	select(item: ICalendarItem<D>) {
-		switch (this.granularity) {
+		switch (this.viewGranularity) {
 			case ELuDateGranularity.year:
 				this.selectYear(item);
 				break;
@@ -214,18 +215,26 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		this.setValue(item.date);
 	}
 	protected selectMonth(item: ICalendarItem<D>) {
-		this.header = item;
-		this.granularity = ELuDateGranularity.day;
-		this.render();
+		if (this.granularity === ELuDateGranularity.month) {
+			this.setValue(item.date);
+		} else {
+			this.header = item;
+			this.viewGranularity = ELuDateGranularity.day;
+			this.render();
+		}
 	}
 	protected selectYear(item: ICalendarItem<D>) {
-		this.header = item;
-		this.granularity = ELuDateGranularity.month;
-		this.render();
+		if (this.granularity === ELuDateGranularity.year) {
+			this.setValue(item.date);
+		} else {
+			this.header = item;
+			this.viewGranularity = ELuDateGranularity.month;
+			this.render();
+		}
 	}
 
 	previous() {
-		switch (this.granularity) {
+		switch (this.viewGranularity) {
 			case ELuDateGranularity.year:
 				this.previousDecade();
 				break;
@@ -240,7 +249,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		this.render();
 	}
 	next() {
-		switch (this.granularity) {
+		switch (this.viewGranularity) {
 			case ELuDateGranularity.year:
 				this.nextDecade();
 				break;
@@ -256,7 +265,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 	}
 	trackBy(idx, item) { return item.id; }
 	changeGranularity() {
-		this.granularity = this.header.granularity;
+		this.viewGranularity = this.header.granularity;
 		this.render();
 	}
 	protected nextMonth() {

--- a/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
@@ -51,7 +51,7 @@ export class LuDateInputDirective<D> extends ALuInput<D> implements Validator {
 		this.setValue(value);
 	}
 	private parse(text): D {
-		const date = this._adapter.parse(text);
+		const date = this._adapter.parse(text, this.granularity);
 		return date;
 	}
 	@HostListener('focus')

--- a/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Renderer2, ChangeDetectorRef, forwardRef, HostListener, Input, Inject } from '@angular/core';
+import { Directive, ElementRef, Renderer2, ChangeDetectorRef, forwardRef, HostListener, Input, Inject, OnInit } from '@angular/core';
 import { ALuInput } from '@lucca-front/ng/input';
 import { NG_VALUE_ACCESSOR, Validator, NG_VALIDATORS, ValidationErrors, AbstractControl } from '@angular/forms';
 import { ALuDateAdapter, ELuDateGranularity } from '@lucca-front/ng/core';
@@ -20,7 +20,7 @@ import { LuDateInputIntl } from './date-input.intl';
 		},
 	],
 })
-export class LuDateInputDirective<D> extends ALuInput<D> implements Validator {
+export class LuDateInputDirective<D> extends ALuInput<D> implements Validator, OnInit {
 	private _focused = false;
 	@Input() min?: D;
 	@Input() max?: D;
@@ -37,11 +37,37 @@ export class LuDateInputDirective<D> extends ALuInput<D> implements Validator {
 		@Inject(LuDateInputIntl) private _intl: ILuDateInputLabel,
 	) {
 		super(_changeDetectorRef, _elementRef, _renderer);
-		this.placeholder = this._intl.placeholder;
+	}
+	ngOnInit() {
+		switch (this.granularity) {
+			case ELuDateGranularity.year:
+				this.placeholder = this._intl.placeholderYear;
+				break;
+			case ELuDateGranularity.month:
+				this.placeholder = this._intl.placeholderMonth;
+				break;
+			case ELuDateGranularity.day:
+			default:
+				this.placeholder = this._intl.placeholderDay;
+				break;
+		}
 	}
 	protected render() {
 		if (this._focused) { return; }
-		const text = this.value && this._adapter.isValid(this.value) ? this._adapter.format(this.value, 'shortDate') : '';
+		let format: string;;
+		switch (this.granularity) {
+			case ELuDateGranularity.year:
+				format = this._intl.formatYear;
+				break;
+			case ELuDateGranularity.month:
+				format = this._intl.formatMonth;
+				break;
+			case ELuDateGranularity.day:
+			default:
+				format = this._intl.formatDay;
+				break;
+		}
+		const text = this.value && this._adapter.isValid(this.value) ? this._adapter.format(this.value, format) : '';
 		this._elementRef.nativeElement.value = text;
 	}
 	@HostListener('input', ['$event'])

--- a/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.directive.ts
@@ -24,6 +24,8 @@ export class LuDateInputDirective<D> extends ALuInput<D> implements Validator {
 	private _focused = false;
 	@Input() min?: D;
 	@Input() max?: D;
+	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+
 	@Input() set placeholder(p: string) {
 		this._elementRef.nativeElement.placeholder = p;
 	}

--- a/packages/ng/libraries/date/src/lib/input/date-input.translate.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.translate.ts
@@ -1,20 +1,46 @@
 import { ILuTranslation } from '@lucca-front/ng/core';
 
 export interface ILuDateInputLabel {
-	placeholder: string;
+	placeholderDay: string;
+	placeholderMonth: string;
+	placeholderYear: string;
+	formatDay: string;
+	formatMonth: string;
+	formatYear: string;
 }
 export abstract class ALuDateInputLabel {
-	placeholder: string;
+	placeholderDay: string;
+	placeholderMonth: string;
+	placeholderYear: string;
+	formatDay: string;
+	formatMonth: string;
+	formatYear: string;
 }
 
 export const luDateInputTranslations = {
 	en: {
-		placeholder: 'dd/mm/yyyy',
+		placeholderDay: 'dd/mm/yyyy',
+		placeholderMonth: 'mm/yyyy',
+		placeholderYear: 'yyyy',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
 	},
 	'en-US': {
-		placeholder: 'mm/dd/yyyy',
+		placeholderDay: 'mm/dd/yyyy',
+		placeholderMonth: 'mm/yyyy',
+		placeholderYear: 'yyyy',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
 	},
 	fr: {
 		placeholder: 'jj/mm/aaaa',
+		placeholderDay: 'jj/mm/aaaa',
+		placeholderMonth: 'mm/aaaa',
+		placeholderYear: 'aaaa',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
 	},
 } as ILuTranslation<ILuDateInputLabel>;

--- a/packages/ng/libraries/date/src/lib/picker/date-picker.component.html
+++ b/packages/ng/libraries/date/src/lib/picker/date-picker.component.html
@@ -3,9 +3,9 @@
 	(click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-picker-content" [ngClass]="contentClassesMap" cdkTrapFocus="false" cdkTrapFocusAutoCapture="true">
 			<div class="textfield lu-picker-textfield">
-				<input luDateInput class="textfield-input" [ngModel]="_value" (ngModelChange)="_onInput($event)" (keydown.enter)="_onEnter()"[min]="min" [max]="max">
+				<input luDateInput class="textfield-input" [ngModel]="_value" (ngModelChange)="_onInput($event)" (keydown.enter)="_onEnter()"[min]="min" [max]="max" [granularity]="granularity">
 			</div>
-			<lu-calendar [ngModel]="_value" (ngModelChange)="_onCalendar($event)"[min]="min" [max]="max"></lu-calendar>
+			<lu-calendar [ngModel]="_value" (ngModelChange)="_onCalendar($event)"[min]="min" [max]="max" [granularity]="granularity"></lu-calendar>
 		</div>
 	</div>
 </ng-template>

--- a/packages/ng/libraries/date/src/lib/picker/date-picker.component.ts
+++ b/packages/ng/libraries/date/src/lib/picker/date-picker.component.ts
@@ -2,6 +2,7 @@ import { ALuPickerPanel } from '@lucca-front/ng/picker';
 import { Component, ChangeDetectionStrategy, forwardRef, Output, EventEmitter, TemplateRef, ViewChild, Input } from '@angular/core';
 import { luTransformPopover } from '@lucca-front/ng/popover';
 import { ESCAPE, TAB } from '@angular/cdk/keycodes';
+import { ELuDateGranularity } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-date-picker',
@@ -21,6 +22,7 @@ export class LuDatePickerComponent extends ALuPickerPanel<Date> {
 
 	@Input() min?: Date;
 	@Input() max?: Date;
+	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
 
 	@Output() close = new EventEmitter<void>();
 	@Output() open = new EventEmitter<void>();

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
@@ -10,4 +10,4 @@
 <ng-template luDisplayer let-value>
 	{{ value | luDate }}
 </ng-template>
-<lu-date-picker [min]="min" [max]="max"></lu-date-picker>
+<lu-date-picker [min]="min" [max]="max" [granularity]="granularity"></lu-date-picker>

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
@@ -8,6 +8,6 @@
 	<lu-input-clearer></lu-input-clearer>
 </div>
 <ng-template luDisplayer let-value>
-	{{ value | luDate }}
+	{{ value | luDate: format }}
 </ng-template>
 <lu-date-picker [min]="min" [max]="max" [granularity]="granularity"></lu-date-picker>

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
@@ -40,6 +40,7 @@ extends ALuSelectInputComponent<D>
 implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit, Validator {
 	@Input() min?: D;
 	@Input() max?: D;
+	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 	overlapInput = true;
 	constructor(

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
@@ -9,6 +9,7 @@ import {
 	Input,
 	Renderer2,
 	AfterViewInit,
+	Inject,
 } from '@angular/core';
 import { NG_VALUE_ACCESSOR, ControlValueAccessor, NG_VALIDATORS, Validator, AbstractControl, ValidationErrors } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
@@ -16,6 +17,8 @@ import { ILuInputWithPicker, ALuPickerPanel, ILuPickerPanel } from '@lucca-front
 import { ALuClearer, ILuClearer, ILuInputDisplayer, ALuInputDisplayer } from '@lucca-front/ng/input';
 import { ALuSelectInputComponent } from '@lucca-front/ng/select';
 import { ALuDateAdapter, ELuDateGranularity } from '@lucca-front/ng/core';
+import { ILuDateSelectInputLabel } from './date-select-input.translate';
+import { LuDateSelectInputIntl } from './date-select-input.intl';
 
 @Component({
 	selector: 'lu-date-select',
@@ -43,6 +46,17 @@ implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit, Validator
 	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 	overlapInput = true;
+	get format(): string {
+		switch (this.granularity) {
+			case ELuDateGranularity.year:
+				return this._intl.formatYear;
+			case ELuDateGranularity.month:
+				return this._intl.formatMonth;
+			case ELuDateGranularity.day:
+			default:
+				return this._intl.formatDay;
+		}
+	}
 	constructor(
 		protected _changeDetectorRef: ChangeDetectorRef,
 		protected _overlay: Overlay,
@@ -50,6 +64,8 @@ implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit, Validator
 		protected _viewContainerRef: ViewContainerRef,
 		protected _renderer: Renderer2,
 		private _adapter: ALuDateAdapter<D>,
+		@Inject(LuDateSelectInputIntl) private _intl: ILuDateSelectInputLabel,
+
 		) {
 		super(
 			_changeDetectorRef,

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.intl.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.intl.ts
@@ -1,0 +1,11 @@
+import { Injectable, LOCALE_ID, Inject } from '@angular/core';
+import { LU_DATE_SELECT_INPUT_TRANSLATIONS } from './date-select-input.token';
+import { ILuDateSelectInputLabel } from './date-select-input.translate';
+import { ALuIntl } from '@lucca-front/ng/core';
+
+@Injectable()
+export class LuDateSelectInputIntl extends ALuIntl<ILuDateSelectInputLabel> {
+	constructor(@Inject(LU_DATE_SELECT_INPUT_TRANSLATIONS) translations, @Inject(LOCALE_ID) locale) {
+		super(translations, locale);
+	}
+}

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.module.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.module.ts
@@ -4,6 +4,9 @@ import { LuDateAdapterModule } from '../adapter/index';
 import { LuDatePickerModule } from '../picker/index';
 import { LuInputModule, LuInputClearerModule, LuInputDisplayerModule } from '@lucca-front/ng/input';
 import { OverlayModule } from '@angular/cdk/overlay';
+import { LuDateSelectInputIntl } from './date-select-input.intl';
+import { LU_DATE_SELECT_INPUT_TRANSLATIONS } from './date-select-input.token';
+import { luDateSelectInputTranslations } from './date-select-input.translate';
 
 @NgModule({
 	imports: [
@@ -20,5 +23,9 @@ import { OverlayModule } from '@angular/cdk/overlay';
 	declarations: [
 		LuDateSelectInputComponent,
 	],
+	providers: [
+		LuDateSelectInputIntl,
+		{ provide: LU_DATE_SELECT_INPUT_TRANSLATIONS, useValue: luDateSelectInputTranslations },
+	]
 })
 export class LuDateSelectInputModule {}

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.token.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_DATE_SELECT_INPUT_TRANSLATIONS = new InjectionToken('LuDateSelectInputtranslations');

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.translate.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.translate.ts
@@ -1,0 +1,46 @@
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+export interface ILuDateSelectInputLabel {
+	placeholderDay: string;
+	placeholderMonth: string;
+	placeholderYear: string;
+	formatDay: string;
+	formatMonth: string;
+	formatYear: string;
+}
+export abstract class ALuDateSelectInputLabel {
+	placeholderDay: string;
+	placeholderMonth: string;
+	placeholderYear: string;
+	formatDay: string;
+	formatMonth: string;
+	formatYear: string;
+}
+
+export const luDateSelectInputTranslations = {
+	en: {
+		placeholderDay: 'dd/mm/yyyy',
+		placeholderMonth: 'mm/yyyy',
+		placeholderYear: 'yyyy',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
+	},
+	'en-US': {
+		placeholderDay: 'mm/dd/yyyy',
+		placeholderMonth: 'mm/yyyy',
+		placeholderYear: 'yyyy',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
+	},
+	fr: {
+		placeholder: 'jj/mm/aaaa',
+		placeholderDay: 'jj/mm/aaaa',
+		placeholderMonth: 'mm/aaaa',
+		placeholderYear: 'aaaa',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
+	},
+} as ILuTranslation<ILuDateSelectInputLabel>;


### PR DESCRIPTION
add `@Input() granularity` to 

- lu-date-select component
- lu-date-picker component
- lu-calendar component
- [luDateInput] directive

to allow the end user to only select a month or a year, not necessarily a date
![ez](https://user-images.githubusercontent.com/10089239/86139254-ca2b3200-baef-11ea-8d78-efe4f2924b24.gif)

fixes #1026

-----

left to do
- [x] luDateInput should know how to parse 03/20 on granularity month, whatever the locale
- [x] default displayer for date-select should accomodate the given granularity and just display `Jan 2020` or `janvier 2020` not `Jan 1st 2020` or `1 janvier 2020`


![display](https://user-images.githubusercontent.com/10089239/86139695-59384a00-baf0-11ea-9856-44cb6c15eec7.gif)
_should just display "2021", not "Jan 1, 2021"_