### PR TITLE
Add en-GB date format

### DIFF
--- a/packages/ng/libraries/date/src/lib/input/date-input.translate.ts
+++ b/packages/ng/libraries/date/src/lib/input/date-input.translate.ts
@@ -26,6 +26,14 @@ export const luDateInputTranslations = {
 		formatMonth: 'MM/y',
 		formatYear: 'y',
 	},
+	'en-GB': {
+		placeholderDay: 'dd/mm/yyyy',
+		placeholderMonth: 'mm/yyyy',
+		placeholderYear: 'yyyy',
+		formatDay: 'shortDate',
+		formatMonth: 'MM/y',
+		formatYear: 'y',
+	},
 	'en-US': {
 		placeholderDay: 'mm/dd/yyyy',
 		placeholderMonth: 'mm/yyyy',


### PR DESCRIPTION
The date input should now display the date in the right format in British English despite the injected `en-GB` `localeId`.