### PR TITLE
[add] qualification-select-input - HUB-3792

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -806,6 +806,46 @@
         }
       }
     },
+    "qualification": {
+      "projectType": "library",
+      "root": "packages/ng/qualification",
+      "sourceRoot": "packages/ng/qualification/src",
+      "prefix": "lu",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:ng-packagr",
+          "options": {
+            "tsConfig": "packages/ng/qualification/tsconfig.lib.json",
+            "project": "packages/ng/qualification/ng-package.json"
+          },
+          "configurations": {
+            "production": {
+              "tsConfig": "packages/ng/qualification/tsconfig.lib.prod.json"
+            }
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "packages/ng/qualification/src/test.ts",
+            "tsConfig": "packages/ng/qualification/tsconfig.spec.json",
+            "karmaConfig": "packages/ng/qualification/karma.conf.js"
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "packages/ng/qualification/tsconfig.lib.json",
+              "packages/ng/qualification/tsconfig.spec.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
+          }
+        }
+      }
+    },
     "user": {
       "projectType": "library",
       "root": "packages/ng/user",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,6 +173,7 @@ gulp.task('ng:date:build', () => run('ng build date --prod').exec());
 gulp.task('ng:api:build', () => run('ng build api --prod').exec());
 gulp.task('ng:department:build', () => run('ng build department --prod').exec());
 gulp.task('ng:establishment:build', () => run('ng build establishment --prod').exec());
+gulp.task('ng:qualification:build', () => run('ng build qualification --prod').exec());
 gulp.task('ng:user:build', () => run('ng build user --prod').exec());
 
 gulp.task('ng:material:build', () => run('ng build material --prod').exec());
@@ -219,7 +220,7 @@ gulp.task(
 		),
 		gulp.parallel('ng:option:build','ng:select:build'),
 		gulp.parallel('ng:api:build','ng:date:build'),
-		gulp.parallel('ng:user:build','ng:department:build','ng:establishment:build'),
+		gulp.parallel('ng:user:build','ng:department:build','ng:establishment:build','ng:qualification:build'),
 		'ng:formly:build',
 		'ng:formly:style',
 	),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "lucca-front",
 	"version": "7.0.6",
-	"description": "a library of usefull components for web developpement",
+	"description": "a library of useful components for web developpement",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/LuccaSA/lucca-front.git"

--- a/packages/ng/formly/ng-package.json
+++ b/packages/ng/formly/ng-package.json
@@ -13,7 +13,8 @@
       "@lucca-front/ng/date": "@lucca-front/ng/date",
       "@lucca-front/ng/user": "@lucca-front/ng/user",
       "@lucca-front/ng/department": "@lucca-front/ng/department",
-      "@lucca-front/ng/establishment": "@lucca-front/ng/establishment"
+      "@lucca-front/ng/establishment": "@lucca-front/ng/establishment",
+      "@lucca-front/ng/qualification": "@lucca-front/ng/qualification"
     }
   }
 }

--- a/packages/ng/formly/src/lib/formly.config.ts
+++ b/packages/ng/formly/src/lib/formly.config.ts
@@ -11,6 +11,7 @@ import {
 	LuFormlyFieldEstablishment,
 	LuFormlyFieldCheckbox,
 	LuFormlyFieldRadios,
+	LuFormlyFieldQualification
 } from './types/index';
 // wrappers
 import {
@@ -75,6 +76,11 @@ export const LU_FORMLY_CONFIG = {
 		{
 			name: 'establishment',
 			component: LuFormlyFieldEstablishment,
+			wrappers: ['textfield-layout']
+		},
+		{
+			name: 'qualification',
+			component: LuFormlyFieldQualification,
 			wrappers: ['textfield-layout']
 		}
 	],

--- a/packages/ng/formly/src/lib/formly.module.ts
+++ b/packages/ng/formly/src/lib/formly.module.ts
@@ -11,6 +11,7 @@ import { LuOptionModule } from '@lucca-front/ng/option';
 import { LuApiModule } from '@lucca-front/ng/api';
 import { LuDepartmentModule } from '@lucca-front/ng/department';
 import { LuEstablishmentModule } from '@lucca-front/ng/establishment';
+import { LuQualificationModule } from '@lucca-front/ng/qualification';
 
 import {
 	LuFormlyFieldInput,
@@ -73,6 +74,7 @@ export const LuFormlyChild = FormlyModule.forChild(LU_FORMLY_CONFIG);
 		LuApiModule,
 		LuDepartmentModule,
 		LuEstablishmentModule,
+		LuQualificationModule,
 		LuDateModule,
 
 		// FormlyModule.forChild(LU_FORMLY_CONFIG),

--- a/packages/ng/formly/src/lib/types/index.ts
+++ b/packages/ng/formly/src/lib/types/index.ts
@@ -8,3 +8,4 @@ export * from './radios';
 export * from './select';
 export * from './textarea';
 export * from './user';
+export * from './qualification';

--- a/packages/ng/formly/src/lib/types/qualification.html
+++ b/packages/ng/formly/src/lib/types/qualification.html
@@ -1,5 +1,4 @@
-<!-- TODO -->
-<!-- <lu-qualification-select
+<lu-qualification-select
 	class="textfield-input"
 	[formControl]="formControl"
 	[formlyAttributes]="field"
@@ -8,9 +7,7 @@
 	(blur)="blur()"
 	[placeholder]="to.placeholder"
 	[filters]="to.filters"
-	[appInstanceId]="to.appInstanceId"
-	[operations]="to.operations"
 >
-</lu-qualification-select> -->
+</lu-qualification-select> 
 <span class="textfield-label">{{ to.label }}</span>
 

--- a/packages/ng/formly/src/lib/types/qualification.html
+++ b/packages/ng/formly/src/lib/types/qualification.html
@@ -1,0 +1,16 @@
+<!-- TODO -->
+<!-- <lu-qualification-select
+	class="textfield-input"
+	[formControl]="formControl"
+	[formlyAttributes]="field"
+	[multiple]="to.multiple"
+	(focus)="focus()"
+	(blur)="blur()"
+	[placeholder]="to.placeholder"
+	[filters]="to.filters"
+	[appInstanceId]="to.appInstanceId"
+	[operations]="to.operations"
+>
+</lu-qualification-select> -->
+<span class="textfield-label">{{ to.label }}</span>
+

--- a/packages/ng/formly/src/lib/types/qualification.ts
+++ b/packages/ng/formly/src/lib/types/qualification.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { FieldType } from '@ngx-formly/core';
+
+@Component({
+	selector: 'lu-formly-field-qualification',
+	styleUrls: ['formly-field.common.scss', 'select.scss'],
+	templateUrl: './establishment.html'
+})
+export class LuFormlyFieldQualification extends FieldType {
+	readonly formControl: FormControl;
+	focus() {
+		this.to._isFocused = true;
+	}
+	blur() {
+		this.to._isFocused = false;
+	}
+}

--- a/packages/ng/formly/tsconfig.lib.json
+++ b/packages/ng/formly/tsconfig.lib.json
@@ -25,6 +25,9 @@
       "@lucca-front/ng/establishment": [
         "./dist/ng/establishment"
       ],
+      "@lucca-front/ng/qualification": [
+        "./dist/ng/qualification"
+      ],
       "@lucca-front/ng/date": [
         "./dist/ng/date"
       ],

--- a/packages/ng/qualification/karma.conf.js
+++ b/packages/ng/qualification/karma.conf.js
@@ -1,0 +1,44 @@
+// Karma configuration file, see link for more information
+// https://karma-runner.github.io/1.0/config/configuration-file.html
+
+module.exports = function (config) {
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage'),
+      require('@angular-devkit/build-angular/plugins/karma')
+    ],
+    client: {
+      jasmine: {
+        // you can add configuration options for Jasmine here
+        // the possible options are listed at https://jasmine.github.io/api/edge/Configuration.html
+        // for example, you can disable the random execution with `random: false`
+        // or set a specific seed with `seed: 4321`
+      },
+      clearContext: false // leave Jasmine Spec Runner output visible in browser
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true // removes the duplicated traces
+    },
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../../../coverage/qualification'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: true,
+    browsers: ['Chrome'],
+    singleRun: false,
+    restartOnFileChange: true
+  });
+};

--- a/packages/ng/qualification/ng-package.json
+++ b/packages/ng/qualification/ng-package.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../../dist/ng/qualification",
+  "lib": {
+    "entryFile": "src/public-api.ts",
+    "styleIncludePaths": [
+      "../root/src/style",
+      "../root/src/style/overrides"
+    ],
+    "umdModuleIds": {
+      "@lucca-front/ng/input": "@lucca-front/ng/input",
+      "@lucca-front/ng/core": "@lucca-front/ng/core",
+      "@lucca-front/ng/api": "@lucca-front/ng/api",
+      "@lucca-front/ng/option": "@lucca-front/ng/option",
+      "@lucca-front/ng/select": "@lucca-front/ng/select"
+    }
+  }
+}

--- a/packages/ng/qualification/package.json
+++ b/packages/ng/qualification/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@lucca-front/ng/qualification"
+}

--- a/packages/ng/qualification/src/index.ts
+++ b/packages/ng/qualification/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/index';

--- a/packages/ng/qualification/src/lib/index.ts
+++ b/packages/ng/qualification/src/lib/index.ts
@@ -1,0 +1,2 @@
+export * from './qualification.module';
+export * from './qualification.model';

--- a/packages/ng/qualification/src/lib/index.ts
+++ b/packages/ng/qualification/src/lib/index.ts
@@ -1,2 +1,4 @@
 export * from './qualification.module';
 export * from './qualification.model';
+
+export * from './select/index';

--- a/packages/ng/qualification/src/lib/qualification.model.ts
+++ b/packages/ng/qualification/src/lib/qualification.model.ts
@@ -1,3 +1,10 @@
-export interface IQualification {
+import { ILuApiItem } from '@lucca-front/ng/api';
 
+export interface ILuJob extends ILuApiItem { }
+
+export interface ILuJobLevel extends ILuApiItem { }
+
+export interface ILuQualification extends ILuApiItem {
+	job: ILuJob;
+	level: ILuJobLevel;
 }

--- a/packages/ng/qualification/src/lib/qualification.model.ts
+++ b/packages/ng/qualification/src/lib/qualification.model.ts
@@ -1,0 +1,3 @@
+export interface IQualification {
+
+}

--- a/packages/ng/qualification/src/lib/qualification.module.ts
+++ b/packages/ng/qualification/src/lib/qualification.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+
+@NgModule({
+	imports: [],
+	exports: [],
+})
+export class LuQualificationModule { }

--- a/packages/ng/qualification/src/lib/qualification.module.ts
+++ b/packages/ng/qualification/src/lib/qualification.module.ts
@@ -1,7 +1,12 @@
 import { NgModule } from '@angular/core';
+import { LuQualificationSelectModule } from './select/qualification-select.module';
 
 @NgModule({
-	imports: [],
-	exports: [],
+	imports: [
+		LuQualificationSelectModule
+	],
+	exports: [
+		LuQualificationSelectModule
+	],
 })
 export class LuQualificationModule { }

--- a/packages/ng/qualification/src/lib/select/index.ts
+++ b/packages/ng/qualification/src/lib/select/index.ts
@@ -1,0 +1,2 @@
+export * from './input/index';
+export * from './qualification-select.module';

--- a/packages/ng/qualification/src/lib/select/input/index.ts
+++ b/packages/ng/qualification/src/lib/select/input/index.ts
@@ -1,0 +1,5 @@
+export * from './qualification-select-input.component';
+export * from './qualification-select-input.intl';
+export * from './qualification-select-input.module';
+export * from './qualification-select-input.token';
+export * from './qualification-select-input.translate';

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
@@ -1,0 +1,25 @@
+<div class="lu-select-placeholder">{{ placeholder }}</div>
+<div class="lu-select-value">
+	<div class="lu-select-display-wrapper">
+		<ng-container #display></ng-container>
+	</div>
+</div>
+<div class="lu-select-suffix">
+	<lu-input-clearer></lu-input-clearer>
+</div>
+
+<ng-template luDisplayer [luDisplayerMultiple]="true" let-values>
+	<span *ngIf="multiple && values?.length > 1; else: singleView"><span class="chip mod-unkillable">{{ values.length}}</span> {{intl.qualifications}}</span>
+	<ng-template #singleView>{{(values[0] || values).name}}</ng-template>
+</ng-template>
+
+<lu-option-picker-advanced>
+	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4"
+		fields="id,name,job[id,name]" orderBy="jobId"></lu-api-paged-searcher>
+	<ng-template luForGroups let-group [luForGroupsGroupBy]="groupByJobName">
+		<h4 class="optionItem-groupKey">{{ group.key }}</h4>
+		<lu-option *ngFor="let qualification of group.items; trackBy: trackById" [value]="qualification">
+			{{ qualification.name }}
+		</lu-option>
+	</ng-template>
+</lu-option-picker-advanced>

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
@@ -15,6 +15,7 @@
 
 <lu-option-picker-advanced>
 	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4"></lu-api-paged-searcher>
+	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4" [filters]="['sort=job.name,level.position']"></lu-api-paged-searcher>
 	<ng-template luForGroups let-group [luForGroupsGroupBy]="groupByJobName">
 		<h4 class="optionItem-groupKey">{{ group.key }}</h4>
 		<lu-option *ngFor="let qualification of group.items; trackBy: trackById" [value]="qualification">

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
@@ -1,4 +1,4 @@
-<div class="lu-select-placeholder">{{ placeholder }}</div>
+<div class="lu-select-placeholder">{{placeholder}}</div>
 <div class="lu-select-value">
 	<div class="lu-select-display-wrapper">
 		<ng-container #display></ng-container>
@@ -13,8 +13,7 @@
 	<ng-template #singleView>{{(values[0] || values).name}}</ng-template>
 </ng-template>
 
-<lu-option-picker-advanced>
-	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4"></lu-api-paged-searcher>
+<lu-option-picker-advanced [option-comparer]="byId">
 	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4" [filters]="['sort=job.name,level.position']"></lu-api-paged-searcher>
 	<ng-template luForGroups let-group [luForGroupsGroupBy]="groupByJobName">
 		<h4 class="optionItem-groupKey">{{ group.key }}</h4>

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.html
@@ -14,8 +14,7 @@
 </ng-template>
 
 <lu-option-picker-advanced>
-	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4"
-		fields="id,name,job[id,name]" orderBy="jobId"></lu-api-paged-searcher>
+	<lu-api-paged-searcher api="/organization/structure/api/job-qualifications" standard="v4"></lu-api-paged-searcher>
 	<ng-template luForGroups let-group [luForGroupsGroupBy]="groupByJobName">
 		<h4 class="optionItem-groupKey">{{ group.key }}</h4>
 		<lu-option *ngFor="let qualification of group.items; trackBy: trackById" [value]="qualification">

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.scss
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.scss
@@ -1,0 +1,18 @@
+@import "_definitions";
+@include selectInputStyle;
+
+.optionItem-groupKey {
+	padding: #{_component("options.item.padding-vertical", true)} #{_component("options.item.padding-horizontal", true)};
+	padding: #{_component("options.item.padding-vertical")} #{_component("options.item.padding-horizontal")};
+	margin: 0;
+	border-top: 1px solid _theme("commons.divider.color");
+	font-size: _theme("sizes.small.font-size");
+	width: 100%;
+	text-align: left;
+	text-decoration: underline;
+
+	&:first-of-type {
+		border-top-color: transparent;
+		margin-top: 0;
+	}
+}

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.ts
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.ts
@@ -1,7 +1,7 @@
 import { Overlay } from '@angular/cdk/overlay';
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, Renderer2, ViewContainerRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { ILuOptionPickerPanel } from '@lucca-front/ng/option';
+import { ILuOptionPickerPanel, LuOptionComparer } from '@lucca-front/ng/option';
 import { ILuInputWithPicker } from '@lucca-front/ng/picker';
 import { ALuSelectInputComponent } from '@lucca-front/ng/select';
 import { ILuQualification } from '../../qualification.model';
@@ -24,6 +24,8 @@ import { ILuQualificationSelectInputLabel } from './qualification-select-input.t
 export class LuQualificationSelectInputComponent<D extends ILuQualification = ILuQualification, P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>>
 	extends ALuSelectInputComponent<D, P>
 	implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit {
+
+	byId: LuOptionComparer<D> = (option1: D, option2: D) => option1 && option2 && option1.id === option2.id;
 
 	@Input() filters: string[];
 

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.ts
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.component.ts
@@ -1,0 +1,61 @@
+import { Overlay } from '@angular/cdk/overlay';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, Renderer2, ViewContainerRef } from '@angular/core';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ILuOptionPickerPanel } from '@lucca-front/ng/option';
+import { ILuInputWithPicker } from '@lucca-front/ng/picker';
+import { ALuSelectInputComponent } from '@lucca-front/ng/select';
+import { ILuQualification } from '../../qualification.model';
+import { LuQualificationSelectInputIntl } from './qualification-select-input.intl';
+import { ILuQualificationSelectInputLabel } from './qualification-select-input.translate';
+
+@Component({
+	selector: 'lu-qualification-select',
+	templateUrl: './qualification-select-input.component.html',
+	styleUrls: ['./qualification-select-input.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => LuQualificationSelectInputComponent),
+			multi: true,
+		}
+	],
+})
+export class LuQualificationSelectInputComponent<D extends ILuQualification = ILuQualification, P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>>
+	extends ALuSelectInputComponent<D, P>
+	implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit {
+
+	@Input() filters: string[];
+
+	isSearching = false;
+
+	constructor(
+		protected _changeDetectorRef: ChangeDetectorRef,
+		protected _overlay: Overlay,
+		protected _elementRef: ElementRef,
+		protected _viewContainerRef: ViewContainerRef,
+		protected _renderer: Renderer2,
+		@Inject(LuQualificationSelectInputIntl) public intl: ILuQualificationSelectInputLabel
+	) {
+		super(
+			_changeDetectorRef,
+			_overlay,
+			_elementRef,
+			_viewContainerRef,
+			_renderer,
+		);
+	}
+
+	onIsSearchingChanged(isSearching: boolean) {
+		this.isSearching = isSearching;
+		this._changeDetectorRef.detectChanges();
+	}
+
+	trackById(_: number, item: ILuQualification): number {
+		return item.id;
+	}
+
+	groupByJobName(qualification: ILuQualification): string {
+		return qualification.job.name;
+	}
+}

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.intl.ts
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.intl.ts
@@ -1,0 +1,11 @@
+import { Injectable, LOCALE_ID, Inject } from '@angular/core';
+import { ALuIntl } from '@lucca-front/ng/core';
+import { LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS } from './qualification-select-input.token';
+import { ILuQualificationSelectInputLabel } from './qualification-select-input.translate';
+
+@Injectable()
+export class LuQualificationSelectInputIntl extends ALuIntl<ILuQualificationSelectInputLabel> {
+	constructor(@Inject(LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS) translations, @Inject(LOCALE_ID) locale) {
+		super(translations, locale);
+	}
+}

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.module.ts
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.module.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { LuApiSearcherModule } from '@lucca-front/ng/api';
+import { LuInputModule } from '@lucca-front/ng/input';
+import { LuForGroupsModule, LuOptionModule } from '@lucca-front/ng/option';
+import { LuSelectInputModule } from '@lucca-front/ng/select';
+import { LuQualificationSelectInputComponent } from './qualification-select-input.component';
+import { LuQualificationSelectInputIntl } from './qualification-select-input.intl';
+import { LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS } from './qualification-select-input.token';
+import { luQualificationSelectInputTranslations } from './qualification-select-input.translate';
+
+@NgModule({
+	imports: [
+		CommonModule,
+		LuInputModule,
+		LuOptionModule,
+		LuSelectInputModule,
+		LuForGroupsModule,
+		LuApiSearcherModule
+	],
+	declarations: [
+		LuQualificationSelectInputComponent
+	],
+	exports: [
+		LuQualificationSelectInputComponent,
+	],
+	providers: [
+		{ provide: LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS, useValue: luQualificationSelectInputTranslations },
+		LuQualificationSelectInputIntl,
+	],
+})
+export class LuQualificationSelectInputModule { }

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.token.ts
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS = new InjectionToken('LuQualificationSelectTranslations');

--- a/packages/ng/qualification/src/lib/select/input/qualification-select-input.translate.ts
+++ b/packages/ng/qualification/src/lib/select/input/qualification-select-input.translate.ts
@@ -1,0 +1,20 @@
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+export interface ILuQualificationSelectInputLabel {
+	qualifications: string;
+}
+export abstract class ALuQualificationSelectInputLabel {
+	qualifications: string;
+}
+
+export const luQualificationSelectInputTranslations = {
+	en: {
+		qualifications: 'qualifications'
+	},
+	fr: {
+		qualifications: 'qualifications'
+	},
+	es: {
+		qualifications: 'calificaciones'
+	}
+} as ILuTranslation<ILuQualificationSelectInputLabel>;

--- a/packages/ng/qualification/src/lib/select/qualification-select.module.ts
+++ b/packages/ng/qualification/src/lib/select/qualification-select.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { LuQualificationSelectInputModule } from './input/index';
+
+@NgModule({
+	imports: [
+		LuQualificationSelectInputModule,
+	],
+	exports: [
+		LuQualificationSelectInputModule,
+	],
+})
+export class LuQualificationSelectModule { }

--- a/packages/ng/qualification/src/public-api.ts
+++ b/packages/ng/qualification/src/public-api.ts
@@ -1,0 +1,5 @@
+/*
+ * Public API Surface of qualification
+ */
+
+export * from './index';

--- a/packages/ng/qualification/src/test.ts
+++ b/packages/ng/qualification/src/test.ts
@@ -1,0 +1,26 @@
+// This file is required by karma.conf.js and loads recursively all the .spec and framework files
+
+import 'zone.js/dist/zone';
+import 'zone.js/dist/zone-testing';
+import { getTestBed } from '@angular/core/testing';
+import {
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting
+} from '@angular/platform-browser-dynamic/testing';
+
+declare const require: {
+  context(path: string, deep?: boolean, filter?: RegExp): {
+    keys(): string[];
+    <T>(id: string): T;
+  };
+};
+
+// First, initialize the Angular testing environment.
+getTestBed().initTestEnvironment(
+  BrowserDynamicTestingModule,
+  platformBrowserDynamicTesting()
+);
+// Then we find all the tests.
+const context = require.context('./', true, /\.spec\.ts$/);
+// And load the modules.
+context.keys().map(context);

--- a/packages/ng/qualification/tsconfig.lib.json
+++ b/packages/ng/qualification/tsconfig.lib.json
@@ -1,0 +1,48 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../out-tsc/lib",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": [
+      "dom",
+      "es2018"
+    ],
+    "paths": {
+      "@lucca-front/ng/core": [
+        "./dist/ng/core"
+      ],
+      "@lucca-front/ng/select": [
+        "./dist/ng/select"
+      ],
+      "@lucca-front/ng/picker": [
+        "./dist/ng/picker"
+      ],
+      "@lucca-front/ng/input": [
+        "./dist/ng/input"
+      ],
+      "@lucca-front/ng/popover": [
+        "./dist/ng/popover"
+      ],
+      "@lucca-front/ng/option": [
+        "./dist/ng/option"
+      ],
+      "@lucca-front/ng/api": [
+        "./dist/ng/api"
+      ]
+    }
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
+  },
+  "exclude": [
+    "src/test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/ng/qualification/tsconfig.lib.prod.json
+++ b/packages/ng/qualification/tsconfig.lib.prod.json
@@ -1,0 +1,10 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {
+    "enableIvy": false
+  }
+}

--- a/packages/ng/qualification/tsconfig.spec.json
+++ b/packages/ng/qualification/tsconfig.spec.json
@@ -1,0 +1,17 @@
+/* To learn more about this file see: https://angular.io/config/tsconfig. */
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../out-tsc/spec",
+    "types": [
+      "jasmine"
+    ]
+  },
+  "files": [
+    "src/test.ts"
+  ],
+  "include": [
+    "**/*.spec.ts",
+    "**/*.d.ts"
+  ]
+}

--- a/packages/ng/qualification/tslint.json
+++ b/packages/ng/qualification/tslint.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tslint.json",
+  "rules": {
+    "directive-selector": [
+      true,
+      "attribute",
+      "lu",
+      "camelCase"
+    ],
+    "component-selector": [
+      true,
+      "element",
+      "lu",
+      "kebab-case"
+    ]
+  }
+}

--- a/stories/ng/qualification/qualification-select.stories.ts
+++ b/stories/ng/qualification/qualification-select.stories.ts
@@ -1,0 +1,39 @@
+import { Component, Input } from '@angular/core';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { LuQualificationSelectModule } from '@lucca-front/ng/qualification';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+@Component({
+	selector: 'qualification-select-stories',
+	template: `
+<section class="section">
+	<lu-qualification-select placeholder="Select an qualification"></lu-qualification-select>
+	<lu-qualification-select placeholder="Select an qualification" [multiple]="true"></lu-qualification-select>
+</section>
+`,
+})
+class QualificationSelectStory { }
+
+export default {
+	title: 'NG/QualificationSelect',
+	component: QualificationSelectStory,
+	argTypes: {
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [QualificationSelectStory],
+			imports: [
+				LuQualificationSelectModule,
+				BrowserAnimationsModule,
+			]
+		})
+	]
+} as Meta;
+
+const template: Story<QualificationSelectStory> = (args: QualificationSelectStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+basic.args = {
+}

--- a/stories/ng/qualification/qualification-select.stories.ts
+++ b/stories/ng/qualification/qualification-select.stories.ts
@@ -1,21 +1,22 @@
-import { Component, Input } from '@angular/core';
+import { Component } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { LuApiSelectModule } from '@lucca-front/ng/api';
 import { LuQualificationSelectModule } from '@lucca-front/ng/qualification';
-import { Story, Meta, moduleMetadata } from '@storybook/angular';
+import { Meta, moduleMetadata, Story } from '@storybook/angular';
 
 @Component({
-	selector: 'qualification-select-stories',
+	selector: 'qualification-picker-stories',
 	template: `
 <section class="section">
-	<lu-qualification-select placeholder="Select an qualification"></lu-qualification-select>
-	<lu-qualification-select placeholder="Select an qualification" [multiple]="true"></lu-qualification-select>
+	<lu-qualification-select placeholder="Select a qualification"></lu-qualification-select>
+	<lu-qualification-select placeholder="Select a qualification" [multiple]="true"></lu-qualification-select>
 </section>
 `,
 })
 class QualificationSelectStory { }
 
 export default {
-	title: 'NG/QualificationSelect',
+	title: 'NG/QualificationPicker',
 	component: QualificationSelectStory,
 	argTypes: {
 	},
@@ -24,6 +25,7 @@ export default {
 			entryComponents: [QualificationSelectStory],
 			imports: [
 				LuQualificationSelectModule,
+				LuApiSelectModule,
 				BrowserAnimationsModule,
 			]
 		})

--- a/stories/ng/qualification/qualification-select.stories.ts
+++ b/stories/ng/qualification/qualification-select.stories.ts
@@ -8,8 +8,15 @@ import { Meta, moduleMetadata, Story } from '@storybook/angular';
 	selector: 'qualification-picker-stories',
 	template: `
 <section class="section">
-	<lu-qualification-select placeholder="Select a qualification"></lu-qualification-select>
-	<lu-qualification-select placeholder="Select a qualification" [multiple]="true"></lu-qualification-select>
+	<label class="textfield">
+		<lu-qualification-select placeholder="Select a qualification" class="textfield-input" ></lu-qualification-select>
+		<span class="textfield-label">Qualification</span>
+	</label>
+	<br/>
+	<label class="textfield">
+		<lu-qualification-select placeholder="Select a qualification" [multiple]="true" class="textfield-input" ></lu-qualification-select>
+		<span class="textfield-label">Qualifications</span>
+	</label>
 </section>
 `,
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,9 @@
       "@lucca-front/ng/establishment": [
         "./packages/ng/establishment/src/index"
       ],
+      "@lucca-front/ng/qualification": [
+        "./packages/ng/qualification/src/index"
+      ],
       "@lucca-front/ng/user": [
         "./packages/ng/user/src/index"
       ],


### PR DESCRIPTION
Adds a new component to edit qualifications

![image](https://user-images.githubusercontent.com/8553617/134670311-7f03223a-557a-4d6b-9fb8-b5adbd677050.png)

![image](https://user-images.githubusercontent.com/8553617/134670237-8b2b0063-1fc9-47b4-a6a4-a26ef4da3001.png)

The component is heavily inspired by [the one used on the HR file](https://github.com/LuccaSA/Lucca.Directory/tree/master/front/hr-file/src/app/formly/types/job-qualification-edit). However the style was slighlty altered to look more like the establishment-select, which has a similar display. 