### PR TITLE
fix(scss) remove !important on margin-bottom and color values

### DIFF
--- a/packages/scss/src/_typo.scss
+++ b/packages/scss/src/_typo.scss
@@ -18,7 +18,7 @@ body {
 }
 
 @mixin commonsTitleStyles($suffix:"") {
-	color: _color("text.dark") #{$suffix};
+	color: _color("text.dark");
 	font-weight: 600 #{$suffix};
 }
 
@@ -26,7 +26,7 @@ body {
 	font-size: _theme("sizes.biggest.font-size") #{$suffix};
 	line-height: _theme("sizes.biggest.line-height") #{$suffix};
 	margin-top: 0;
-	margin-bottom: _theme("spacings.small") #{$suffix};
+	margin-bottom: _theme("spacings.small");
 
 	&.mod-headline {
 		font-size: _theme("sizes.headline.font-size") #{$suffix};
@@ -38,35 +38,35 @@ body {
 	font-size: _theme("sizes.bigger.font-size") #{$suffix};
 	line-height: _theme("sizes.bigger.line-height") #{$suffix};
 	margin-top: 0;
-	margin-bottom: _theme("spacings.small") #{$suffix};
+	margin-bottom: _theme("spacings.small");
 }
 
 @mixin h3Styles($suffix:"") {
 	font-size: _theme("sizes.big.font-size") #{$suffix};
 	line-height: _theme("sizes.big.line-height") #{$suffix};
 	margin-top: 0;
-	margin-bottom: _theme("spacings.small") #{$suffix};
+	margin-bottom: _theme("spacings.small");
 }
 
 @mixin h4Styles($suffix:"") {
 	font-size: _theme("sizes.standard.font-size") #{$suffix};
 	line-height: _theme("sizes.standard.line-height") #{$suffix};
 	margin-top: 0;
-	margin-bottom: _theme("spacings.small") #{$suffix};
+	margin-bottom: _theme("spacings.small");
 }
 
 @mixin h5Styles($suffix:"") {
 	font-size: _theme("sizes.small.font-size") #{$suffix};
 	line-height: _theme("sizes.small.line-height") #{$suffix};
 	margin-top: 0;
-	margin-bottom: _theme("spacings.small") #{$suffix};
+	margin-bottom: _theme("spacings.small");
 }
 
 @mixin h6Styles($suffix:"") {
 	font-size: _theme("sizes.smaller.font-size") #{$suffix};
 	line-height: _theme("sizes.smaller.line-height") #{$suffix};
 	margin-top: 0;
-	margin-bottom: _theme("spacings.small") #{$suffix};
+	margin-bottom: _theme("spacings.small");
 }
 
 h1, h2, h3, h4, h5, h6 {


### PR DESCRIPTION
Custom styles should be able to override the library's original values.