### PR TITLE
feat(ng-a11y) popover triggers

### DIFF
--- a/packages/ng/popover/src/lib/trigger/popover-trigger.model.ts
+++ b/packages/ng/popover/src/lib/trigger/popover-trigger.model.ts
@@ -94,7 +94,7 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 	get triggerEvent() { return this._triggerEvent; }
 	set triggerEvent(te: LuPopoverTriggerEvent) {
 		this._triggerEvent = te;
-		if (te = 'hover') {
+		if (te === 'hover' || te === 'focus') {
 			if (this._hoveredSubscription) {
 				this._hoveredSubscription.unsubscribe();
 			}
@@ -142,23 +142,23 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 	}
 
 	onMouseEnter() {
-		if (this.triggerEvent === 'hover') {
+		if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 			this._hovered$.next(true);
 		}
 	}
 
 	onMouseLeave() {
-		if (this.triggerEvent === 'hover') {
+		if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 			this._hovered$.next(false);
 		}
 	}
 	onFocus() {
-		if (this.triggerEvent === 'focus') {
+		if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 			this.openPopover();
 		}
 	}
 	onBlur() {
-		if (this.triggerEvent === 'focus') {
+		if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 			this.closePopover();
 		}
 	}
@@ -242,7 +242,7 @@ implements ILuPopoverTrigger<TPanel, TTarget> {
 	protected _subscribeToPanelEvents(): void {
 		if (this._overlayRef) {
 			this._panelEventsSubscriptions = new Subscription();
-			if (this.triggerEvent === 'hover') {
+			if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 
 				this._panelEventsSubscriptions.add(
 					this.panel.hovered

--- a/packages/ng/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
@@ -42,22 +42,22 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 	@Output('luTooltipOnOpen') onOpen = new EventEmitter<void>();
 	/** Event emitted when the associated popover is closed. */
 	@Output('luTooltipOnClose') onClose = new EventEmitter<void>();
+
 	@HostListener('mouseenter')
 	onMouseEnter() {
 		super.onMouseEnter();
 	}
-
 	@HostListener('mouseleave')
 	onMouseLeave() {
 		super.onMouseLeave();
 	}
 	@HostListener('focus')
 	onFocus(){
-		super.onMouseEnter();
+		super.onFocus();
 	}
 	@HostListener('blur')
 	onBlur() {
-		super.onMouseLeave();
+		super.onBlur();
 	}
 	private _handleTabindex = false;
 	// @HostBinding('attr.tabindex') tabindex;

--- a/stories/ng/popover/popover.stories.ts
+++ b/stories/ng/popover/popover.stories.ts
@@ -7,15 +7,21 @@ import { Story, Meta, moduleMetadata } from '@storybook/angular';
 @Component({
 	selector: 'popover-stories',
 	template: `
+<button class="button mod-outline">don't click me</button>
 <button class="button"
 	[luPopover]="popover"
 	[luPopoverPosition]="position"
->click me</button>
+	[luPopoverAlignment]="alignement"
+	[luPopoverTrigger]="trigger"
+>{{trigger}} me</button>
+<button class="button mod-outline">don't click me either</button>
 <lu-popover #popover>{{popoverContent}}</lu-popover>
 `,
 }) class PopoverStory {
 	@Input() popoverContent: string;
 	@Input() position: string;
+	@Input() alignment: string;
+	@Input() trigger: string;
 }
 
 export default {
@@ -26,6 +32,18 @@ export default {
 			control: {
 				type: 'radio',
 				options: ['above', 'below', 'before', 'after']
+			}
+		},
+		alignment: {
+			control: {
+				type: 'radio',
+				options: ['top', 'bottom', 'left', 'right', 'center']
+			}
+		},
+		trigger: {
+			control: {
+				type: 'radio',
+				options: ['none', 'hover', 'focus', 'click']
 			}
 		},
 	},
@@ -48,4 +66,22 @@ export const basic = template.bind({});
 basic.args = {
 	popoverContent: 'popover content',
 	position: 'below',
+	alignment: 'center',
+	trigger: 'click',
+}
+
+export const hover = template.bind({});
+hover.args = {
+	popoverContent: 'popover content',
+	position: 'below',
+	alignment: 'center',
+	trigger: 'hover',
+}
+
+export const focus = template.bind({});
+focus.args = {
+	popoverContent: 'popover content',
+	position: 'below',
+	alignment: 'center',
+	trigger: 'focus',
 }


### PR DESCRIPTION
fixes #1393 

popover triggers `hover` and `focus` now act the same because js events focus and hover should be understood as 2 ways to represent the same end user interaction with the element

so a popover with trigger `hover` will open when the trigger is focused, and a popover with the `focus` trigger will appear when hovered