### PR TITLE
fix(ng) quick fixes

### DIFF
--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.html
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.html
@@ -4,7 +4,7 @@
 			<span aria-hidden="true" class="lucca-icon">arrow_west</span>
 			<span class="u-mask">Previous</span>
 		</button>
-		<button class="calendar-header-date" (click)="changeGranularity()">
+		<button class="calendar-header-date" (click)="increaseGranularity()">
 			{{ header.label }}
 		</button>
 		<button class="calendar-header-nav" (click)="next()">

--- a/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
+++ b/packages/ng/libraries/date/src/lib/calendar/calendar-input.component.ts
@@ -43,6 +43,7 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 				return 'mod-dailyView';
 		}
 	}
+
 	// daily view
 	labels: string[] = [];
 	constructor(
@@ -263,10 +264,14 @@ export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlV
 		}
 		this.render();
 	}
-	trackBy(idx, item) { return item.id; }
-	changeGranularity() {
-		this.viewGranularity = this.header.granularity;
-		this.render();
+	trackBy(idx, item) {
+		return item.id;
+	}
+	increaseGranularity() {
+		if (this.header.granularity !== ELuDateGranularity.decade) {
+			this.viewGranularity = this.header.granularity;
+			this.render();
+		}
 	}
 	protected nextMonth() {
 		const d = this._adapter.add(this.header.date, 1, ELuDateGranularity.month);

--- a/packages/ng/libraries/establishment/src/lib/select/select-all/establishment-select-all.translate.ts
+++ b/packages/ng/libraries/establishment/src/lib/select/select-all/establishment-select-all.translate.ts
@@ -9,5 +9,17 @@ export const luEstablishmentSelectAllTranslations = {
 	fr: {
 		select: 'Tout sélectionner',
 		deselect: 'Tout Déselectionner'
-	}
+	},
+	de: {
+		select: 'Alle auswählen',
+		deselect: 'Alle abwählen'
+	},
+	pt: {
+		select: 'Selecionar tudo',
+		deselect: 'Desselecionar tudo'
+	},
+	es: {
+		select: 'Seleccionar todo',
+		deselect: 'Desmarcar todo'
+	},
 } as ILuTranslation<ILuOptionSelectAllLabel>;

--- a/packages/ng/libraries/option/src/lib/selector/all/select-all.translate.ts
+++ b/packages/ng/libraries/option/src/lib/selector/all/select-all.translate.ts
@@ -16,6 +16,18 @@ export const luOptionSelectAllTranslations = {
 	},
 	fr: {
 		select: 'Tout sélectionner',
-		deselect: 'Tout désélectionner',
+		deselect: 'Tout Déselectionner'
+	},
+	de: {
+		select: 'Alle auswählen',
+		deselect: 'Alle abwählen'
+	},
+	pt: {
+		select: 'Selecionar tudo',
+		deselect: 'Desselecionar tudo'
+	},
+	es: {
+		select: 'Seleccionar todo',
+		deselect: 'Desmarcar todo'
 	},
 } as ILuTranslation<ILuOptionSelectAllLabel>;

--- a/packages/ng/libraries/root/src/style/components/_popup.scss
+++ b/packages/ng/libraries/root/src/style/components/_popup.scss
@@ -108,16 +108,16 @@
 		max-width: none;
 		max-height: 100vh;
 		width: 100%;
-		width: fill-available;
+		width: stretch;
 		height: 100vh;
-		height: fill-available;
+		height: stretch;
 	}
 
 	.lu-modal-panel-inner {
 		max-height: 100vh;
-		max-height: fill-available;
+		max-height: stretch;
 		height: 100vh;
-		height: fill-available;
+		height: stretch;
 	}
 }
 


### PR DESCRIPTION
- add es, de, pt translations for `select all / deselect all`
- prevent the calendar-input from going to unsupported granularity
- scss autoprefixer warning due to `fill-available` used in class .lu-modal-panel

fix #1249 
fix #1250
fix #1235 