### PR TITLE
fix(ng-popup) max-size responsiveness

### DIFF
--- a/packages/ng/libraries/root/src/style/components/_popup.scss
+++ b/packages/ng/libraries/root/src/style/components/_popup.scss
@@ -107,7 +107,7 @@
 		border-radius: 0;
 		max-width: none;
 		max-height: 100vh;
-		width: 100vw;
+		width: 100%;
 		width: fill-available;
 		height: 100vh;
 		height: fill-available;

--- a/packages/ng/libraries/root/src/style/components/_popup.scss
+++ b/packages/ng/libraries/root/src/style/components/_popup.scss
@@ -11,7 +11,6 @@
 
 	@each $panel-size, $size-obj in _getMap("components.popup.sizes") {
 		&.mod-#{$panel-size}, &.size-#{$panel-size} {
-			max-width: none;
 			width: _component("popup.sizes."+$panel-size);
 		}
 	}

--- a/packages/ng/libraries/root/src/style/components/_popup.scss
+++ b/packages/ng/libraries/root/src/style/components/_popup.scss
@@ -105,7 +105,7 @@
 @include media_smaller_than("sm") {
 	.lu-popup-panel {
 		border-radius: 0;
-		max-width: 100vw;
+		max-width: none;
 		max-height: 100vh;
 		width: 100vw;
 		width: fill-available;

--- a/packages/ng/libraries/root/src/style/components/_popup.scss
+++ b/packages/ng/libraries/root/src/style/components/_popup.scss
@@ -101,3 +101,22 @@
 		opacity: 0;
 	}
 }
+
+@include media_smaller_than("sm") {
+	.lu-popup-panel {
+		border-radius: 0;
+		max-width: 100vw;
+		max-height: 100vh;
+		width: 100vw;
+		width: fill-available;
+		height: 100vh;
+		height: fill-available;
+	}
+
+	.lu-modal-panel-inner {
+		max-height: 100vh;
+		max-height: fill-available;
+		height: 100vh;
+		height: fill-available;
+	}
+}


### PR DESCRIPTION
fixes #1047 
Modals are now fullscreen on mobile.