### PR TITLE
Fix(scss) table mod card double border and radius

### DIFF
--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -150,6 +150,14 @@
 				padding-right: _component("table.card.padding");
 			}
 		}
+		.table-body-row {
+			background-color: transparent;
+			&:last-child {
+				.table-body-row-cell {
+					border-bottom: none;
+				}
+			}
+		}
 		.table-body-row-cell {
 			&:first-child {
 				padding-left: _component("table.card.padding");


### PR DESCRIPTION
Fixes display issues on `.table.mod-card`:
- broken border radius
- double bottom border

-----

![image](https://user-images.githubusercontent.com/5755913/133078355-67ff644d-b9f0-4e7f-b92d-cff2642308ff.png)

![image](https://user-images.githubusercontent.com/5755913/133078378-75982d98-88f9-4a8d-8e9b-4a5c49cef06d.png)
