### PR TITLE
fix(scss) switch to grey palette for disabled state

### DIFF
--- a/packages/scss/src/components/_action-icon.scss
+++ b/packages/scss/src/components/_action-icon.scss
@@ -90,7 +90,7 @@
 
 .actionIcon {
 	&[disabled], &.is-disabled, &.is-loading {
-		opacity: _theme("commons.disabled.opacity");
+		color: _color("grey", 500);
 		pointer-events: none;
 		cursor: default;
 	}

--- a/stories/qa/icon/icon.stories.html
+++ b/stories/qa/icon/icon.stories.html
@@ -36,7 +36,7 @@
 	<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">edit</span><span class="u-mask">Edit</span></button>
 	<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">trash</span><span class="u-mask">Delete</span></button>
 	<button class="actionIcon"><span aria-hidden="true" class="lucca-icon">star</span><span class="u-mask">Bookmark</span></button>
-	<button class="actionIcon"><span aria-hidden="true" class="lucca-icon u-textError">hearth</span><span class="u-mask">Like</span></button>
+	<button class="actionIcon palette-error"><span aria-hidden="true" class="lucca-icon">hearth</span><span class="u-mask">Like</span></button>
 </section>
 
 <section class="contentSection">
@@ -44,7 +44,7 @@
 	<button class="actionIcon" disabled><span aria-hidden="true" class="lucca-icon">edit</span><span class="u-mask">Edit</span></button>
 	<button class="actionIcon" disabled><span aria-hidden="true" class="lucca-icon">trash</span><span class="u-mask">Delete</span></button>
 	<button class="actionIcon" disabled><span aria-hidden="true" class="lucca-icon">star</span><span class="u-mask">Bookmark</span></button>
-	<button class="actionIcon" disabled><span aria-hidden="true" class="lucca-icon u-textError">heart</span><span class="u-mask">Like</span></button>
+	<button class="actionIcon palette-error" disabled><span aria-hidden="true" class="lucca-icon">heart</span><span class="u-mask">Like</span></button>
 </section>
 
 <!-- LOADING -->


### PR DESCRIPTION
Uses `grey 500` as color for icons on `.actionIcon[disabled]` instead of lowering the button's opacity:
- fixes display issues for `.actionIcon` in tables
- sets icon color to `grey 500` even when `.palette-*` has been added