### PR TITLE
re-hide input search `x` in chrome

### DIFF
--- a/packages/scss/src/_normalize.scss
+++ b/packages/scss/src/_normalize.scss
@@ -296,7 +296,7 @@
    * Remove the inner padding in Chrome and Safari on macOS.
    */
   
-  [type="search"]::-webkit-search-decoration {
+  [type="search"]::-webkit-search-cancel-button, [type="search"]::-webkit-search-decoration {
 	-webkit-appearance: none;
   }
   


### PR DESCRIPTION
i dont know why but this happened in normalize

https://github.com/necolas/normalize.css/issues/685

annd i dont like it