### PR TITLE
feat(scss) table layout fixed and sticky

### DIFF
--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -538,8 +538,10 @@
 }
 
 
-// Fixed colmuns width
-$nb-max-columns: 12;
+// Fixed columns width
+$min-col-width: 1; //value in rem
+$max-col-width: 30; //value in rem
+
 .table {
 	&.mod-layoutFixed {
 		table-layout: fixed;
@@ -556,20 +558,49 @@ $nb-max-columns: 12;
 
 .table-head-row-cell,
 .table-body-row-cell {
-	@each $bp-name, $bp-obj in _getMap("breakpoints") {
-		@for $i from 1 through $nb-max-columns {
-			&.mod-layoutFixed-#{$i} {
-				width: percentage($i / $nb-max-columns);
-				max-width: percentage($i / $nb-max-columns);
-			}
+	@for $i from $min-col-width through $max-col-width {
+		&.mod-layoutFixed-#{$i} {
+			min-width: $i * 1rem;
+			width: $i * 1rem;
+			max-width: $i * 1rem;
 		}
+	}
+	@each $bp-name, $bp-obj in _getMap("breakpoints") {
 		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
-			@for $i from 1 through $nb-max-columns {
+			@for $i from $min-col-width through $max-col-width {
 				&.mod-layoutFixed-#{$bp-name}#{$i} {
-					width: percentage($i / $nb-max-columns);
-					max-width: percentage($i / $nb-max-columns);
+					min-width: $i * 1rem;
+					width: $i * 1rem;
+					max-width: $i * 1rem;
 				}
 			}
 		}
-	  }
+	}
+}
+
+// Sticky columns
+.table {
+	&.mod-columnSticky {
+		width: auto;
+		background-color: _color("white");
+	}
+}
+
+.table-head-row-cell,
+.table-body-row-cell {
+	
+	&[class*="mod-columnSticky"] {
+		position: sticky;
+		background-color: _color("white");
+		z-index: 1;
+	}
+
+	@for $i from 0 through $max-col-width {
+		&.mod-columnSticky-leftOffset#{$i} {
+			left: $i * 1rem;
+		}
+		&.mod-columnSticky-rightOffset#{$i} {
+			right: $i * 1rem;
+		}
+	}
 }

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -539,8 +539,8 @@
 
 
 // Fixed columns width
-$min-col-width: 1; //value in rem
-$max-col-width: 30; //value in rem
+$min-col-width: 2; //value in rem
+$max-col-width: 20; //value in rem
 
 .table {
 	&.mod-layoutFixed {

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -582,6 +582,7 @@ $max-col-width: 20; //value in rem
 .table {
 	&.mod-columnSticky {
 		width: auto;
+		min-width: 100%;
 		background-color: _color("white");
 	}
 

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -584,6 +584,23 @@ $max-col-width: 20; //value in rem
 		width: auto;
 		background-color: _color("white");
 	}
+
+	@each $bp-name, $bp-obj in _getMap("breakpoints") {
+		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
+			&.mod-columnSticky-#{$bp-name} {
+				width: auto;
+				background-color: _color("white");
+				.table-head-row-cell,
+				.table-body-row-cell {
+					&[class*="mod-columnSticky"] {
+						position: sticky;
+						background-color: _color("white");
+						z-index: 1;
+					}
+				}
+			}
+		}
+	}
 }
 
 .table-head-row-cell,

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -187,6 +187,7 @@
 			}
 		}
 	}
+
 }
 
 .table-body-row {
@@ -245,7 +246,8 @@
 	}
 }
 
-.table-body-row, .table-head-row {
+.table-body-row, 
+.table-head-row {
 	&.mod-selectable {
 		.table-body-row-cell, .table-head-row-cell {
 			&:first-child {
@@ -313,7 +315,8 @@
 	font-weight: 400;
 }
 
-.table-body-row-cell, .table-head-row-cell {
+.table-body-row-cell, 
+.table-head-row-cell {
 
 	&.mod-actions {
 		padding: .3rem _theme("spacings.smaller") .3rem 0;
@@ -532,4 +535,41 @@
 			}
 		}
 	}
+}
+
+
+// Fixed colmuns width
+$nb-max-columns: 12;
+.table {
+	&.mod-layoutFixed {
+		table-layout: fixed;
+	}
+
+	@each $bp-name, $bp-obj in _getMap("breakpoints") {
+		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
+			&.mod-layoutFixed-#{$bp-name} {
+				table-layout: fixed;
+			}
+		}
+	}
+}
+
+.table-head-row-cell,
+.table-body-row-cell {
+	@each $bp-name, $bp-obj in _getMap("breakpoints") {
+		@for $i from 1 through $nb-max-columns {
+			&.mod-layoutFixed-#{$i} {
+				width: percentage($i / $nb-max-columns);
+				max-width: percentage($i / $nb-max-columns);
+			}
+		}
+		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
+			@for $i from 1 through $nb-max-columns {
+				&.mod-layoutFixed-#{$bp-name}#{$i} {
+					width: percentage($i / $nb-max-columns);
+					max-width: percentage($i / $nb-max-columns);
+				}
+			}
+		}
+	  }
 }

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -591,7 +591,7 @@
 			<tr class="table-head-row">
 				<th class="table-head-row-cell mod-layoutFixed-8 mod-columnSticky-leftOffset0">Head cell</th>
 				<th class="table-head-row-cell mod-layoutFixed-7 mod-columnSticky-leftOffset8">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-2 mod-columnSticky-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-columnSticky-leftOffset15">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
@@ -600,14 +600,14 @@
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-4 mod-columnSticky-rightOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-columnSticky-rightOffset0">Head cell</th>
 			</tr>
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row">
 				<td class="table-body-row-cell mod-columnSticky-leftOffset0">fixed width: 8 // offset 0</td>
 				<td class="table-body-row-cell mod-columnSticky-leftOffset8">fixed width: 7 // offset 8</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">fixed width: 2 // offset 8 + 7 = 15</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset15">fixed width: 5 // offset 8 + 7 = 15</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
@@ -616,7 +616,7 @@
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">fixed width: 4 // offset 0</td>
+				<td class="table-body-row-cell mod-columnSticky-rightOffset0">fixed width: 5 // offset 0</td>
 			</tr>
 			<tr class="table-body-row">
 				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -530,8 +530,8 @@
 	<table class="table mod-layoutFixed">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-1">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-3">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-4">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-15">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
@@ -557,8 +557,8 @@
 	<table class="table mod-layoutFixed-md">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-md1">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-md3">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-md4">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-md15">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
@@ -580,6 +580,75 @@
 			</tr>
 		</tbody>
 	</table>
+	<em><b>Tip:</b> the column sizing is based on a 12 columns system, like the grid component</em>
+</section>
+
+<!-- Sticky columns -->
+<section class="contentSection">
+	<h2>Sticky columns</h2>
+	<table class="table mod-layoutFixed mod-columnSticky">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-8 mod-columnSticky-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-7 mod-columnSticky-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-2 mod-columnSticky-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-4 mod-columnSticky-rightOffset0">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	
 	<em><b>Tip:</b> the column sizing is based on a 12 columns system, like the grid component</em>
 </section>
 

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -530,15 +530,15 @@
 	<table class="table mod-layoutFixed">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-4">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-15">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-12">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row">
-				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Head cell with mod-layoutFixed-8</td>
+				<td class="table-body-row-cell">Head cell with mod-layoutFixed-12</td>
 				<td class="table-body-row-cell">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
@@ -557,15 +557,15 @@
 	<table class="table mod-layoutFixed-md">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-md4">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-md15">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-md8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-md12">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row">
-				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Head cell with mod-layoutFixed-8</td>
+				<td class="table-body-row-cell">Head cell with mod-layoutFixed-12</td>
 				<td class="table-body-row-cell">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
@@ -580,7 +580,7 @@
 			</tr>
 		</tbody>
 	</table>
-	<em><b>Tip:</b> the column sizing is based on a 12 columns system, like the grid component</em>
+	<em><b>Tip:</b> the numeric value used in the class will be calculated in rem. Ex <code class="code">.mod-layoutFixed-<strong>8</strong></code> means a cell width of <strong>8</strong> rem</em>
 </section>
 
 <!-- Sticky columns -->
@@ -605,9 +605,9 @@
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset0">fixed width: 8 // offset 0</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset8">fixed width: 7 // offset 8</td>
+				<td class="table-body-row-cell mod-columnSticky-leftOffset15">fixed width: 2 // offset 8 + 7 = 15</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
@@ -616,7 +616,7 @@
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-rightOffset0">fixed width: 4 // offset 0</td>
 			</tr>
 			<tr class="table-body-row">
 				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
@@ -649,7 +649,7 @@
 		</tbody>
 	</table>
 	
-	<em><b>Tip:</b> the column sizing is based on a 12 columns system, like the grid component</em>
+	<em><b>Tip:</b> each cell must have a class <code class="code">.mod-columnSticky-leftOffset<strong>X</strong></code> or <code class="code">.mod-columnSticky-righOffset<strong>X</strong></code> with <strong>X</strong> equal to the cumulative size of previous cells in the specified axis (from left or from right)</em>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -524,5 +524,64 @@
 	</table>
 </section>
 
+<!-- Fixed columns width -->
+<section class="contentSection">
+	<h2>Fixed layout columns</h2>
+	<table class="table mod-layoutFixed">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-1">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-3">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	<h2 class="u-marginTopStandard">Fixed layout columns starting at breakpoint</h2>
+	<table class="table mod-layoutFixed-md">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-md1">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-md3">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	<em><b>Tip:</b> the column sizing is based on a 12 columns system, like the grid component</em>
+</section>
+
 <!-- To tell the ui-diff tool that the page has finished rendering -->
 <span id="ready"></span>


### PR DESCRIPTION
Add `.mod-layoutFixed` table, used to precisely size table column from 2 to 20 rem (can be configured);
- usable globaly or at breakpoint

Add sticky (right, left, or both) column system for table, using `.mod-layoutFixed`