### PR TITLE
feat(scss) Callout

### DIFF
--- a/packages/scss/src/components/_callout.scss
+++ b/packages/scss/src/components/_callout.scss
@@ -1,5 +1,5 @@
 .callout {
-	background-color: _component("callout.background-color");
+	background-color: _component("callout.background");
 	border-radius: _theme("commons.border.radius");
 	border: _theme("commons.divider.width") solid _color("grey", 200, true);
 	margin: _component("callout.margin");

--- a/packages/scss/src/components/_callout.scss
+++ b/packages/scss/src/components/_callout.scss
@@ -1,7 +1,7 @@
 .callout {
-	background-color: _component("callout.background");
+	background-color: _component("callout.background-color");
 	border-radius: _theme("commons.border.radius");
-	border: 1px solid _color("grey", 200, true);
+	border: _theme("commons.divider.width") solid _color("grey", 200, true);
 	margin: _component("callout.margin");
 	padding: _component("callout.padding");
 	position: relative;
@@ -92,7 +92,7 @@
 @mixin calloutDefaultPalette($palette) {
 	background-color: _color($palette, 100);
 	color: _color($palette, 800);
-	border: 1px solid _color($palette, 200);
+	border: _theme("commons.divider.width") solid _color($palette, 200);
 }
 .callout {
 	@each $name, $palette in _getMap("palettes") {

--- a/packages/scss/src/components/_callout.scss
+++ b/packages/scss/src/components/_callout.scss
@@ -1,6 +1,7 @@
 .callout {
 	background-color: _component("callout.background");
 	border-radius: _theme("commons.border.radius");
+	border: 1px solid _color("grey", 200, true);
 	margin: _component("callout.margin");
 	padding: _component("callout.padding");
 	position: relative;
@@ -17,6 +18,7 @@
 
 .callout-title {
 	font-weight: 600;
+	margin-bottom: _theme("spacings.smallest");
 }
 
 .callout-kill {
@@ -88,8 +90,9 @@
 }
 
 @mixin calloutDefaultPalette($palette) {
-	background-color: _color($palette, 50);
+	background-color: _color($palette, 100);
 	color: _color($palette, 800);
+	border: 1px solid _color($palette, 200);
 }
 .callout {
 	@each $name, $palette in _getMap("palettes") {

--- a/packages/scss/src/theming/components/_callout.theme.scss
+++ b/packages/scss/src/theming/components/_callout.theme.scss
@@ -1,6 +1,6 @@
 $callout: (
   margin: 0 0 _theme("spacings.small"),
   padding: _theme("spacings.smaller") _theme("spacings.small"),
-  background-color: _color("grey", "100")
+  background: _color("grey", "100")
 );
 $theme: _set($theme, "components.callout", $callout);

--- a/packages/scss/src/theming/components/_callout.theme.scss
+++ b/packages/scss/src/theming/components/_callout.theme.scss
@@ -1,6 +1,6 @@
 $callout: (
   margin: 0 0 _theme("spacings.small"),
   padding: _theme("spacings.smaller") _theme("spacings.small"),
-  background: _theme("commons.background.base")
+  background: _color("grey", "100")
 );
 $theme: _set($theme, "components.callout", $callout);

--- a/packages/scss/src/theming/components/_callout.theme.scss
+++ b/packages/scss/src/theming/components/_callout.theme.scss
@@ -1,6 +1,6 @@
 $callout: (
   margin: 0 0 _theme("spacings.small"),
   padding: _theme("spacings.smaller") _theme("spacings.small"),
-  background: _color("grey", "100")
+  background-color: _color("grey", "100")
 );
 $theme: _set($theme, "components.callout", $callout);

--- a/stories/qa/callout/callout.stories.html
+++ b/stories/qa/callout/callout.stories.html
@@ -36,7 +36,7 @@
 <section class="contentSection">
 	<h2>Callout title</h2>
 	<div class="callout">
-		<h3 class="callout-title">I'm Mr Meeseeks!</h3>
+		<strong class="callout-title">Need help?</strong>
 		<div class="callout-content">Look at meee</div>
 	</div>
 </section>

--- a/stories/qa/callout/callout.stories.html
+++ b/stories/qa/callout/callout.stories.html
@@ -1,4 +1,5 @@
 <h1>Callouts</h1>
+
 <section class="contentSection">
 	<h2>Basics</h2>
 	<!-- Basics -->
@@ -17,6 +18,7 @@
 	</div>
 </section>
 
+<!-- Palette -->
 <section class="contentSection">
 	<h2>Palette</h2>
 	<div class="callout palette-success">
@@ -30,13 +32,16 @@
 	</div>
 </section>
 
+<!-- Callout title -->
 <section class="contentSection">
 	<h2>Callout title</h2>
 	<div class="callout">
-		<h3 class="callout-title">I'm Mr Meeseeks!</h3> Look at meee
+		<h3 class="callout-title">I'm Mr Meeseeks!</h3>
+		<div class="callout-content">Look at meee</div>
 	</div>
 </section>
 
+<!-- Killable callour -->
 <section class="contentSection">
 	<h2>Killable callout</h2>
 	<div class="callout">
@@ -45,31 +50,37 @@
 	</div>
 </section>
 
+<!-- Callout icon -->
 <section class="contentSection">
 	<h2>Callout icon</h2>
 
 	<div class="callout mod-icon">
 		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">help</span></div>
-		<b class="callout-title">Need help?</b> I'm a standard callout. :)
+		<strong class="callout-title">Need help?</strong>
+		<div class="callout-content">I'm a standard callout. :)</div>
 	</div>
 
 	<div class="callout mod-icon mod-small">
 		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">help</span></div>
-		<b class="callout-title">Need help?</b> I'm a standard callout. :)
+		<strong class="callout-title">Need help?</strong>
+		<div class="callout-content">I'm a standard callout. :)</div>
 	</div>
 
 	<div class="callout mod-icon palette-success">
 		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">tick_bold</span></div>
-		<b class="callout-title">Cool!</b> I'm a success callout. :)
+		<strong class="callout-title">Cool!</strong>
+		<div class="callout-content">I'm a success callout. :)</div>
 	</div>
 
 	<div class="callout mod-icon palette-warning">
 		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">warning</span></div>
-		<b class="callout-title">Hmmm...</b> I'm a warning callout. :|
+		<strong class="callout-title">Hmmm...</strong>
+		<div class="callout-content">I'm a warning callout. :|</div>
 	</div>
 
 	<div class="callout mod-icon palette-error">
 		<div class="callout-icon"><span aria-hidden="true" class="lucca-icon">error</span></div>
-		<b class="callout-title">Oops!</b> I'm an error callout. :(
+		<strong class="callout-title">Oops!</strong>
+		<div class="callout-content">I'm an error callout. :(</div>
 	</div>
 </section>

--- a/stories/qa/callout/callout.stories.ts
+++ b/stories/qa/callout/callout.stories.ts
@@ -9,17 +9,6 @@ import { Story, Meta, moduleMetadata } from '@storybook/angular';
 export default {
   title: 'QA/Callout',
   component: CalloutStory,
-	parameters: {
-		backgrounds: {
-			default: 'toto',
-			values: [
-				{
-					name: 'base',
-					value: '#fff',
-				}
-			]
-		}
-	},
 	decorators: [
 		moduleMetadata({
 			entryComponents: [CalloutStory]

--- a/stories/qa/callout/callout.stories.ts
+++ b/stories/qa/callout/callout.stories.ts
@@ -9,6 +9,17 @@ import { Story, Meta, moduleMetadata } from '@storybook/angular';
 export default {
   title: 'QA/Callout',
   component: CalloutStory,
+	parameters: {
+		backgrounds: {
+			default: 'toto',
+			values: [
+				{
+					name: 'base',
+					value: '#fff',
+				}
+			]
+		}
+	},
 	decorators: [
 		moduleMetadata({
 			entryComponents: [CalloutStory]


### PR DESCRIPTION
fixes #1348 

- [x] Put the title in block to make the content go underneath
- [x] Pay attention to the alignment when there is an icon
- [x] Change the default background + palette to 100
- [x] Add borders (200)
- [x] Be careful with border-radius on icons