### PR TITLE
feat(ng-tooltip) Accessible tooltip

### DIFF
--- a/packages/ng/libraries/tooltip/src/lib/panel/tooltip-panel.component.html
+++ b/packages/ng/libraries/tooltip/src/lib/panel/tooltip-panel.component.html
@@ -1,8 +1,15 @@
 <!-- <div [ngClass]="panelClassesMap" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" [innerHtml]="content | luSafeContent: 'html'">
 </div> -->
 <ng-template>
-	<div class="lu-tooltip-panel" role="tooltip" [ngClass]="panelClassesMap" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()"
-	 [@transformTooltip]="'enter'">
+	<div
+		class="lu-tooltip-panel"
+		role="tooltip"
+		[ngClass]="panelClassesMap"
+		(mouseover)="onMouseOver()"
+		(mouseleave)="onMouseLeave()"
+		[attr.id]="panelId"
+		[@transformTooltip]="'enter'"
+	>
 		<div class="lu-tooltip-content" [ngClass]="contentClassesMap" [innerHtml]="content | luSafeContent: 'html'"></div>
 	</div>
 </ng-template>

--- a/packages/ng/libraries/tooltip/src/lib/panel/tooltip-panel.component.html
+++ b/packages/ng/libraries/tooltip/src/lib/panel/tooltip-panel.component.html
@@ -1,7 +1,7 @@
 <!-- <div [ngClass]="panelClassesMap" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()" [innerHtml]="content | luSafeContent: 'html'">
 </div> -->
 <ng-template>
-	<div class="lu-tooltip-panel" role="dialog" [ngClass]="panelClassesMap" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()"
+	<div class="lu-tooltip-panel" role="tooltip" [ngClass]="panelClassesMap" (mouseover)="onMouseOver()" (mouseleave)="onMouseLeave()"
 	 [@transformTooltip]="'enter'">
 		<div class="lu-tooltip-content" [ngClass]="contentClassesMap" [innerHtml]="content | luSafeContent: 'html'"></div>
 	</div>

--- a/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
@@ -56,6 +56,11 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 	}
 	@HostBinding('attr.tabindex') tabindex = 0;
 
+	/** accessibility attribute - dont override */
+	@HostBinding('attr.id') get _attrId() { return this._triggerId; }
+	/** accessibility attribute - dont override */
+	@HostBinding('attr.aria-describedby') get _attrAriaDescribedBy() { return this._panelId; }
+
 	constructor(
 		protected _overlay: Overlay,
 		protected _elementRef: ElementRef,
@@ -66,6 +71,7 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 		super(_overlay, _elementRef, _viewContainerRef);
 		this.target = new LuPopoverTarget();
 		this.target.elementRef = this._elementRef;
+		this._triggerId = this._elementRef.nativeElement.getAttribute('id') || this._triggerId;
 		this.triggerEvent = 'hover';
 		this.target.position = 'above';
 		this.enterDelay = 300;

--- a/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/libraries/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
@@ -10,6 +10,7 @@ import {
 	OnDestroy,
 	Output,
 	EventEmitter,
+	HostBinding,
 } from '@angular/core';
 	import { Overlay } from '@angular/cdk/overlay';
 	import { ALuPopoverTrigger, LuPopoverPosition, LuPopoverTarget } from '@lucca-front/ng/popover';
@@ -45,6 +46,15 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 	onMouseLeave() {
 		super.onMouseLeave();
 	}
+	@HostListener('focus')
+	onFocus(){
+		super.onMouseEnter();
+	}
+	@HostListener('blur')
+	onBlur() {
+		super.onMouseLeave();
+	}
+	@HostBinding('attr.tabindex') tabindex = 0;
 
 	constructor(
 		protected _overlay: Overlay,


### PR DESCRIPTION
During a guild workshop, we dived into how to make our tooltip accessible (following this French doc on the subject https://www.accede-web.com/notices/interface-riche/infobulles-personnalisees/):
- [x] Focus behaviour by adding a tabindex systematically and listeners on focus/blur
- [x] role="tooltip"
- [x] Generate a custom ID on the tooltip to use for the aria-describedby of the described element
- [ ] Bonus: handle dismiss when pressing the Escape key
