### PR TITLE
[ng] api-select - rework to force refresh on open

### DIFF
--- a/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.component.ts
+++ b/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.component.ts
@@ -130,7 +130,7 @@ extends ALuApiOptionPagedSearcher<T, S> implements OnInit {
 		super.onOpen();
 	}
 	resetClue() {
-		this.clueControl.reset('')
+		this.clueControl.reset('');
 	}
 }
 

--- a/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.model.ts
+++ b/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.model.ts
@@ -11,6 +11,7 @@ import {
 	distinctUntilChanged,
 	catchError,
 	map,
+	debounceTime,
 } from 'rxjs/operators';
 
 import { ILuApiItem } from '../../api.model';
@@ -32,14 +33,18 @@ implements ILuApiOptionFeeder<T>, ILuOnOpenSubscriber {
 	protected _clue$: Observable<string>;
 
 	set clue$(clue$: Observable<string>) {
-		this.initObservables(clue$);
+		// this.initObservables(clue$);
+		this._clue$ = clue$;
 	}
 	constructor(protected _service: S) {}
+	init() {
+		this.initObservables();
+	}
 	onOpen() {
 		this.resetClue();
 	}
-	protected initObservables(clue$) {
-		this._clue$ = clue$.pipe(share());
+	protected initObservables() {
+		// this._clue$ = clue$.pipe(share());
 		const results$ = this._clue$
 		.pipe(
 			switchMap(clue => this._service.searchAll(clue)),
@@ -124,18 +129,23 @@ implements ILuApiOptionPagedSearcher<T>, ILuOnScrollBottomSubscriber {
 			this._page$.next(this._page + 1);
 		}
 	}
-	protected initObservables(clue$) {
-		const distinctPage$ = this._page$.pipe(distinctUntilChanged(), tap(p => this._page = p));
 
-		this._clue$ = clue$.pipe(
-			tap(() => this._page$.next(0)),
+	protected initObservables() {
+		const distinctPage$ = this._page$.pipe(
 			distinctUntilChanged(),
-			share()
+			tap(p => this._page = p),
 		);
+
+		// this._clue$ = clue$.pipe(
+		// 	tap(() => this._page$.next(0)),
+		// 	// distinctUntilChanged(),
+		// 	share()
+		// );
 		const results$ = combineLatest(
 			distinctPage$,
 			this._clue$,
 		).pipe(
+			debounceTime(100),
 			switchMap(([page, clue]) => this._service.searchPaged(clue, page)),
 			catchError(err => of([])),
 			share(),

--- a/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.html
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.html
@@ -2,10 +2,7 @@
 	<div class="lu-picker-panel lu-option-picker-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
 	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-picker-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
-			<ng-content *ngIf="!(loading$ | async); else loading"></ng-content>
+			<ng-content [class.is-loading]="loading$ | async"></ng-content>
 		</div>
 	</div>
-</ng-template>
-<ng-template #loading>
-	<div class="lu-picker-loading loading mod-block"></div>
 </ng-template>

--- a/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.html
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.html
@@ -1,8 +1,9 @@
 <ng-template>
 	<div class="lu-picker-panel lu-option-picker-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
 	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
-		<div class="lu-picker-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
-			<ng-content [class.is-loading]="loading$ | async"></ng-content>
+		<div [class.is-loading]="loading$ | async" class="lu-picker-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
+			<ng-content></ng-content>
+			<div *ngIf="loading$ | async" class="loading lu-picker-loading"></div>	
 		</div>
 	</div>
 </ng-template>

--- a/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.ts
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.ts
@@ -98,14 +98,6 @@ extends ALuOptionPickerComponent<T, O> implements AfterViewInit {
 				startWith(true),
 				shareReplay(),
 			);
-			this.loading$.pipe(
-				delay(1),
-			).subscribe(l => {
-				if (!l) {
-					// replay onOpen when loading is done
-					this.onOpen();
-				}
-			});
 		}
 	}
 	protected initSelectors() {

--- a/packages/ng/libraries/option/src/lib/picker/tree-option-picker-advanced.component.html
+++ b/packages/ng/libraries/option/src/lib/picker/tree-option-picker-advanced.component.html
@@ -2,10 +2,7 @@
 	<div class="lu-picker-panel lu-tree-option-picker-panel" role="dialog" [ngClass]="panelClassesMap" [class.mod-multiple]="multiple"
 	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-picker-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
-			<ng-content *ngIf="!(loading$ | async); else loading"></ng-content>
+			<ng-content [class.is-loading]="loading$ | async"></ng-content>
 		</div>
 	</div>
-</ng-template>
-<ng-template #loading>
-	<div class="lu-picker-loading loading mod-block"></div>
 </ng-template>

--- a/packages/ng/libraries/option/src/lib/picker/tree-option-picker-advanced.component.ts
+++ b/packages/ng/libraries/option/src/lib/picker/tree-option-picker-advanced.component.ts
@@ -101,14 +101,6 @@ extends ALuTreeOptionPickerComponent<T, O> implements AfterViewInit {
 				startWith(true),
 				shareReplay(),
 			);
-			this.loading$.pipe(
-				delay(1),
-			).subscribe(l => {
-				if (!l) {
-					// replay onOpen when loading is done
-					this.onOpen();
-				}
-			});
 		}
 	}
 	protected initSelectors() {

--- a/packages/ng/libraries/root/src/style/components/_picker.scss
+++ b/packages/ng/libraries/root/src/style/components/_picker.scss
@@ -5,25 +5,26 @@
 }
 
 .lu-picker-content {
+	$height: 17.5rem; // magic number
+
 	@extend %popover-content;
 	padding: 0;
-	max-height: 280px;
+	max-height: $height; 
 	overflow-y: auto;
 	display: block;
 	transform-origin: top left;
 	animation: scaleIn 150ms cubic-bezier(0.25, 0.8, 0.25, 1);
 
-	.is-loading {
-		// @vvalentin - i need code here to replace 
-		// <div class="lu-picker-loading loading mod-block"></div>
-
+	&.is-loading {
+		height: $height;
 	}
 }
 
 .lu-picker-loading {
-	height: 280px;
-	margin: 0;
-	overflow: hidden;
+	position: absolute;
+	left: 50%;
+	top: 50%;
+	transform: translateX(-50%) translateY(-50%);
 }
 
 .lu-picker-header {
@@ -34,6 +35,7 @@
 	right: 0;
 	display: block;
 	z-index: 1;
+	
 }
 
 .lu-picker-textfield {

--- a/packages/ng/libraries/root/src/style/components/_picker.scss
+++ b/packages/ng/libraries/root/src/style/components/_picker.scss
@@ -12,6 +12,12 @@
 	display: block;
 	transform-origin: top left;
 	animation: scaleIn 150ms cubic-bezier(0.25, 0.8, 0.25, 1);
+
+	.is-loading {
+		// @vvalentin - i need code here to replace 
+		// <div class="lu-picker-loading loading mod-block"></div>
+
+	}
 }
 
 .lu-picker-loading {

--- a/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
@@ -1,8 +1,8 @@
-import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, HostBinding } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, HostBinding, OnInit } from '@angular/core';
 import { ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber } from '@lucca-front/ng/core';
 import { ALuOptionOperator } from '@lucca-front/ng/option';
 import { FormControl } from '@angular/forms';
-import { debounceTime } from 'rxjs/operators';
+import { debounceTime, tap } from 'rxjs/operators';
 import { LuUserPagedSearcherService } from './user-searcher.service';
 import { ALuUserPagedSearcherService } from './user-searcher.model';
 import { ILuUser } from '../../user.model';
@@ -36,7 +36,7 @@ import { ALuApiOptionPagedSearcher } from '@lucca-front/ng/api';
 	],
 })
 export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser, S extends ALuUserPagedSearcherService<U> = ALuUserPagedSearcherService<U>>
-extends ALuApiOptionPagedSearcher<U, S> {
+extends ALuApiOptionPagedSearcher<U, S> implements OnInit {
 	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef, static: true }) searchInput: ElementRef;
 	@Input() set fields(fields: string) { this._service.fields = fields; }
@@ -52,16 +52,22 @@ extends ALuApiOptionPagedSearcher<U, S> {
 		@Inject(ALuUserPagedSearcherService) @Self() selfService: ALuUserPagedSearcherService,
 	) {
 		super((hostService || selfService) as S);
-		this.clueControl = new FormControl(undefined);
-		this.clue$ = this.clueControl.valueChanges
-		.pipe(debounceTime(250));
 	}
 
 	onOpen() {
 		this.searchInput.nativeElement.focus();
 		super.onOpen();
 	}
+	ngOnInit() {
+		this.clueControl = new FormControl(undefined);
+		this.clue$ = this.clueControl.valueChanges
+		.pipe(
+			tap(c => this.resetPage()),
+			// debounceTime(250),
+		);
+		super.init();
+	}
 	resetClue() {
-		this.clueControl.setValue('');
+		this.clueControl.reset('');
 	}
 }


### PR DESCRIPTION
fixes #1040 

@vvalentin-lucca i need some stylin done because i had to change the way the loading placeholder is handled in option-picker advanced
_before_
```html
<ng-content *ngIf="!(loading$ | async); else loading"></ng-content>
<ng-template #loading>	
	<div class="lu-picker-loading loading mod-block"></div>	
</ng-template>
```

_after_
```html
<ng-content [class.is-loading]="loading$ | async"></ng-content>
```