### PR TITLE
Fix margins for titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lucca-front",
-  "version": "6.2.2",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lucca-front",
-  "version": "6.2.2",
+  "version": "7.0.1",
   "description": "a library of usefull components for web developpement",
   "repository": {
     "type": "git",

--- a/packages/scss/src/_typo.scss
+++ b/packages/scss/src/_typo.scss
@@ -25,7 +25,9 @@ body {
 @mixin h1Styles($suffix:"") {
 	font-size: _theme("sizes.biggest.font-size") #{$suffix};
 	line-height: _theme("sizes.biggest.line-height") #{$suffix};
+	margin-top: 0;
 	margin-bottom: _theme("spacings.small") #{$suffix};
+
 	&.mod-headline {
 		font-size: _theme("sizes.headline.font-size") #{$suffix};
 		line-height: _theme("sizes.headline.line-height") #{$suffix};
@@ -35,30 +37,35 @@ body {
 @mixin h2Styles($suffix:"") {
 	font-size: _theme("sizes.bigger.font-size") #{$suffix};
 	line-height: _theme("sizes.bigger.line-height") #{$suffix};
+	margin-top: 0;
 	margin-bottom: _theme("spacings.small") #{$suffix};
 }
 
 @mixin h3Styles($suffix:"") {
 	font-size: _theme("sizes.big.font-size") #{$suffix};
 	line-height: _theme("sizes.big.line-height") #{$suffix};
+	margin-top: 0;
 	margin-bottom: _theme("spacings.small") #{$suffix};
 }
 
 @mixin h4Styles($suffix:"") {
 	font-size: _theme("sizes.standard.font-size") #{$suffix};
 	line-height: _theme("sizes.standard.line-height") #{$suffix};
+	margin-top: 0;
 	margin-bottom: _theme("spacings.small") #{$suffix};
 }
 
 @mixin h5Styles($suffix:"") {
 	font-size: _theme("sizes.small.font-size") #{$suffix};
 	line-height: _theme("sizes.small.line-height") #{$suffix};
+	margin-top: 0;
 	margin-bottom: _theme("spacings.small") #{$suffix};
 }
 
 @mixin h6Styles($suffix:"") {
 	font-size: _theme("sizes.smaller.font-size") #{$suffix};
 	line-height: _theme("sizes.smaller.line-height") #{$suffix};
+	margin-top: 0;
 	margin-bottom: _theme("spacings.small") #{$suffix};
 }
 


### PR DESCRIPTION
The top margins of titles were no longer redefined and inherited normalize.