### PR TITLE
ref(ng-modal|sp) hide the error thingy in the modal|sidepanel footer

### DIFF
--- a/packages/ng/libraries/modal/src/lib/modal-panel.component.html
+++ b/packages/ng/libraries/modal/src/lib/modal-panel.component.html
@@ -7,9 +7,6 @@
 		<ng-container cdkPortalOutlet #outlet></ng-container>
 	</div>
 	<div class="lu-modal-footer">
-		<!-- <ng-template [ngIf]="error$ | async as error"> -->
-			<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
-		<!-- </ng-template> -->
 		<button
 			*ngIf="!isSubmitHidden"
 			class="button palette-{{submitPalette}}"

--- a/packages/ng/libraries/sidepanel/src/lib/sidepanel-panel.component.html
+++ b/packages/ng/libraries/sidepanel/src/lib/sidepanel-panel.component.html
@@ -7,9 +7,6 @@
 		<ng-container cdkPortalOutlet #outlet></ng-container>
 	</div>
 	<div class="lu-modal-footer">
-		<!-- <ng-template [ngIf]="error$ | async as error"> -->
-			<label *ngIf="error$ | async as error" class="label palette-error">{{error}}</label>
-		<!-- </ng-template> -->
 		<button
 			*ngIf="!isSubmitHidden"
 			class="button palette-{{submitPalette}}"


### PR DESCRIPTION
nobody uses it, and its ugly anyway