### PR TITLE
feat(ng-date) date-inputs - better disabling - startOn

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.html
@@ -12,4 +12,11 @@
 	<lu-date-select class="textfield-input" [(ngModel)]="date" disabled [min]="min"></lu-date-select>
 	<span class="textfield-label">attr disabled</span>
 </label>
-<code>{{date | luDate }}</code>
+<code>{{ date | luDate }}</code>
+
+<h2>open on april 2020</h2>
+<lu-calendar [(ngModel)]="date" [startOn]="startOn"></lu-calendar>
+<label class="textfield">
+	<lu-date-select class="textfield-input" [(ngModel)]="date" [startOn]="startOn"></lu-date-select>
+	<span class="textfield-label">enabled</span>
+</label>

--- a/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.html
@@ -1,0 +1,15 @@
+<h1>date-select-enh</h1>
+<h2>Single</h2>
+<label class="textfield">
+	<lu-date-select class="textfield-input" [(ngModel)]="date" [min]="min"></lu-date-select>
+	<span class="textfield-label">enabled</span>
+</label>
+<label class="textfield">
+	<lu-date-select class="textfield-input is-disabled" [(ngModel)]="date" [min]="min"></lu-date-select>
+	<span class="textfield-label">class is-disabled</span>
+</label>
+<label class="textfield">
+	<lu-date-select class="textfield-input" [(ngModel)]="date" disabled [min]="min"></lu-date-select>
+	<span class="textfield-label">attr disabled</span>
+</label>
+<code>{{date | luDate }}</code>

--- a/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'sand-date-select-enh',
+	templateUrl: './date-select-enh.component.html'
+})
+export class DateSelectEnhComponent {
+	date;
+	min = new Date();
+}

--- a/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.component.ts
@@ -7,4 +7,5 @@ import { Component } from '@angular/core';
 export class DateSelectEnhComponent {
 	date;
 	min = new Date();
+	startOn = new Date(2020, 3, 2);
 }

--- a/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-select-enh/date-select-enh.module.ts
@@ -1,0 +1,34 @@
+import { LOCALE_ID, NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { RouterModule } from '@angular/router';
+import { ALuDateAdapter, LuNativeDateAdapter } from '@lucca-front/ng/core';
+import { LuDateModule } from '@lucca-front/ng/date';
+import { DateSelectEnhComponent } from './date-select-enh.component';
+
+import localeFr from '@angular/common/locales/fr';
+import localeGb from '@angular/common/locales/en-GB';
+import { registerLocaleData } from '@angular/common';
+
+registerLocaleData(localeFr);
+registerLocaleData(localeGb);
+
+@NgModule({
+	declarations: [
+		DateSelectEnhComponent,
+	],
+	imports: [
+		LuDateModule,
+		FormsModule,
+		RouterModule.forChild([
+			{ path: '', component: DateSelectEnhComponent },
+		]),
+	],
+	providers: [
+		{ provide: LOCALE_ID, useValue: 'fr-FR' },
+		// { provide: LOCALE_ID, useValue: 'en-GB' },
+		// { provide: LOCALE_ID, useValue: 'en-US' },
+		{ provide: ALuDateAdapter, useClass: LuNativeDateAdapter },
+	]
+})
+export class DateSelectEnhModule {}

--- a/packages/ng/applications/sandbox/src/app/issues/date-select-enh/index.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/date-select-enh/index.ts
@@ -1,0 +1,1 @@
+export * from './date-select-enh.module';

--- a/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/issues.router.ts
@@ -67,6 +67,7 @@ const routes: Routes = [
 	{ path: 'establishment', loadChildren: () => import('./establishment').then(m => m.EstablishmentModule) },
 	{ path: 'api-v4', loadChildren: () => import('./api-v4').then(m => m.ApiV4Module) },
 	{ path: 'drag-drop', loadChildren: () => import('./drag-drop').then(m => m.DragDropModule) },
+	{ path: 'date-select-enh', loadChildren: () => import('./date-select-enh').then(m => m.DateSelectEnhModule) },
 ];
 /*tslint:enable*/
 const issues = [ ...routes].map(r => r.path);

--- a/packages/ng/applications/sandbox/src/app/issues/select-option-placeholder/select-option-placeholder.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/select-option-placeholder/select-option-placeholder.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { ILuTree } from '@lucca-front/ng/core';
 const node1 = { id: 1, name: 'root 1' };
 const node11 = { id: 11, name: 'node 1.1' };
 const node111 = { id: 111, name: 'leaf 1.1.1' };
@@ -170,15 +171,15 @@ export class SelectOptionPlaceholderComponent {
 		{ name: 'yellowgreen', code: '#9acd32' },
 	];
 
-	options = [{
+	options: ILuTree[] = [{
 		value: node1,
 		children: [
-			{ value: node11, children: [ { value: node111 } ] },
+			{ value: node11, children: [ { value: node111, children: [] } ] },
 			{ value: node12, children: [] },
 		]
 	}, {
 		value: node2,
-		children: [ { value: node21 }]
+		children: [ { value: node21, children: [] }]
 	}];
 	collection = [];
 }

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.html
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.html
@@ -2,24 +2,27 @@
 	<header class="calendar-header">
 		<button class="calendar-header-nav" (click)="previous()">
 			<span aria-hidden="true" class="lucca-icon">arrow_west</span>
-			<span class="u-mask">Previous month</span>
+			<span class="u-mask">Previous</span>
 		</button>
 		<button class="calendar-header-date" (click)="changeGranularity()">
-			<!-- {{ month | date: 'MMMM y'}} -->
 			{{ header.label }}
 		</button>
-		<!-- <button class="calendar-header-previous"></button>
-		<button class="calendar-header-next"></button> -->
 		<button class="calendar-header-nav" (click)="next()">
 			<span aria-hidden="true" class="lucca-icon">arrow_east</span>
-			<span class="u-mask">Next month</span>
+			<span class="u-mask">Next</span>
 		</button>
 	</header>
 	<section class="calendar-labels" [ngClass]="mod">
 		<div class="calendar-labels-item" *ngFor="let label of labels">{{ label }}</div>
 	</section>
 	<section class="calendar-grid" [ngClass]="mod">
-		<button class="calendar-grid-item" *ngFor="let item of items; trackBy: trackBy" [ngClass]="item.mods" (click)="select(item)">
+		<button
+			*ngFor="let item of items; trackBy: trackBy"
+			class="calendar-grid-item"
+			[ngClass]="item.mods"
+			[disabled]="item.isDisabled"
+			(click)="select(item)"
+		>
 			<div class="calendar-grid-item-content">{{ item.label }}</div>
 		</button>
 	</section>

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -28,6 +28,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 	@Input() min?: D;
 	@Input() max?: D;
 	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+	@Input() startOn: D = this._adapter.forgeToday();
 
 	viewGranularity: ELuDateGranularity;
 	header: ICalendarItem<D>;
@@ -59,8 +60,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		this.initDayLabels();
 	}
 	writeValue(value?: D) {
-		const today = this._adapter.forgeToday();
-		const date = value && this._adapter.isValid(value) ? this._adapter.clone(value) : today;
+		const date = value && this._adapter.isValid(value) ? this._adapter.clone(value) : this.startOn;
 		this.header = this._factory.forgeMonth(date);
 		super.writeValue(value);
 	}

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -146,10 +146,10 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 				item.mods.push('is-active');
 			}
 			if (min && this._adapter.compare(day, min, ELuDateGranularity.day) < 0) {
-				item.mods.push('is-disabled');
+				item.isDisabled = true;
 			}
 			if (max && this._adapter.compare(day, max, ELuDateGranularity.day) > 0) {
-				item.mods.push('is-disabled');
+				item.isDisabled = true;
 			}
 		});
 	}
@@ -166,10 +166,10 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 				item.mods.push('is-active');
 			}
 			if (min && this._adapter.compare(month, min, ELuDateGranularity.month) < 0) {
-				item.mods.push('is-disabled');
+				item.isDisabled = true;
 			}
 			if (max && this._adapter.compare(month, max, ELuDateGranularity.month) > 0) {
-				item.mods.push('is-disabled');
+				item.isDisabled = true;
 			}
 		});
 	}
@@ -186,10 +186,10 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 				item.mods.push('is-active');
 			}
 			if (min && this._adapter.compare(year, min, ELuDateGranularity.year) < 0) {
-				item.mods.push('is-disabled');
+				item.isDisabled = true;
 			}
 			if (max && this._adapter.compare(year, max, ELuDateGranularity.year) > 0) {
-				item.mods.push('is-disabled');
+				item.isDisabled = true;
 			}
 		});
 	}

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-item.class.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-item.class.ts
@@ -5,6 +5,7 @@ export abstract class ACalendarItem<D> implements ICalendarItem<D> {
 	get id() { return `${this.granularity}-${this.date.toString()}`; }
 	date: D;
 	mods: string[] = [];
+	isDisabled: boolean = false;
 	label: string;
 	readonly granularity: ELuDateGranularity;
 }

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-item.interface.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-item.interface.ts
@@ -5,5 +5,6 @@ export interface ICalendarItem<D> {
 	date: D;
 	mods: string[];
 	label: string;
+	isDisabled: boolean;
 	granularity: ELuDateGranularity;
 }

--- a/packages/ng/libraries/date/src/lib/picker/date-picker.component.html
+++ b/packages/ng/libraries/date/src/lib/picker/date-picker.component.html
@@ -2,10 +2,24 @@
 	<div class="lu-picker-panel lu-date-picker-panel" role="dialog" [ngClass]="panelClassesMap"
 	(click)="onClick()" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" (mousedown)="onMouseDown($event)">
 		<div class="lu-picker-content" [ngClass]="contentClassesMap" cdkTrapFocus="false" cdkTrapFocusAutoCapture="true">
-			<div class="textfield lu-picker-textfield">
-				<input luDateInput class="textfield-input" [ngModel]="_value" (ngModelChange)="_onInput($event)" (keydown.enter)="_onEnter()"[min]="min" [max]="max" [granularity]="granularity">
-			</div>
-			<lu-calendar [ngModel]="_value" (ngModelChange)="_onCalendar($event)"[min]="min" [max]="max" [granularity]="granularity"></lu-calendar>
+			<label class="textfield lu-picker-textfield">
+				<input luDateInput class="textfield-input"
+					[ngModel]="_value"
+					(ngModelChange)="_onInput($event)"
+					(keydown.enter)="_onEnter()"
+					[min]="min"
+					[max]="max"
+					[granularity]="granularity"
+				>
+			</label>
+			<lu-calendar
+				[ngModel]="_value"
+				(ngModelChange)="_onCalendar($event)"
+				[min]="min"
+				[max]="max"
+				[granularity]="granularity"
+				[startOn]="startOn"
+			></lu-calendar>
 		</div>
 	</div>
 </ng-template>

--- a/packages/ng/libraries/date/src/lib/picker/date-picker.component.ts
+++ b/packages/ng/libraries/date/src/lib/picker/date-picker.component.ts
@@ -2,7 +2,7 @@ import { ALuPickerPanel } from '@lucca-front/ng/picker';
 import { Component, ChangeDetectionStrategy, forwardRef, Output, EventEmitter, TemplateRef, ViewChild, Input } from '@angular/core';
 import { luTransformPopover } from '@lucca-front/ng/popover';
 import { ESCAPE, TAB } from '@angular/cdk/keycodes';
-import { ELuDateGranularity } from '@lucca-front/ng/core';
+import { ALuDateAdapter, ELuDateGranularity } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-date-picker',
@@ -17,23 +17,29 @@ import { ELuDateGranularity } from '@lucca-front/ng/core';
 		},
 	]
 })
-export class LuDatePickerComponent extends ALuPickerPanel<Date> {
-	_value: Date;
+export class LuDatePickerComponent<D> extends ALuPickerPanel<D> {
+	_value: D;
 
-	@Input() min?: Date;
-	@Input() max?: Date;
+	@Input() min?: D;
+	@Input() max?: D;
 	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+	@Input() startOn: D = this._adapter.forgeToday();
 
 	@Output() close = new EventEmitter<void>();
 	@Output() open = new EventEmitter<void>();
 	@Output() hovered = new EventEmitter<boolean>();
-	@Output() onSelectValue = new EventEmitter<Date>();
+	@Output() onSelectValue = new EventEmitter<D>();
 
 	@ViewChild(TemplateRef, { static: true })
 	set vcTemplateRef(tr: TemplateRef<any>) {
 		this.templateRef = tr;
 	}
-
+	
+	constructor(
+		private _adapter: ALuDateAdapter<D>,
+	) {
+		super();
+	}
 	_emitOpenEvent(): void {
 		this.open.emit();
 	}
@@ -43,20 +49,20 @@ export class LuDatePickerComponent extends ALuPickerPanel<Date> {
 	_emitHoveredEvent(h): void {
 		this.hovered.emit(h);
 	}
-	_emitSelectValue(val: Date) {
+	_emitSelectValue(val: D) {
 		this.onSelectValue.emit(val);
 	}
-	setValue(value: Date) {
+	setValue(value: D) {
 		this._value = value;
 	}
-	_onCalendar(val: Date) {
+	_onCalendar(val: D) {
 		this._value = val;
 		this._emitSelectValue(val);
 		// if (!this.multiple) {
 			this._emitCloseEvent();
 		// }
 	}
-	_onInput(val: Date) {
+	_onInput(val: D) {
 		this._value = val;
 		this._emitSelectValue(val);
 	}

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.html
@@ -10,4 +10,4 @@
 <ng-template luDisplayer let-value>
 	{{ value | luDate: format }}
 </ng-template>
-<lu-date-picker [min]="min" [max]="max" [granularity]="granularity"></lu-date-picker>
+<lu-date-picker [min]="min" [max]="max" [granularity]="granularity" [startOn]="startOn"></lu-date-picker>

--- a/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/select/date-select-input.component.ts
@@ -46,6 +46,8 @@ implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit, Validator
 	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
 	@Input('placeholder') set inputPlaceholder(p: string) { this._placeholder = p; }
 	@Input() hideClearer: boolean = false;
+	@Input() startOn: D = this._adapter.forgeToday();
+
 	get format(): string {
 		switch (this.granularity) {
 			case ELuDateGranularity.year:


### PR DESCRIPTION
partially fixes #1184 
fixes #1027

- use `disabled` instead of `class.is-disabled` to disable days in the calendar input when they are outside the min-max period
- add `startOn` input on calndar zand date-select comps to open the calendar on a specific date
