### PR TITLE
feat(scss-a11y) better a11y for checkbox mixed

### DIFF
--- a/packages/scss/demo/components/forms/forms-checkboxes.html
+++ b/packages/scss/demo/components/forms/forms-checkboxes.html
@@ -95,15 +95,19 @@
 </code>
 </section>
 
-<!-- Incomplete checkbox -->
+<!-- Mixed checkbox -->
 <section class="contentSection">
-	<h2>Incomplete checkbox</h2>
+	<h2>Mixed checkbox</h2>
 	<label class="checkbox">
-		<input class="checkbox-input is-incomplete" type="checkbox" checked />
-		<span class="checkbox-label">Incomplete checkbox</span>
+		<input class="checkbox-input" type="checkbox" aria-hidden="true" checked="checked" />
+		<span class="checkbox-mixed" role="checkbox" aria-checked="mixed"></span>
+		<span class="checkbox-label">Mixed checkbox</span>
 	</label>
-	<p>For an incomplete checkbox, add class <code class="code">is-incomplete</code> to input <code class="code">checkbox-input</code>.</p>
-</section>
+	<code class="code mod-block">&lt;label class=&quot;checkbox&quot;&gt;
+		&lt;input class=&quot;checkbox-input&quot; type=&quot;checkbox&quot; aria-hidden=&quot;true&quot; checked=&quot;checked&quot; /&gt;
+		&lt;span class=&quot;checkbox-mixed&quot; role=&quot;checkbox&quot; aria-checked=&quot;mixed&quot;&gt;&lt;/span&gt;
+		&lt;span class=&quot;checkbox-label&quot;&gt;Mixed checkbox&lt;/span&gt;
+	&lt;/label&gt;</code></section>
 
 <!-- Big checkbox -->
 <section class="contentSection">

--- a/packages/scss/src/components/inputs/checkbox/_checkbox.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkbox.scss
@@ -182,6 +182,7 @@
 		}
 	}
 
+	~ .checkbox-mixed ~ .checkbox-label,
 	&.is-incomplete ~ .checkbox-label {
 		&::before {
 			@include makeIcon("partial");


### PR DESCRIPTION
Added a line for better feedback to assistive technologies (avoiding [a bug with Safari](https://bugs.webkit.org/show_bug.cgi?id=203138) that can't do it on the input).

fix #1285