### PR TITLE
fix(scss) field invalid state

### DIFF
--- a/packages/scss/src/components/inputs/field/_field.scss
+++ b/packages/scss/src/components/inputs/field/_field.scss
@@ -186,7 +186,7 @@
 		@include fieldState($fieldname, "warning");
 	}
 
-	&.is-invalid, &.is-error, &:invalid {
+	&.is-invalid, &.is-error {
 		@include fieldState($fieldname, "error");
 	}
 }


### PR DESCRIPTION
The native error handling in HTML 5 does not have the desired behaviour with custom styles, so we remove it.