### PR TITLE
Fix overlapping breakpoints + u-wrap

### DIFF
--- a/packages/scss/demo/components/mixins.html
+++ b/packages/scss/demo/components/mixins.html
@@ -33,8 +33,8 @@ _color("palette_name", "key") // return the palette.key value
 <code class="code mod-block">@include loading($size);</code>
 	<h3>Media queries</h3>
 	<p>Using the breakpoint values in the breakpoints map, you can easily handle your media queries</p>
-<code class="code mod-block">@include media_smaller_than("breakpoint_key"){} // <==> @media (max-width: breakpoint_value) {}
+<code class="code mod-block">@include media_smaller_than("breakpoint_key"){} // <==> @media (max-width: breakpoint_value - 1) {}
 @include media_larger_than("breakpoint_key"){} //<==> @media (min-width: breakpoint_value) {}
-@include media_between("breakpoint1_key", "breakpoint2_key"){} //<==> @media (min-width: breakpoint1_value) and (max-width: breakpoint2_value) {}
+@include media_between("breakpoint1_key", "breakpoint2_key"){} //<==> @media (min-width: breakpoint1_value) and (max-width: breakpoint2_value - 1) {}
 </code>
 </section>

--- a/packages/scss/demo/components/mixins.html
+++ b/packages/scss/demo/components/mixins.html
@@ -33,8 +33,8 @@ _color("palette_name", "key") // return the palette.key value
 <code class="code mod-block">@include loading($size);</code>
 	<h3>Media queries</h3>
 	<p>Using the breakpoint values in the breakpoints map, you can easily handle your media queries</p>
-<code class="code mod-block">@include media_smaller_than("breakpoint_key"){} // <==> @media (max-width: breakpoint_value - 1) {}
+<code class="code mod-block">@include media_smaller_than("breakpoint_key"){} // <==> @media (max-width: breakpoint_value - 1px) {}
 @include media_larger_than("breakpoint_key"){} //<==> @media (min-width: breakpoint_value) {}
-@include media_between("breakpoint1_key", "breakpoint2_key"){} //<==> @media (min-width: breakpoint1_value) and (max-width: breakpoint2_value - 1) {}
+@include media_between("breakpoint1_key", "breakpoint2_key"){} //<==> @media (min-width: breakpoint1_value) and (max-width: breakpoint2_value - 1px) {}
 </code>
 </section>

--- a/packages/scss/demo/demo.css
+++ b/packages/scss/demo/demo.css
@@ -109,7 +109,7 @@
 	padding: 60px 0 100px 180px;
 }
 
-@media screen and (max-width: 992px) {
+@media screen and (max-width: 991px) {
 	.demo-body {
 		padding-left: 0;
 	}
@@ -127,7 +127,7 @@
 	overflow: auto;
 }
 
-@media screen and (max-width: 992px) {
+@media screen and (max-width: 991px) {
 	.demo-nav {
 		display: none;
 	}
@@ -164,7 +164,7 @@
 	max-width: 850px;
 }
 
-@media screen and (max-width: 1200px) {
+@media screen and (max-width: 1199px) {
 	.container.mod-demo {
 		max-width: 700px;
 	}

--- a/packages/scss/src/_typo.scss
+++ b/packages/scss/src/_typo.scss
@@ -66,7 +66,7 @@ p {
 	margin: 0 0 .7rem;
 }
 
-b {
+b, strong {
 	font-weight: 600;
 }
 

--- a/packages/scss/src/components/_container.scss
+++ b/packages/scss/src/components/_container.scss
@@ -10,7 +10,7 @@
 		}
 	}
 
-	@media (max-width: _component("container.min-width", true) - 1) {
+	@include media_smaller_than("sm") {
 		width: 100%;
 	}
 

--- a/packages/scss/src/components/_container.scss
+++ b/packages/scss/src/components/_container.scss
@@ -10,7 +10,7 @@
 		}
 	}
 
-	@media (max-width: _component("container.min-width", true)) {
+	@media (max-width: _component("container.min-width", true) - 1) {
 		width: 100%;
 	}
 

--- a/packages/scss/src/components/_section.scss
+++ b/packages/scss/src/components/_section.scss
@@ -3,12 +3,12 @@
 	border-bottom: 1px solid #E5E5E5;
 	padding: 3rem;
 
-	@media (max-width: _theme("breakpoints.md.breakAt") - 1) {
+	@include media_smaller_than("md") {
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
 
-	@media (max-width: _theme("breakpoints.sm.breakAt") - 1) {
+	@include media_smaller_than("sm") {
 		padding-left: 1rem;
 		padding-right: 1rem;
 	}

--- a/packages/scss/src/components/_section.scss
+++ b/packages/scss/src/components/_section.scss
@@ -3,12 +3,12 @@
 	border-bottom: 1px solid #E5E5E5;
 	padding: 3rem;
 
-	@media (max-width: _theme("breakpoints.md.breakAt")) {
+	@media (max-width: _theme("breakpoints.md.breakAt") - 1) {
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
 
-	@media (max-width: _theme("breakpoints.sm.breakAt")) {
+	@media (max-width: _theme("breakpoints.sm.breakAt") - 1) {
 		padding-left: 1rem;
 		padding-right: 1rem;
 	}

--- a/packages/scss/src/mixins/_responsiveness.scss
+++ b/packages/scss/src/mixins/_responsiveness.scss
@@ -1,6 +1,6 @@
 @mixin media_smaller_than($breakpoint) {
 	@if map-has-key(_getMap("breakpoints"), $breakpoint) {
-		@media (max-width: #{_theme("breakpoints.#{$breakpoint}.breakAt", true)}) {
+		@media (max-width: #{_theme("breakpoints.#{$breakpoint}.breakAt", true)} - 1) {
 			@content;
 		}
 	}
@@ -24,7 +24,7 @@
 
 @mixin media_between($breakpoint1, $breakpoint2) {
 	@if map-has-key(_getMap("breakpoints"), $breakpoint1) and map-has-key(_getMap("breakpoints"), $breakpoint2) {
-		@media (min-width: #{_theme("breakpoints.#{$breakpoint1}.breakAt", true)}) and (max-width: #{_theme("breakpoints.#{$breakpoint2}.breakAt", true)}) {
+		@media (min-width: #{_theme("breakpoints.#{$breakpoint1}.breakAt", true)}) and (max-width: #{_theme("breakpoints.#{$breakpoint2}.breakAt", true)} - 1) {
 			@content;
 		}
 	}

--- a/packages/scss/src/mixins/_responsiveness.scss
+++ b/packages/scss/src/mixins/_responsiveness.scss
@@ -1,6 +1,6 @@
 @mixin media_smaller_than($breakpoint) {
 	@if map-has-key(_getMap("breakpoints"), $breakpoint) {
-		@media (max-width: #{_theme("breakpoints.#{$breakpoint}.breakAt", true)} - 1) {
+		@media (max-width: _theme("breakpoints.#{$breakpoint}.breakAt", true) - 1px) {
 			@content;
 		}
 	}
@@ -24,7 +24,7 @@
 
 @mixin media_between($breakpoint1, $breakpoint2) {
 	@if map-has-key(_getMap("breakpoints"), $breakpoint1) and map-has-key(_getMap("breakpoints"), $breakpoint2) {
-		@media (min-width: #{_theme("breakpoints.#{$breakpoint1}.breakAt", true)}) and (max-width: #{_theme("breakpoints.#{$breakpoint2}.breakAt", true)} - 1) {
+		@media (min-width: _theme("breakpoints.#{$breakpoint1}.breakAt", true)) and (max-width: _theme("breakpoints.#{$breakpoint2}.breakAt", true) - 1px) {
 			@content;
 		}
 	}

--- a/packages/scss/src/utilities/_misc.scss
+++ b/packages/scss/src/utilities/_misc.scss
@@ -28,6 +28,10 @@
 	white-space: nowrap;
 }
 
+.u-wrap {
+	white-space: normal;
+}
+
 // ICONS
 //
 .u-help {


### PR DESCRIPTION
- At a given breakpoint, `media_smaller_than` and `media_larger_than` were triggered at the same time.
- Add font-weight for `strong` and `u-wrap` class.

-----

Before: 

https://codepen.io/vincent-valentin/pen/PoZRKwG

![Capture d’écran - 2020-07-07 à 11 29 38](https://user-images.githubusercontent.com/64789527/86764542-67ceb600-c048-11ea-8566-18abe2a8842b.png)

-----

After:

https://codepen.io/vincent-valentin/pen/PoZRKNb

![Capture d’écran - 2020-07-07 à 11 31 05](https://user-images.githubusercontent.com/64789527/86764602-73ba7800-c048-11ea-9d31-671fc2d7653b.png)


