### PR TITLE
[add] Border card and mod elevate

### DIFF
--- a/packages/scss/demo/components/cards.html
+++ b/packages/scss/demo/components/cards.html
@@ -87,3 +87,14 @@
 		</div>
 	</div>
 </section>
+
+<!-- Elevated -->
+<h2>Elevated card</h2>
+<section class="contentSection">
+	<div class="card mod-elevated">
+		<div class="card-content">
+			With elevation
+		</div>
+	</div>
+</section>
+

--- a/packages/scss/src/components/_card.scss
+++ b/packages/scss/src/components/_card.scss
@@ -1,7 +1,7 @@
 .card {
-	background: white;
-	border-radius: 3px;
-	@include elevate(1);
+	background-color: white;
+	border-radius: _component("card.border.radius");
+	border: 1px solid _component("card.border.color");
 	display: block;
 	margin-bottom: 1rem;
 	position: relative;
@@ -14,7 +14,7 @@
 
 .card-footer {
 	align-items: center;
-	border-top: _theme("commons.divider.width") solid _theme("commons.divider.color");
+	border-top: 1px solid _component("card.border.color");
 	display: flex;
 	min-height: 3rem;
 	padding: _component("card.footer.padding");
@@ -30,7 +30,7 @@
 
 .card {
 	&.mod-grey {
-		background: _theme("commons.background.base");
+		background-color: _component("card.mod-grey");
 	}
 
 	&.mod-clickable {
@@ -39,6 +39,16 @@
 		text-decoration: none;
 
 		&:hover {
+			border-color: _component("card.hover.border");
+			background-color: _component("card.hover.background");
+		}
+		
+	}
+
+	&.mod-elevated {
+		border: 0;
+		@include elevate(1);
+		&.mod-clickable:hover {
 			@include elevate(3);
 		}
 	}

--- a/packages/scss/src/components/_card.scss
+++ b/packages/scss/src/components/_card.scss
@@ -1,5 +1,5 @@
 .card {
-	background-color: white;
+	background-color: _color("white");
 	border-radius: _component("card.border.radius");
 	border: 1px solid _component("card.border.color");
 	display: block;

--- a/packages/scss/src/theming/components/_card.theme.scss
+++ b/packages/scss/src/theming/components/_card.theme.scss
@@ -4,6 +4,15 @@ $card: (
 	),
 	footer: (
 		padding: .33rem 1.5rem,
+	),
+	mod-grey: _theme("commons.background.base"),
+	border: (
+		radius: 8px,
+		color: _theme("commons.divider.color")
+	),
+	hover: (
+		border: _color("grey", "400"),
+		background: _color("grey", "100")
 	)
 );
 

--- a/packages/scss/src/theming/components/_card.theme.scss
+++ b/packages/scss/src/theming/components/_card.theme.scss
@@ -7,7 +7,7 @@ $card: (
 	),
 	mod-grey: _theme("commons.background.base"),
 	border: (
-		radius: 8px,
+		radius: _theme("commons.border.radius-big"),
 		color: _theme("commons.divider.color")
 	),
 	hover: (


### PR DESCRIPTION
Cards now have a border and no elevation. Previous style is available with a .mod-elevated