### PR TITLE
[FIX] Hover State for chip kill

### DIFF
--- a/packages/scss/src/components/_chips.scss
+++ b/packages/scss/src/components/_chips.scss
@@ -7,13 +7,6 @@
 	padding: .15rem 1.8rem .15rem .75rem;
 	position: relative;
 	vertical-align: middle;
-	&:hover, &:focus {
-		background: _color("primary", "600");
-	}
-	&:focus {
-		box-shadow: 0 0 1px 2px _color("primary", "400");
-		outline: none;
-	}
 }
 
 .chip-kill {
@@ -40,7 +33,12 @@
 	}
 
 	&:hover {
-		background-color: _color("error");
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06);
+		background-color: _component("chip.kill.hover");
+	}
+	&:focus {
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 2px _component("chip.kill.hover");
+		outline: 0;
 	}
 }
 
@@ -54,6 +52,17 @@
 
 		.chip-kill {
 			display: none;
+		}
+	}
+
+	&.mod-clickable {
+		cursor: pointer;
+		&:hover, &:focus {
+			background: _color("primary", "600");
+		}
+		&:focus {
+			box-shadow: 0 0 0 4px _color("primary", "200");
+			outline: none;
 		}
 	}
 }

--- a/packages/scss/src/theming/_components.scss
+++ b/packages/scss/src/theming/_components.scss
@@ -5,6 +5,7 @@
 	"components/callout.theme",
 	"components/card.theme",
 	"components/checkbox.theme",
+	"components/chips.theme",
 	"components/content-section.theme",
 	"components/container.theme",
 	"components/error-page.theme",
@@ -28,7 +29,6 @@
 	"components/tag.theme",
 	"components/radio-buttons.theme";
 
-	// "components/chips.theme",
 	// "components/code.theme",
 	// "components/form.theme",
 	// "components/global.theme",

--- a/packages/scss/src/theming/components/_chips.theme.scss
+++ b/packages/scss/src/theming/components/_chips.theme.scss
@@ -1,0 +1,7 @@
+$chip: (
+	kill: (
+		hover: _color("primary", "300")
+	)
+);
+
+$theme: _set($theme, "components.chip", $chip);


### PR DESCRIPTION
- [x] adds theming variable `components.chip`
- [x] chips doesn't have hover by default. You need to use `.mod-clickable` if you want it to be... clickable.