### PR TITLE
feat(root): add ng-add schematic

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -187,6 +187,12 @@ gulp.task('ng:formly:style', () => {
 	.pipe(gulp.dest(`dist/ng/formly/style`));
 });
 
+gulp.task('ng:schematics:build', () => run('tsc --project packages/ng/schematics').exec());
+gulp.task('ng:schematics:collection', () => {
+	return gulp.src([`packages/ng/schematics/collection.json`])
+	.pipe(gulp.dest(`dist/ng/schematics`));
+});
+
 gulp.task(
 	'ng',
 	gulp.series(
@@ -216,5 +222,7 @@ gulp.task(
 		'ng:material:style',
 		'ng:formly:build',
 		'ng:formly:style',
+		'ng:schematics:build',
+		'ng:schematics:collection',
 	),
 );

--- a/packages/ng/root/package.json
+++ b/packages/ng/root/package.json
@@ -6,6 +6,7 @@
     "type": "git",
     "url": "git+https://github.com/LuccaSA/lucca-front.git"
   },
+  "schematics": "./schematics/collection.json",
   "license": "MIT",
   "public": true,
   "keywords": [

--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "ng-add": {
+      "description": "Add my lucca-front to the project.",
+      "factory": "./ng-add/index#ngAdd"
+    }
+  }
+}

--- a/packages/ng/schematics/ng-add/file-content.ts
+++ b/packages/ng/schematics/ng-add/file-content.ts
@@ -1,0 +1,15 @@
+export const stylesScss = `
+$noCssVar: true;
+
+@import '~@lucca-front/scss/src/main.overridable'
+	, '~@lucca-front/ng/style/main.overridable.scss'
+	, 'scss/shame';
+
+:root {
+	@include generateCSSVarsFromTheme($theme);
+}
+`;
+
+export const shameScss = `// 'My room is not messy; it is an obstable course designed to keep me fit'
+// Put here the CSS which will need a refactor, or some code that you want to see in Lucca Front.
+`;

--- a/packages/ng/schematics/ng-add/index.ts
+++ b/packages/ng/schematics/ng-add/index.ts
@@ -1,0 +1,22 @@
+import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
+import { createPalettesOverrideScss, createShameScss, updateAngularJson, updateStylesScss } from './tasks';
+
+export function ngAdd(): Rule {
+	return async (tree: Tree, context: SchematicContext) => {
+		context.addTask(new NodePackageInstallTask({ packageName: '@lucca-front/icons' }));
+		context.addTask(new NodePackageInstallTask({ packageName: '@lucca-front/scss' }));
+
+		// Add LF @import and init css vars
+		updateStylesScss(tree);
+
+		// Add empty shame file
+		createShameScss(tree);
+
+		// Copy default palette in scss/overrides/_palettes.override.scss
+		createPalettesOverrideScss(tree);
+
+		// Add stylePreprocessorOptions
+		updateAngularJson(tree);
+	};
+}

--- a/packages/ng/schematics/ng-add/tasks.ts
+++ b/packages/ng/schematics/ng-add/tasks.ts
@@ -1,0 +1,42 @@
+import { Tree } from '@angular-devkit/schematics';
+import { shameScss, stylesScss } from './file-content';
+
+const files = {
+	globalStyles: 'src/styles.scss',
+	shameStyles: 'src/scss/_shame.scss',
+	palettesOverride: 'src/scss/overrides/_palettes.override.scss',
+} as const;
+
+export function updateStylesScss(tree: Tree) {
+	const existingLength = tree.read(files.globalStyles)?.toString().length ?? 0;
+	const styleUpdateRecord = tree.beginUpdate(files.globalStyles)
+		.insertRight(existingLength, stylesScss);
+	tree.commitUpdate(styleUpdateRecord);
+}
+
+export function updateAngularJson(tree: Tree) {
+	const angularJson = JSON.parse(tree.read('angular.json')?.toString() ?? '{}');
+	const { defaultProject, projects } = angularJson;
+	projects[defaultProject].architect.build.options.stylePreprocessorOptions = {
+		includePaths: [
+			'src/scss/overrides',
+			'src/scss',
+			'node_modules/@lucca-front/ng/style/overrides',
+			'node_modules/@lucca-front/scss/src/overrides',
+			'node_modules/@lucca-front/ng/style'
+		],
+	};
+
+	tree.overwrite('angular.json', JSON.stringify(angularJson, undefined, '  ') + '\n');
+}
+
+export function createPalettesOverrideScss(tree: Tree) {
+	tree.create(
+		files.palettesOverride,
+		tree.read('node_modules/@lucca-front/scss/src/theming/_palettes.scss') ?? ''
+	);
+}
+
+export function createShameScss(tree: Tree) {
+	tree.create(files.shameStyles, shameScss);
+}

--- a/packages/ng/schematics/tsconfig.json
+++ b/packages/ng/schematics/tsconfig.json
@@ -1,0 +1,72 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "es6",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    "lib": ["es2018", "dom"],                       /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                             /* Allow javascript files to be compiled. */
+    // "checkJs": true,                             /* Report errors in .js files. */
+    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    "outDir": "../../../dist/ng/schematics",        /* Redirect output structure to the directory. */
+    "rootDir": "./",                                /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "noEmit": true,                              /* Do not emit outputs. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                                 /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                    /* Enable strict null checks. */
+    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    // "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
+    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                             /* List of folders to include type definitions from. */
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
Add support for `ng add @lucca-front/ng` in order to quickly install LF using @angular/cli.

This command :

- Adds `@lucca-front/ng`
- Adds `@lucca-front/icons`
- Adds `@lucca-front/scss`
- Updates `styles.scss` with
	```scss
	$noCssVar: true;
	@import '~@lucca-front/scss/src/main.overridable'
	  , '~@lucca-front/ng/style/main.overridable.scss'
	  , 'scss/shame';
	:root {
		@include generateCSSVarsFromTheme($theme);
	}
	```
- Adds empty `scss/_shame.scss`
- Adds `stylePreprocessorOptions` in `angular.json`
- Adds `src/scss/overrides/_palettes.override.scss` with default palette