### PR TITLE
Mask the help text

### DIFF
--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -342,7 +342,7 @@
 				flex-direction: row;
 
 				.navSide-item-link-title {
-					display: none;
+					@include mask;
 				}
 				&:hover {
 					background-color: _component("navSide.bottom-section-palette.hovered-bg");


### PR DESCRIPTION
The text is hidden so that it is not removed from the assistance tools.