### PR TITLE
[NG][FIX] Stop importing all of material CSS

### DIFF
--- a/packages/ng/material/src/style/main.overridable.scss
+++ b/packages/ng/material/src/style/main.overridable.scss
@@ -8,4 +8,4 @@ $lucca-front-mat-typography: mat.define-typography-config(
   $font-family: _theme('commons.font.family', true),
 );
 
-@include mat.core($lucca-front-mat-typography);
+@include mat.all-component-typographies($lucca-front-mat-typography);

--- a/packages/ng/material/src/style/main.scss
+++ b/packages/ng/material/src/style/main.scss
@@ -8,4 +8,4 @@ $lucca-front-mat-typography: mat.define-typography-config(
   $font-family: _theme('commons.font.family', true),
 );
 
-@include mat.core($lucca-front-mat-typography);
+@include mat.all-component-typographies($lucca-front-mat-typography);


### PR DESCRIPTION
PR #1428 used `mat.core` mixin, importing all the style from material. We replace it with the mixin `mat.all-component-typographies()` which is the correct update of the deprecated code.