### PR TITLE
feat(ng) user-select optinal use of the directoru v4 user api - beta

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -66,6 +66,7 @@ const routes: Routes = [
 	{ path: 'former-employees', loadChildren: () => import('./former-employees').then(m => m.FormerEmployeesModule) },
 	{ path: 'establishment', loadChildren: () => import('./establishment').then(m => m.EstablishmentModule) },
 	{ path: 'api-v4', loadChildren: () => import('./api-v4').then(m => m.ApiV4Module) },
+	{ path: 'user-v4', loadChildren: () => import('./user-v4').then(m => m.UserV4Module) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/user-v4/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-v4/index.ts
@@ -1,0 +1,1 @@
+export * from './user-v4.module';

--- a/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.component.html
@@ -1,7 +1,7 @@
 <h1>user-v4</h1>
 <h2>all in one</h2>
 <div class="textfield">
-	<lu-user-select class="textfield-input" [(ngModel)]="user" [fields]="fields"></lu-user-select>
+	<lu-user-select class="textfield-input" [(ngModel)]="user" [fields]="fields" standard="v4"></lu-user-select>
 	<label for="" class="textfield-label">user select</label>
 </div>
 <code>{{user | json }}</code>

--- a/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.component.html
@@ -1,0 +1,8 @@
+<h1>user-v4</h1>
+<h2>all in one</h2>
+<div class="textfield">
+	<lu-user-select class="textfield-input" [(ngModel)]="user" [fields]="fields"></lu-user-select>
+	<label for="" class="textfield-label">user select</label>
+</div>
+<code>{{user | json }}</code>
+<h2>operators</h2>

--- a/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'sand-user-v4',
+	templateUrl: './user-v4.component.html'
+})
+export class UserV4Component {
+	user = null;
+	fields = 'id,firstName,lastName,culture.code';
+}

--- a/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/user-v4/user-v4.module.ts
@@ -1,0 +1,31 @@
+import { NgModule } from '@angular/core';
+
+import { RouterModule } from '@angular/router';
+import { UserV4Component } from './user-v4.component';
+
+import { HttpClientModule } from '@angular/common/http';
+import { RedirectModule } from '../../redirect';
+import { FormsModule } from '@angular/forms';
+import { ALuUserService, LuUserModule, LuUserV4Service } from '@lucca-front/ng/user';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+	declarations: [
+		UserV4Component,
+	],
+	imports: [
+		HttpClientModule,
+		RedirectModule,
+		FormsModule,
+		LuUserModule,
+		CommonModule,
+
+		RouterModule.forChild([
+			{ path: '', component: UserV4Component },
+		]),
+	],
+	providers: [
+		// { provide: ALuUserService, useClass: LuUserV4Service },
+	]
+})
+export class UserV4Module {}

--- a/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.html
@@ -13,7 +13,14 @@
 </ng-template>
 <lu-option-picker-advanced [option-comparer]="byId">
 	<header class="lu-picker-header">
-		<lu-user-paged-searcher [enableFormerEmployees]="enableFormerEmployees"></lu-user-paged-searcher>
+		<lu-user-paged-searcher
+			[fields]="fields"
+			[filters]="filters"
+			[orderBy]="orderBy"
+			[appInstanceId]="appInstanceId"
+			[operations]="operations"
+			[enableFormerEmployees]="enableFormerEmployees"
+		></lu-user-paged-searcher>
 	</header>
 	<lu-user-homonyms></lu-user-homonyms>
 	<lu-option *luUserMeOption="let user" [value]="user">

--- a/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.html
+++ b/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.html
@@ -20,6 +20,7 @@
 			[appInstanceId]="appInstanceId"
 			[operations]="operations"
 			[enableFormerEmployees]="enableFormerEmployees"
+			[standard]="standard"
 		></lu-user-paged-searcher>
 	</header>
 	<lu-user-homonyms></lu-user-homonyms>

--- a/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/input/user-select-input.component.ts
@@ -45,27 +45,22 @@ import { ALuUserService, LuUserV3Service } from '../../service/index';
 			useExisting: forwardRef(() => LuUserSelectInputComponent),
 			multi: true,
 		},
-		{
-			provide: ALuUserService,
-			useClass: LuUserV3Service,
-		},
 	],
 })
 export class LuUserSelectInputComponent<U extends ILuUser = ILuUser>
 extends ALuSelectInputComponent<U>
 implements ControlValueAccessor, ILuInputWithPicker<U>, AfterViewInit {
-	protected _service: LuUserV3Service<U>;
 
 	searchFormat = LuDisplayFullname.lastfirst;
 
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 
-	@Input() set fields(fields: string) { this._service.fields = fields; }
-	@Input() set filters(filters: string[]) { this._service.filters = filters; }
-	@Input() set orderBy(orderBy: string) { this._service.orderBy = orderBy; }
-	@Input() set appInstanceId(appInstanceId: number | string) { this._service.appInstanceId = appInstanceId; }
-	@Input() set operations(operations: number[]) { this._service.operations = operations; }
-
+	@Input() fields: string;
+	@Input() filters: string[];
+	@Input() orderBy: string;
+	@Input() appInstanceId: number | string;
+	@Input() operations: number[];
+	@Input() standard: string = 'v3';
 	@Input() enableFormerEmployees = false;
 
 	byId: LuOptionComparer<U> = (option1: U, option2: U) => option1 && option2 && option1.id === option2.id;
@@ -76,8 +71,6 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterViewInit {
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
 		protected _renderer: Renderer2,
-		@Inject(ALuUserService) @Optional() @SkipSelf() hostService: LuUserV3Service<U>,
-		@Inject(ALuUserService) @Self() selfService: LuUserV3Service<U>,
 		@Inject(LuUserSelectInputIntl) public intl: ILuUserSelectInputLabel,
 	) {
 		super(
@@ -87,7 +80,6 @@ implements ControlValueAccessor, ILuInputWithPicker<U>, AfterViewInit {
 			_viewContainerRef,
 			_renderer,
 		);
-		this._service = hostService || selfService;
 	}
 
 

--- a/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
@@ -12,7 +12,7 @@ import { ALuOptionOperator } from '@lucca-front/ng/option';
 import { FormControl, FormGroup } from '@angular/forms';
 import { distinctUntilChanged, debounceTime, switchMap, catchError, share, startWith, withLatestFrom, mapTo, map } from 'rxjs/operators';
 import { ILuUser } from '../../user.model';
-import { ALuUserService, LuUserV3Service } from '../../service/index';
+import { ALuUserService, LuUserHybridService } from '../../service/index';
 import { Subject, Observable, Subscription, combineLatest, of, merge } from 'rxjs';
 import { LuUserSearcherIntl } from './user-searcher.intl';
 import { ILuUserSearcherLabel } from './user-searcher.translate';
@@ -45,7 +45,7 @@ import { ILuUserSearcherLabel } from './user-searcher.translate';
 		},
 		{
 			provide: ALuUserService,
-			useClass: LuUserV3Service,
+			useClass: LuUserHybridService,
 		},
 	],
 })
@@ -53,12 +53,13 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser>
 	implements OnInit, OnDestroy, ILuOnOpenSubscriber, ILuOnScrollBottomSubscriber, ILuOnCloseSubscriber
 {
 
-	private _service: LuUserV3Service<U>;
+	private _service: LuUserHybridService<U>;
 	private _subs = new Subscription();
 
 	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef, static: true }) searchInput: ElementRef;
 
+	@Input() set standard(standard: string) { if (standard !== undefined) this._service.standard = standard; }
 	@Input() set fields(fields: string) { if (fields !== undefined) { this._service.fields = fields; } }
 	@Input() set filters(filters: string[]) { if (filters !== undefined) { this._service.filters = filters; } }
 	@Input() set orderBy(orderBy: string) { if (orderBy !== undefined) { this._service.orderBy = orderBy; } }
@@ -78,10 +79,10 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser>
 
 	constructor(
 		@Inject(ALuUserService) @Optional() @SkipSelf() hostService: ALuUserService,
-		@Inject(ALuUserService) @Self() selfService: LuUserV3Service<U>,
+		@Inject(ALuUserService) @Self() selfService: LuUserHybridService<U>,
 		@Inject(LuUserSearcherIntl) public intl: ILuUserSearcherLabel,
 	) {
-		this._service = (hostService || selfService) as LuUserV3Service<U>;
+		this._service = (hostService || selfService) as LuUserHybridService<U>;
 	}
 
 	ngOnInit() {

--- a/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
@@ -92,6 +92,7 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser>
 		const formValue$ = this.form.valueChanges.pipe(
 			startWith(this.form.value),
 		);
+		this._subs.add(formValue$.subscribe(() => this._page$.next(0)));
 		this._page$ = new Subject<number>();
 		const distinctPage$ = this._page$.pipe(
 			distinctUntilChanged(),

--- a/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
+++ b/packages/ng/libraries/user/src/lib/select/searcher/user-searcher.component.ts
@@ -59,11 +59,11 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser>
 	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef, static: true }) searchInput: ElementRef;
 
-	@Input() set fields(fields: string) { this._service.fields = fields; }
-	@Input() set filters(filters: string[]) { this._service.filters = filters; }
-	@Input() set orderBy(orderBy: string) { this._service.orderBy = orderBy; }
-	@Input() set appInstanceId(appInstanceId: number | string) { this._service.appInstanceId = appInstanceId; }
-	@Input() set operations(operations: number[]) { this._service.operations = operations; }
+	@Input() set fields(fields: string) { if (fields !== undefined) { this._service.fields = fields; } }
+	@Input() set filters(filters: string[]) { if (filters !== undefined) { this._service.filters = filters; } }
+	@Input() set orderBy(orderBy: string) { if (orderBy !== undefined) { this._service.orderBy = orderBy; } }
+	@Input() set appInstanceId(appInstanceId: number | string) { if (appInstanceId !== undefined) { this._service.appInstanceId = appInstanceId; } }
+	@Input() set operations(operations: number[]) { if (operations !== undefined) { this._service.operations = operations; } }
 	@Input() enableFormerEmployees = false;
 
 	form: FormGroup;
@@ -80,7 +80,6 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser>
 		@Inject(ALuUserService) @Optional() @SkipSelf() hostService: ALuUserService,
 		@Inject(ALuUserService) @Self() selfService: LuUserV3Service<U>,
 		@Inject(LuUserSearcherIntl) public intl: ILuUserSearcherLabel,
-
 	) {
 		this._service = (hostService || selfService) as LuUserV3Service<U>;
 	}

--- a/packages/ng/libraries/user/src/lib/service/index.ts
+++ b/packages/ng/libraries/user/src/lib/service/index.ts
@@ -1,2 +1,3 @@
 export * from './user-service.model';
 export * from './user-v3.service';
+export * from './user-v4.service';

--- a/packages/ng/libraries/user/src/lib/service/index.ts
+++ b/packages/ng/libraries/user/src/lib/service/index.ts
@@ -1,3 +1,4 @@
 export * from './user-service.model';
 export * from './user-v3.service';
 export * from './user-v4.service';
+export * from './user-hybrid.service';

--- a/packages/ng/libraries/user/src/lib/service/user-hybrid.service.ts
+++ b/packages/ng/libraries/user/src/lib/service/user-hybrid.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
+import { ILuUserService } from './user-service.model';
+import { LuUserV3Service } from './user-v3.service';
+import { ALuUserService } from './user-service.model';
+import { ILuUser } from '../user.model';
+import { LuUserV4Service } from './user-v4.service';
+
+@Injectable()
+export class LuUserHybridService<U extends ILuUser = ILuUser> extends ALuUserService<U> implements ILuUserService<U> {
+	private _v3Service: LuUserV3Service<U>;
+	private _v4Service: LuUserV4Service<U>;
+
+	private _standard = 'v3';
+	set standard(std: string) { this._standard = std; }
+
+	// api v3 only
+	set fields(fields: string) { this._v3Service.fields = fields; }
+	set filters(filters: string[]) { this._v3Service.filters = filters; }
+	set orderBy(orderBy: string) { this._v3Service.orderBy = orderBy; }
+	set appInstanceId(appInstanceId: number | string) { this._v3Service.appInstanceId = appInstanceId; }
+	set operations(operations: number[]) { this._v3Service.operations = operations; }
+
+	private get _service(): ALuUserService<U> {
+		switch(this._standard) {
+			case 'v4':
+				return this._v4Service;
+			case 'v3':
+			default:
+				return this._v3Service;
+		}
+	}
+
+	constructor(
+		private _http: HttpClient,
+	) {
+		super();
+		this._v3Service = new LuUserV3Service(this._http);
+		this._v4Service = new LuUserV4Service(this._http);
+	}
+
+	getMe(): Observable<U> {
+		return this._service.getMe();
+	}
+
+	getAll(filters: string[] = []): Observable<U[]> {
+		return this._service.getAll(filters);
+	}
+
+	getPaged(page: number, filters: string[] = []): Observable<U[]> {
+		return this._service.getPaged(page, filters);
+	}
+
+	searchAll(clue: string, filters: string[] = []): Observable<U[]> {
+		return this._service.searchAll(clue, filters);
+	}
+
+	searchPaged(clue: string, page: number, filters: string[] = []): Observable<U[]> {
+		return this._service.searchPaged(clue, page, filters);
+	}
+}

--- a/packages/ng/libraries/user/src/lib/service/user-v4.service.ts
+++ b/packages/ng/libraries/user/src/lib/service/user-v4.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ILuUser } from '../user.model';
+import { ILuUserService } from './user-service.model';
+import { LuApiV4Service } from '@lucca-front/ng/api';
+
+
+@Injectable()
+export class LuUserV4Service<U extends ILuUser = ILuUser> extends LuApiV4Service<U> implements ILuUserService<U> {
+	protected _api = `/directory/api/4.0/users`;
+
+	constructor(protected _http: HttpClient) {
+		super(_http);
+	}
+
+	getMe(): Observable<U> {
+		return this._http.get<U>(`${this._api}/me`);
+	}
+}


### PR DESCRIPTION
added `@Input() standard: 'v3' | 'v4'` to `lu-user-xxx` components to swap between using /api/v3/users and /directory/api/4.0/users apis

all features of the user-select are not yet supported by the new api, scopes for example aren't, so dont enable it willy nilly

also fixes bug with search barnor resetting the paging

wiating for this PR to be merged and deployed https://github.com/LuccaSA/Lucca.Directory/pull/968