### PR TITLE
feat(scss) optimize SCSS dist size by using autoprefixer options

### DIFF
--- a/packages/scss/.browserslistrc
+++ b/packages/scss/.browserslistrc
@@ -1,1 +1,1 @@
-last 2 versions
+defaults


### PR DESCRIPTION
This pull request set scss package autoprefixer browserlist option to defaults. The objective is to reduce dist size.

fixes #1188