### PR TITLE
[fix] api-select on open loading placeholder

### DIFF
--- a/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.component.html
+++ b/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.component.html
@@ -1,4 +1,4 @@
 <div class="textfield mod-search" [class.is-loading]="loading$ | async">
 	<input #searchInput class="textfield-input" [formControl]="clueControl">
 </div>
-<lu-option-placeholder *ngIf="empty$ | async" (onClear)="resetClue()"></lu-option-placeholder>
+<lu-option-placeholder *ngIf="(empty$ | async) && !(loading$ | async)" (onClear)="resetClue()"></lu-option-placeholder>

--- a/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.component.ts
+++ b/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, HostBinding, OnInit } from '@angular/core';
-import { ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, OnInit } from '@angular/core';
+import { ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber, ALuOnCloseSubscriber } from '@lucca-front/ng/core';
 import { ALuOptionOperator } from '@lucca-front/ng/option';
 import { ALuApiOptionSearcher, ALuApiSearcherService, ALuApiOptionPagedSearcher, ALuApiPagedSearcherService } from './api-searcher.model';
 import { ILuApiItem } from '../../api.model';
@@ -20,6 +20,11 @@ import { debounceTime, tap } from 'rxjs/operators';
 		},
 		{
 			provide: ALuOnOpenSubscriber,
+			useExisting: forwardRef(() => LuApiSearcherComponent),
+			multi: true,
+		},
+		{
+			provide: ALuOnCloseSubscriber,
 			useExisting: forwardRef(() => LuApiSearcherComponent),
 			multi: true,
 		},

--- a/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.model.ts
+++ b/packages/ng/libraries/api/src/lib/select/searcher/api-searcher.model.ts
@@ -43,6 +43,9 @@ implements ILuApiOptionFeeder<T>, ILuOnOpenSubscriber {
 	onOpen() {
 		this.resetClue();
 	}
+	onClose() {
+		this.clearOptions();
+	}
 	protected initObservables() {
 		// this._clue$ = clue$.pipe(share());
 		const results$ = this._clue$
@@ -62,6 +65,9 @@ implements ILuApiOptionFeeder<T>, ILuOnOpenSubscriber {
 		);
 	}
 	abstract resetClue();
+	protected clearOptions() {
+		this.outOptions$.next([]);
+	}
 }
 
 export abstract class ALuApiSearcherService<T extends ILuApiItem = ILuApiItem>

--- a/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.html
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.html
@@ -3,7 +3,7 @@
 	 (click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div [class.is-loading]="loading$ | async" class="lu-picker-content" [ngClass]="contentClassesMap" [cdkTrapFocus]="trapFocus" luScroll (onScrollBottom)="onScrollBottom()">
 			<ng-content></ng-content>
-			<div *ngIf="loading$ | async" class="loading lu-picker-loading"></div>	
+			<div *ngIf="loading$ | async" class="loading lu-picker-loading"></div>
 		</div>
 	</div>
 </ng-template>

--- a/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.ts
+++ b/packages/ng/libraries/option/src/lib/picker/option-picker-advanced.component.ts
@@ -70,6 +70,16 @@ extends ALuOptionPickerComponent<T, O> implements AfterViewInit {
 		this._onOpenSubscribers.forEach(o => {
 			o.onOpen();
 		});
+		const operators = this._operators || [];
+		const lastOperator = operators[operators.length - 1];
+		if (lastOperator && lastOperator.outOptions$) {
+			this.loading$ = lastOperator.outOptions$.pipe(
+				first(),
+				mapTo(false),
+				startWith(true),
+				shareReplay(),
+			);
+		}
 		super.onOpen();
 	}
 	onClose() {
@@ -90,15 +100,6 @@ extends ALuOptionPickerComponent<T, O> implements AfterViewInit {
 			operator.inOptions$ = options$;
 			options$ = operator.outOptions$;
 		});
-		const lastOperator = operators[operators.length - 1];
-		if (lastOperator && lastOperator.outOptions$) {
-			this.loading$ = lastOperator.outOptions$.pipe(
-				first(),
-				mapTo(false),
-				startWith(true),
-				shareReplay(),
-			);
-		}
 	}
 	protected initSelectors() {
 		this._selectors = this._selectorsQL.toArray();

--- a/packages/ng/libraries/root/src/style/components/_picker.scss
+++ b/packages/ng/libraries/root/src/style/components/_picker.scss
@@ -17,9 +17,6 @@
 
 	&.is-loading {
 		height: $height;
-		.loading {
-			background-color: _color("white");
-		}
 	}
 }
 

--- a/packages/ng/libraries/root/src/style/components/_picker.scss
+++ b/packages/ng/libraries/root/src/style/components/_picker.scss
@@ -17,6 +17,9 @@
 
 	&.is-loading {
 		height: $height;
+		.loading {
+			background-color: _color("white");
+		}
 	}
 }
 

--- a/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.html
+++ b/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.html
@@ -1,4 +1,4 @@
 <div class="textfield mod-search" [class.is-loading]="loading$ | async">
 	<input #searchInput class="textfield-input" [formControl]="clueControl">
 </div>
-<lu-option-placeholder *ngIf="empty$ | async" (onClear)="resetClue()"></lu-option-placeholder>
+<lu-option-placeholder *ngIf="(empty$ | async) && !(loading$ | async)" (onClear)="resetClue()"></lu-option-placeholder>

--- a/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, forwardRef, Input, ViewChild, ElementRef, SkipSelf, Self, Optional, Inject, HostBinding, OnInit } from '@angular/core';
-import { ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber } from '@lucca-front/ng/core';
+import { ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber, ALuOnCloseSubscriber } from '@lucca-front/ng/core';
 import { ALuOptionOperator } from '@lucca-front/ng/option';
 import { FormControl } from '@angular/forms';
 import { debounceTime, tap } from 'rxjs/operators';
@@ -21,6 +21,11 @@ import { ALuApiOptionPagedSearcher } from '@lucca-front/ng/api';
 		},
 		{
 			provide: ALuOnOpenSubscriber,
+			useExisting: forwardRef(() => LuUserPagedSearcherComponent),
+			multi: true,
+		},
+		{
+			provide: ALuOnCloseSubscriber,
 			useExisting: forwardRef(() => LuUserPagedSearcherComponent),
 			multi: true,
 		},


### PR DESCRIPTION
after #1063, when an api-select opened we forced refresh but kept the old results (or the placeholder) visible.

with this fix we force a recompute of the loading state and hide current results behind teh loader