### PR TITLE
Focus for actionIcon, button-group and button states

### DIFF
--- a/packages/scss/demo/demo.css
+++ b/packages/scss/demo/demo.css
@@ -243,6 +243,7 @@
 	background: #444;
 	display: inline-block;
 	padding: .5rem 1rem;
+	margin: 0 .5rem;
 	border-radius: 3px;
 }
 

--- a/packages/scss/src/components/_action-icon.scss
+++ b/packages/scss/src/components/_action-icon.scss
@@ -6,7 +6,7 @@
 
 	&:hover {
 		&:not([disabled]) {
-			background-color: _color($palette, "see-through");
+			background-color: _color($palette, "50");
 			color: _color($palette);
 		}
 	}

--- a/packages/scss/src/components/_action-icon.scss
+++ b/packages/scss/src/components/_action-icon.scss
@@ -1,20 +1,54 @@
-.actionIcon {
-	background: transparent;
-	border: 0;
-	border-radius: _component("commons.border.radius");
-	color: _component("actionIcon.color");
-	cursor: pointer;
-	height: 2rem;
-	margin-left: .1rem;
-	transition: all _theme("commons.animations.durations.fast") ease;
-	width: 2rem;
-	vertical-align: middle;
+// MIXINS
+// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+@mixin actionIconColoring($palette) {
+	color: _color($palette, "light");
 
 	&:hover {
 		&:not([disabled]) {
-			background: _component("actionIcon.hover.background");
+			background-color: _color($palette, "see-through");
+			color: _color($palette);
+		}
+	}
+
+	&:focus {
+		color: _color($palette);
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "50");
+	}
+}
+
+// CLASSES
+// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+.actionIcon {
+	background-color: transparent;
+	border: 0;
+	border-radius: _component("commons.border.radius");
+	color: _component("actionIcon.color");
+	height: _theme("spacings.big");
+	width: _theme("spacings.big");
+	transition: all _theme("commons.animations.durations.fast") ease;
+	vertical-align: middle;
+	text-decoration: none;
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	cursor: pointer;
+
+	& + & {
+		margin-left: .1rem;
+	}
+
+	&:hover {
+		&:not([disabled]) {
+			background-color: _component("actionIcon.hover.background");
 			color: _component("actionIcon.hover.color");
 		}
+	}
+
+	&:focus {
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color("button.default-palette", "200");
+		outline: none;
 	}
 
 	.lucca-icon, .#{_theme("icons.prefix", true)} {
@@ -29,26 +63,23 @@
 .actionIcon {
 	&.mod-invert {
 		color: _component("actionIcon.invert.color");
-
-		&:hover {
-			background: rgba(255, 255, 255, .15);
-			color: _component("actionIcon.invert.color");
+	
+		&:hover, &:focus {
+			&:not([disabled]) {
+				background-color: rgba(255, 255, 255, .1);
+				color: _component("actionIcon.invert.color");
+			}
 		}
-	}
 
-	@mixin buttonColoring($palette) {
-		color: _color($palette, "light");
-
-		&:hover {
-			background: _color($palette, "see-through");
-			color: _color($palette);
+		&:focus {
+			box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px rgba(0, 0, 0, .1);
 		}
 	}
 
 	// palette colors
 	@each $name, $palette in _getMap("palettes") {
 		&.palette-#{$name} {
-			@include buttonColoring($name);
+			@include actionIconColoring($name);
 		}
 	}
 }
@@ -58,21 +89,18 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .actionIcon {
-	&[disabled] {
-		cursor: default;
-		opacity: _theme("commons.disabled.opacity");
-	}
-
-	&.is-disabled {
+	&[disabled],
+	&.is-disabled,
+	&.is-loading {
 		opacity: _theme("commons.disabled.opacity");
 		pointer-events: none;
+		cursor: default;
 	}
 
 	&.is-loading {
 		@include loading(1rem);
+
 		color: transparent;
-		opacity: _theme("commons.disabled.opacity");
-		pointer-events: none;
 		position: relative;
 	}
 }

--- a/packages/scss/src/components/_button.scss
+++ b/packages/scss/src/components/_button.scss
@@ -1,7 +1,72 @@
+// MIXINS
+// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+@mixin buttonColoring($palette) {
+	background: _color($palette);
+	color: _color($palette, "text");
+
+	&:hover:not([disabled]) {
+		background: _color($palette, "500");
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06);
+	}
+
+	&:focus {
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "200");
+		outline: 0;
+	}
+
+	&:active:not([disabled]) {
+		background: _color($palette, "800");
+	}
+
+	.button-counter {
+		background: _color($palette, "200");
+	}
+}
+
+@mixin buttonLinkColoring($palette) {
+	&:focus:not([disabled]) {
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "100"), inset 0 0 0 1px _color($palette, "300");
+		background: _color($palette, "100");
+	}
+}
+
+@mixin buttonOutlineColoring($palette) {
+	box-shadow: inset 0 0 0 1px _color($palette, "500");
+	color: _color($palette);
+
+	&:hover:not([disabled]) {
+		background: _color($palette, "50");
+		color: _color($palette);
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), inset 0 0 0 1px _color($palette);
+	}
+
+	&:focus:not([disabled]) {
+		background: _color($palette, "50");
+		color: _color($palette);
+		box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "50"), inset 0 0 0 1px _color($palette, "500");
+		outline: 0;
+	}
+
+	&:active:not([disabled]) {
+		background: _color($palette, "50");
+		color: _color($palette, "dark");
+		box-shadow: inset 0 0 0 1px _color($palette, "800");
+	}
+
+	.button-counter {
+		background: _color($palette);
+	}
+}
+
+// CLASSES
+// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+
+
 .button {
+	cursor: pointer;
 	border: 0;
 	border-radius: _component("button.border.radius");
-	cursor: pointer;
 	display: inline-block;
 	font-family: unquote(_component("button.font.family"));
 	font-size: _component("button.font-size");
@@ -54,29 +119,6 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .button {
-	@mixin buttonColoring($palette) {
-		background: _color($palette);
-		color: _color($palette, "text");
-
-		&:hover:not([disabled]) {
-			background: _color($palette, "500");
-			box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06);
-		}
-
-		&:focus {
-			box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "200");
-			outline: 0;
-		}
-
-		&:active:not([disabled]) {
-			background: _color($palette, "800");
-		}
-
-		.button-counter {
-			background: _color($palette, "200");
-		}
-	}
-
 	// default color
 	@include buttonColoring("button.default-palette");
 
@@ -105,29 +147,8 @@
 	}
 
 	&.mod-link {
-		background: transparent;
+		background-color: transparent;
 		color: _color("text.default");
-
-		&:hover {
-			background: _color("primary", "50");
-			color: _color("primary");
-		}
-
-		@mixin buttonLinkColoring($palette) {
-			&:focus:not([disabled]) {
-				box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "100"), inset 0 0 0 1px _color($palette, "300");
-				background: _color($palette, "100");
-			}
-		}
-
-		&.mod-invert {
-			color: white;
-
-			&:hover, &:focus {
-				background: rgba(255, 255, 255, .1);
-				color: rgba(255, 255, 255, .8);
-			}
-		}
 
 		// default color
 		@include buttonLinkColoring("button.default-palette");
@@ -136,6 +157,26 @@
 		@each $name, $palette in _getMap("palettes") {
 			&.palette-#{$name} {
 				@include buttonLinkColoring($name);
+			}
+		}
+
+		&:hover {
+			background-color: _color("primary", "50");
+			color: _color("primary");
+		}
+
+		&.mod-invert {
+			color: white;
+	
+			&:hover, &:focus {
+				&:not([disabled]) {
+					background-color: rgba(255, 255, 255, .1);
+					color: white;
+				}
+			}
+
+			&:focus {
+				box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px rgba(0, 0, 0, .1);
 			}
 		}
 	}
@@ -165,34 +206,6 @@
 		&:hover {
 			background: _color("primary", "50");
 			color: _color("primary");
-		}
-
-		@mixin buttonOutlineColoring($palette) {
-			box-shadow: inset 0 0 0 1px _color($palette, "500");
-			color: _color($palette);
-
-			&:hover:not([disabled]) {
-				background: _color($palette, "50");
-				color: _color($palette);
-				box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), inset 0 0 0 1px _color($palette);
-			}
-
-			&:focus:not([disabled]) {
-				background: _color($palette, "50");
-				color: _color($palette);
-				box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.04), 0px 1px 2px rgba(0, 0, 0, 0.06), 0 0 0 4px _color($palette, "50"), inset 0 0 0 1px _color($palette, "500");
-				outline: 0;
-			}
-
-			&:active:not([disabled]) {
-				background: _color($palette, "50");
-				color: _color($palette, "dark");
-				box-shadow: inset 0 0 0 1px _color($palette, "800");
-			}
-
-			.button-counter {
-				background: _color($palette);
-			}
 		}
 
 		// default color
@@ -265,51 +278,35 @@
 		}
 	}
 
-	/* Success */
+	/* States */
 
 	&.is-success {
-		background: _color("success");
-		color: transparent;
-		pointer-events: none;
-		user-select: none;
+		@include buttonColoring("success");
 
 		&::after {
 			@include makeIcon("tick");
-			bottom: 0;
-			color: white;
-			font-size: calc(1.5 * #{_component("button.font-size")});
-			height: _component("button.line-height");
-			left: 0;
-			margin: auto;
-			position: absolute;
-			right: 0;
-			top: 0;
-			vertical-align: middle;
-		}
-
-		&.mod-small {
-			&::after {
-				font-size: calc(1.5 * #{_component("button.small.font-size")});
-				height: _component("button.small.font-size");
-			}
 		}
 	}
 
-	/* Error */
-
 	&.is-error {
-		background: _color("error");
+		@include buttonColoring("error");
+
+		&::after {
+			@include makeIcon("cross");
+		}
+	}
+
+	&.is-success, &.is-error {
 		color: transparent;
 		pointer-events: none;
 		user-select: none;
 
 		&::after {
-			@include makeIcon("cross");
-			bottom: 0;
 			color: white;
 			font-size: calc(1.5 * #{_component("button.font-size")});
 			height: _component("button.line-height");
 			left: 0;
+			bottom: 0;
 			margin: auto;
 			position: absolute;
 			right: 0;
@@ -330,23 +327,16 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .button-group {
-	display: flex;
+	display: inline-flex;
 
-	&.mod-more {
-		display: inline-flex;
-
-		&:focus-within {
-			box-shadow: 0 0 0 4px _color("primary", "200");
-		}
-
-		.button {
-			&:focus {
-				background-color: _color("primary", "600");
-			}
-		}
+	&:focus-within {
+		box-shadow: 0 0 0 4px _color("primary", "200");
+		border-radius: _component("button.border.radius");
 	}
 
 	.button {
+		@include buttonColoring("button.default-palette");
+
 		border-radius: 0;
 		display: block;
 		margin: 0;
@@ -354,9 +344,6 @@
 		padding-right: _theme("spacings.small");
 		position: relative;
 		border-right: 1px solid rgba(0, 0, 0, .1);
-	}
-
-	> .button {
 
 		&:first-child {
 			border-radius: _component("button.border.radius") 0 0 _component("button.border.radius");
@@ -369,6 +356,11 @@
 
 		&:hover, &:focus {
 			z-index: 1;
+		}
+
+		&:focus {
+			background-color: _color("primary", "600");
+			box-shadow: none;
 		}
 	}
 }

--- a/packages/scss/src/components/inputs/radio-buttons/_radio-buttons.scss
+++ b/packages/scss/src/components/inputs/radio-buttons/_radio-buttons.scss
@@ -42,7 +42,7 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .radioButtons-item-label {
-	@mixin buttonColoring($palette) {
+	@mixin radioColoring($palette) {
 		color: _color($palette, "800");
 		box-shadow: inset 0 0 0 1px _color($palette, "200");
 
@@ -53,18 +53,18 @@
 	}
 
 	// default color
-	@include buttonColoring("radio.default-palette");
+	@include radioColoring("radio.default-palette");
 
 	// palette colors
 	@each $name, $palette in _getMap("palettes") {
 		&.palette-#{$name} {
-			@include buttonColoring($name);
+			@include radioColoring($name);
 		}
 	}
 }
 
 .radioButtons-item-input {
-	@mixin buttonColoring($palette) {
+	@mixin radioColoring($palette) {
 		&:checked ~ .radioButtons-item-label {
 			background: _color($palette, "50");
 			box-shadow: inset 0 0 0 1px _color($palette, "200");
@@ -86,12 +86,12 @@
 	}
 
 	// default color
-	@include buttonColoring("radio.default-palette");
+	@include radioColoring("radio.default-palette");
 
 	// palette colors
 	@each $name, $palette in _getMap("palettes") {
 		&.palette-#{$name} {
-			@include buttonColoring($name);
+			@include radioColoring($name);
 		}
 	}
 }


### PR DESCRIPTION
`actionIcon`:
- better centering
- margin only if sibling 
- focus state
- focus state for palettes
- `mod-invert` fixed
- focus state for `mod-invert`

`button`:
- focus for `button-group`
- focus for `is-success` and `is-error`
- `mod-invert` fixed
- focus state for `mod-invert`

-----

![image](https://user-images.githubusercontent.com/64789527/87316084-91df1700-c525-11ea-9e3d-3d81098c2b98.png)

![image](https://user-images.githubusercontent.com/64789527/87315858-3ad94200-c525-11ea-82e5-9f3893870f11.png)

![image](https://user-images.githubusercontent.com/64789527/87315917-517f9900-c525-11ea-92ce-091ef3404289.png)

-----


![image](https://user-images.githubusercontent.com/64789527/87316015-78d66600-c525-11ea-8ca6-7bc87a031884.png)

![image](https://user-images.githubusercontent.com/64789527/87316034-7f64dd80-c525-11ea-882b-25691b5c9899.png)

![image](https://user-images.githubusercontent.com/64789527/87315988-6f4cfe00-c525-11ea-9da2-1856c792fa46.png)

![image](https://user-images.githubusercontent.com/64789527/87315957-64926900-c525-11ea-9fe5-3578637d796b.png)


