### PR TITLE
fix(ng) tooltip and select shenanigans

### DIFF
--- a/packages/ng/applications/sandbox/src/app/issues/refacto-tooltip/refacto-tooltip.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/refacto-tooltip/refacto-tooltip.component.html
@@ -5,3 +5,14 @@
 <h2>popover</h2>
 <button class="button" [luPopover]="basic">click me</button>
 <lu-popover #basic>basic-est of popovers</lu-popover>
+
+<hr />
+
+<span class="label" *ngIf="display" luTooltip="ngif">blinking throuh ngif</span>
+<span class="label" [class.u-displayNone]="!display" luTooltip="display-none">blinking throuh display-none</span>
+<p [class.u-displayNone]="!display">
+	lorem ipsum yaddi yaddi yadda - this text block changes the position of the tooltip trigger below it
+</p>
+<span class="label" luTooltip="moving trigger/target">moving cuz layout changes</span>
+
+<pre>{{ interval$ | async }}</pre>

--- a/packages/ng/applications/sandbox/src/app/issues/refacto-tooltip/refacto-tooltip.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/refacto-tooltip/refacto-tooltip.component.ts
@@ -1,8 +1,23 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { interval, Subscription } from 'rxjs';
+import { delay } from 'rxjs/operators';
 
 @Component({
 	selector: 'lu-refacto-tooltip',
 	templateUrl: './refacto-tooltip.component.html'
 })
-export class RefactoTooltipComponent {
+export class RefactoTooltipComponent implements OnInit, OnDestroy {
+	private _subs = new Subscription();
+	display = true;
+	interval$ = interval(2000);
+	ngOnInit() {
+		const sub = this.interval$.pipe(
+			delay(300),
+		)
+		.subscribe(() => this.display = !this.display);
+		this._subs.add(sub)
+	}
+	ngOnDestroy() {
+		this._subs.unsubscribe();
+	}
 }

--- a/packages/ng/applications/sandbox/src/app/issues/refacto-tooltip/refacto-tooltip.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/refacto-tooltip/refacto-tooltip.module.ts
@@ -4,6 +4,7 @@ import { RouterModule } from '@angular/router';
 import { RefactoTooltipComponent } from './refacto-tooltip.component';
 import { LuPopoverModule } from '@lucca-front/ng/popover';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+import { CommonModule } from '@angular/common';
 
 
 
@@ -12,6 +13,7 @@ import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 		RefactoTooltipComponent,
 	],
 	imports: [
+		CommonModule,
 		LuPopoverModule,
 		LuTooltipModule,
 		RouterModule.forChild([

--- a/packages/ng/applications/sandbox/src/app/issues/refactor-select/refactor-select.component.html
+++ b/packages/ng/applications/sandbox/src/app/issues/refactor-select/refactor-select.component.html
@@ -65,3 +65,19 @@
 	</div>
 </div>
 </section>
+
+<section>
+	<label class="textfield">
+		<lu-select class="textfield-input" [formControl]="ctrl" *ngIf="showSelect">
+			<span *luDisplayer="let value">{{value}}</span>
+			<lu-input-clearer *ngIf="true"></lu-input-clearer>
+			<lu-option-picker>
+				<lu-option value="1">1</lu-option>
+				<lu-option value="2">2</lu-option>
+			</lu-option-picker>
+		</lu-select>
+		<span class="textfield-label">Textfield label</span>
+	</label>
+	<button class="button" (click)="toggle()">toggle</button>
+	<pre>touched : {{ctrl.touched}}</pre>
+</section>

--- a/packages/ng/applications/sandbox/src/app/issues/refactor-select/refactor-select.component.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/refactor-select/refactor-select.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
 
 @Component({
 	selector: 'lu-refactor-select',
@@ -8,4 +9,9 @@ export class RefactorSelectComponent {
 	item = '1';
 	collection = ['1'];
 	model = '1';
+	ctrl = new FormControl();
+	showSelect = true;
+	toggle() {
+		this.showSelect = !this.showSelect
+	}
 }

--- a/packages/ng/applications/sandbox/src/app/issues/refactor-select/refactor-select.module.ts
+++ b/packages/ng/applications/sandbox/src/app/issues/refactor-select/refactor-select.module.ts
@@ -5,7 +5,7 @@ import { RefactorSelectComponent } from './refactor-select.component';
 import { LuSelectModule } from '@lucca-front/ng/select';
 import { LuInputModule } from '@lucca-front/ng/input';
 import { LuOptionModule } from '@lucca-front/ng/option';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 
 
@@ -18,6 +18,7 @@ import { CommonModule } from '@angular/common';
 		LuSelectModule,
 		LuOptionModule,
 		FormsModule,
+		ReactiveFormsModule,
 		LuInputModule,
 		CommonModule,
 		RouterModule.forChild([

--- a/packages/ng/libraries/dropdown/src/lib/trigger/dropdown-trigger.directive.ts
+++ b/packages/ng/libraries/dropdown/src/lib/trigger/dropdown-trigger.directive.ts
@@ -62,7 +62,10 @@ implements ILuPopoverTrigger<TPanel, ILuPopoverTarget>, AfterViewInit, OnDestroy
 		this._checkTarget();
 	}
 	ngOnDestroy() {
-		this.closePopover();
+		this._cleanUpSubscriptions();
+		if (this._popoverOpen) {
+			this.closePopover();
+		}
 		this.destroyPopover();
 	}
 	protected _emitOpen(): void {

--- a/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.directive.ts
+++ b/packages/ng/libraries/popover/src/lib/trigger/popover-trigger.directive.ts
@@ -120,7 +120,10 @@ implements ILuPopoverTrigger<TPanel, TTarget>, AfterViewInit, OnDestroy {
 		this._checkTarget();
 	}
 	ngOnDestroy() {
-		this.closePopover();
+		this._cleanUpSubscriptions();
+		if (this._popoverOpen) {
+			this.closePopover();
+		}
 		this.destroyPopover();
 	}
 	protected _emitOpen(): void {

--- a/packages/ng/libraries/select/src/lib/input/select-input.component.ts
+++ b/packages/ng/libraries/select/src/lib/input/select-input.component.ts
@@ -157,7 +157,9 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, AfterViewInit, OnDestroy
 	}
 
 	ngOnDestroy() {
-		this.closePopover();
+		if (this._popoverOpen) {
+			this.closePopover();
+		}
 		this.destroyPopover();
 		this.onDestroy();
 	}

--- a/packages/ng/libraries/select/src/lib/input/select-input.model.ts
+++ b/packages/ng/libraries/select/src/lib/input/select-input.model.ts
@@ -117,7 +117,13 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, ILuInput<T> {
 	}
 
 	onDestroy() {
+		if (this._popoverOpen) {
+			this.closePopover();
+		}
+		this.destroyPopover();
 		this._subs.unsubscribe();
+		this._cleanUpSubscriptions();
+
 	}
 
 	protected _getOverlayConfig(): OverlayConfig {

--- a/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
@@ -69,7 +69,10 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 		this._checkTarget();
 	}
 	ngOnDestroy() {
-		this.closePopover();
+		this._cleanUpSubscriptions();
+		if (this._popoverOpen) {
+			this.closePopover();
+		}
 		this.destroyPopover();
 	}
 	protected _emitOpen(): void {


### PR DESCRIPTION
destroying a select was calling `closePopover` (even if popover wasnt opened and closePopover was marking the control as `touched`. now we close the popover if it was opened - very big brain solution
fix #1255 

all popover-triggers and extensions (tooltip, dropdown, select) were not properly cleaning their subscription, as a result a popover or tooltip could be triggered to appear _after_ its trigger had been destroyed
fix #1259 

