### PR TITLE
feat(scss-a11y) better a11y for checkbox mixed

### DIFF
--- a/packages/scss/src/components/inputs/checkbox/_checkbox.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkbox.scss
@@ -182,6 +182,7 @@
 		}
 	}
 
+	~ .checkbox-mixed ~ .checkbox-label,
 	&.is-incomplete ~ .checkbox-label {
 		&::before {
 			@include makeIcon("partial");

--- a/stories/scss/form/checkbox/checkbox.stories.html
+++ b/stories/scss/form/checkbox/checkbox.stories.html
@@ -1,0 +1,5 @@
+<label class="checkbox">
+	<input class="checkbox-input" type="checkbox" [attr.aria-hidden]="isAriaHidden" [ngModel]="isChecked" (ngModelChange)="toggle($event)"/>
+	<span *ngIf="isMixed" class="checkbox-mixed" role="checkbox" aria-checked="mixed"></span>
+	<span class="checkbox-label">{{state}}</span>
+</label>

--- a/stories/scss/form/checkbox/checkbox.stories.ts
+++ b/stories/scss/form/checkbox/checkbox.stories.ts
@@ -1,0 +1,50 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'checkbox-stories',
+	templateUrl: './checkbox.stories.html',
+}) class CheckboxStory {
+	@Input() state: string = 'unchecked';
+	get isMixed(): boolean { return this.state === 'mixed'; }
+	get isChecked(): boolean { return this.state === 'checked' || this.state === 'mixed'; }
+	get isAriaHidden(): boolean | null {
+		return this.isMixed ? true : null;
+	}
+	toggle(flag: boolean) {
+		if (flag) {
+			this.state = 'checked';
+		} else {
+			this.state = 'unchecked';
+		}
+	}
+}
+
+export default {
+	title: 'SCSS/Form/Checkboxes',
+	component: CheckboxStory,
+	argTypes: {
+		state: {
+			control: {
+				type: 'radio',
+				options: ['checked', 'unchecked', 'mixed']
+			}
+		},
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [CheckboxStory],
+			imports: [BrowserModule, FormsModule, CommonModule],
+		})
+	]
+} as Meta;
+
+const template: Story<CheckboxStory> = (args: CheckboxStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});


### PR DESCRIPTION
closes #1290

Added a line for better feedback to assistive technologies (avoiding [a bug with Safari](https://bugs.webkit.org/show_bug.cgi?id=203138) that can't do it on the input).

fix #1285

see ?path=/story/scss-form-checkboxes--basic for reference html dom to have for mixed cb