### PR TITLE
fix(scss) remove box-shadow none from textfield mod-filter

### DIFF
--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -276,7 +276,6 @@
 
 		.textfield-input {
 			background-color: transparent;
-			// box-shadow: none;
 			padding: 1rem 2.5rem 0 1rem;
 			font-weight: 600;
 			height: _component("filters.height");

--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -276,7 +276,7 @@
 
 		.textfield-input {
 			background-color: transparent;
-			box-shadow: none;
+			// box-shadow: none;
 			padding: 1rem 2.5rem 0 1rem;
 			font-weight: 600;
 			height: _component("filters.height");


### PR DESCRIPTION
Fix, remove box-shadow none from textfield.mod-filter, for accessibility