### PR TITLE
fix(ng-tooltip) tooltip focus handling

### DIFF
--- a/stories/ng/popover/popover.stories.ts
+++ b/stories/ng/popover/popover.stories.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LuPopoverModule } from '@lucca-front/ng/popover';
 import { Story, Meta, moduleMetadata } from '@storybook/angular';

--- a/stories/ng/tooltip/tooltip.stories.html
+++ b/stories/ng/tooltip/tooltip.stories.html
@@ -1,0 +1,74 @@
+<h1>Tooltips</h1>
+
+<h2>Basics</h2>
+<button
+	class="button"
+	luTooltip="i am a tooltip"
+>
+	i am natively focusable
+</button>
+<span
+	class="label"
+	luTooltip="i am a tooltip"
+>
+	i am not
+</span>
+
+<h2>With disabled tooltips</h2>
+<button
+	class="button"
+	luTooltip="i should not appear"
+	luTooltipDisabled="true"
+>
+	i am natively focusable
+</button>
+<span
+	class="label"
+	luTooltip="i should not appear"
+	luTooltipDisabled="true"
+>
+	i am not
+</span>
+
+<h2>With hardcoded tabindexes</h2>
+<button
+	class="button"
+	luTooltip="i am a tooltip"
+	tabindex="8"
+>
+	i am natively focusable
+</button>
+<span
+	class="label"
+	luTooltip="i am a tooltip"
+	tabindex="8"
+>
+	i am not
+</span>
+
+<h2>With hardcoded tabindexes and tooltipdisabled</h2>
+<button
+	class="button"
+	luTooltip="i should not appear"
+	tabindex="8"
+	luTooltipDisabled="true"
+>
+	i am natively focusable
+</button>
+<span
+	class="label"
+	luTooltip="i should not appear"
+	tabindex="8"
+	luTooltipDisabled="true"
+>
+	i am not
+</span>
+<h2>On a disabled button</h2>
+<button
+	class="button"
+	luTooltip="i should not appear"
+	disabled="true"
+>
+	i am natively focusable
+</button>
+

--- a/stories/ng/tooltip/tooltip.stories.ts
+++ b/stories/ng/tooltip/tooltip.stories.ts
@@ -1,0 +1,32 @@
+import { Component, Input } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'tooltip-stories',
+	templateUrl: './tooltip.stories.html',
+}) class TooltipStory {
+}
+
+export default {
+  title: 'NG/Tooltip/Focus',
+  component: TooltipStory,
+	decorators: [
+		moduleMetadata({
+			entryComponents: [TooltipStory],
+			imports: [
+				LuTooltipModule,
+				BrowserAnimationsModule,
+			]
+		})
+	]
+} as Meta;
+
+const template: Story<TooltipStory> = (args: TooltipStory) => ({
+  props: args,
+});
+
+export const basic = template.bind({});
+basic.args = {}


### PR DESCRIPTION
better handling of the focus by the tooltip trigger

- if it's on an element natively focusable (button, a, ...) or already with a tabindex, the tooltip trigger doesn't try to touch the focusability of the tag
- if it's on a non focusable dom element, it adds a tabindex=0 _only when not disabled_

fixes #1294 (i hope)

