### PR TITLE
Table.sticky.overhaul

### DIFF
--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -187,26 +187,6 @@
 			}
 		}
 	}
-
-	&[class*="mod-stickyHeader"] {
-		.table-head-row-cell {
-			background-color: _color("white");
-			position: sticky;
-			z-index: 1;
-		}
-	}
-
-	&.mod-stickyHeader {
-		.table-head-row-cell {
-			top: 0;
-		}
-	}
-
-	&.mod-stickyHeader-withBanner {
-		.table-head-row-cell {
-			top: _theme("commons.banner-height");
-		}
-	}
 }
 
 .table-body-row {
@@ -591,8 +571,11 @@
 	}
 }
 
-// Sticky columns
+/*****************
+* STICKY
+******************/
 .table {
+	//Sticky Columns
 	@mixin stickyColumnCommons {
 		width: auto;
 		min-width: 100%;
@@ -629,21 +612,25 @@
 			display: block;
 			width:  _component("table.fixed-column.sticky-shadow.width");
 			height: 100%;
-			background-size: _component("table.fixed-column.sticky-shadow.width") 100%;
-			background-repeat: no-repeat;
 			background-color: transparent;
 		}
 	}
 	[class*="mod-stickyColumn-left"] .stickyColumn-shadow-wrapper {
-		left: -10px;
+		left: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
 		&::after {
 			background-image: linear-gradient(to right, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
 		}
 	}
 	[class*="mod-stickyColumn-right"] .stickyColumn-shadow-wrapper {
-		right: -10px;
+		right: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
 		&::after {
 			background-image: linear-gradient(to left, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
+		}
+	}
+	.mod-stickyHeader-shadow .stickyColumn-shadow-wrapper {
+		top: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
+		&::after {
+			background-image: linear-gradient(to bottom, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
 		}
 	}
 
@@ -680,6 +667,78 @@
 					}
 				}
 			}
+		}
+	}
+
+	//Sticky Header
+	&[class*="mod-stickyHeader"] {
+		.table-head-row-cell {
+			background-color: _color("white");
+			position: sticky;
+			z-index: 1;
+		}
+		&.mod-stickyColumn {
+			.table-head-row-cell {
+				z-index: 5;
+				&.mod-columnSticky-shadowMask::before {
+					content: "";
+					position: absolute;
+					width: 10px;
+					left: -10px;
+					top: 0;
+					bottom: 0;
+					background: _color("white");
+					z-index: 4;
+				}
+				&:not(.mod-columnSticky-shadowMask):not([class*="mod-stickyColumn"]) + .mod-columnSticky-shadowMask::before {
+					left: auto;
+					right: -10px;
+				}
+				&[class*="mod-stickyColumn"] {
+					z-index: 6;
+					&:not(.mod-stickyColumn-shadow) {
+						z-index: 7;
+					}
+				}
+			}
+		}
+	}
+
+	.mod-stickyHeader-shadow {
+		.table-body-row-cell {
+			position: sticky;
+			top: calc(65px + 10px);
+			z-index: 4;
+			height: 0;
+			padding: 0;
+			border: 0;
+			background: transparent;
+			.stickyColumn-shadow-wrapper {
+				width: 100%;
+				height: 0;
+				border: 0;
+				&::after {
+					top: calc(65px + 10px);
+					width: 100%;
+					height: _component("table.fixed-column.sticky-shadow.width");
+					opacity: .5;
+				}
+			}
+		}
+		+ .table-body-row .table-body-row-cell {
+			border-top: 0;
+		}
+	}
+
+	&.mod-stickyHeader {
+		.table-head-row-cell {
+			top: 0;
+		}
+	}
+
+	&.mod-stickyHeader-withBanner {
+		.table-head-row-cell {
+			top: _theme("commons.banner-height");
 		}
 	}
 }

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -188,16 +188,21 @@
 		}
 	}
 
-	&.mod-stickyHeader {
+	&[class*="mod-stickyHeader"] {
 		.table-head-row-cell {
 			background-color: _color("white");
 			position: sticky;
 			z-index: 1;
+		}
+	}
+
+	&.mod-stickyHeader {
+		.table-head-row-cell {
 			top: 0;
 		}
 	}
 
-	&.mod-topBanner {
+	&.mod-stickyHeader-withBanner {
 		.table-head-row-cell {
 			top: _theme("commons.banner-height");
 		}

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -606,44 +606,44 @@
 			}
 			//columns sticky css drop shadow on scroll
 			&.mod-stickyColumn-shadow {
+				z-index: 1;
 				width: _component("table.fixed-column.sticky-shadow.width");
 				min-width: _component("table.fixed-column.sticky-shadow.width");
 				max-width: _component("table.fixed-column.sticky-shadow.width");
 				padding: 0;
-				background-size: _component("table.fixed-column.sticky-shadow.width") 100%;
-				background-repeat: no-repeat;
-				background-color: transparent;
-				z-index: 1;
-				&[class*="mod-stickyColumn-left"] {
-					background-image: linear-gradient(to right, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
-				}
-				&[class*="mod-stickyColumn-right"] {
-					background-image: linear-gradient(to left, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
-				}
+				background: transparent;
 			}
-			//mask for left stickies columns drop shadow when there is no scroll
-			&.mod-stickyColumn-shadowMask {
-				position: relative;
-				z-index: auto;
-				&::before {
-					content: "";
-					display: block;
-					width: _component("table.fixed-column.sticky-shadow.width");
-					position: absolute;
-					top: 0;
-					bottom: 0;
-					left: _component("table.fixed-column.sticky-shadow.width", true) * -1;
-					z-index: 2;
-					background: _color("white");	
-				}
-			}
-			//mask for right stickies columns drop shadow when there is no scroll
-			&:not([class*="mod-stickyColumn"]) + .mod-stickyColumn-shadowMask {
-				&::before {
-					left: auto;
-					right: _component("table.fixed-column.sticky-shadow.width", true) * -1;
-				}
-			}
+		}
+	}
+
+	.stickyColumn-shadow-wrapper {
+		position: absolute;
+		top: 0;
+		bottom: calc(#{_theme("commons.divider.width")} * -1);
+		display: flex;
+		width: _component("table.fixed-column.sticky-shadow.width");
+		border-bottom: _theme("commons.divider.width") solid _theme("commons.divider.color");
+		&::after {
+			content: "";
+			position: sticky;
+			display: block;
+			width:  _component("table.fixed-column.sticky-shadow.width");
+			height: 100%;
+			background-size: _component("table.fixed-column.sticky-shadow.width") 100%;
+			background-repeat: no-repeat;
+			background-color: transparent;
+		}
+	}
+	[class*="mod-stickyColumn-left"] .stickyColumn-shadow-wrapper {
+		left: -10px;
+		&::after {
+			background-image: linear-gradient(to right, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
+		}
+	}
+	[class*="mod-stickyColumn-right"] .stickyColumn-shadow-wrapper {
+		right: -10px;
+		&::after {
+			background-image: linear-gradient(to left, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
 		}
 	}
 
@@ -660,7 +660,6 @@
 		}
 	}
 
-
 	//Sticky column offset
 	&[class*="mod-stickyColumn"] {
 		.table-head-row-cell,
@@ -668,9 +667,17 @@
 			@for $i from 0 through _component("table.sticky-column.max-offset", true) {
 				&.mod-stickyColumn-leftOffset#{$i} {
 					left: $i * 1rem;
+					&.mod-stickyColumn-shadow,
+					.stickyColumn-shadow-wrapper::after {
+						left: calc(#{$i} * 1rem + #{_component("table.fixed-column.sticky-shadow.width")});
+					}
 				}
 				&.mod-stickyColumn-rightOffset#{$i} {
 					right: $i * 1rem;
+					&.mod-stickyColumn-shadow,
+					.stickyColumn-shadow-wrapper::after {
+						right: calc(#{$i} * 1rem + #{_component("table.fixed-column.sticky-shadow.width")});
+					}
 				}
 			}
 		}

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -588,19 +588,19 @@
 
 // Sticky columns
 .table {
-	@mixin columnStickyCommons {
+	@mixin stickyColumnCommons {
 		width: auto;
 		min-width: 100%;
 		background-color: _color("white");
 		.table-head-row-cell,
 		.table-body-row-cell {
-			&[class*="mod-columnSticky-"] {
+			&[class*="mod-stickyColumn-"] {
 				position: sticky;
 				background-color: _color("white");
 				z-index: 3;
 			}
 			//columns sticky css drop shadow on scroll
-			&.mod-columnSticky-shadow {
+			&.mod-stickyColumn-shadow {
 				width: _component("table.fixed-column.sticky-shadow.width");
 				min-width: _component("table.fixed-column.sticky-shadow.width");
 				max-width: _component("table.fixed-column.sticky-shadow.width");
@@ -609,15 +609,15 @@
 				background-repeat: no-repeat;
 				background-color: transparent;
 				z-index: 1;
-				&[class*="mod-columnSticky-left"] {
+				&[class*="mod-stickyColumn-left"] {
 					background-image: linear-gradient(to right, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
 				}
-				&[class*="mod-columnSticky-right"] {
+				&[class*="mod-stickyColumn-right"] {
 					background-image: linear-gradient(to left, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
 				}
 			}
 			//mask for left stickies columns drop shadow when there is no scroll
-			&.mod-columnSticky-shadowMask {
+			&.mod-stickyColumn-shadowMask {
 				position: relative;
 				z-index: auto;
 				&::before {
@@ -633,7 +633,7 @@
 				}
 			}
 			//mask for right stickies columns drop shadow when there is no scroll
-			&:not([class*="mod-columnSticky"]) + .mod-columnSticky-shadowMask {
+			&:not([class*="mod-stickyColumn"]) + .mod-stickyColumn-shadowMask {
 				&::before {
 					left: auto;
 					right: _component("table.fixed-column.sticky-shadow.width", true) * -1;
@@ -643,28 +643,28 @@
 	}
 
 	//Sticky commons include, globaly and by BP
-	&.mod-columnSticky {
-		@include columnStickyCommons;
+	&.mod-stickyColumn {
+		@include stickyColumnCommons;
 	}
 
 	@each $bp-name, $bp-obj in _getMap("breakpoints") {
 		@media only screen and (min-width: map-get($bp-obj, breakAt)) {
-			&.mod-columnSticky-#{$bp-name} {
-				@include columnStickyCommons;
+			&.mod-stickyColumn-#{$bp-name} {
+				@include stickyColumnCommons;
 			}
 		}
 	}
 
 
 	//Sticky column offset
-	&[class*="mod-columnSticky"] {
+	&[class*="mod-stickyColumn"] {
 		.table-head-row-cell,
 		.table-body-row-cell {
 			@for $i from 0 through _component("table.fixed-column.max-col-width", true) {
-				&.mod-columnSticky-leftOffset#{$i} {
+				&.mod-stickyColumn-leftOffset#{$i} {
 					left: $i * 1rem;
 				}
-				&.mod-columnSticky-rightOffset#{$i} {
+				&.mod-stickyColumn-rightOffset#{$i} {
 					right: $i * 1rem;
 				}
 			}

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -596,41 +596,53 @@
 				padding: 0;
 				background: transparent;
 			}
+			.stickyColumn-shadow-wrapper {
+				display: flex;
+			}
 		}
-	}
+	
+		[class*="mod-stickyColumn-left"] .stickyColumn-shadow-wrapper {
+			left: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
+			&::after {
+				background-image: linear-gradient(to right, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
+			}
+		}
+	
+		[class*="mod-stickyColumn-right"] .stickyColumn-shadow-wrapper {
+			right: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
+			&::after {
+				background-image: linear-gradient(to left, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
+			}
+		}
 
-	.stickyColumn-shadow-wrapper {
-		position: absolute;
-		top: 0;
-		bottom: calc(#{_theme("commons.divider.width")} * -1);
-		display: flex;
-		width: _component("table.fixed-column.sticky-shadow.width");
-		border-bottom: _theme("commons.divider.width") solid _theme("commons.divider.color");
-		&::after {
-			content: "";
-			position: sticky;
-			display: block;
-			width:  _component("table.fixed-column.sticky-shadow.width");
-			height: 100%;
-			background-color: transparent;
-		}
-	}
-	[class*="mod-stickyColumn-left"] .stickyColumn-shadow-wrapper {
-		left: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
-		&::after {
-			background-image: linear-gradient(to right, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
-		}
-	}
-	[class*="mod-stickyColumn-right"] .stickyColumn-shadow-wrapper {
-		right: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
-		&::after {
-			background-image: linear-gradient(to left, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
-		}
-	}
-	.mod-stickyHeader-shadow .stickyColumn-shadow-wrapper {
-		top: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
-		&::after {
-			background-image: linear-gradient(to bottom, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
+		&[class*="mod-stickyHeader"] {
+			//Sticky Header + sticky column
+			&[class*="mod-stickyColumn"] {
+				.table-head-row-cell {	
+					&[class*="mod-stickyColumn"] {
+						z-index: 6;
+						&:not(.mod-stickyColumn-shadow) {
+							z-index: 7;
+						}
+					}
+					//shadowMask to fill void in header due to stickyColumn drop shadow tech
+					&.mod-columnSticky-shadowMask::before {
+						content: "";
+						position: absolute;
+						left: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
+						top: 0;
+						bottom: 0;
+						z-index: 4;
+						width: _component("table.fixed-column.sticky-shadow.width");
+						background: _color("white");
+					}
+					&:not(.mod-columnSticky-shadowMask):not([class*="mod-stickyColumn"]) + .mod-columnSticky-shadowMask::before {
+						left: auto;
+						right: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
+					}
+					
+				}
+			}
 		}
 	}
 
@@ -669,62 +681,73 @@
 			}
 		}
 	}
+	
+	//Sticky drop shadow
+	[class*="sticky"][class*="shadow-wrapper"] {
+		position: absolute;
+		top: 0;
+		bottom: calc(#{_theme("commons.divider.width")} * -1);
+		display: flex;
+		width: _component("table.fixed-column.sticky-shadow.width");
+		border-bottom: _theme("commons.divider.width") solid _theme("commons.divider.color");
+		&::after {
+			content: "";
+			position: sticky;
+			display: block;
+			width:  _component("table.fixed-column.sticky-shadow.width");
+			height: 100%;
+			background-color: transparent;
+		}
+	}
+
+	.mod-stickyColumn-shadow {
+		width: 0;
+		position: static;
+	}
 
 	//Sticky Header
 	&[class*="mod-stickyHeader"] {
 		.table-head-row-cell {
 			background-color: _color("white");
 			position: sticky;
-			z-index: 1;
+			z-index: 5;
 		}
-		&.mod-stickyColumn {
-			.table-head-row-cell {
-				z-index: 5;
-				&.mod-columnSticky-shadowMask::before {
-					content: "";
-					position: absolute;
-					width: 10px;
-					left: -10px;
-					top: 0;
-					bottom: 0;
-					background: _color("white");
-					z-index: 4;
-				}
-				&:not(.mod-columnSticky-shadowMask):not([class*="mod-stickyColumn"]) + .mod-columnSticky-shadowMask::before {
-					left: auto;
-					right: -10px;
-				}
-				&[class*="mod-stickyColumn"] {
-					z-index: 6;
-					&:not(.mod-stickyColumn-shadow) {
-						z-index: 7;
-					}
+		//Sticky header + sticky column at breakpoint
+		@each $bp-name, $bp-obj in _getMap("breakpoints") {
+			@media only screen and (max-width: map-get($bp-obj, breakAt)) {
+				&.mod-stickyColumn-#{$bp-name} .table-head-row-cell {
+					left: auto !important;
+					right: auto !important;
 				}
 			}
 		}
 	}
 
+	//header drop shadow only when sticky
 	.mod-stickyHeader-shadow {
 		.table-body-row-cell {
 			position: sticky;
-			top: calc(65px + 10px);
+			top: calc(var(--sticky-header-shadow-offset-top) + #{_component("table.fixed-column.sticky-shadow.width")});
 			z-index: 4;
 			height: 0;
 			padding: 0;
 			border: 0;
 			background: transparent;
-			.stickyColumn-shadow-wrapper {
+		}
+		.stickyHeader-shadow-wrapper {
+			top: calc(#{_component("table.fixed-column.sticky-shadow.width")} * -1);
+			width: 100%;
+			height: 0;
+			border: 0;
+			&::after {
+				top: calc(var(--sticky-header-shadow-offset-top) + #{_component("table.fixed-column.sticky-shadow.width")});
 				width: 100%;
-				height: 0;
-				border: 0;
-				&::after {
-					top: calc(65px + 10px);
-					width: 100%;
-					height: _component("table.fixed-column.sticky-shadow.width");
-					opacity: .5;
-				}
+				height: _component("table.fixed-column.sticky-shadow.width");
+				background-image: linear-gradient(to bottom, transparentize(_component("table.fixed-column.sticky-shadow.color", true), .75), transparentize(_component("table.fixed-column.sticky-shadow.color", true), 1));
+				opacity: .5;
 			}
 		}
+		
 		+ .table-body-row .table-body-row-cell {
 			border-top: 0;
 		}
@@ -739,6 +762,12 @@
 	&.mod-stickyHeader-withBanner {
 		.table-head-row-cell {
 			top: _theme("commons.banner-height");
+		}
+		.mod-stickyHeader-shadow .table-body-row-cell {
+			top: calc(#{_theme("commons.banner-height")} + var(--sticky-header-shadow-offset-top) + #{_component("table.fixed-column.sticky-shadow.width")});
+			.stickyHeader-shadow-wrapper::after {
+				top: calc(#{_theme("commons.banner-height")} + var(--sticky-header-shadow-offset-top) + #{_component("table.fixed-column.sticky-shadow.width")});
+			}
 		}
 	}
 }

--- a/packages/scss/src/components/_table.scss
+++ b/packages/scss/src/components/_table.scss
@@ -660,7 +660,7 @@
 	&[class*="mod-stickyColumn"] {
 		.table-head-row-cell,
 		.table-body-row-cell {
-			@for $i from 0 through _component("table.fixed-column.max-col-width", true) {
+			@for $i from 0 through _component("table.sticky-column.max-offset", true) {
 				&.mod-stickyColumn-leftOffset#{$i} {
 					left: $i * 1rem;
 				}

--- a/packages/scss/src/theming/components/_table.theme.scss
+++ b/packages/scss/src/theming/components/_table.theme.scss
@@ -18,8 +18,11 @@ $table: (
 		max-col-width: 20,
 		sticky-shadow: (
 			width: .625rem,
-			color: _color("grey", "800", true)
-		)
+			color: _color("grey", "800", true),
+		),
+	),
+	sticky-column: (
+		max-offset: 50
 	)
 );
 

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -709,7 +709,7 @@
 <!-- Sticky columns with shadow-->
 <section class="contentSection">
 	<h2>Sticky columns with shadow on overflow</h2>
-	<table class="table mod-layoutFixed mod-stickyColumn">
+	<table class="table mod-layoutFixed mod-stickyColumn mod-stickyHeader">
 		<thead class="table-head">
 			<tr class="table-head-row">
 				<th class="table-head-row-cell mod-layoutFixed-8 mod-stickyColumn-leftOffset0">Head cell</th>
@@ -718,12 +718,12 @@
 				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
-				<th class="table-head-row-cell">Head cell</th>
-				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
 				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</th>
@@ -731,6 +731,11 @@
 			</tr>
 		</thead>
 		<tbody class="table-body">
+			<tr class="table-body-row mod-stickyHeader-shadow">
+				<td class="table-body-row-cell" style="--offsetTop: 65px;" colspan="12" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+			</tr>
 			<tr class="table-body-row">
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
@@ -738,12 +743,12 @@
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</td>
-				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</td>
@@ -756,12 +761,12 @@
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</td>
-				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</td>
@@ -774,12 +779,12 @@
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</td>
-				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
 					<div class="stickyColumn-shadow-wrapper"></div>
 				</td>
@@ -787,6 +792,7 @@
 			</tr>
 		</tbody>
 	</table>
+	<div style="height: 550px"></div>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -583,7 +583,7 @@
 			</tr>
 		</tbody>
 	</table>
-	<em><b>Tip:</b> You can align on top with a <code class="code">mod-stickyHeader</code> class or <code class="code">mod-stickyHeader mod-topBanner</code>.</em>
+	<em><b>Tip:</b> You can align on top with a <code class="code">mod-stickyHeader</code> class or <code class="code">mod-stickyHeader-withBanner</code>.</em>
 </section>
 
 <!-- Fixed columns width -->

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -648,126 +648,126 @@
 <!-- Sticky columns -->
 <section class="contentSection">
 	<h2>Sticky columns</h2>
-	<table class="table mod-layoutFixed mod-columnSticky">
+	<table class="table mod-layoutFixed mod-stickyColumn">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-8 mod-columnSticky-leftOffset0">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-7 mod-columnSticky-leftOffset8">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-5 mod-columnSticky-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-8 mod-stickyColumn-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-7 mod-stickyColumn-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-leftOffset15">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-5 mod-columnSticky-rightOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-rightOffset0">Head cell</th>
 			</tr>
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">fixed width: 8 // offset 0</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">fixed width: 7 // offset 8</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">fixed width: 5 // offset 8 + 7 = 15</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">fixed width: 8 // offset 0</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">fixed width: 7 // offset 8</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">fixed width: 5 // offset 8 + 7 = 15</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">fixed width: 5 // offset 0</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">fixed width: 5 // offset 0</td>
 			</tr>
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 		</tbody>
 	</table>
 	
-	<em><b>Tip:</b> each cell must have a class <code class="code">.mod-columnSticky-leftOffset<strong>X</strong></code> or <code class="code">.mod-columnSticky-righOffset<strong>X</strong></code> with <strong>X</strong> equal to the cumulative size of previous cells in the specified axis (from left or from right)</em>
+	<em><b>Tip:</b> each cell must have a class <code class="code">.mod-stickyColumn-leftOffset<strong>X</strong></code> or <code class="code">.mod-stickyColumn-righOffset<strong>X</strong></code> with <strong>X</strong> equal to the cumulative size of previous cells in the specified axis (from left or from right)</em>
 </section>
 
 <!-- Sticky columns with shadow-->
 <section class="contentSection">
 	<h2>Sticky columns with shadow on overflow</h2>
-	<table class="table mod-layoutFixed mod-columnSticky">
+	<table class="table mod-layoutFixed mod-stickyColumn">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-8 mod-columnSticky-leftOffset0">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-7 mod-columnSticky-leftOffset8">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-5 mod-columnSticky-leftOffset15">Head cell</th>
-				<th class="table-head-row-cell mod-columnSticky-leftOffset20 mod-columnSticky-shadow" role="presentation"></th>
-				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-8 mod-stickyColumn-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-7 mod-stickyColumn-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></th>
+				<th class="table-head-row-cell mod-stickyColumn-shadowMask">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
-				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
-				<th class="table-head-row-cell mod-columnSticky-rightOffset5 mod-columnSticky-shadow" role="presentation"></th>
-				<th class="table-head-row-cell mod-layoutFixed-5 mod-columnSticky-rightOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-shadowMask">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-rightOffset0">Head cell</th>
 			</tr>
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset20 mod-columnSticky-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset5 mod-columnSticky-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset20 mod-columnSticky-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset5 mod-columnSticky-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
-				<td class="table-body-row-cell mod-columnSticky-leftOffset0">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset8">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset15">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-leftOffset20 mod-columnSticky-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset5 mod-columnSticky-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-columnSticky-rightOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 		</tbody>
 	</table>

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -715,14 +715,18 @@
 				<th class="table-head-row-cell mod-layoutFixed-8 mod-stickyColumn-leftOffset0">Head cell</th>
 				<th class="table-head-row-cell mod-layoutFixed-7 mod-stickyColumn-leftOffset8">Head cell</th>
 				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-leftOffset15">Head cell</th>
-				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></th>
-				<th class="table-head-row-cell mod-stickyColumn-shadowMask">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
-				<th class="table-head-row-cell mod-stickyColumn-shadowMask">Head cell</th>
-				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
 				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-rightOffset0">Head cell</th>
 			</tr>
 		</thead>
@@ -731,42 +735,54 @@
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell ">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
 				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell ">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
 				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 			<tr class="table-body-row">
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
 				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation"></td>
-				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell ">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
-				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation"></td>
+				<td class="table-body-row-cell ">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
 				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
 			</tr>
 		</tbody>

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -584,8 +584,70 @@
 		</tbody>
 	</table>
 	<em><b>Tip:</b> You can align on top with a <code class="code">mod-stickyHeader</code> class or <code class="code">mod-stickyHeader-withBanner</code>.</em>
+	<h2>Sticky Header with shadow on scroll</h2>
+	<table class="table mod-stickyHeader">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row mod-stickyHeader-shadow" style="--sticky-header-shadow-offset-top: 49px;">
+				<td class="table-body-row-cell" colspan="3" role="presentation">
+					<div class="stickyHeader-shadow-wrapper"></div>
+				</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	<em><b>Tip: </b>The value of <code class="code">--sticky-header-shadow-offset-top</code> on <code class="code">.table-body-row.mod-stickyHeader-shadow</code> must be equal to the table header height</em>
 </section>
-
 <!-- Fixed columns width -->
 <section class="contentSection">
 	<h2>Fixed layout columns</h2>
@@ -616,11 +678,11 @@
 		</tbody>
 	</table>
 	<h2 class="u-marginTopStandard">Fixed layout columns starting at breakpoint</h2>
-	<table class="table mod-layoutFixed-s">
+	<table class="table mod-layoutFixed-xs">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell mod-layoutFixed-s8">Head cell</th>
-				<th class="table-head-row-cell mod-layoutFixed-s12">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs12">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
@@ -644,7 +706,6 @@
 	</table>
 	<em><b>Tip:</b> the numeric value used in the class will be calculated in rem. Ex <code class="code">.mod-layoutFixed-<strong>8</strong></code> means a cell width of <strong>8</strong> rem</em>
 </section>
-
 <!-- Sticky columns -->
 <section class="contentSection">
 	<h2>Sticky columns</h2>
@@ -702,13 +763,225 @@
 			</tr>
 		</tbody>
 	</table>
-	
+	<h2 class="u-marginTopStandard">Sticky columns starting at breakpoint</h2>
+	<table class="table mod-layoutFixed-xs mod-stickyColumn-xs">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-xs8 mod-stickyColumn-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs7 mod-stickyColumn-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs5 mod-stickyColumn-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs5 mod-stickyColumn-rightOffset0">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">fixed width: 8 // offset 0</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">fixed width: 7 // offset 8</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">fixed width: 5 // offset 8 + 7 = 15</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">fixed width: 5 // offset 0</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
 	<em><b>Tip:</b> each cell must have a class <code class="code">.mod-stickyColumn-leftOffset<strong>X</strong></code> or <code class="code">.mod-stickyColumn-righOffset<strong>X</strong></code> with <strong>X</strong> equal to the cumulative size of previous cells in the specified axis (from left or from right)</em>
 </section>
 
 <!-- Sticky columns with shadow-->
 <section class="contentSection">
 	<h2>Sticky columns with shadow on overflow</h2>
+	<table class="table mod-layoutFixed mod-stickyColumn">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-8 mod-stickyColumn-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-7 mod-stickyColumn-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
+				<th class="table-head-row-cell mod-layoutFixed-5 mod-stickyColumn-rightOffset0">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	<h2 class="u-marginTopStandard">Sticky Column with shadow on overflow, starting at breakpoint</h2>
+	<table class="table mod-layoutFixed-xs mod-stickyColumn-xs">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-xs8 mod-stickyColumn-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs7 mod-stickyColumn-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs5 mod-stickyColumn-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs5 mod-stickyColumn-rightOffset0">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	<h2 class="u-marginTopStandard">Sticky header + sticky column, with shadow on overflow</h2>
 	<table class="table mod-layoutFixed mod-stickyColumn mod-stickyHeader">
 		<thead class="table-head">
 			<tr class="table-head-row">
@@ -732,8 +1005,8 @@
 		</thead>
 		<tbody class="table-body">
 			<tr class="table-body-row mod-stickyHeader-shadow">
-				<td class="table-body-row-cell" style="--offsetTop: 65px;" colspan="12" role="presentation">
-					<div class="stickyColumn-shadow-wrapper"></div>
+				<td class="table-body-row-cell" style="--sticky-header-shadow-offset-top: 65px;" colspan="12" role="presentation">
+					<div class="stickyHeader-shadow-wrapper"></div>
 				</td>
 			</tr>
 			<tr class="table-body-row">
@@ -792,7 +1065,91 @@
 			</tr>
 		</tbody>
 	</table>
-	<div style="height: 550px"></div>
+	<h2 class="u-marginTopStandard">Sticky header + sticky column starting at breakpoint, with shadow on overflow</h2>
+	<table class="table mod-layoutFixed-xs mod-stickyColumn-xs mod-stickyHeader">
+		<thead class="table-head">
+			<tr class="table-head-row">
+				<th class="table-head-row-cell mod-layoutFixed-xs8 mod-stickyColumn-leftOffset0">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs7 mod-stickyColumn-leftOffset8">Head cell</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs5 mod-stickyColumn-leftOffset15">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell">Head cell</th>
+				<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+				<th class="table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</th>
+				<th class="table-head-row-cell mod-layoutFixed-xs5 mod-stickyColumn-rightOffset0">Head cell</th>
+			</tr>
+		</thead>
+		<tbody class="table-body">
+			<tr class="table-body-row mod-stickyHeader-shadow">
+				<td class="table-body-row-cell" style="--sticky-header-shadow-offset-top: 65px;" colspan="12" role="presentation">
+					<div class="stickyHeader-shadow-wrapper"></div>
+				</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+			<tr class="table-body-row">
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset0">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset8">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset15">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell">Body cell</td>
+				<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow" role="presentation">
+					<div class="stickyColumn-shadow-wrapper"></div>
+				</td>
+				<td class="table-body-row-cell mod-stickyColumn-rightOffset0">Body cell</td>
+			</tr>
+		</tbody>
+	</table>
+	<div style="height: 600px"><!-- Juste there for easier sticky tests on Y axis --></div>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->


### PR DESCRIPTION
Naming consistency :
- rename mod-columnSticky to mod-stickyColumn
- rename mod-topBanner to mod-stickyHeader-withBanner

Feat :
- Add mod-stickyHeader-shadow for automatic dropshadow on scroll
- Make mod-stickyColumn and mod-stickyHeader to be fully compatible together, with or without drop shadow, with or without breakpoint management

![table](https://user-images.githubusercontent.com/65592565/133800504-75a12b7b-fffc-466a-ba09-9cbe947a15ef.gif)


