### PR TITLE
Fix hyphen

### DIFF
--- a/packages/scss/src/utilities/_spacing.scss
+++ b/packages/scss/src/utilities/_spacing.scss
@@ -1,19 +1,24 @@
-$prefix: "u-";
-$properties: "margin", "padding", "border";
-$hyphen: "-";
-$directions: "top", "bottom", "left", "right", "all";
-$suffix: "!important";
+$prefix: "u-" !default;
+$properties: "margin", "padding", "border" !default;
+$hyphen: "-" !default;
+$directions: "top", "bottom", "left", "right", "" !default;
+$suffix: "!important" !default;
+
+$sep: "";
 
 @each $property in $properties {
 	@each $name, $value in $spacings {
 		@each $direction in $directions {
-			@if ($direction == "all") {
-				$hyphen: "";
-				$direction: "";
+			@if ($direction == "") {
+				$sep: "";
 			}
-			.#{$prefix}#{$property}#{str-capitalize($direction)}#{str-capitalize($name)} {
-				@if ($property != "border" or $value == 0) {
-					#{$property}#{$hyphen}#{$direction}: _theme("spacings." + $name) #{$suffix};
+			@else {
+				$sep: $hyphen;
+			}
+
+			@if ($property != "border" or $value == 0) {
+				.#{$prefix}#{$property}#{str-capitalize($direction)}#{str-capitalize($name)} {
+					#{$property}#{$sep}#{$direction}: _theme("spacings." + $name) #{$suffix};
 				}
 			}
 		}


### PR DESCRIPTION
The variable was not restored to its original state and that was causing problems.

Before:
```
.u-marginLeftSmall {
	marginleft: 1rem !important;
}
```

After:
```
.u-marginLeftSmall {
	margin-left: 1rem !important;
}
```

All the code generated is here (and is passed to the CSS validator): https://codepen.io/vincent-valentin/pen/BajxNzx?editors=0100