### PR TITLE
fix(ng/material) use v12 syntax for @angular/material theming

### DIFF
--- a/packages/ng/material/src/style/main-v11.overridable.scss
+++ b/packages/ng/material/src/style/main-v11.overridable.scss
@@ -1,0 +1,15 @@
+/*
+ * @deprecated
+ * This entry point will be deprecated in LF 8.
+ * This file uses old @angular/material syntax and is not working on v12+.
+ */
+
+@import '~@angular/material/theming';
+
+@import 'theming.overridable';
+@import 'components';
+
+// CHANGE DEFAULT FONTS TO LUCCA-FRONT FONTS
+@include angular-material-typography(
+	mat-typography-config($font-family: _theme('commons.font.family', true))
+);

--- a/packages/ng/material/src/style/main-v11.scss
+++ b/packages/ng/material/src/style/main-v11.scss
@@ -1,0 +1,15 @@
+/*
+ * @deprecated
+ * This entry point will be deprecated in LF 8.
+ * This file uses old @angular/material syntax and is not working on v12+.
+ */
+
+@import '~@angular/material/theming';
+
+@import 'theming';
+@import 'components';
+
+// CHANGE DEFAULT FONTS TO LUCCA-FRONT FONTS
+@include angular-material-typography(
+	mat-typography-config($font-family: _theme('commons.font.family', true))
+);

--- a/packages/ng/material/src/style/main.overridable.scss
+++ b/packages/ng/material/src/style/main.overridable.scss
@@ -1,9 +1,11 @@
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @import 'theming.overridable';
 @import 'components';
 
 // CHANGE DEFAULT FONTS TO LUCCA-FRONT FONTS
-@include angular-material-typography(
-	mat-typography-config($font-family: _theme('commons.font.family', true))
+$lucca-front-mat-typography: mat.define-typography-config(
+  $font-family: _theme('commons.font.family', true),
 );
+
+@include mat.core($my-custom-typography);

--- a/packages/ng/material/src/style/main.scss
+++ b/packages/ng/material/src/style/main.scss
@@ -1,9 +1,11 @@
-@import '~@angular/material/theming';
+@use '~@angular/material' as mat;
 
 @import 'theming';
 @import 'components';
 
 // CHANGE DEFAULT FONTS TO LUCCA-FRONT FONTS
-@include angular-material-typography(
-	mat-typography-config($font-family: _theme('commons.font.family', true))
+$lucca-front-mat-typography: mat.define-typography-config(
+  $font-family: _theme('commons.font.family', true),
 );
+
+@include mat.core($my-custom-typography);


### PR DESCRIPTION
LF overrides @angular/material typography using [v11 syntax](https://v11.material.angular.io/guide/typography).

This PR uses [v12+ syntax](https://material.angular.io/guide/typography).

As LF has to be compatible with Angular v11 and v12, two new SCSS entry point have been added. When using Angular 11 with LF 7 : 
```scss
/* Before */
@import "~@lucca-front/ng/material/style/main.overridable.scss";

/* After*/
@import "~@lucca-front/ng/material/style/main-v11.overridable.scss";
```