### PR TITLE
fix(scss) Box - better positioning of the arrow

### DIFF
--- a/packages/scss/src/components/_box.scss
+++ b/packages/scss/src/components/_box.scss
@@ -31,7 +31,7 @@
 			height: 0;
 			left: _component("box.toggle.arrow.left");
 			position: absolute;
-			top: calc(-1 * #{_component("box.toggle.arrow.size")});
+			bottom: 100%;
 			width: 0;
 		}
 


### PR DESCRIPTION
The arrow was sometimes badly positioned with the calculation on its size.

![Capture d’écran 2021-06-16 à 15 51 59](https://user-images.githubusercontent.com/64789527/122231608-d9e78600-ceba-11eb-8125-e17705d7d5c1.png)

![Capture d’écran 2021-06-16 à 15 52 18](https://user-images.githubusercontent.com/64789527/122231609-da801c80-ceba-11eb-9049-9e1524047320.png)