### PR TITLE
feat(ng-ets) Do not group by legal unit if not usefull

### DIFF
--- a/packages/ng/api/src/lib/service/api-v4.service.ts
+++ b/packages/ng/api/src/lib/service/api-v4.service.ts
@@ -55,4 +55,11 @@ export class LuApiV4Service<T extends ILuApiItem = ILuApiItem> extends ALuApiSer
 			map(res => res.items),
 		);
 	}
+	count(): Observable<number> {
+		const query = [...this.filters, 'fields.root=count', 'limit=0'].filter(f => !!f);
+		const url = [this._api, query.join('&')].join('?');
+		return this._http.get<{ count: number }>(url).pipe(
+			map(res => res.count)
+		);
+	}
 }

--- a/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.html
+++ b/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.html
@@ -30,13 +30,12 @@
 			[filters]="filters"
 			[appInstanceId]="appInstanceId"
 			[operations]="operations"
-		>
-		</lu-establishment-select-all>
+		></lu-establishment-select-all>
 	</header>
 
 	<ng-template luForLegalUnits let-group>
 		<div class="optionGroup">
-			<ng-container *ngIf="!isSearching">
+			<ng-container *ngIf="groupByLu && !isSearching">
 				<button
 					*ngIf="multiple; else singleViewGroup"
 					class="optionGroupName button mod-link mod-block"
@@ -58,7 +57,7 @@
 				class="establishmentOption">
 				<ng-container *ngIf="isSearching; else emptySearch">
 					<span class="u-displayBlock">{{establishment.name}}</span>
-					<span class="u-displayBlock u-textLight u-textSmall">{{ group.key.name }}</span>
+					<span *ngIf="groupByLu" class="u-displayBlock u-textLight u-textSmall">{{ group.key.name }}</span>
 				</ng-container>
 				<ng-template #emptySearch>
 					<span>{{establishment.name}}</span>

--- a/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.ts
+++ b/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.ts
@@ -1,22 +1,12 @@
-import {
-	ChangeDetectionStrategy,
-	Component,
-	ChangeDetectorRef,
-	forwardRef,
-	ViewContainerRef,
-	ElementRef,
-	Renderer2,
-	Inject,
-	AfterViewInit, Input
-} from '@angular/core';
-import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { Overlay } from '@angular/cdk/overlay';
-
-import { ILuInputWithPicker } from '@lucca-front/ng/picker';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, OnInit, Optional, Renderer2, Self, SkipSelf, ViewContainerRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ILuOptionPickerPanel, LuOptionComparer } from '@lucca-front/ng/option';
+import { ILuInputWithPicker } from '@lucca-front/ng/picker';
 import { ALuSelectInputComponent } from '@lucca-front/ng/select';
-
+import { combineLatest } from 'rxjs';
 import { ILuEstablishment } from '../../establishment.model';
+import { ALuEstablishmentService, ALuLegalUnitService, LuEstablishmentService, LuLegalUnitService } from '../../service/index';
 import { LuEstablishmentSelectInputIntl } from './establishment-select-input.intl';
 import { ILuEstablishmentSelectInputLabel } from './establishment-select-input.translate';
 
@@ -30,12 +20,20 @@ import { ILuEstablishmentSelectInputLabel } from './establishment-select-input.t
 			provide: NG_VALUE_ACCESSOR,
 			useExisting: forwardRef(() => LuEstablishmentSelectInputComponent),
 			multi: true,
+		},
+		{
+			provide: ALuEstablishmentService,
+			useClass: LuEstablishmentService
+		},
+		{
+			provide: ALuLegalUnitService,
+			useClass: LuLegalUnitService
 		}
 	],
 })
 export class LuEstablishmentSelectInputComponent<D extends ILuEstablishment = ILuEstablishment, P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>>
 	extends ALuSelectInputComponent<D, P>
-	implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit {
+	implements ControlValueAccessor, ILuInputWithPicker<D>, OnInit, AfterViewInit {
 
 	byId: LuOptionComparer<D> = (option1: D, option2: D) => option1 && option2 && option1.id === option2.id;
 
@@ -43,7 +41,12 @@ export class LuEstablishmentSelectInputComponent<D extends ILuEstablishment = IL
 	@Input() appInstanceId: number;
 	@Input() operations: number[];
 
+	private _establishmentService: LuEstablishmentService;
+	private _legalUnitService: LuLegalUnitService;
+
 	isSearching = false;
+	groupByLu = true;
+
 	get sort(): string {
 		return this.isSearching ? 'name' : 'legalunit.name,name';
 	}
@@ -54,7 +57,11 @@ export class LuEstablishmentSelectInputComponent<D extends ILuEstablishment = IL
 		protected _elementRef: ElementRef,
 		protected _viewContainerRef: ViewContainerRef,
 		protected _renderer: Renderer2,
-		@Inject(LuEstablishmentSelectInputIntl) public intl: ILuEstablishmentSelectInputLabel,
+		@Inject(ALuLegalUnitService) @Optional() @SkipSelf() hostLuService: ALuLegalUnitService,
+		@Inject(ALuLegalUnitService) @Self() selfLuService: LuLegalUnitService,
+		@Inject(ALuEstablishmentService) @Optional() @SkipSelf() hostEstablishmentService: ALuEstablishmentService,
+		@Inject(ALuEstablishmentService) @Self() selfEstablishmentService: LuEstablishmentService,
+		@Inject(LuEstablishmentSelectInputIntl) public intl: ILuEstablishmentSelectInputLabel
 	) {
 		super(
 			_changeDetectorRef,
@@ -63,6 +70,21 @@ export class LuEstablishmentSelectInputComponent<D extends ILuEstablishment = IL
 			_viewContainerRef,
 			_renderer,
 		);
+		this._establishmentService = (hostEstablishmentService || selfEstablishmentService) as LuEstablishmentService;
+		this._legalUnitService = (hostLuService || selfLuService) as LuLegalUnitService;
+	}
+
+	ngOnInit() {
+		combineLatest([
+			this._legalUnitService.count(),
+			this._establishmentService.count()
+		])
+			.subscribe(([luCount, establishmentCount]) => {
+				this.groupByLu =
+					luCount > 1 &&
+					establishmentCount > 1 &&
+					luCount !== establishmentCount;
+			});
 	}
 
 	onIsSearchingChanged(isSearching: boolean) {

--- a/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.ts
+++ b/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.ts
@@ -75,16 +75,18 @@ export class LuEstablishmentSelectInputComponent<D extends ILuEstablishment = IL
 	}
 
 	ngOnInit() {
-		combineLatest([
-			this._legalUnitService.count(),
-			this._establishmentService.count()
-		])
-			.subscribe(([luCount, establishmentCount]) => {
-				this.groupByLu =
-					luCount > 1 &&
-					establishmentCount > 1 &&
-					luCount !== establishmentCount;
-			});
+		this._subs.add(
+			combineLatest([
+				this._legalUnitService.count(),
+				this._establishmentService.count()
+			])
+				.subscribe(([luCount, establishmentCount]) => {
+					this.groupByLu =
+						luCount > 1 &&
+						establishmentCount > 1 &&
+						luCount !== establishmentCount;
+				})
+		);
 	}
 
 	onIsSearchingChanged(isSearching: boolean) {

--- a/packages/ng/establishment/src/lib/service/index.ts
+++ b/packages/ng/establishment/src/lib/service/index.ts
@@ -1,2 +1,4 @@
 export * from './establishment-service.model';
 export * from './establishment.service';
+export * from './legal-unit-service.model';
+export * from './legal-unit.service';

--- a/packages/ng/establishment/src/lib/service/legal-unit-service.model.ts
+++ b/packages/ng/establishment/src/lib/service/legal-unit-service.model.ts
@@ -1,0 +1,9 @@
+import { ALuApiService, ILuApiService } from '@lucca-front/ng/api';
+import { ILuLegalUnit } from '../establishment.model';
+
+export interface ILuLegalUnitService<E extends ILuLegalUnit = ILuLegalUnit>
+	extends ILuApiService<E> { }
+
+export abstract class ALuLegalUnitService<E extends ILuLegalUnit = ILuLegalUnit>
+	extends ALuApiService<E>
+	implements ILuLegalUnitService<E> { }

--- a/packages/ng/establishment/src/lib/service/legal-unit.service.ts
+++ b/packages/ng/establishment/src/lib/service/legal-unit.service.ts
@@ -1,0 +1,31 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { LuApiV4Service } from '@lucca-front/ng/api';
+import { ILuLegalUnit } from '../establishment.model';
+
+@Injectable()
+export class LuLegalUnitService extends LuApiV4Service<ILuLegalUnit> {
+	protected _api = `/organization/structure/api/legal-units`;
+
+	protected _appInstanceId: number = null;
+	set appInstanceId(id: number) { this._appInstanceId = id; }
+	protected _operations: number[] = [];
+	set operations(ops: number[]) { this._operations = ops || []; }
+	get filters(): string[] {
+		const isScopeFiltered = this._appInstanceId && this._operations.length;
+
+		if (isScopeFiltered) {
+			const appIdFilter = `appInstanceId=${this._appInstanceId}`;
+			const operationFilter = `operations=${this._operations.join(',')}`;
+
+			return [...this._filters, appIdFilter, operationFilter];
+		}
+
+		return this._filters;
+	}
+	set filters(filters: string[]) {
+		this._filters = filters || [];
+	}
+
+	constructor(protected _http: HttpClient) { super(_http); }
+}

--- a/packages/ng/select/src/lib/input/select-input.model.ts
+++ b/packages/ng/select/src/lib/input/select-input.model.ts
@@ -123,7 +123,6 @@ implements ControlValueAccessor, ILuInputWithPicker<T>, ILuInput<T> {
 		this.destroyPopover();
 		this._subs.unsubscribe();
 		this._cleanUpSubscriptions();
-
 	}
 
 	protected _getOverlayConfig(): OverlayConfig {

--- a/stories/ng/establishment-select/establishment-select.stories.ts
+++ b/stories/ng/establishment-select/establishment-select.stories.ts
@@ -1,0 +1,39 @@
+import { Component, Input } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { LuEstablishmentSelectModule } from '@lucca-front/ng/establishment';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+@Component({
+	selector: 'establishment-select-stories',
+	template: `
+<section class="section">
+	<lu-establishment-select placeholder="Select an establishment"></lu-establishment-select>
+	<lu-establishment-select placeholder="Select an establishment" [multiple]="true"></lu-establishment-select>
+</section>
+`,
+}) class EstablishmentSelectStory {
+}
+
+export default {
+  title: 'NG/EstablishmentSelect',
+  component: EstablishmentSelectStory,
+	argTypes: {
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [EstablishmentSelectStory],
+			imports: [
+				LuEstablishmentSelectModule,
+				BrowserAnimationsModule,
+			]
+		})
+	]
+} as Meta;
+
+const template: Story<EstablishmentSelectStory> = (args: EstablishmentSelectStory) => ({
+  props: args,
+});
+
+export const basic = template.bind({});
+basic.args = {
+}


### PR DESCRIPTION
Establishment picker: do not display nor group by legal units when they are not used by the tenant.
A tenant is considered not using the legal units when there is either only one LU, only one establishment, or the same number of LUs and establishments.

### Fixed issues
- [issue #1318](https://github.com/LuccaSA/lucca-front/issues/1318) - ets-select - better display for small tenants

[HUB-3353]

[HUB-3353]: https://luccasoftware.atlassian.net/browse/HUB-3353