### PR TITLE
refactor(scss) responsive container and breakpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,30 +152,34 @@ You can set up custom breakpoints values in breakpoints.override.scss
 
 ```
 $breakpoints: (
-	"sm": (
-		"breakAt": 576px,
-		"spacing": 20px,
+	xxxs: (
+		"breakAt": 320px,
 	),
-	"md": (
-		"breakAt": 768px,
-		"spacing": 30px,
+	xxs: (
+		"breakAt": 480px,
 	),
-	"lg": (
-		"breakAt": 992px,
-		"spacing": 40px,
+	xs: (
+		"breakAt": 640px,
 	),
-	"xl": (
-		"breakAt": 1200px,
-		"spacing": 60px,
+	s: (
+		"breakAt": 800px,
 	),
-	"xxl": (
-		"breakAt": 1350px,
-		"spacing": 60px,
+	m: (
+		"breakAt": 1024px,
 	),
-	"xxxl": (
-		"breakAt": 1500px,
-		"spacing": 60px,
+	l: (
+		"breakAt": 1280px,
+	),
+	xl: (
+		"breakAt": 1366px,
+	),
+	xxl: (
+		"breakAt": 1600px,
+	),
+	xxxl: (
+		"breakAt": 1920px,
 	)
 );
+
 $theme: _set($theme, "breakpoints", $breakpoints);
 ```

--- a/demo/index.html
+++ b/demo/index.html
@@ -16,10 +16,10 @@
     <div class="home-header-description">A framework for developing web application by lucca</div>
   </header>
 
-  <div class="container mod-sm">
+  <div class="container mod-xs">
     <a href="./scss/" class="card mod-clickable mod-sass">
       <div class="card-visual">
-        <img class="card-visual-asset" src="assets/sass.png">
+        <img alt="" class="card-visual-asset" src="assets/sass.png">
       </div>
       <div class="card-content">
         <h2>Sass components</h2>
@@ -28,7 +28,7 @@
     </a>
     <a href="./ng/" class="card mod-clickable mod-ng">
       <div class="card-visual">
-        <img class="card-visual-asset" src="assets/ng.png">
+        <img alt="" class="card-visual-asset" src="assets/ng.png">
       </div>
       <div class="card-content">
         <h2>Angular components</h2>

--- a/packages/ng/material/src/style/components/_dialog.scss
+++ b/packages/ng/material/src/style/components/_dialog.scss
@@ -15,10 +15,10 @@
 		bottom: 0;
 		width: 60%;
 		max-width: 800px;
-		@include media_smaller_than('md') {
+		@include media_smaller_than("s") {
 			width: 80%;
 		}
-		@include media_smaller_than('sm') {
+		@include media_smaller_than("xs") {
 			width: 100%;
 		}
 

--- a/packages/ng/root/src/style/components/_popup.scss
+++ b/packages/ng/root/src/style/components/_popup.scss
@@ -102,7 +102,7 @@
 	}
 }
 
-@include media_smaller_than("sm") {
+@include media_smaller_than("xxs") {
 	.lu-popup-panel {
 		border-radius: 0;
 		max-width: none;

--- a/packages/scss/src/components/_container.scss
+++ b/packages/scss/src/components/_container.scss
@@ -1,69 +1,10 @@
 .container {
-	padding: _component("container.margin-top") .5rem 0;
+	padding: _component("container.padding");
 	position: relative;
-	margin: 0 auto _component("container.margin-bottom");
 	max-width: _component("container.max-width");
 
-	@each $bp-name, $bp-obj in $breakpoints {
-		@include media_larger_than($bp-name) {
-			width: calc(#{map-get($bp-obj, breakAt)} - #{map-get($bp-obj, spacing)});
-		}
-	}
-
-	@include media_smaller_than("sm") {
-		width: 100%;
-	}
-
-	&:last-child {
-		padding-bottom: _component("container.margin-bottom");
-		margin-bottom: 0;
-	}
-}
-
-
-// MODS
-// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-
-.container {
-	@each $bp-name, $bp-obj in $breakpoints {
-		&.mod-#{$bp-name} {
-			max-width: calc(#{map-get($bp-obj, breakAt)} - #{map-get($bp-obj, spacing)});
-		}
-	}
-
-	&.mod-withStickyHeader {
-		padding-top: _component("header.height");
-	}
-}
-
-
-// LAYOUT WITH ASIDE
-// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-
-.navSide ~ .main-content, .mod-withMenu .main-content {
-	.container {
-		@each $bp-name, $bp-obj in $breakpoints {
-			@include media_larger_than($bp-name) {
-				width: calc(#{map-get($bp-obj, breakAt)} - #{map-get($bp-obj, spacing)} - #{_theme("components.navSide.width")});
-			}
-		}
-
-		@include media_smaller_than(_theme("commons.mobile", true)) {
-			width: calc(100% - #{_theme("breakpoints.md.spacing")});
-		}
-	}
-}
-
-.navSide.mod-compact ~ .main-content, .mod-withMenuCompact .main-content {
-	.container {
-		@each $bp-name, $bp-obj in $breakpoints {
-			@include media_larger_than($bp-name) {
-				width: calc(#{map-get($bp-obj, breakAt)} - #{map-get($bp-obj, spacing)} - #{_theme("components.navSide.compact.width")});
-			}
-		}
-
-		@include media_smaller_than(_theme("commons.mobile", true)) {
-			width: calc(100% - #{_theme("breakpoints.md.spacing")});
-		}
+	&.mod-center {
+		margin-left: auto;
+		margin-right: auto;
 	}
 }

--- a/packages/scss/src/components/_error-page.scss
+++ b/packages/scss/src/components/_error-page.scss
@@ -40,7 +40,7 @@
 	min-width: 350px;
 }
 
-@include media_smaller_than("md") {
+@include media_smaller_than("s") {
 	.errorPage {
 		overflow-y: auto;
 	}

--- a/packages/scss/src/components/_grid.scss
+++ b/packages/scss/src/components/_grid.scss
@@ -28,7 +28,7 @@
 }
 
 @each $bp-name, $bp-obj in $breakpoints {
-	@media only screen and (min-width: map-get($bp-obj, breakAt)) {
+	@media (min-width: map-get($bp-obj, breakAt)) {
 		.grid-#{$bp-name} {
 			flex-basis: 0;
 			flex-grow: 1;
@@ -58,7 +58,7 @@
 	}
 
 	@each $bp-name, $bp-obj in $breakpoints {
-		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
+		@media (min-width: map-get($bp-obj, breakAt)) {
 			&.mod-#{$bp-name}Start {
 				justify-content: flex-start;
 				text-align: start;
@@ -101,7 +101,7 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 .grid {
 	@each $bp-name, $bp-obj in $breakpoints {
-		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
+		@media (min-width: map-get($bp-obj, breakAt)) {
 			.u-#{$bp-name}First {
 				order: -1;
 			}

--- a/packages/scss/src/components/_header.scss
+++ b/packages/scss/src/components/_header.scss
@@ -72,7 +72,7 @@
 	.header.mod-sticky {
 		left: _theme("components.navSide.width");
 
-		@include media_smaller_than("md") {
+		@include media_smaller_than("s") {
 			top: _component("navSide.mobile.toggle-height");
 		}
 	}
@@ -82,7 +82,7 @@
 	.header.mod-sticky {
 		left: _theme("components.navSide.compact.width");
 
-		@include media_smaller_than("md") {
+		@include media_smaller_than("s") {
 			top: _component("navSide.mobile.toggle-height");
 		}
 	}

--- a/packages/scss/src/components/_layout.scss
+++ b/packages/scss/src/components/_layout.scss
@@ -2,14 +2,14 @@
 	min-height: 100vh;
 	display: grid;
 
-	@include media_larger_than("xl") {
+	@include media_larger_than("l") {
 		grid-template-columns: _theme("components.navSide.compact.width") 1fr _theme("components.aside.width");
 		grid-template-rows: _theme("commons.banner-height") 1fr;
 		grid-template-areas: "banner banner banner"
 			"navside content aside";
 	}
 
-	@include media_smaller_than("xl") {
+	@include media_smaller_than("l") {
 		grid-template-columns: _theme("components.navSide.compact.width") 1fr;
 		grid-template-rows: _theme("commons.banner-height") 1fr auto;
 		grid-template-areas: "banner banner"
@@ -17,7 +17,7 @@
 		"navside aside";
 	}
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		grid-template-columns: 1fr;
 		grid-template-rows: _theme("commons.banner-height") auto 1fr auto;
 		grid-template-areas: "banner"
@@ -28,7 +28,7 @@
 }
 
 .layout-content-container {
-	max-width: calc(#{_theme("breakpoints.lg.breakAt", true)} / 16px * 1rem);
+	max-width: calc(#{_theme("breakpoints.m.breakAt", true)} / 16px * 1rem);
 }
 
 .layout-banner {
@@ -47,7 +47,7 @@
 	display: flex;
 	flex-direction: column;
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		position: static;
 	}
 }
@@ -57,7 +57,7 @@
 	position: sticky;
 	top: _theme("commons.banner-height");
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		position: static;
 	}
 }
@@ -75,7 +75,7 @@
 	position: sticky;
 	bottom: 0;
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		position: static;
 	}
 }
@@ -88,13 +88,13 @@
 	position: sticky;
 	top: _theme("commons.banner-height");
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		min-height: 0;
 	}
 }
 
 .layout-aside {
-	@include media_smaller_than("xl") {
+	@include media_smaller_than("l") {
 		min-height: 0;
 		position: static;
 	}
@@ -111,7 +111,7 @@
 	max-height: calc(100vh - #{_theme("commons.banner-height")});
 
 	&.is-active {
-		@include media_smaller_than("md") {
+		@include media_smaller_than("s") {
 			position: fixed;
 			top: _theme("commons.banner-height");
 			height: calc(100vh - #{_theme("commons.banner-height")});
@@ -132,7 +132,7 @@
 	bottom: 0;
 	background-color: _color("white");
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		margin-top: 0;
 		position: static;
 	}
@@ -149,7 +149,7 @@
 	position: sticky;
 	top: 0;
 
-	@include media_larger_than("md") {
+	@include media_larger_than("s") {
 		display: none;
 	}
 }
@@ -163,7 +163,7 @@
 // the contents of the navside
 .layout-navside-content {
 	// if you are on the move
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		// if it is preceded by a menu activation button that is not activated
 		.layout-navside-toggle[aria-expanded="false"] ~ & {
 			// is hidden
@@ -212,7 +212,7 @@
 
 	&.mod-asideBefore {
 		&:not(.mod-asideRemoved) {
-			@include media_larger_than("xl") {
+			@include media_larger_than("l") {
 				grid-template-columns: _theme("components.navSide.width") _theme("components.aside.width") 1fr;
 				grid-template-areas: "banner	banner banner"
 					"navside aside	content";
@@ -268,15 +268,15 @@
 
 	&.mod-navsideLarge {
 
-		@include media_larger_than("xl") {
+		@include media_larger_than("l") {
 			grid-template-columns: _theme("components.navSide.width") 1fr _theme("components.aside.width");
 		}
 
-		@include media_smaller_than("xl") {
+		@include media_smaller_than("l") {
 			grid-template-columns: _theme("components.navSide.width") 1fr;
 		}
 
-		@include media_smaller_than("md") {
+		@include media_smaller_than("s") {
 			grid-template-columns: 1fr;
 		}
 	}

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -261,7 +261,7 @@
 
 // MOD COMPACT (must be defined only for desktop)
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-@include media_larger_than("md") {
+@include media_larger_than("s") {
 	.navSide.mod-compact {
 		background-color: _component("navSide.compact-palette.bg-color");
 		text-align: center;

--- a/packages/scss/src/components/_section.scss
+++ b/packages/scss/src/components/_section.scss
@@ -3,12 +3,12 @@
 	border-bottom: 1px solid #E5E5E5;
 	padding: 3rem;
 
-	@include media_smaller_than("md") {
+	@include media_smaller_than("s") {
 		padding-left: 2rem;
 		padding-right: 2rem;
 	}
 
-	@include media_smaller_than("sm") {
+	@include media_smaller_than("xs") {
 		padding-left: 1rem;
 		padding-right: 1rem;
 	}

--- a/packages/scss/src/theming/_breakpoints.scss
+++ b/packages/scss/src/theming/_breakpoints.scss
@@ -1,31 +1,30 @@
 $breakpoints: (
-	xs: (	
-		breakAt: 0px,
-		spacing: 0px,
+	xxxs: (
+		"breakAt": 320px,
 	),
-	sm: (
-		breakAt: 576px,
-		spacing: 20px,
+	xxs: (
+		"breakAt": 480px,
 	),
-	md: (
-		breakAt: 768px,
-		spacing: 30px,
+	xs: (
+		"breakAt": 640px,
 	),
-	lg: (
-		breakAt: 992px,
-		spacing: 40px,
+	s: (
+		"breakAt": 800px,
+	),
+	m: (
+		"breakAt": 1024px,
+	),
+	l: (
+		"breakAt": 1280px,
 	),
 	xl: (
-		breakAt: 1200px,
-		spacing: 60px,
+		"breakAt": 1366px,
 	),
 	xxl: (
-		breakAt: 1350px,
-		spacing: 60px,
+		"breakAt": 1600px,
 	),
 	xxxl: (
-		breakAt: 1500px,
-		spacing: 60px,
+		"breakAt": 1920px,
 	)
 );
 

--- a/packages/scss/src/theming/_commons.scss
+++ b/packages/scss/src/theming/_commons.scss
@@ -63,7 +63,7 @@ $commons: (
 	banner-height: 50px,
 	transition: unquote("all 150ms ease"),
 	focused: 0 0 1px 2px #A6C7FF,
-	mobile: "md",
+	mobile: "s",
 	loading: (
 		background: _color("primary", "200"),
 		frontground: _color("primary", "color"),

--- a/packages/scss/src/theming/components/_container.theme.scss
+++ b/packages/scss/src/theming/components/_container.theme.scss
@@ -1,5 +1,5 @@
 $container: (
-  padding: 3.5rem
+  padding: 3.5rem,
   max-width: _theme("breakpoints.xxl.breakAt"),
 );
 

--- a/packages/scss/src/theming/components/_container.theme.scss
+++ b/packages/scss/src/theming/components/_container.theme.scss
@@ -1,7 +1,6 @@
 $container: (
-  margin-top: 3rem,
-  margin-bottom: 4rem,
-  max-width: _theme("breakpoints.xxxl.breakAt"),
-  min-width: _theme("breakpoints.sm.breakAt")
+  padding: 3.5rem
+  max-width: _theme("breakpoints.xxl.breakAt"),
 );
+
 $theme: _set($theme, "components.container", $container);

--- a/stories/qa/container/container.stories.html
+++ b/stories/qa/container/container.stories.html
@@ -4,7 +4,17 @@
 <section class="contentSection">
 	<h2>Containers</h2>
 	<p>To wrap your content in a responsive container, use <code class="code">&lt;div class="container"&gt;...&lt;/div&gt;</code>. Check <a href="#templates">templates section</a> to see live examples.</p>
-	<p>You can reduce or increase the container width by adding a mod: <code class="code">mod-xs</code>, <code class="code">mod-sm</code>, <code class="code">mod-md</code>, <code class="code">mod-lg</code>, <code class="code">mod-xl</code>, <code class="code">mod-xxl</code> or <code class="code">mod-xxxl</code>.
+	<p>
+			You can reduce or increase the container width by adding a mod:
+			<code class="code">mod-xxxs</code>,
+			<code class="code">mod-xxs</code>,
+			<code class="code">mod-xs</code>,
+			<code class="code">mod-s</code>,
+			<code class="code">mod-m</code>,
+			<code class="code">mod-l</code>,
+			<code class="code">mod-xl</code>,
+			<code class="code">mod-xxl</code> or
+			<code class="code">mod-xxxl</code>.
 	<p>If you have a sticky header or filter, you can add an extra space using this mod: <code class="code">mod-withStickyHeader</code>.</p>
 </section>
 

--- a/stories/qa/grid/grid.stories.html
+++ b/stories/qa/grid/grid.stories.html
@@ -4,26 +4,26 @@
 <section class="contentSection">
 	<h2>Grid</h2>
 	<div class="grid">
-		<div class="grid-xs6"><div class="demo-grid">grid-xs6</div></div>
-		<div class="grid-xs6"><div class="demo-grid">grid-xs6</div></div>
+		<div class="grid-xxxs6"><div class="demo-grid">grid-xxxs6</div></div>
+		<div class="grid-xxxs6"><div class="demo-grid">grid-xxxs6</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-sm4"><div class="demo-grid">grid-sm4</div></div>
-		<div class="grid-sm8"><div class="demo-grid">grid-sm8</div></div>
+		<div class="grid-xs4"><div class="demo-grid">grid-xs4</div></div>
+		<div class="grid-xs8"><div class="demo-grid">grid-xs8</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-md7"><div class="demo-grid">grid-md7</div></div>
-		<div class="grid-md5"><div class="demo-grid">grid-md5</div></div>
+		<div class="grid-s7"><div class="demo-grid">grid-s7</div></div>
+		<div class="grid-s5"><div class="demo-grid">grid-s5</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-xs6"&gt;...&lt;/div&gt;
-	&lt;div class="grid-xs6"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6"&gt;...&lt;/div&gt;
 &lt;/div&gt;
 </code>
 </section>
@@ -32,14 +32,14 @@
 <section class="contentSection">
 	<h2>Offsets</h2>
 	<div class="grid">
-		<div class="grid-xs8 grid-xsOffset4"><div class="demo-grid">grid-xs8 grid-xsOffset4</div></div>
+		<div class="grid-xxxs8 grid-xxxsOffset4"><div class="demo-grid">grid-xxxs8 grid-xxxsOffset4</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-xs6 grid-xsOffset3"><div class="demo-grid">grid-xs6 grid-xsOffset3</div></div>
-		<div class="grid-xs3"><div class="demo-grid">grid-xs3</div></div>
+		<div class="grid-xxxs6 grid-xxxsOffset3"><div class="demo-grid">grid-xxxs6 grid-xxxsOffset3</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">grid-xxxs3</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-xs8 grid-xsOffset4"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs8 grid-xxxsOffset4"&gt;...&lt;/div&gt;
 &lt;/div&gt;
 </code>
 </section>
@@ -49,15 +49,15 @@
 	<h2>Auto width</h2>
 	<p>You can remove the columns numbers to devide the grid uniformly:</p>
 	<div class="grid">
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-md"&gt;...&lt;/div&gt;
-	&lt;div class="grid-md"&gt;...&lt;/div&gt;
+	&lt;div class="grid-s"&gt;...&lt;/div&gt;
+	&lt;div class="grid-s"&gt;...&lt;/div&gt;
 	...
 &lt;/div&gt;
 </code>
@@ -68,22 +68,22 @@
 <section class="contentSection">
 	<h2>Horizontal alignment</h2>
 	<p>You can align columns horizontaly inside the grid:</p>
-	<div class="grid mod-xsStart">
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+	<div class="grid mod-xxxsStart">
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
-	<div class="grid mod-xsCenter">
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+	<div class="grid mod-xxxsCenter">
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
-	<div class="grid mod-xsEnd">
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+	<div class="grid mod-xxxsEnd">
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
-<code class="code mod-block">&lt;div class="grid mod-xsStart"&gt;
+<code class="code mod-block">&lt;div class="grid mod-xxxsStart"&gt;
 ...
 </code>
-<code class="code mod-block">&lt;div class="grid mod-xsCenter"&gt;
+<code class="code mod-block">&lt;div class="grid mod-xxxsCenter"&gt;
 ...
 </code>
-<code class="code mod-block">&lt;div class="grid mod-xsEnd"&gt;
+<code class="code mod-block">&lt;div class="grid mod-xxxsEnd"&gt;
 ...
 </code>
 	<em><b>Tip:</b> It will also work with <code class="code">-xs</code>, <code class="code">-sm</code>, <code class="code">-md</code>, <code class="code">-lg</code>, <code class="code">-xl</code>, <code class="code">-xxl</code>, or <code class="code">-lg</code></em>
@@ -93,25 +93,25 @@
 <section class="contentSection">
 	<h2>Vertical alignment</h2>
 	<p>You can align columns verticaly inside the grid:</p>
-	<div class="grid mod-xsTop">
-		<div class="grid-xs6"><div class="demo-grid" style="height:100px"></div></div>
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+	<div class="grid mod-xxxsTop">
+		<div class="grid-xxxs6"><div class="demo-grid" style="height:100px"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
-	<div class="grid mod-xsMiddle">
-		<div class="grid-xs6"><div class="demo-grid" style="height:100px"></div></div>
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+	<div class="grid mod-xxxsMiddle">
+		<div class="grid-xxxs6"><div class="demo-grid" style="height:100px"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
-	<div class="grid mod-xsBottom">
-		<div class="grid-xs6"><div class="demo-grid" style="height:100px"></div></div>
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+	<div class="grid mod-xxxsBottom">
+		<div class="grid-xxxs6"><div class="demo-grid" style="height:100px"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
-<code class="code mod-block">&lt;div class="grid mod-xsTop"&gt;
+<code class="code mod-block">&lt;div class="grid mod-xxxsTop"&gt;
 ...
 </code>
-<code class="code mod-block">&lt;div class="grid mod-xsMiddle"&gt;
+<code class="code mod-block">&lt;div class="grid mod-xxxsMiddle"&gt;
 ...
 </code>
-<code class="code mod-block">&lt;div class="grid mod-xsBottom"&gt;
+<code class="code mod-block">&lt;div class="grid mod-xxxsBottom"&gt;
 ...
 </code>
 <em><b>Tip:</b> It will also work with <code class="code">-xs</code>, <code class="code">-sm</code>, <code class="code">-md</code>, <code class="code">-lg</code>, <code class="code">-xl</code>, <code class="code">-xxl</code>, or <code class="code">-lg</code></em>
@@ -122,20 +122,20 @@
 	<h2>Reorder</h2>
 	<p>You can reorder columns with utilities:</p>
 	<div class="grid">
-		<div class="grid-xs3"><div class="demo-grid">1</div></div>
-		<div class="grid-xs3"><div class="demo-grid">2</div></div>
-		<div class="grid-xs3 u-xsFirst"><div class="demo-grid">3 u-xsFirst</div></div>
-		<div class="grid-xs3"><div class="demo-grid">4</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">1</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">2</div></div>
+		<div class="grid-xxxs3 u-xsFirst"><div class="demo-grid">3 u-xsFirst</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">4</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-xs3"><div class="demo-grid">1</div></div>
-		<div class="grid-xs3 u-xsLast"><div class="demo-grid">2 u-xsLast</div></div>
-		<div class="grid-xs3"><div class="demo-grid">3</div></div>
-		<div class="grid-xs3"><div class="demo-grid">4</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">1</div></div>
+		<div class="grid-xxxs3 u-xsLast"><div class="demo-grid">2 u-xsLast</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">3</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">4</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-xs6 u-xsLast"&gt;...&lt;/div&gt;
-	&lt;div class="grid-xs6 u-xsFirst"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6 u-xsLast"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6 u-xsFirst"&gt;...&lt;/div&gt;
 &lt;/div&gt;
 </code>
 	<em><b>Tip:</b> It will also work with <code class="code">-xs</code>, <code class="code">-sm</code>, <code class="code">-md</code>, <code class="code">-lg</code>, <code class="code">-xl</code>, <code class="code">-xxl</code>, or <code class="code">-lg</code></em>

--- a/to-migrate/ng/drag-drop/drag-drop.component.html
+++ b/to-migrate/ng/drag-drop/drag-drop.component.html
@@ -10,10 +10,10 @@
 <ul class="dragDrop-list list" cdkDropList (cdkDropListDropped)="drop($event)">
 	<li class="dragDrop-item list-item"*ngFor="let movie of movies" cdkDrag>
 		<div class="dragDrop-item-content list-item-content grid">
-			<div class="grid-md1">
+			<div class="grid-s1">
 				<i class="column-drag lucca-icon">drag</i>
 			</div>
-			<div class="grid-md">
+			<div class="grid-s">
 				<span class="column-description">{{movie}}</span>
 			</div>
 		</div>

--- a/to-migrate/scss/components/containers.html
+++ b/to-migrate/scss/components/containers.html
@@ -3,6 +3,16 @@
 <section class="contentSection">
 	<h1>Containers</h1>
 	<p>To wrap your content in a responsive container, use <code class="code">&lt;div class="container"&gt;...&lt;/div&gt;</code>. Check <a href="#templates">templates section</a> to see live examples.</p>
-	<p>You can reduce or increase the container width by adding a mod: <code class="code">mod-xs</code>, <code class="code">mod-sm</code>, <code class="code">mod-md</code>, <code class="code">mod-lg</code>, <code class="code">mod-xl</code>, <code class="code">mod-xxl</code> or <code class="code">mod-xxxl</code>.
+	<p>
+		You can reduce or increase the container width by adding a mod:
+		<code class="code">mod-xxxs</code>,
+		<code class="code">mod-xxs</code>,
+		<code class="code">mod-xs</code>,
+		<code class="code">mod-s</code>,
+		<code class="code">mod-m</code>,
+		<code class="code">mod-l</code>,
+		<code class="code">mod-xl</code>,
+		<code class="code">mod-xxl</code> or
+		<code class="code">mod-xxxl</code>.
 	<p>If you have a sticky header or filter, you can add an extra space using this mod: <code class="code">mod-withStickyHeader</code>.</p>
 </section>

--- a/to-migrate/scss/components/forms/forms-checkboxes.html
+++ b/to-migrate/scss/components/forms/forms-checkboxes.html
@@ -5,7 +5,7 @@
 	<div class="form">
 		<div class="form-group">
 			<div class="grid">
-				<div class="grid-sm4">
+				<div class="grid-xs4">
 					<label class="checkbox">
 						<input class="checkbox-input" type="checkbox" checked />
 						<span class="checkbox-label">Checkbox</span>
@@ -15,7 +15,7 @@
 						<span class="checkbox-label">Checkbox</span>
 					</label>
 				</div>
-				<div class="grid-sm4">
+				<div class="grid-xs4">
 					<label class="checkbox">
 						<input class="checkbox-input" type="checkbox" disabled checked />
 						<span class="checkbox-label">Disabled checkbox</span>
@@ -43,7 +43,7 @@
 	<div class="form">
 		<div class="form-group">
 			<div class="grid">
-				<div class="grid-sm4">
+				<div class="grid-xs4">
 					<div class="checkbox mod-small">
 						<input class="checkbox-input" type="checkbox" id="checkbox0" checked>
 						<label class="checkbox-label" for="checkbox0">Checkbox</label>
@@ -53,7 +53,7 @@
 						<label class="checkbox-label" for="checkbox1">Checkbox</label>
 					</div>
 				</div>
-				<div class="grid-sm4">
+				<div class="grid-xs4">
 					<div class="checkbox mod-small">
 						<input class="checkbox-input" type="checkbox" id="checkbox2" disabled checked>
 						<label class="checkbox-label" for="checkbox2">Disabled checkbox</label>

--- a/to-migrate/scss/components/forms/forms-files.html
+++ b/to-migrate/scss/components/forms/forms-files.html
@@ -8,7 +8,7 @@
 
 	<div class="grid">
 
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<h2>Default</h2>
 			<label class="file">
 				<input class="file-input" type="file" title="" accept=".xls,.xlsx,.csv" />
@@ -233,7 +233,7 @@
 &lt;/label&gt;</code>
 		</div>
 
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<h2>Default and small modifier</h2>
 			<label class="file mod-small">
 				<input class="file-input" type="file" title="" accept=".xls,.xlsx,.csv" />

--- a/to-migrate/scss/components/forms/forms-framed.html
+++ b/to-migrate/scss/components/forms/forms-framed.html
@@ -11,7 +11,10 @@
 		 your inputs to size them on a single line. Widths will be evenly distributed according to the number of elements.
 	</p>
 	<p>
-		You can also modify this distribution by adding classes such as <code class="code">.mod-xl4</code> or <code class="code">.mod-xs6</code> on cols for example.
+		You can also modify this distribution by adding classes such as
+		<code class="code">.mod-l4</code> or
+		<code class="code">.mod-xxxs6</code>
+		on cols for example.
 	</p>
 
 	<!-- fieldset legend -->
@@ -99,10 +102,10 @@
 						<span class="textfield-label">auto</span>
 					</label>
 				</div>
-				<div class="form-group-line-col mod-sm">
+				<div class="form-group-line-col mod-xs">
 					<label class="textfield">
 						<input class="textfield-input" type="text">
-						<span class="textfield-label">mod-sm6</span>
+						<span class="textfield-label">mod-xs6</span>
 					</label>
 				</div>
 			</div>
@@ -113,10 +116,10 @@
 						<span class="textfield-label">auto</span>
 					</label>
 				</div>
-				<div class="form-group-line-col mod-lg3">
+				<div class="form-group-line-col mod-m3">
 					<label class="textfield">
 						<input class="textfield-input" type="text">
-						<span class="textfield-label">mod-lg3</span>
+						<span class="textfield-label">mod-m3</span>
 					</label>
 				</div>
 			</div>
@@ -127,10 +130,10 @@
 						<span class="textfield-label">auto</span>
 					</label>
 				</div>
-				<div class="form-group-line-col mod-md9">
+				<div class="form-group-line-col mod-s9">
 					<label class="textfield">
 						<input class="textfield-input" type="text">
-						<span class="textfield-label">mod-md9</span>
+						<span class="textfield-label">mod-s9</span>
 					</label>
 				</div>
 			</div>
@@ -1827,7 +1830,7 @@
 						<span class="textfield-label">Textfield label</span>
 					</label>
 				</div>
-				<div class="form-group-line-col mod-md6">
+				<div class="form-group-line-col mod-s6">
 					<label class="textfield">
 						<input class="textfield-input" type="text" placeholder="placeholder" value="Test disabled" disabled>
 						<span class="textfield-label">Textfield label</span>
@@ -1934,7 +1937,7 @@
 				</div>
 			</div>
 			<div class="form-group-line">
-				<div class="form-group-line-col mod-md8 fieldsetWrapper">
+				<div class="form-group-line-col mod-s8 fieldsetWrapper">
 					<fieldset class="checkboxesfield">
 						<legend class="radiosfield-label">Checkboxesfield label</legend>
 						<label class="checkbox">
@@ -1951,7 +1954,7 @@
 						</label>
 					</fieldset>
 				</div>
-				<div class="form-group-line-col mod-md6 fieldsetWrapper">
+				<div class="form-group-line-col mod-s6 fieldsetWrapper">
 					<div class="checkboxesfield">
 						<div class="radiosfield-label"></div>
 						<label class="checkbox">

--- a/to-migrate/scss/components/forms/forms-radios.html
+++ b/to-migrate/scss/components/forms/forms-radios.html
@@ -5,7 +5,7 @@
 	<div class="form">
 		<div class="form-group">
 			<div class="grid">
-				<div class="grid-md4">
+				<div class="grid-s4">
 					<label class="radio">
 						<input class="radio-input" type="radio" name="radioList1" checked />
 						<span class="radio-label">Radio</span>
@@ -15,7 +15,7 @@
 						<span class="radio-label">Radio</span>
 					</label>
 				</div>
-				<div class="grid-md4">
+				<div class="grid-s4">
 					<label class="radio">
 						<input class="radio-input" type="radio" name="radioList2" disabled checked />
 						<span class="radio-label">Disabled radio</span>
@@ -42,7 +42,7 @@
 <div class="form">
 	<div class="form-group">
 		<div class="grid">
-			<div class="grid-md4">
+			<div class="grid-s4">
 				<div class="radio mod-small">
 					<input class="radio-input" type="radio" name="radioList1" id="radio0" checked>
 					<label class="radio-label" for="radio0">Radio</label>
@@ -52,7 +52,7 @@
 					<label class="radio-label" for="radio1">Radio</label>
 				</div>
 			</div>
-			<div class="grid-md4">
+			<div class="grid-s4">
 				<div class="radio mod-small">
 					<input class="radio-input" type="radio" name="radioList2" id="radio2" disabled checked>
 					<label class="radio-label" for="radio2">Disabled radio</label>
@@ -128,7 +128,7 @@
 <section class="contentSection">
 	<h2>Radiosfield</h2>
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<fieldset class="radiosfield">
 				<legend class="radiosfield-label">radiosfield label</legend>
 				<div class="radiosfield-input">
@@ -147,7 +147,7 @@
 				</div>
 			</fieldset>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<fieldset class="radiosfield mod-compact">
 				<legend class="radiosfield-label">radiosfield label</legend>
 				<div class="radiosfield-input">

--- a/to-migrate/scss/components/forms/forms-switches.html
+++ b/to-migrate/scss/components/forms/forms-switches.html
@@ -3,7 +3,7 @@
 
 	<!-- Basics -->
 	<div class="grid">
-		<div class="grid-xs4">
+		<div class="grid-xxxs4">
 			<div class="form-group">
 				<div>
 					<label class="switch">
@@ -19,7 +19,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="grid-xs4">
+		<div class="grid-xxxs4">
 			<div class="form-group">
 				<div>
 					<label class="switch">
@@ -49,7 +49,7 @@
 
 	<!-- Basics -->
 	<div class="grid">
-		<div class="grid-xs4">
+		<div class="grid-xxxs4">
 			<div class="form-group">
 				<div class="switch mod-small">
 					<input class="switch-input" type="checkbox" id="switch0">
@@ -61,7 +61,7 @@
 				</div>
 			</div>
 		</div>
-		<div class="grid-xs4">
+		<div class="grid-xxxs4">
 			<div class="form-group">
 				<div class="switch mod-small">
 					<input class="switch-input" type="checkbox" id="switch2" disabled>

--- a/to-migrate/scss/components/forms/forms-textfields.html
+++ b/to-migrate/scss/components/forms/forms-textfields.html
@@ -4,13 +4,13 @@
 	<!-- Basics -->
 
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<label class="textfield mod-block">
 				<input class="textfield-input" type="text" placeholder="placeholder" />
 				<span class="textfield-label">Textfield label</span>
 			</label>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<label class="textfield mod-block">
 				<input class="textfield-input" type="text" value="disabled input" disabled />
 				<span class="textfield-label">Textfield label</span>
@@ -26,13 +26,13 @@
 <section class="contentSection">
 	<!-- SMALL -->
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<label class="textfield mod-small mod-block">
 				<input class="textfield-input" type="text" placeholder="placeholder" />
 				<span class="textfield-label">Textfield label</span>
 			</label>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<label class="textfield mod-small mod-block">
 				<input class="textfield-input" type="text" value="disabled input" disabled />
 				<span class="textfield-label">Textfield label</span>
@@ -47,7 +47,7 @@
 </section>
 <section class="contentSection">
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-material mod-block">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -55,7 +55,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-material mod-block">
 					<input class="textfield-input is-filled" type="text" value="disabled input" disabled />
@@ -72,7 +72,7 @@
 </section>
 <section class="contentSection">
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-compact mod-block">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -80,7 +80,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-compact mod-block">
 					<input class="textfield-input" type="text" value="disabled input" disabled />
@@ -97,7 +97,7 @@
 </section>
 <section class="contentSection">
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-outlined mod-block">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -105,7 +105,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-outlined mod-block">
 					<input class="textfield-input is-filled" type="text" value="disabled input" disabled />
@@ -122,7 +122,7 @@
 </section>
 <section class="contentSection">
 	<div class="grid">
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-block mod-password">
 					<input class="textfield-input" type="password" placeholder="placeholder" value="azerty12345#@!%;" />
@@ -143,7 +143,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md6">
+		<div class="grid-s6">
 			<div class="form-group">
 				<label class="textfield mod-block mod-password">
 					<input class="textfield-input" type="text" placeholder="placeholder" value="azerty12345#@!%;" />
@@ -192,7 +192,7 @@
 	<h2>Helper / Warning / Error / Success</h2>
 
 	<div class="grid">
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-block">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -211,7 +211,7 @@
 &lt;/label&gt;
 </code>
 		</div>
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-block">
 					<input class="textfield-input is-warning" type="text" placeholder="placeholder" />
@@ -230,7 +230,7 @@
 &lt;/label&gt;
 </code>
 		</div>
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-block">
 					<input class="textfield-input is-error" type="text" placeholder="placeholder" />
@@ -249,7 +249,7 @@
 &lt;/label&gt;
 </code>
 		</div>
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-block">
 					<input class="textfield-input is-success" type="text" placeholder="placeholder" />
@@ -272,7 +272,7 @@
 </section>
 <section class="contentSection">
 	<div class="grid">
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-material mod-block">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -283,7 +283,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-material mod-block">
 					<input class="textfield-input is-warning" type="text" placeholder="placeholder" />
@@ -294,7 +294,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-material mod-block">
 					<input class="textfield-input is-error" type="text" placeholder="placeholder" />
@@ -305,7 +305,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md3">
+		<div class="grid-s3">
 			<div class="form-group">
 				<label class="textfield mod-material mod-block">
 					<input class="textfield-input is-success" type="text" placeholder="placeholder" />
@@ -320,7 +320,7 @@
 </section>
 <section class="contentSection">
 	<div class="grid">
-		<div class="grid-sm6 grid-smOffset2">
+		<div class="grid-xs6 grid-xsOffset2">
 			<label class="textfield mod-compact mod-block">
 				<input class="textfield-input" type="text" placeholder="placeholder" />
 				<span class="textfield-label">Textfield label</span>
@@ -357,7 +357,7 @@
 <section class="contentSection">
 	<h2>Palettes</h2>
 	<div class="grid">
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="demo-palettes">
 				<label class="textfield mod-block palette-primary">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -369,7 +369,7 @@
 				&lt;span class="textfield-label"&gt;…&lt;/span&gt;
 			&lt;/label&gt;</code>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="demo-palettes">
 				<label class="textfield mod-block palette-secondary">
 					<input class="textfield-input" type="text" placeholder="placeholder" /> 
@@ -381,7 +381,7 @@
 				&lt;span class="textfield-label"&gt;…&lt;/span&gt;
 			&lt;/label&gt;</code>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="demo-palettes">
 				<label class="textfield mod-block palette-grey">
 					<input class="textfield-input" type="text" placeholder="placeholder" /> 
@@ -393,7 +393,7 @@
 				&lt;span class="textfield-label"&gt;…&lt;/span&gt;
 			&lt;/label&gt;</code>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="demo-palettes">
 				<label class="textfield mod-block palette-success">
 					<input class="textfield-input" type="text" placeholder="placeholder" />
@@ -405,7 +405,7 @@
 				&lt;span class="textfield-label"&gt;…&lt;/span&gt;
 			&lt;/label&gt;</code>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="demo-palettes">
 				<label class="textfield mod-block palette-warning">
 					<input class="textfield-input" type="text" placeholder="placeholder" /> 
@@ -417,7 +417,7 @@
 				&lt;span class="textfield-label&gt;…&lt;/span&gt;
 			&lt;/label&gt;</code>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="demo-palettes">
 				<label class="textfield mod-block palette-error">
 					<input class="textfield-input" type="text" placeholder="placeholder" /> 
@@ -438,13 +438,13 @@
 <!-- Inline validation -->
 <section class="contentSection">
 	<div class="grid mod-xsBottom">
-		<div class="grid-xs4">
+		<div class="grid-xxxs4">
 			<label class="textfield mod-block">
 				<input class="textfield-input" type="text" placeholder="Focus / Unfocus me" onblur="validationFocus(this)" />
 				<span class="textfield-label">Loading > valid</span>
 			</label>
 		</div>
-		<div class="grid-xs4">
+		<div class="grid-xxxs4">
 			<label class="textfield mod-block">
 				<input class="textfield-input" type="text" placeholder="Focus / Unfocus me" onblur="unvalidationFocus(this)" />
 				<span class="textfield-label">Loading > invalid</span>
@@ -458,7 +458,7 @@
 	<h2>Suffix</h2>
 	<p>You can use a class <code class="code">mod-withSuffix</code> to support a suffix on your input.</p>
 	<div class="grid mod-xsBottom">
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="form-group">
 				<label class="textfield mod-block mod-withSuffix">
 					<input class="textfield-input" type="text">
@@ -467,7 +467,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="form-group">
 				<label class="textfield mod-block mod-withSuffix mod-material">
 					<input class="textfield-input" type="text">
@@ -476,7 +476,7 @@
 				</label>
 			</div>
 		</div>
-		<div class="grid-md4">
+		<div class="grid-s4">
 			<div class="form-group">
 				<label class="textfield mod-block mod-withSuffix mod-compact">
 					<input class="textfield-input" type="text">
@@ -557,19 +557,19 @@
 <section class="contentSection">
 	<h2>Search</h2>
 	<div class="grid mod-xsBottom">
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-search mod-block">
 				<input class="textfield-input" type="text" placeholder="e.g. Clark Kent" />
 				<span class="textfield-label">Search</span>
 			</label>
 		</div>
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-material mod-search mod-block">
 				<input class="textfield-input" type="text" placeholder="e.g. Clark Kent" />
 				<span class="textfield-label">Search</span>
 			</label>
 		</div>
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-compact mod-search mod-block u-marginReset">
 				<input class="textfield-input" type="text" placeholder="e.g. Clark Kent" />
 				<span class="textfield-label">Search</span>
@@ -587,7 +587,7 @@
 <section class="contentSection">
 	<h2>Clearable</h2>
 	<div class="grid mod-xsBottom">
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-search mod-block mod-clearable">
 				<input class="textfield-input" type="text" placeholder="e.g. Clark Kent" />
 				<span class="textfield-label">Search</span>
@@ -597,7 +597,7 @@
 				</a>
 			</label>
 		</div>
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-material mod-search mod-block mod-clearable">
 				<input class="textfield-input" type="text" placeholder="e.g. Clark Kent" />
 				<label class="textfield-label">Search</label>
@@ -607,7 +607,7 @@
 				</a>
 			</label>
 		</div>
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-compact mod-search mod-block u-marginReset mod-clearable">
 				<input class="textfield-input" type="text" placeholder="e.g. Clark Kent" />
 				<span class="textfield-label">Search</span>
@@ -617,7 +617,7 @@
 				</a>
 			</label>
 		</div>
-		<div class="grid-sm4">
+		<div class="grid-xs4">
 			<label class="textfield mod-clearable">
 				<input class="textfield-input" type="text" />
 				<span class="textfield-label">Textfield label</span>
@@ -688,7 +688,7 @@
 	<h2>Multilines</h2>
 	<div class="form">
 		<div class="grid">
-			<div class="grid-sm6">
+			<div class="grid-xs6">
 				<div class="form-group">
 					<label class="textfield mod-multiline mod-block">
 						<textarea class="textfield-input"></textarea>
@@ -696,7 +696,7 @@
 					</label>
 				</div>
 			</div>
-			<div class="grid-sm6">
+			<div class="grid-xs6">
 				<div class="form-group">
 					<label class="textfield mod-multiline mod-block">
 						<textarea class="textfield-input is-filled" disabled>Disabled textarea ø Disabled textarea ø Disabled textarea ø Disabled textarea ø</textarea>
@@ -706,7 +706,7 @@
 			</div>
 		</div>
 		<div class="grid">
-			<div class="grid-sm6">
+			<div class="grid-xs6">
 				<div class="form-group">
 					<label class="textfield mod-material mod-multiline mod-block">
 						<textarea class="textfield-input"></textarea>
@@ -714,7 +714,7 @@
 					</label>
 				</div>
 			</div>
-			<div class="grid-sm6">
+			<div class="grid-xs6">
 				<div class="form-group">
 					<label class="textfield mod-material mod-multiline mod-block">
 						<textarea class="textfield-input is-filled" disabled>Disabled textarea ø Disabled textarea ø Disabled textarea ø Disabled textarea ø</textarea>
@@ -724,7 +724,7 @@
 			</div>
 		</div>
 		<div class="grid">
-			<div class="grid-sm6">
+			<div class="grid-xs6">
 				<div class="form-group">
 					<label class="textfield mod-multiline mod-compact mod-block">
 						<textarea class="textfield-input"></textarea>
@@ -732,7 +732,7 @@
 					</label>
 				</div>
 			</div>
-			<div class="grid-sm6">
+			<div class="grid-xs6">
 				<div class="form-group">
 					<label class="textfield mod-multiline mod-compact mod-block">
 						<textarea class="textfield-input is-filled" disabled>Disabled textarea ø Disabled textarea ø Disabled textarea ø Disabled textarea ø</textarea>

--- a/to-migrate/scss/components/grids.html
+++ b/to-migrate/scss/components/grids.html
@@ -4,26 +4,26 @@
 <section class="contentSection">
 	<h1>Grid</h1>
 	<div class="grid">
-		<div class="grid-xs6"><div class="demo-grid">grid-xs6</div></div>
-		<div class="grid-xs6"><div class="demo-grid">grid-xs6</div></div>
+		<div class="grid-xxxs6"><div class="demo-grid">grid-xxxs6</div></div>
+		<div class="grid-xxxs6"><div class="demo-grid">grid-xxxs6</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-sm4"><div class="demo-grid">grid-sm4</div></div>
-		<div class="grid-sm8"><div class="demo-grid">grid-sm8</div></div>
+		<div class="grid-xs4"><div class="demo-grid">grid-xs4</div></div>
+		<div class="grid-xs8"><div class="demo-grid">grid-xs8</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-md7"><div class="demo-grid">grid-md7</div></div>
-		<div class="grid-md5"><div class="demo-grid">grid-md5</div></div>
+		<div class="grid-s7"><div class="demo-grid">grid-s7</div></div>
+		<div class="grid-s5"><div class="demo-grid">grid-s5</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
-		<div class="grid-lg3 grid-md6"><div class="demo-grid">grid-lg3 grid-md6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
+		<div class="grid-m3 grid-s6"><div class="demo-grid">grid-m3 grid-s6</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-xs6"&gt;...&lt;/div&gt;
-	&lt;div class="grid-xs6"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6"&gt;...&lt;/div&gt;
 &lt;/div&gt;
 </code>
 </section>
@@ -32,14 +32,14 @@
 <section class="contentSection">
 	<h2>Offsets</h2>
 	<div class="grid">
-		<div class="grid-xs8 grid-xsOffset4"><div class="demo-grid">grid-xs8 grid-xsOffset4</div></div>
+		<div class="grid-xxxs8 grid-xxxsOffset4"><div class="demo-grid">grid-xxxs8 grid-xxxsOffset4</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-xs6 grid-xsOffset3"><div class="demo-grid">grid-xs6 grid-xsOffset3</div></div>
-		<div class="grid-xs3"><div class="demo-grid">grid-xs3</div></div>
+		<div class="grid-xxxs6 grid-xxxsOffset3"><div class="demo-grid">grid-xxxs6 grid-xxxsOffset3</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">grid-xxxs3</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-xs8 grid-xsOffset4"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs8 grid-xxxsOffset4"&gt;...&lt;/div&gt;
 &lt;/div&gt;
 </code>
 </section>
@@ -49,15 +49,15 @@
 	<h2>Auto width</h2>
 	<p>You can remove the columns numbers to devide the grid uniformly:</p>
 	<div class="grid">
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
-		<div class="grid-md"><div class="demo-grid">grid-md</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
+		<div class="grid-s"><div class="demo-grid">grid-s</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-md"&gt;...&lt;/div&gt;
-	&lt;div class="grid-md"&gt;...&lt;/div&gt;
+	&lt;div class="grid-s"&gt;...&lt;/div&gt;
+	&lt;div class="grid-s"&gt;...&lt;/div&gt;
 	...
 &lt;/div&gt;
 </code>
@@ -69,13 +69,13 @@
 	<h2>Horizontal alignment</h2>
 	<p>You can align columns horizontaly inside the grid:</p>
 	<div class="grid mod-xsStart">
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
 	<div class="grid mod-xsCenter">
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
 	<div class="grid mod-xsEnd">
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid mod-xsStart"&gt;
 ...
@@ -94,16 +94,16 @@
 	<h2>Vertical alignment</h2>
 	<p>You can align columns verticaly inside the grid:</p>
 	<div class="grid mod-xsTop">
-		<div class="grid-xs6"><div class="demo-grid" style="height:100px"></div></div>
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid" style="height:100px"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
 	<div class="grid mod-xsMiddle">
-		<div class="grid-xs6"><div class="demo-grid" style="height:100px"></div></div>
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid" style="height:100px"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
 	<div class="grid mod-xsBottom">
-		<div class="grid-xs6"><div class="demo-grid" style="height:100px"></div></div>
-		<div class="grid-xs6"><div class="demo-grid"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid" style="height:100px"></div></div>
+		<div class="grid-xxxs6"><div class="demo-grid"></div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid mod-xsTop"&gt;
 ...
@@ -122,20 +122,20 @@
 	<h2>Reorder</h2>
 	<p>You can reorder columns with utilities:</p>
 	<div class="grid">
-		<div class="grid-xs3"><div class="demo-grid">1</div></div>
-		<div class="grid-xs3"><div class="demo-grid">2</div></div>
-		<div class="grid-xs3 u-xsFirst"><div class="demo-grid">3 u-xsFirst</div></div>
-		<div class="grid-xs3"><div class="demo-grid">4</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">1</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">2</div></div>
+		<div class="grid-xxxs3 u-xsFirst"><div class="demo-grid">3 u-xsFirst</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">4</div></div>
 	</div>
 	<div class="grid">
-		<div class="grid-xs3"><div class="demo-grid">1</div></div>
-		<div class="grid-xs3 u-xsLast"><div class="demo-grid">2 u-xsLast</div></div>
-		<div class="grid-xs3"><div class="demo-grid">3</div></div>
-		<div class="grid-xs3"><div class="demo-grid">4</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">1</div></div>
+		<div class="grid-xxxs3 u-xsLast"><div class="demo-grid">2 u-xsLast</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">3</div></div>
+		<div class="grid-xxxs3"><div class="demo-grid">4</div></div>
 	</div>
 <code class="code mod-block">&lt;div class="grid"&gt;
-	&lt;div class="grid-xs6 u-xsLast"&gt;...&lt;/div&gt;
-	&lt;div class="grid-xs6 u-xsFirst"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6 u-xsLast"&gt;...&lt;/div&gt;
+	&lt;div class="grid-xxxs6 u-xsFirst"&gt;...&lt;/div&gt;
 &lt;/div&gt;
 </code>
 	<em><b>Tip:</b> It will also work with <code class="code">-xs</code>, <code class="code">-sm</code>, <code class="code">-md</code>, <code class="code">-lg</code>, <code class="code">-xl</code>, <code class="code">-xxl</code>, or <code class="code">-lg</code></em>

--- a/to-migrate/scss/components/templates.html
+++ b/to-migrate/scss/components/templates.html
@@ -2,7 +2,7 @@
 <section class="contentSection">
 	<h1>Templates</h1>
 	<div class="grid">
-		<div class="grid-xs6">
+		<div class="grid-xxxs6">
 			<h2>With nav aside</h2>
 			<ul>
 				<li><a href="templates/fullmenu.html" target="_blank">Full menu</a></li>
@@ -17,7 +17,7 @@
 				<li><a href="templates/side-filters.html" target="_blank">Compact menu with filters</a></li>
 			</ul>
 		</div>
-		<div class="grid-xs6">
+		<div class="grid-xxxs6">
 			<h2>Without nav aside</h2>
 			<ul>
 				<li><a href="templates/noside.html" target="_blank">Basic</a></li>
@@ -29,7 +29,7 @@
 				<li><a href="templates/noside-filters.html" target="_blank">With filters</a></li>
 			</ul>
 		</div>
-		<div class="grid-xs6">
+		<div class="grid-xxxs6">
 			<h2>Others</h2>
 			<ul>
 				<li><a href="templates/error.html" target="_blank">Error Page</a></li>

--- a/to-migrate/scss/demo.css
+++ b/to-migrate/scss/demo.css
@@ -109,7 +109,7 @@
 	padding: 60px 0 100px 180px;
 }
 
-@media not all and (min-width: 990px) {
+@media not all and (min-width: 64em) {
 	.demo-body {
 		padding-left: 0;
 	}
@@ -127,7 +127,7 @@
 	overflow: auto;
 }
 
-@media not all and (min-width: 990px) {
+@media not all and (min-width: 64em) {
 	.demo-nav {
 		display: none;
 	}
@@ -164,7 +164,7 @@
 	max-width: 850px;
 }
 
-@media not all and (min-width: 1200px) {
+@media not all and (min-width: 80em) {
 	.container.mod-demo {
 		max-width: 700px;
 	}

--- a/to-migrate/scss/lucca-front.css
+++ b/to-migrate/scss/lucca-front.css
@@ -3778,25 +3778,25 @@ abbr[title] {
   margin-bottom: 0;
 }
 
-.container.mod-xs {
+.container.mod-xxxs {
   max-width: calc(0px - 0px);
 }
-.container.mod-sm {
+.container.mod-xs {
   max-width: calc(576px - 20px);
 }
-.container.mod-md {
+.container.mod-s {
   max-width: calc(768px - 30px);
 }
-.container.mod-lg {
+.container.mod-m {
   max-width: calc(992px - 40px);
 }
-.container.mod-xl {
+.container.mod-l {
   max-width: calc(1200px - 60px);
 }
-.container.mod-xxl {
+.container.mod-xl {
   max-width: calc(1350px - 60px);
 }
-.container.mod-xxxl {
+.container.mod-xxl {
   max-width: calc(1500px - 60px);
 }
 .container.mod-withStickyHeader {
@@ -4080,6 +4080,92 @@ abbr[title] {
 .form-group-line-col > * {
   flex-grow: 1;
 }
+.form-group-line-col.mod-xxxs1 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs2 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs3 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs4 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs5 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs6 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs7 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs8 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs9 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs10 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs11 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-xxxs12 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+@media (min-width: 0em ) {
+  .form-group-line-col.mod-xxxs1 {
+    flex-basis: 8.3333333333%;
+  }
+  .form-group-line-col.mod-xxxs2 {
+    flex-basis: 16.6666666667%;
+  }
+  .form-group-line-col.mod-xxxs3 {
+    flex-basis: 25%;
+  }
+  .form-group-line-col.mod-xxxs4 {
+    flex-basis: 33.3333333333%;
+  }
+  .form-group-line-col.mod-xxxs5 {
+    flex-basis: 41.6666666667%;
+  }
+  .form-group-line-col.mod-xxxs6 {
+    flex-basis: 50%;
+  }
+  .form-group-line-col.mod-xxxs7 {
+    flex-basis: 58.3333333333%;
+  }
+  .form-group-line-col.mod-xxxs8 {
+    flex-basis: 66.6666666667%;
+  }
+  .form-group-line-col.mod-xxxs9 {
+    flex-basis: 75%;
+  }
+  .form-group-line-col.mod-xxxs10 {
+    flex-basis: 83.3333333333%;
+  }
+  .form-group-line-col.mod-xxxs11 {
+    flex-basis: 91.6666666667%;
+  }
+  .form-group-line-col.mod-xxxs12 {
+    flex-basis: 100%;
+  }
+}
 .form-group-line-col.mod-xs1 {
   flex-basis: 100%;
   flex-grow: 0;
@@ -4128,7 +4214,7 @@ abbr[title] {
   flex-basis: 100%;
   flex-grow: 0;
 }
-@media (min-width: 0em ) {
+@media (min-width: 36em ) {
   .form-group-line-col.mod-xs1 {
     flex-basis: 8.3333333333%;
   }
@@ -4166,261 +4252,261 @@ abbr[title] {
     flex-basis: 100%;
   }
 }
-.form-group-line-col.mod-sm1 {
+.form-group-line-col.mod-s1 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm2 {
+.form-group-line-col.mod-s2 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm3 {
+.form-group-line-col.mod-s3 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm4 {
+.form-group-line-col.mod-s4 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm5 {
+.form-group-line-col.mod-s5 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm6 {
+.form-group-line-col.mod-s6 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm7 {
+.form-group-line-col.mod-s7 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm8 {
+.form-group-line-col.mod-s8 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm9 {
+.form-group-line-col.mod-s9 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm10 {
+.form-group-line-col.mod-s10 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm11 {
+.form-group-line-col.mod-s11 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-sm12 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-@media (min-width: 36em ) {
-  .form-group-line-col.mod-sm1 {
-    flex-basis: 8.3333333333%;
-  }
-  .form-group-line-col.mod-sm2 {
-    flex-basis: 16.6666666667%;
-  }
-  .form-group-line-col.mod-sm3 {
-    flex-basis: 25%;
-  }
-  .form-group-line-col.mod-sm4 {
-    flex-basis: 33.3333333333%;
-  }
-  .form-group-line-col.mod-sm5 {
-    flex-basis: 41.6666666667%;
-  }
-  .form-group-line-col.mod-sm6 {
-    flex-basis: 50%;
-  }
-  .form-group-line-col.mod-sm7 {
-    flex-basis: 58.3333333333%;
-  }
-  .form-group-line-col.mod-sm8 {
-    flex-basis: 66.6666666667%;
-  }
-  .form-group-line-col.mod-sm9 {
-    flex-basis: 75%;
-  }
-  .form-group-line-col.mod-sm10 {
-    flex-basis: 83.3333333333%;
-  }
-  .form-group-line-col.mod-sm11 {
-    flex-basis: 91.6666666667%;
-  }
-  .form-group-line-col.mod-sm12 {
-    flex-basis: 100%;
-  }
-}
-.form-group-line-col.mod-md1 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md2 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md3 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md4 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md5 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md6 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md7 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md8 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md9 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md10 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md11 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-md12 {
+.form-group-line-col.mod-s12 {
   flex-basis: 100%;
   flex-grow: 0;
 }
 @media (min-width: 48em ) {
-  .form-group-line-col.mod-md1 {
+  .form-group-line-col.mod-s1 {
     flex-basis: 8.3333333333%;
   }
-  .form-group-line-col.mod-md2 {
+  .form-group-line-col.mod-s2 {
     flex-basis: 16.6666666667%;
   }
-  .form-group-line-col.mod-md3 {
+  .form-group-line-col.mod-s3 {
     flex-basis: 25%;
   }
-  .form-group-line-col.mod-md4 {
+  .form-group-line-col.mod-s4 {
     flex-basis: 33.3333333333%;
   }
-  .form-group-line-col.mod-md5 {
+  .form-group-line-col.mod-s5 {
     flex-basis: 41.6666666667%;
   }
-  .form-group-line-col.mod-md6 {
+  .form-group-line-col.mod-s6 {
     flex-basis: 50%;
   }
-  .form-group-line-col.mod-md7 {
+  .form-group-line-col.mod-s7 {
     flex-basis: 58.3333333333%;
   }
-  .form-group-line-col.mod-md8 {
+  .form-group-line-col.mod-s8 {
     flex-basis: 66.6666666667%;
   }
-  .form-group-line-col.mod-md9 {
+  .form-group-line-col.mod-s9 {
     flex-basis: 75%;
   }
-  .form-group-line-col.mod-md10 {
+  .form-group-line-col.mod-s10 {
     flex-basis: 83.3333333333%;
   }
-  .form-group-line-col.mod-md11 {
+  .form-group-line-col.mod-s11 {
     flex-basis: 91.6666666667%;
   }
-  .form-group-line-col.mod-md12 {
+  .form-group-line-col.mod-s12 {
     flex-basis: 100%;
   }
 }
-.form-group-line-col.mod-lg1 {
+.form-group-line-col.mod-m1 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg2 {
+.form-group-line-col.mod-m2 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg3 {
+.form-group-line-col.mod-m3 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg4 {
+.form-group-line-col.mod-m4 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg5 {
+.form-group-line-col.mod-m5 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg6 {
+.form-group-line-col.mod-m6 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg7 {
+.form-group-line-col.mod-m7 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg8 {
+.form-group-line-col.mod-m8 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg9 {
+.form-group-line-col.mod-m9 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg10 {
+.form-group-line-col.mod-m10 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg11 {
+.form-group-line-col.mod-m11 {
   flex-basis: 100%;
   flex-grow: 0;
 }
-.form-group-line-col.mod-lg12 {
+.form-group-line-col.mod-m12 {
   flex-basis: 100%;
   flex-grow: 0;
 }
 @media (min-width: 62em ) {
-  .form-group-line-col.mod-lg1 {
+  .form-group-line-col.mod-m1 {
     flex-basis: 8.3333333333%;
   }
-  .form-group-line-col.mod-lg2 {
+  .form-group-line-col.mod-m2 {
     flex-basis: 16.6666666667%;
   }
-  .form-group-line-col.mod-lg3 {
+  .form-group-line-col.mod-m3 {
     flex-basis: 25%;
   }
-  .form-group-line-col.mod-lg4 {
+  .form-group-line-col.mod-m4 {
     flex-basis: 33.3333333333%;
   }
-  .form-group-line-col.mod-lg5 {
+  .form-group-line-col.mod-m5 {
     flex-basis: 41.6666666667%;
   }
-  .form-group-line-col.mod-lg6 {
+  .form-group-line-col.mod-m6 {
     flex-basis: 50%;
   }
-  .form-group-line-col.mod-lg7 {
+  .form-group-line-col.mod-m7 {
     flex-basis: 58.3333333333%;
   }
-  .form-group-line-col.mod-lg8 {
+  .form-group-line-col.mod-m8 {
     flex-basis: 66.6666666667%;
   }
-  .form-group-line-col.mod-lg9 {
+  .form-group-line-col.mod-m9 {
     flex-basis: 75%;
   }
-  .form-group-line-col.mod-lg10 {
+  .form-group-line-col.mod-m10 {
     flex-basis: 83.3333333333%;
   }
-  .form-group-line-col.mod-lg11 {
+  .form-group-line-col.mod-m11 {
     flex-basis: 91.6666666667%;
   }
-  .form-group-line-col.mod-lg12 {
+  .form-group-line-col.mod-m12 {
+    flex-basis: 100%;
+  }
+}
+.form-group-line-col.mod-l1 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l2 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l3 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l4 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l5 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l6 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l7 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l8 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l9 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l10 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l11 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+.form-group-line-col.mod-l12 {
+  flex-basis: 100%;
+  flex-grow: 0;
+}
+@media (min-width: 75em ) {
+  .form-group-line-col.mod-l1 {
+    flex-basis: 8.3333333333%;
+  }
+  .form-group-line-col.mod-l2 {
+    flex-basis: 16.6666666667%;
+  }
+  .form-group-line-col.mod-l3 {
+    flex-basis: 25%;
+  }
+  .form-group-line-col.mod-l4 {
+    flex-basis: 33.3333333333%;
+  }
+  .form-group-line-col.mod-l5 {
+    flex-basis: 41.6666666667%;
+  }
+  .form-group-line-col.mod-l6 {
+    flex-basis: 50%;
+  }
+  .form-group-line-col.mod-l7 {
+    flex-basis: 58.3333333333%;
+  }
+  .form-group-line-col.mod-l8 {
+    flex-basis: 66.6666666667%;
+  }
+  .form-group-line-col.mod-l9 {
+    flex-basis: 75%;
+  }
+  .form-group-line-col.mod-l10 {
+    flex-basis: 83.3333333333%;
+  }
+  .form-group-line-col.mod-l11 {
+    flex-basis: 91.6666666667%;
+  }
+  .form-group-line-col.mod-l12 {
     flex-basis: 100%;
   }
 }
@@ -4472,7 +4558,7 @@ abbr[title] {
   flex-basis: 100%;
   flex-grow: 0;
 }
-@media (min-width: 75em ) {
+@media (min-width: 84.375em ) {
   .form-group-line-col.mod-xl1 {
     flex-basis: 8.3333333333%;
   }
@@ -4558,7 +4644,7 @@ abbr[title] {
   flex-basis: 100%;
   flex-grow: 0;
 }
-@media (min-width: 84.375em ) {
+@media (min-width: 93.75em ) {
   .form-group-line-col.mod-xxl1 {
     flex-basis: 8.3333333333%;
   }
@@ -4593,92 +4679,6 @@ abbr[title] {
     flex-basis: 91.6666666667%;
   }
   .form-group-line-col.mod-xxl12 {
-    flex-basis: 100%;
-  }
-}
-.form-group-line-col.mod-xxxl1 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl2 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl3 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl4 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl5 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl6 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl7 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl8 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl9 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl10 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl11 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-.form-group-line-col.mod-xxxl12 {
-  flex-basis: 100%;
-  flex-grow: 0;
-}
-@media (min-width: 93.75em ) {
-  .form-group-line-col.mod-xxxl1 {
-    flex-basis: 8.3333333333%;
-  }
-  .form-group-line-col.mod-xxxl2 {
-    flex-basis: 16.6666666667%;
-  }
-  .form-group-line-col.mod-xxxl3 {
-    flex-basis: 25%;
-  }
-  .form-group-line-col.mod-xxxl4 {
-    flex-basis: 33.3333333333%;
-  }
-  .form-group-line-col.mod-xxxl5 {
-    flex-basis: 41.6666666667%;
-  }
-  .form-group-line-col.mod-xxxl6 {
-    flex-basis: 50%;
-  }
-  .form-group-line-col.mod-xxxl7 {
-    flex-basis: 58.3333333333%;
-  }
-  .form-group-line-col.mod-xxxl8 {
-    flex-basis: 66.6666666667%;
-  }
-  .form-group-line-col.mod-xxxl9 {
-    flex-basis: 75%;
-  }
-  .form-group-line-col.mod-xxxl10 {
-    flex-basis: 83.3333333333%;
-  }
-  .form-group-line-col.mod-xxxl11 {
-    flex-basis: 91.6666666667%;
-  }
-  .form-group-line-col.mod-xxxl12 {
     flex-basis: 100%;
   }
 }
@@ -5147,7 +5147,7 @@ abbr[title] {
   margin-right: -0.5rem;
 }
 
-.grid-xxxl12, .grid-xxxl11, .grid-xxxl10, .grid-xxxl9, .grid-xxxl8, .grid-xxxl7, .grid-xxxl6, .grid-xxxl5, .grid-xxxl4, .grid-xxxl3, .grid-xxxl2, .grid-xxxl1, .grid-xxxl, .grid-xxl12, .grid-xxl11, .grid-xxl10, .grid-xxl9, .grid-xxl8, .grid-xxl7, .grid-xxl6, .grid-xxl5, .grid-xxl4, .grid-xxl3, .grid-xxl2, .grid-xxl1, .grid-xxl, .grid-xl12, .grid-xl11, .grid-xl10, .grid-xl9, .grid-xl8, .grid-xl7, .grid-xl6, .grid-xl5, .grid-xl4, .grid-xl3, .grid-xl2, .grid-xl1, .grid-xl, .grid-lg12, .grid-lg11, .grid-lg10, .grid-lg9, .grid-lg8, .grid-lg7, .grid-lg6, .grid-lg5, .grid-lg4, .grid-lg3, .grid-lg2, .grid-lg1, .grid-lg, .grid-md12, .grid-md11, .grid-md10, .grid-md9, .grid-md8, .grid-md7, .grid-md6, .grid-md5, .grid-md4, .grid-md3, .grid-md2, .grid-md1, .grid-md, .grid-sm12, .grid-sm11, .grid-sm10, .grid-sm9, .grid-sm8, .grid-sm7, .grid-sm6, .grid-sm5, .grid-sm4, .grid-sm3, .grid-sm2, .grid-sm1, .grid-sm, .grid-xs12, .grid-xs11, .grid-xs10, .grid-xs9, .grid-xs8, .grid-xs7, .grid-xs6, .grid-xs5, .grid-xs4, .grid-xs3, .grid-xs2, .grid-xs1, .grid-xs {
+.grid-xxl12, .grid-xxl11, .grid-xxl10, .grid-xxl9, .grid-xxl8, .grid-xxl7, .grid-xxl6, .grid-xxl5, .grid-xxl4, .grid-xxl3, .grid-xxl2, .grid-xxl1, .grid-xxl, .grid-xl12, .grid-xl11, .grid-xl10, .grid-xl9, .grid-xl8, .grid-xl7, .grid-xl6, .grid-xl5, .grid-xl4, .grid-xl3, .grid-xl2, .grid-xl1, .grid-xl, .grid-l12, .grid-l11, .grid-l10, .grid-l9, .grid-l8, .grid-l7, .grid-l6, .grid-l5, .grid-l4, .grid-l3, .grid-l2, .grid-l1, .grid-l, .grid-m12, .grid-m11, .grid-m10, .grid-m9, .grid-m8, .grid-m7, .grid-m6, .grid-m5, .grid-m4, .grid-m3, .grid-m2, .grid-m1, .grid-m, .grid-s12, .grid-s11, .grid-s10, .grid-s9, .grid-s8, .grid-s7, .grid-s6, .grid-s5, .grid-s4, .grid-s3, .grid-s2, .grid-s1, .grid-s, .grid-xs12, .grid-xs11, .grid-xs10, .grid-xs9, .grid-xs8, .grid-xs7, .grid-xs6, .grid-xs5, .grid-xs4, .grid-xs3, .grid-xs2, .grid-xs1, .grid-xs, .grid-xxxs12, .grid-xxxs11, .grid-xxxs10, .grid-xxxs9, .grid-xxxs8, .grid-xxxs7, .grid-xxxs6, .grid-xxxs5, .grid-xxxs4, .grid-xxxs3, .grid-xxxs2, .grid-xxxs1, .grid-xxxs {
   flex: 0 0 auto;
   flex-basis: 100%;
   max-width: 100%;
@@ -5157,6 +5157,121 @@ abbr[title] {
 }
 
 @media only screen and (min-width: 0px) {
+  .grid-xxxs {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+
+  .grid-xxxs1 {
+    flex-basis: 8.3333333333%;
+    max-width: 8.3333333333%;
+  }
+
+  .grid-xxxsOffset1 {
+    margin-left: 8.3333333333%;
+  }
+
+  .grid-xxxs2 {
+    flex-basis: 16.6666666667%;
+    max-width: 16.6666666667%;
+  }
+
+  .grid-xxxsOffset2 {
+    margin-left: 16.6666666667%;
+  }
+
+  .grid-xxxs3 {
+    flex-basis: 25%;
+    max-width: 25%;
+  }
+
+  .grid-xxxsOffset3 {
+    margin-left: 25%;
+  }
+
+  .grid-xxxs4 {
+    flex-basis: 33.3333333333%;
+    max-width: 33.3333333333%;
+  }
+
+  .grid-xxxsOffset4 {
+    margin-left: 33.3333333333%;
+  }
+
+  .grid-xxxs5 {
+    flex-basis: 41.6666666667%;
+    max-width: 41.6666666667%;
+  }
+
+  .grid-xxxsOffset5 {
+    margin-left: 41.6666666667%;
+  }
+
+  .grid-xxxs6 {
+    flex-basis: 50%;
+    max-width: 50%;
+  }
+
+  .grid-xxxsOffset6 {
+    margin-left: 50%;
+  }
+
+  .grid-xxxs7 {
+    flex-basis: 58.3333333333%;
+    max-width: 58.3333333333%;
+  }
+
+  .grid-xxxsOffset7 {
+    margin-left: 58.3333333333%;
+  }
+
+  .grid-xxxs8 {
+    flex-basis: 66.6666666667%;
+    max-width: 66.6666666667%;
+  }
+
+  .grid-xxxsOffset8 {
+    margin-left: 66.6666666667%;
+  }
+
+  .grid-xxxs9 {
+    flex-basis: 75%;
+    max-width: 75%;
+  }
+
+  .grid-xxxsOffset9 {
+    margin-left: 75%;
+  }
+
+  .grid-xxxs10 {
+    flex-basis: 83.3333333333%;
+    max-width: 83.3333333333%;
+  }
+
+  .grid-xxxsOffset10 {
+    margin-left: 83.3333333333%;
+  }
+
+  .grid-xxxs11 {
+    flex-basis: 91.6666666667%;
+    max-width: 91.6666666667%;
+  }
+
+  .grid-xxxsOffset11 {
+    margin-left: 91.6666666667%;
+  }
+
+  .grid-xxxs12 {
+    flex-basis: 100%;
+    max-width: 100%;
+  }
+
+  .grid-xxxsOffset12 {
+    margin-left: 100%;
+  }
+}
+@media only screen and (min-width: 576px) {
   .grid-xs {
     flex-basis: 0;
     flex-grow: 1;
@@ -5271,352 +5386,352 @@ abbr[title] {
     margin-left: 100%;
   }
 }
-@media only screen and (min-width: 576px) {
-  .grid-sm {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-
-  .grid-sm1 {
-    flex-basis: 8.3333333333%;
-    max-width: 8.3333333333%;
-  }
-
-  .grid-smOffset1 {
-    margin-left: 8.3333333333%;
-  }
-
-  .grid-sm2 {
-    flex-basis: 16.6666666667%;
-    max-width: 16.6666666667%;
-  }
-
-  .grid-smOffset2 {
-    margin-left: 16.6666666667%;
-  }
-
-  .grid-sm3 {
-    flex-basis: 25%;
-    max-width: 25%;
-  }
-
-  .grid-smOffset3 {
-    margin-left: 25%;
-  }
-
-  .grid-sm4 {
-    flex-basis: 33.3333333333%;
-    max-width: 33.3333333333%;
-  }
-
-  .grid-smOffset4 {
-    margin-left: 33.3333333333%;
-  }
-
-  .grid-sm5 {
-    flex-basis: 41.6666666667%;
-    max-width: 41.6666666667%;
-  }
-
-  .grid-smOffset5 {
-    margin-left: 41.6666666667%;
-  }
-
-  .grid-sm6 {
-    flex-basis: 50%;
-    max-width: 50%;
-  }
-
-  .grid-smOffset6 {
-    margin-left: 50%;
-  }
-
-  .grid-sm7 {
-    flex-basis: 58.3333333333%;
-    max-width: 58.3333333333%;
-  }
-
-  .grid-smOffset7 {
-    margin-left: 58.3333333333%;
-  }
-
-  .grid-sm8 {
-    flex-basis: 66.6666666667%;
-    max-width: 66.6666666667%;
-  }
-
-  .grid-smOffset8 {
-    margin-left: 66.6666666667%;
-  }
-
-  .grid-sm9 {
-    flex-basis: 75%;
-    max-width: 75%;
-  }
-
-  .grid-smOffset9 {
-    margin-left: 75%;
-  }
-
-  .grid-sm10 {
-    flex-basis: 83.3333333333%;
-    max-width: 83.3333333333%;
-  }
-
-  .grid-smOffset10 {
-    margin-left: 83.3333333333%;
-  }
-
-  .grid-sm11 {
-    flex-basis: 91.6666666667%;
-    max-width: 91.6666666667%;
-  }
-
-  .grid-smOffset11 {
-    margin-left: 91.6666666667%;
-  }
-
-  .grid-sm12 {
-    flex-basis: 100%;
-    max-width: 100%;
-  }
-
-  .grid-smOffset12 {
-    margin-left: 100%;
-  }
-}
 @media only screen and (min-width: 768px) {
-  .grid-md {
+  .grid-s {
     flex-basis: 0;
     flex-grow: 1;
     max-width: 100%;
   }
 
-  .grid-md1 {
+  .grid-s1 {
     flex-basis: 8.3333333333%;
     max-width: 8.3333333333%;
   }
 
-  .grid-mdOffset1 {
+  .grid-sOffset1 {
     margin-left: 8.3333333333%;
   }
 
-  .grid-md2 {
+  .grid-s2 {
     flex-basis: 16.6666666667%;
     max-width: 16.6666666667%;
   }
 
-  .grid-mdOffset2 {
+  .grid-sOffset2 {
     margin-left: 16.6666666667%;
   }
 
-  .grid-md3 {
+  .grid-s3 {
     flex-basis: 25%;
     max-width: 25%;
   }
 
-  .grid-mdOffset3 {
+  .grid-sOffset3 {
     margin-left: 25%;
   }
 
-  .grid-md4 {
+  .grid-s4 {
     flex-basis: 33.3333333333%;
     max-width: 33.3333333333%;
   }
 
-  .grid-mdOffset4 {
+  .grid-sOffset4 {
     margin-left: 33.3333333333%;
   }
 
-  .grid-md5 {
+  .grid-s5 {
     flex-basis: 41.6666666667%;
     max-width: 41.6666666667%;
   }
 
-  .grid-mdOffset5 {
+  .grid-sOffset5 {
     margin-left: 41.6666666667%;
   }
 
-  .grid-md6 {
+  .grid-s6 {
     flex-basis: 50%;
     max-width: 50%;
   }
 
-  .grid-mdOffset6 {
+  .grid-sOffset6 {
     margin-left: 50%;
   }
 
-  .grid-md7 {
+  .grid-s7 {
     flex-basis: 58.3333333333%;
     max-width: 58.3333333333%;
   }
 
-  .grid-mdOffset7 {
+  .grid-sOffset7 {
     margin-left: 58.3333333333%;
   }
 
-  .grid-md8 {
+  .grid-s8 {
     flex-basis: 66.6666666667%;
     max-width: 66.6666666667%;
   }
 
-  .grid-mdOffset8 {
+  .grid-sOffset8 {
     margin-left: 66.6666666667%;
   }
 
-  .grid-md9 {
+  .grid-s9 {
     flex-basis: 75%;
     max-width: 75%;
   }
 
-  .grid-mdOffset9 {
+  .grid-sOffset9 {
     margin-left: 75%;
   }
 
-  .grid-md10 {
+  .grid-s10 {
     flex-basis: 83.3333333333%;
     max-width: 83.3333333333%;
   }
 
-  .grid-mdOffset10 {
+  .grid-sOffset10 {
     margin-left: 83.3333333333%;
   }
 
-  .grid-md11 {
+  .grid-s11 {
     flex-basis: 91.6666666667%;
     max-width: 91.6666666667%;
   }
 
-  .grid-mdOffset11 {
+  .grid-sOffset11 {
     margin-left: 91.6666666667%;
   }
 
-  .grid-md12 {
+  .grid-s12 {
     flex-basis: 100%;
     max-width: 100%;
   }
 
-  .grid-mdOffset12 {
+  .grid-sOffset12 {
     margin-left: 100%;
   }
 }
 @media only screen and (min-width: 992px) {
-  .grid-lg {
+  .grid-m {
     flex-basis: 0;
     flex-grow: 1;
     max-width: 100%;
   }
 
-  .grid-lg1 {
+  .grid-m1 {
     flex-basis: 8.3333333333%;
     max-width: 8.3333333333%;
   }
 
-  .grid-lgOffset1 {
+  .grid-mOffset1 {
     margin-left: 8.3333333333%;
   }
 
-  .grid-lg2 {
+  .grid-m2 {
     flex-basis: 16.6666666667%;
     max-width: 16.6666666667%;
   }
 
-  .grid-lgOffset2 {
+  .grid-mOffset2 {
     margin-left: 16.6666666667%;
   }
 
-  .grid-lg3 {
+  .grid-m3 {
     flex-basis: 25%;
     max-width: 25%;
   }
 
-  .grid-lgOffset3 {
+  .grid-mOffset3 {
     margin-left: 25%;
   }
 
-  .grid-lg4 {
+  .grid-m4 {
     flex-basis: 33.3333333333%;
     max-width: 33.3333333333%;
   }
 
-  .grid-lgOffset4 {
+  .grid-mOffset4 {
     margin-left: 33.3333333333%;
   }
 
-  .grid-lg5 {
+  .grid-m5 {
     flex-basis: 41.6666666667%;
     max-width: 41.6666666667%;
   }
 
-  .grid-lgOffset5 {
+  .grid-mOffset5 {
     margin-left: 41.6666666667%;
   }
 
-  .grid-lg6 {
+  .grid-m6 {
     flex-basis: 50%;
     max-width: 50%;
   }
 
-  .grid-lgOffset6 {
+  .grid-mOffset6 {
     margin-left: 50%;
   }
 
-  .grid-lg7 {
+  .grid-m7 {
     flex-basis: 58.3333333333%;
     max-width: 58.3333333333%;
   }
 
-  .grid-lgOffset7 {
+  .grid-mOffset7 {
     margin-left: 58.3333333333%;
   }
 
-  .grid-lg8 {
+  .grid-m8 {
     flex-basis: 66.6666666667%;
     max-width: 66.6666666667%;
   }
 
-  .grid-lgOffset8 {
+  .grid-mOffset8 {
     margin-left: 66.6666666667%;
   }
 
-  .grid-lg9 {
+  .grid-m9 {
     flex-basis: 75%;
     max-width: 75%;
   }
 
-  .grid-lgOffset9 {
+  .grid-mOffset9 {
     margin-left: 75%;
   }
 
-  .grid-lg10 {
+  .grid-m10 {
     flex-basis: 83.3333333333%;
     max-width: 83.3333333333%;
   }
 
-  .grid-lgOffset10 {
+  .grid-mOffset10 {
     margin-left: 83.3333333333%;
   }
 
-  .grid-lg11 {
+  .grid-m11 {
     flex-basis: 91.6666666667%;
     max-width: 91.6666666667%;
   }
 
-  .grid-lgOffset11 {
+  .grid-mOffset11 {
     margin-left: 91.6666666667%;
   }
 
-  .grid-lg12 {
+  .grid-m12 {
     flex-basis: 100%;
     max-width: 100%;
   }
 
-  .grid-lgOffset12 {
+  .grid-mOffset12 {
     margin-left: 100%;
   }
 }
 @media only screen and (min-width: 1200px) {
+  .grid-l {
+    flex-basis: 0;
+    flex-grow: 1;
+    max-width: 100%;
+  }
+
+  .grid-l1 {
+    flex-basis: 8.3333333333%;
+    max-width: 8.3333333333%;
+  }
+
+  .grid-lOffset1 {
+    margin-left: 8.3333333333%;
+  }
+
+  .grid-l2 {
+    flex-basis: 16.6666666667%;
+    max-width: 16.6666666667%;
+  }
+
+  .grid-lOffset2 {
+    margin-left: 16.6666666667%;
+  }
+
+  .grid-l3 {
+    flex-basis: 25%;
+    max-width: 25%;
+  }
+
+  .grid-lOffset3 {
+    margin-left: 25%;
+  }
+
+  .grid-l4 {
+    flex-basis: 33.3333333333%;
+    max-width: 33.3333333333%;
+  }
+
+  .grid-lOffset4 {
+    margin-left: 33.3333333333%;
+  }
+
+  .grid-l5 {
+    flex-basis: 41.6666666667%;
+    max-width: 41.6666666667%;
+  }
+
+  .grid-lOffset5 {
+    margin-left: 41.6666666667%;
+  }
+
+  .grid-l6 {
+    flex-basis: 50%;
+    max-width: 50%;
+  }
+
+  .grid-lOffset6 {
+    margin-left: 50%;
+  }
+
+  .grid-l7 {
+    flex-basis: 58.3333333333%;
+    max-width: 58.3333333333%;
+  }
+
+  .grid-lOffset7 {
+    margin-left: 58.3333333333%;
+  }
+
+  .grid-l8 {
+    flex-basis: 66.6666666667%;
+    max-width: 66.6666666667%;
+  }
+
+  .grid-lOffset8 {
+    margin-left: 66.6666666667%;
+  }
+
+  .grid-l9 {
+    flex-basis: 75%;
+    max-width: 75%;
+  }
+
+  .grid-lOffset9 {
+    margin-left: 75%;
+  }
+
+  .grid-l10 {
+    flex-basis: 83.3333333333%;
+    max-width: 83.3333333333%;
+  }
+
+  .grid-lOffset10 {
+    margin-left: 83.3333333333%;
+  }
+
+  .grid-l11 {
+    flex-basis: 91.6666666667%;
+    max-width: 91.6666666667%;
+  }
+
+  .grid-lOffset11 {
+    margin-left: 91.6666666667%;
+  }
+
+  .grid-l12 {
+    flex-basis: 100%;
+    max-width: 100%;
+  }
+
+  .grid-lOffset12 {
+    margin-left: 100%;
+  }
+}
+@media only screen and (min-width: 1350px) {
   .grid-xl {
     flex-basis: 0;
     flex-grow: 1;
@@ -5731,7 +5846,7 @@ abbr[title] {
     margin-left: 100%;
   }
 }
-@media only screen and (min-width: 1350px) {
+@media only screen and (min-width: 1500px) {
   .grid-xxl {
     flex-basis: 0;
     flex-grow: 1;
@@ -5846,125 +5961,39 @@ abbr[title] {
     margin-left: 100%;
   }
 }
-@media only screen and (min-width: 1500px) {
-  .grid-xxxl {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 100%;
-  }
-
-  .grid-xxxl1 {
-    flex-basis: 8.3333333333%;
-    max-width: 8.3333333333%;
-  }
-
-  .grid-xxxlOffset1 {
-    margin-left: 8.3333333333%;
-  }
-
-  .grid-xxxl2 {
-    flex-basis: 16.6666666667%;
-    max-width: 16.6666666667%;
-  }
-
-  .grid-xxxlOffset2 {
-    margin-left: 16.6666666667%;
-  }
-
-  .grid-xxxl3 {
-    flex-basis: 25%;
-    max-width: 25%;
-  }
-
-  .grid-xxxlOffset3 {
-    margin-left: 25%;
-  }
-
-  .grid-xxxl4 {
-    flex-basis: 33.3333333333%;
-    max-width: 33.3333333333%;
-  }
-
-  .grid-xxxlOffset4 {
-    margin-left: 33.3333333333%;
-  }
-
-  .grid-xxxl5 {
-    flex-basis: 41.6666666667%;
-    max-width: 41.6666666667%;
-  }
-
-  .grid-xxxlOffset5 {
-    margin-left: 41.6666666667%;
-  }
-
-  .grid-xxxl6 {
-    flex-basis: 50%;
-    max-width: 50%;
-  }
-
-  .grid-xxxlOffset6 {
-    margin-left: 50%;
-  }
-
-  .grid-xxxl7 {
-    flex-basis: 58.3333333333%;
-    max-width: 58.3333333333%;
-  }
-
-  .grid-xxxlOffset7 {
-    margin-left: 58.3333333333%;
-  }
-
-  .grid-xxxl8 {
-    flex-basis: 66.6666666667%;
-    max-width: 66.6666666667%;
-  }
-
-  .grid-xxxlOffset8 {
-    margin-left: 66.6666666667%;
-  }
-
-  .grid-xxxl9 {
-    flex-basis: 75%;
-    max-width: 75%;
-  }
-
-  .grid-xxxlOffset9 {
-    margin-left: 75%;
-  }
-
-  .grid-xxxl10 {
-    flex-basis: 83.3333333333%;
-    max-width: 83.3333333333%;
-  }
-
-  .grid-xxxlOffset10 {
-    margin-left: 83.3333333333%;
-  }
-
-  .grid-xxxl11 {
-    flex-basis: 91.6666666667%;
-    max-width: 91.6666666667%;
-  }
-
-  .grid-xxxlOffset11 {
-    margin-left: 91.6666666667%;
-  }
-
-  .grid-xxxl12 {
-    flex-basis: 100%;
-    max-width: 100%;
-  }
-
-  .grid-xxxlOffset12 {
-    margin-left: 100%;
-  }
-}
 .grid.mod-reverse {
   flex-direction: row-reverse;
 }
 @media only screen and (min-width: 0px) {
+  .grid.mod-xxxsStart {
+    justify-content: flex-start;
+    text-align: start;
+  }
+  .grid.mod-xxxsCenter {
+    justify-content: center;
+    text-align: center;
+  }
+  .grid.mod-xxxsEnd {
+    justify-content: flex-end;
+    text-align: end;
+  }
+  .grid.mod-xxxsTop {
+    align-items: flex-start;
+  }
+  .grid.mod-xxxsMiddle {
+    align-items: center;
+  }
+  .grid.mod-xxxsBottom {
+    align-items: flex-end;
+  }
+  .grid.mod-xxxsAround {
+    justify-content: space-around;
+  }
+  .grid.mod-xxxsBetween {
+    justify-content: space-between;
+  }
+}
+@media only screen and (min-width: 576px) {
   .grid.mod-xsStart {
     justify-content: flex-start;
     text-align: start;
@@ -5993,94 +6022,94 @@ abbr[title] {
     justify-content: space-between;
   }
 }
-@media only screen and (min-width: 576px) {
-  .grid.mod-smStart {
-    justify-content: flex-start;
-    text-align: start;
-  }
-  .grid.mod-smCenter {
-    justify-content: center;
-    text-align: center;
-  }
-  .grid.mod-smEnd {
-    justify-content: flex-end;
-    text-align: end;
-  }
-  .grid.mod-smTop {
-    align-items: flex-start;
-  }
-  .grid.mod-smMiddle {
-    align-items: center;
-  }
-  .grid.mod-smBottom {
-    align-items: flex-end;
-  }
-  .grid.mod-smAround {
-    justify-content: space-around;
-  }
-  .grid.mod-smBetween {
-    justify-content: space-between;
-  }
-}
 @media only screen and (min-width: 768px) {
-  .grid.mod-mdStart {
+  .grid.mod-sStart {
     justify-content: flex-start;
     text-align: start;
   }
-  .grid.mod-mdCenter {
+  .grid.mod-sCenter {
     justify-content: center;
     text-align: center;
   }
-  .grid.mod-mdEnd {
+  .grid.mod-sEnd {
     justify-content: flex-end;
     text-align: end;
   }
-  .grid.mod-mdTop {
+  .grid.mod-sTop {
     align-items: flex-start;
   }
-  .grid.mod-mdMiddle {
+  .grid.mod-xsiddle {
     align-items: center;
   }
-  .grid.mod-mdBottom {
+  .grid.mod-sBottom {
     align-items: flex-end;
   }
-  .grid.mod-mdAround {
+  .grid.mod-sAround {
     justify-content: space-around;
   }
-  .grid.mod-mdBetween {
+  .grid.mod-sBetween {
     justify-content: space-between;
   }
 }
 @media only screen and (min-width: 992px) {
-  .grid.mod-lgStart {
+  .grid.mod-mStart {
     justify-content: flex-start;
     text-align: start;
   }
-  .grid.mod-lgCenter {
+  .grid.mod-mCenter {
     justify-content: center;
     text-align: center;
   }
-  .grid.mod-lgEnd {
+  .grid.mod-mEnd {
     justify-content: flex-end;
     text-align: end;
   }
-  .grid.mod-lgTop {
+  .grid.mod-mTop {
     align-items: flex-start;
   }
-  .grid.mod-lgMiddle {
+  .grid.mod-mMiddle {
     align-items: center;
   }
-  .grid.mod-lgBottom {
+  .grid.mod-mBottom {
     align-items: flex-end;
   }
-  .grid.mod-lgAround {
+  .grid.mod-mAround {
     justify-content: space-around;
   }
-  .grid.mod-lgBetween {
+  .grid.mod-mBetween {
     justify-content: space-between;
   }
 }
 @media only screen and (min-width: 1200px) {
+  .grid.mod-lStart {
+    justify-content: flex-start;
+    text-align: start;
+  }
+  .grid.mod-lCenter {
+    justify-content: center;
+    text-align: center;
+  }
+  .grid.mod-lEnd {
+    justify-content: flex-end;
+    text-align: end;
+  }
+  .grid.mod-lTop {
+    align-items: flex-start;
+  }
+  .grid.mod-lMiddle {
+    align-items: center;
+  }
+  .grid.mod-lBottom {
+    align-items: flex-end;
+  }
+  .grid.mod-lAround {
+    justify-content: space-around;
+  }
+  .grid.mod-lBetween {
+    justify-content: space-between;
+  }
+}
+@media only screen and (min-width: 1350px) {
   .grid.mod-xlStart {
     justify-content: flex-start;
     text-align: start;
@@ -6109,7 +6138,7 @@ abbr[title] {
     justify-content: space-between;
   }
 }
-@media only screen and (min-width: 1350px) {
+@media only screen and (min-width: 1500px) {
   .grid.mod-xxlStart {
     justify-content: flex-start;
     text-align: start;
@@ -6135,35 +6164,6 @@ abbr[title] {
     justify-content: space-around;
   }
   .grid.mod-xxlBetween {
-    justify-content: space-between;
-  }
-}
-@media only screen and (min-width: 1500px) {
-  .grid.mod-xxxlStart {
-    justify-content: flex-start;
-    text-align: start;
-  }
-  .grid.mod-xxxlCenter {
-    justify-content: center;
-    text-align: center;
-  }
-  .grid.mod-xxxlEnd {
-    justify-content: flex-end;
-    text-align: end;
-  }
-  .grid.mod-xxxlTop {
-    align-items: flex-start;
-  }
-  .grid.mod-xxxlMiddle {
-    align-items: center;
-  }
-  .grid.mod-xxxlBottom {
-    align-items: flex-end;
-  }
-  .grid.mod-xxxlAround {
-    justify-content: space-around;
-  }
-  .grid.mod-xxxlBetween {
     justify-content: space-between;
   }
 }

--- a/to-migrate/scss/templates/form.html
+++ b/to-migrate/scss/templates/form.html
@@ -12,7 +12,7 @@
 	<body>
 		<main class="main mod-noAside u-paddingTopBiggest">
 			<section class="main-content">
-				<div class="container mod-sm">
+				<div class="container mod-xs">
 					<div class="card">
 						<div class="card-content">
 							<form class="form">


### PR DESCRIPTION
- Container's refactoring;
- modification and addition of breakpoints.

For the record:
- new `xxxs` breakpoint at **320px**;
- new `xxs` breakpoint at **480px**;
- renaming of breapoint `sm` (576px) to `xs` now at **640px**;
- renaming of breapoint `md` (768px) to `s` now at **800px**;
- renaming of breapoint `lg` (992px) to `m` now at **1024px**;
- renaming of breapoint `xl` (1200px) to `l` now at **1280px**;
- renaming of breapoint `xxl` (1250px) to `xl` now at **1366px** (the old `xl` was 1200px);
- renaming of breapoint `xxxl` (1500px) to `xxl` now at **1600px** (the old `xxl` was 1250px);
- new `xxxl` breakpoint at **1920px** (the old `xxxl` was 1500px).

Old: https://codepen.io/vincent-valentin/full/vYLaJNv
New: https://codepen.io/vincent-valentin/full/abdKBLz

[Migration guidelines here](https://luccasoftware.atlassian.net/wiki/spaces/PD/pages/3531047151/LF+7).