### PR TITLE
fix(scss) callout icon color

### DIFF
--- a/packages/scss/src/components/_callout.scss
+++ b/packages/scss/src/components/_callout.scss
@@ -22,7 +22,7 @@
 .callout-kill {
 	background-color: transparent;
 	border: 0;
-	color: _color("text.default");
+	color: currentColor;
 	cursor: pointer;
 	height: 1.5rem;
 	padding: 0;
@@ -50,7 +50,8 @@
 	margin: auto;
 	border-radius: 50%;
 	text-align: center;
-
+	color: currentColor;
+	
 	.lucca-icon {
 		font-size: 1.2rem;
 		vertical-align: middle;
@@ -90,14 +91,6 @@
 @mixin calloutDefaultPalette($palette) {
 	background-color: _color($palette, 50);
 	color: _color($palette, 800);
-
-	.callout-icon {
-		color: _color($palette);
-	}
-
-	.callout-kill {
-		color: _color($palette);
-	}
 }
 .callout {
 	@each $name, $palette in _getMap("palettes") {


### PR DESCRIPTION
Instead of redefining the colors from the palettes, one inherits directly from the current color.