### PR TITLE
LF 7.2.0

### DIFF
--- a/packages/scss/src/components/_main.scss
+++ b/packages/scss/src/components/_main.scss
@@ -35,6 +35,6 @@
 
 	.navSide.mod-withBanner ~ .main-content, .main-content.mod-withBanner, .mod-withBanner .main-content {
 		height: calc(100vh - #{_theme("commons.banner-height")} - #{_component("navSide.mobile.toggle-height")});
-		margin-top: _component("navSide.mobile.toggle-height");
+		margin-top: calc(#{_theme("commons.banner-height")} + _component("navSide.mobile.toggle-height"));
 	}
 }

--- a/packages/scss/src/components/_main.scss
+++ b/packages/scss/src/components/_main.scss
@@ -35,6 +35,6 @@
 
 	.navSide.mod-withBanner ~ .main-content, .main-content.mod-withBanner, .mod-withBanner .main-content {
 		height: calc(100vh - #{_theme("commons.banner-height")} - #{_component("navSide.mobile.toggle-height")});
-		margin-top: calc(#{_theme("commons.banner-height")} + _component("navSide.mobile.toggle-height"));
+		margin-top: calc(#{_theme("commons.banner-height")} + #{_component("navSide.mobile.toggle-height")});
 	}
 }

--- a/packages/scss/src/components/_nav-side.scss
+++ b/packages/scss/src/components/_nav-side.scss
@@ -1,17 +1,26 @@
 .navSide {
 	background-color: _component("navSide.fullwidth-palette.bg-color");
 	bottom: 0;
-	display: block;
 	left: 0;
 	padding-top: _component("navSide.padding-top");
 	position: fixed;
 	top: 0;
 	width: _component("navSide.width");
 	z-index: 100;
+	display: flex;
+    flex-direction: column;
+}
+
+.navSide-wrapper {
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+	min-height: 0;
 }
 
 // NECESSARY TO AVOID MOVEMENT WHEN THE SCROLLBAR APPEARS
 .navSide-mainSection {
+	flex-grow: 1;
 	display: block;
 	height: 100%;
 	overflow-x: hidden;
@@ -41,12 +50,16 @@
 
 .navSide-scrollWrapper {
 	width: _component("navSide.width");
-	padding: _theme("spacings.smaller");
+	padding: 0.5em;
+	margin: 0;
+    list-style-type: none;
 }
 
-.navSide-item + .navSide-item, .navSide-item-subMenu-link + .navSide-item-subMenu-link {
-	margin-top: 2px;
+.navSide-item:not(.mod-mobileToggle) + .navSide-item, .navSide-item-subMenu-link + .navSide-item-subMenu-link,
+.navSide-item-subMenu-item + .navSide-item-subMenu-item {
+	margin-top: .125em;
 }
+
 
 // MOBILE TOGGLE
 .navSide-item.mod-mobileToggle {
@@ -54,14 +67,39 @@
 }
 
 .navSide-item-link, .navSide-item-subMenu-link {
+	background-color: transparent;
+	border: 0;
+	cursor: pointer;
+	text-align: left;
+	width: 100%;
+	height: 100%;
 	align-items: center;
 	color: _component("navSide.fullwidth-palette.text");
 	display: flex;
 	text-decoration: none;
 	transition: all _theme("commons.animations.durations.fast") ease;
 	user-select: none;
-	height: 100%;
 	border-radius: _theme("commons.border.radius");
+
+	&[aria-expanded="true"] {
+		.navSide-item-arrow {
+			transform: rotate(-0.25turn);
+		}
+	}
+
+	&:focus-visible {
+		outline: none;
+		box-shadow: 0 0 0 2px _component("navSide.fullwidth-palette.selected-text");
+		background-color: _component("navSide.fullwidth-palette.hovered-bg");
+		color: _component("navSide.fullwidth-palette.hovered-text");
+		position: relative;
+		z-index: 1;
+	}
+
+	&.is-active {
+		background-color: _component("navSide.fullwidth-palette.selected-bg");
+		color: _component("navSide.fullwidth-palette.selected-text");
+	}
 }
 
 // MAIN-ITEM
@@ -70,8 +108,8 @@
 .navSide-item-link {
 	font-size: _component("navSide.main-font-size");
 	font-weight: 600;
-	line-height: 1rem;
-	padding: _theme("spacings.small");
+	line-height: 1em;
+	padding: 1em;
 
 	&:hover {
 		background-color: _component("navSide.fullwidth-palette.hovered-bg");
@@ -82,51 +120,51 @@
 .navSide-item-link-title {
 	line-height: 1.2;
 	margin-left: 1em;
-	margin-right: 10px;
+	margin-right: .625em;
 	vertical-align: middle;
 	width: 100%;
 }
 
 .navSide-item-alert {
 	background-color: _component("navSide.fullwidth-palette.alert-color");
-	border-radius: .5rem;
+	border-radius: .666em;
 	color: _component("navSide.fullwidth-palette.alert-text");
 	font-size: _theme("sizes.smaller.font-size");
-	height: 1rem;
-	line-height: 1rem;
+	height: 1.333em;
+	line-height: 1.333em;
 	margin-left: auto;
-	margin-right: .5rem;
-	padding: 0 .5em;
+	margin-right: .666em;
+	padding: 0 .666em;
 	transition: background-color _theme("commons.animations.durations.standard") ease;
 }
 
 .navSide-item-arrow {
-	font-size: .8rem;
-	height: .6rem;
+	font-size: .8em;
 	margin-left: auto;
 	transform: rotate(0);
 	transition: transform _theme("commons.animations.durations.fast") ease-out;
+	flex-shrink: 0;
+	width: 1em;
+	height: 1em;
+	display: grid;
+	place-items: center;
+	transform-origin: 50% 50%;
 }
 
 // SUB MENU
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 .navSide-item-subMenu {
 	font-size: _component("navSide.sub-font-size");
-	max-height: 0;
-	overflow: hidden;
-	transition-duration: _theme("commons.animations.durations.fast");
-	transition-property: max-height;
-	transition-timing-function: ease-in-out;
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
+	overflow: visible;
 }
 
 .navSide-item-subMenu-link {
 	font-weight: 400;
 	line-height: 1.4;
-	opacity: 0;
-	padding: _theme("spacings.smaller") 1rem _theme("spacings.smaller") 3.2rem;
-	transform: translate3d(-1.5em, 0, 0);
-	transition: opacity _theme("commons.animations.durations.fast") ease-out,
-              transform _theme("commons.animations.durations.standard") ease-out .05s;
+	padding: .5em 1em .5em 3.2em;
 	vertical-align: middle;
 }
 
@@ -140,7 +178,7 @@
 	.navSide-item, .navSide-item-link {
 		height: 100%;
 		background-color: transparent;
-		padding: _theme("spacings.smaller");
+		padding: .5em;
 	}
 
 	.navSide-item-link {
@@ -148,7 +186,7 @@
 		color: _component("navSide.bottom-section-palette.text");
 		cursor: pointer;
 		box-sizing: border-box;
-		padding: _theme("spacings.small");
+		padding: 1em;
 
 		&:hover {
 			background-color: _component("navSide.bottom-section-palette.hovered-bg");
@@ -162,43 +200,31 @@
 	}
 }
 
-.navSide.mod-withBottomSection {
-	.navSide-mainSection {
-		height: calc(100% - #{_component("navSide.bottom-section-height")});
-	}
-}
-
 // ACTIVE & OPEN STATE
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-.navSide-item.is-active {
-	.navSide-item-link {
-		opacity: 1;
-	}
-}
 
-.navSide-item.is-open {
-	.navSide-item-arrow {
-		transform: rotate(-.25turn);
-	}
-
-	.navSide-item-subMenu {
-		max-height: _component("navSide.submenu.max-height"); // TODO: SEE IF THIS CAN BE REMOVED
-		transition-duration: _theme("commons.animations.durations.slow");
-	}
-
-	.navSide-item-subMenu-link {
-		opacity: 1;
-		transform: translate3d(0, 0, 0);
-		transition: all _theme("commons.animations.durations.fast") ease-out 0;
-
-		&:hover {
-			background-color: _component("navSide.fullwidth-palette.hovered-bg");
-			color: _component("navSide.fullwidth-palette.hovered-text");
+.navSide-item {
+	&.is-open {
+		.navSide-item-arrow {
+			transform: rotate(-.25turn);
 		}
 
-		&.is-active {
-			background-color: _component("navSide.fullwidth-palette.selected-bg");
-			color: _component("navSide.fullwidth-palette.selected-text");
+		.navSide-item-subMenu-link {
+			&:hover {
+				background-color: _component("navSide.fullwidth-palette.hovered-bg");
+				color: _component("navSide.fullwidth-palette.hovered-text");
+			}
+
+			&.is-active {
+				background-color: _component("navSide.fullwidth-palette.selected-bg");
+				color: _component("navSide.fullwidth-palette.selected-text");
+			}
+		}
+	}
+
+	&:not(.is-open) {
+		.navSide-item-subMenu {
+			display: none;
 		}
 	}
 }
@@ -208,9 +234,14 @@
 	color: _component("navSide.fullwidth-palette.selected-text");
 	opacity: 1;
 
+	
+}
+
+.navSide-item-subMenu-link.is-active,
+.navSide-item-link.is-active {
 	.navSide-item-alert {
-		background-color: _component("navSide.fullwidth-palette.selected-alert-color");
-		color: _component("navSide.fullwidth-palette.selected-alert-text");
+		background-color: _component("navSide.fullwidth-palette.selected-alert-text");
+		color: _component("navSide.fullwidth-palette.selected-alert-color");
 	}
 }
 
@@ -276,8 +307,9 @@
 			flex-direction: column;
 			font-size: _component("navSide.compact.font-size");
 			justify-content: center;
-			padding: _theme("spacings.small") _theme("spacings.smaller");
+			padding: 1em .5em;
 			position: relative;
+			text-align: center;
 
 			.navSide-item-link-title {
 				margin: .8em 0 0;
@@ -293,8 +325,8 @@
 			color: _component("navSide.compact-palette.alert-text");
 			padding: 0 .4em;
 			position: relative;
-			top: 10px;
-			margin: auto;
+			top: .625em;
+			margin: .166em;
 		}
 
 		.navSide-item-placeholder {
@@ -355,31 +387,30 @@
 
 
 // Mobile version
-@include media_smaller_than(_theme("commons.mobile", true)) {
+@include media_smaller_than("s") {
 	.navSide {
-		position: relative;
 		padding-top: _component("navSide.mobile.toggle-height");
 		width: 100%;
+		bottom: auto;
 
-		&, &.mod-withBottomSection {
-			.navSide-mainSection, .navSide-scrollWrapper {
-				width: 100%;
-				height: auto;
+		
+		.navSide-mainSection, .navSide-scrollWrapper {
+			width: 100%;
+			height: auto;
+		}
+		
+
+		&:not(.is-open) {
+			.navSide-item {
+				&:not(.mod-mobileToggle) {
+					display: none;
+				}
 			}
 		}
 	}
+
 	.navSide-scrollWrapper {
 		padding: 0;
-	}
-
-	.navSide-item:not(.mod-mobileToggle), .navSide-item-placeholder {
-		position: absolute;
-		visibility: hidden;
-		transform: translateX(-15px);
-		opacity: 0;
-		top: 0;
-		bottom: 100%;
-		overflow: hidden;
 	}
 
 	.navSide-item.mod-mobileToggle {
@@ -387,12 +418,19 @@
 		height: _component("navSide.mobile.toggle-height");
 		background-color: _color("primary", 800);
 		cursor: pointer;
-		overflow: hidden;
 		position: fixed;
 		top: 0;
 		left: 0;
 		right: 0;
 		z-index: 1;
+
+		.navSide-item-link {
+			border-radius: 0;
+	
+			&:focus-visible {
+				box-shadow: 0 0 0 2px _component("navSide.fullwidth-palette.selected-text") inset;
+			}
+		}
 	}
 
 	.navSide.mod-withBanner {
@@ -417,20 +455,24 @@
 		}
 
 		.navSide-scrollWrapper {
-			padding: _theme("spacings.smaller");
-		}
-
-		.navSide-item:not(.mod-mobileToggle), .navSide-item-placeholder {
-			position: static;
-			visibility: visible;
-			transform: translateX(0);
-			opacity: 1;
-			transition: all .2s cubic-bezier(.25, .8, .25, 1);
-			@for $i from 0 through 10 {
-				&:nth-child(#{$i+2}) {
-					transition-delay: $i*.05s;
-				}
-			}
+			padding: .5em;
 		}
 	}
+}
+
+::ng-deep {
+    @include media_smaller_than('s') {
+        .hasMenu {
+            &,
+            body {
+                touch-action: none;
+                overscroll-behavior: none;
+                -webkit-overflow-scrolling: auto;
+            }
+
+            body {
+                overflow: hidden !important;
+            }
+        }
+    }
 }

--- a/stories/scss/navSide/navSide.stories.html
+++ b/stories/scss/navSide/navSide.stories.html
@@ -1,0 +1,92 @@
+<div class="navSide" [class.mod-withBanner]="withBanner" [class.mod-compact]="compact" [class.is-open]="mobileMenuOpened">
+	<nav role="navigation" [attr.aria-label]="titleNav" class="navSide-wrapper">
+		<div class="navSide-mainSection">
+			<div class="navSide-item mod-mobileToggle" *ngIf="mobileToggle">
+				<button type="button" [attr.aria-expanded]="mobileMenuOpened" class="navSide-item-link" (click)="$event.preventDefault(); mobileMenuOpened=!mobileMenuOpened">
+					<span class="navSide-item-link-title">Menu</span>
+					<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowEast"></span>
+				</button>
+			</div>
+
+			<ng-container *ngIf="loading; else menu">
+				<div aria-hidden="true">
+					<div class="navSide-item-placeholder" [class.mod-inverted]="loadingInverted"></div>
+					<div class="navSide-item-placeholder" [class.mod-inverted]="loadingInverted"></div>
+					<div class="navSide-item-placeholder" [class.mod-inverted]="loadingInverted"></div>
+				</div>
+			</ng-container>
+
+			<ng-template #menu>
+				<ul class="navSide-scrollWrapper">
+					<li class="navSide-item" [class.is-open]="firstSubMenuOpened">
+						<button type="button" class="navSide-item-link" [attr.aria-expanded]="firstSubMenuOpened" (click)="$event.preventDefault(); firstSubMenuOpened=!firstSubMenuOpened">
+							<span aria-hidden="true" class="lucca-icon icon-heart"></span>
+							<span class="navSide-item-link-title">Section 1</span>
+							<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowEast"></span>
+						</button>
+						<ul class="navSide-item-subMenu">
+							<li class="navSide-item-subMenu-item" [class.u-animatedSlideInLeft]="firstSubMenuOpened">
+								<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Subsection #1.1</a>
+							</li>
+							<li class="navSide-item-subMenu-item" [class.u-animatedSlideInLeft]="firstSubMenuOpened">
+								<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">
+									Subsection #1.2 with large name
+									<span class="navSide-item-alert"><span class="u-mask">, </span>12</span>
+								</a>
+							</li>
+						</ul>
+					</li>
+					<li class="navSide-item" [class.is-open]="secondSubMenuOpened">
+						<button type="button" class="navSide-item-link" [attr.aria-expanded]="secondSubMenuOpened" (click)="$event.preventDefault(); secondSubMenuOpened=!secondSubMenuOpened">
+							<span aria-hidden="true" class="lucca-icon icon-user"></span>
+							<span class="navSide-item-link-title">Section#2 with a larger name</span>
+							<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowEast"></span>
+						</button>
+						<ul class="navSide-item-subMenu">
+							<li class="navSide-item-subMenu-item" [class.u-animatedSlideInLeft]="secondSubMenuOpened">
+								<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Section #2.1</a>
+							</li>
+							<li class="navSide-item-subMenu-item" [class.u-animatedSlideInLeft]="secondSubMenuOpened">
+								<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Section #2.2</a>
+							</li>
+							<li class="navSide-item-subMenu-item" [class.u-animatedSlideInLeft]="secondSubMenuOpened">
+								<a href="#" class="navSide-item-subMenu-link is-active" (click)="$event.preventDefault()">
+									Section #2.3
+									<span class="navSide-item-alert"><span class="u-mask">, </span>1</span>
+								</a>
+							</li>
+							<li class="navSide-item-subMenu-item" [class.u-animatedSlideInLeft]="secondSubMenuOpened">
+								<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">
+									Section #2.4
+									<span class="navSide-item-alert"><span class="u-mask">, </span>12</span>
+								</a>
+							</li>
+						</ul>
+					</li>
+					<li class="navSide-item">
+						<a href="#" class="navSide-item-link is-active" (click)="$event.preventDefault()">
+							<span aria-hidden="true" class="lucca-icon icon-analytics"></span>
+							<span class="navSide-item-link-title">Section #3</span>
+						</a>
+					</li>
+					<li class="navSide-item">
+						<a href="#" class="navSide-item-link" (click)="$event.preventDefault()">
+							<span aria-hidden="true" class="lucca-icon icon-sliders"></span>
+							<span class="navSide-item-link-title">Section #4</span>
+							<span class="navSide-item-alert"><span class="u-mask">, </span>3</span>
+							<span class="navSide-item-alert"><span class="u-mask">, </span>9</span>
+						</a>
+					</li>
+				</ul>
+			</ng-template>
+		</div>
+		<div class="navSide-bottomSection" *ngIf="withBottomSection">
+			<div class="navSide-item">
+				<button type="button" class="navSide-item-link">
+					<span aria-hidden="true" class="lucca-icon icon-help"></span>
+					<span class="navSide-item-link-title">Help</span>
+				</button>
+			</div>
+		</div>
+	</nav>
+</div>

--- a/stories/scss/navSide/navSide.stories.ts
+++ b/stories/scss/navSide/navSide.stories.ts
@@ -1,0 +1,53 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+@Component({
+	selector: 'navSide-stories',
+	templateUrl: './navSide.stories.html',
+}) class NavSideStory {
+	@Input() withBanner: boolean = false;
+	@Input() compact: boolean = false;
+	@Input() mobileMenuOpened: boolean = false;
+	@Input() withBottomSection: boolean = false;
+	@Input() mobileToggle: boolean = false;
+	@Input() firstSubMenuOpened = false;
+	@Input() secondSubMenuOpened = false;
+	@Input() loading: boolean = false;
+	@Input() loadingInverted: boolean = false;
+	@Input() titleNav: string = '';
+}
+
+export default {
+	title: 'SCSS/NavSide',
+	component: NavSideStory,
+	argTypes: {
+		
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [NavSideStory],
+			imports: [BrowserModule, CommonModule],
+		})
+	]
+} as Meta;
+
+const template: Story<NavSideStory> = (args: NavSideStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+
+basic.args = {
+	firstSubMenuOpened: false,
+	secondSubMenuOpened: true,
+	withBanner: false,
+	compact: false,
+	withBottomSection: true,
+	mobileMenuOpened: true,
+	mobileToggle: true,
+	loading: false,
+	loadingInverted: false,
+	titleNav: 'Cleemy Achats',
+};

--- a/stories/scss/navSideLegacy/navSideLegacy.stories.html
+++ b/stories/scss/navSideLegacy/navSideLegacy.stories.html
@@ -1,0 +1,73 @@
+<aside class="navSide" [class.mod-withBanner]="withBanner" [class.mod-compact]="compact" [class.is-open]="mobileMenuOpened">
+	<div class="navSide-mainSection">
+		<nav class="navSide-scrollWrapper">
+			<div class="navSide-item mod-mobileToggle" *ngIf="mobileToggle">
+				<a href="#" class="navSide-item-link" (click)="$event.preventDefault(); mobileMenuOpened=!mobileMenuOpened">
+					<span class="navSide-item-link-title">Menu</span>
+					<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowEast"></span>
+				</a>
+			</div>
+
+			<ng-container *ngIf="loading; else menu">
+				<div class="navSide-item-placeholder" [class.mod-inverted]="loadingInverted"></div>
+				<div class="navSide-item-placeholder" [class.mod-inverted]="loadingInverted"></div>
+				<div class="navSide-item-placeholder" [class.mod-inverted]="loadingInverted"></div>
+			</ng-container>
+
+			<ng-template #menu>
+				<div class="navSide-item" [class.is-open]="firstSubMenuOpened">
+					<a href="#" class="navSide-item-link" (click)="$event.preventDefault(); firstSubMenuOpened=!firstSubMenuOpened">
+						<span aria-hidden="true" class="lucca-icon icon-heart"></span>
+						<span class="navSide-item-link-title">Section 1</span>
+						<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowEast"></span>
+					</a>
+					<nav class="navSide-item-subMenu">
+						<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Subsection #1.1</a>
+						<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Subsection #1.2 with large name <span class="navSide-item-alert">12</span></a>
+					</nav>
+				</div>
+				<div class="navSide-item" [class.is-open]="secondSubMenuOpened">
+					<a href="#" class="navSide-item-link" (click)="$event.preventDefault(); secondSubMenuOpened=!secondSubMenuOpened">
+						<span aria-hidden="true" class="lucca-icon icon-user"></span>
+						<span class="navSide-item-link-title">Section#2 with a larger name</span>
+						<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowEast"></span>
+					</a>
+					<nav class="navSide-item-subMenu">
+						<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Section #2.1</a>
+						<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">Section #2.2</a>
+						<a href="#" class="navSide-item-subMenu-link is-active" (click)="$event.preventDefault()">
+							Section #2.3
+							<span class="navSide-item-alert">1</span>
+						</a>
+						<a href="#" class="navSide-item-subMenu-link" (click)="$event.preventDefault()">
+							Section #2.4
+							<span class="navSide-item-alert">12</span>
+						</a>
+					</nav>
+				</div>
+				<div class="navSide-item">
+					<a href="#" class="navSide-item-link is-active" (click)="$event.preventDefault()">
+						<span aria-hidden="true" class="lucca-icon icon-analytics"></span>
+						<span class="navSide-item-link-title">Section #3</span>
+					</a>
+				</div>
+				<div class="navSide-item">
+					<a href="#" class="navSide-item-link" (click)="$event.preventDefault()">
+						<span aria-hidden="true" class="lucca-icon icon-sliders"></span>
+						<span class="navSide-item-link-title">Section #4</span>
+						<span class="navSide-item-alert">3</span>
+						<span class="navSide-item-alert">9</span>
+					</a>
+				</div>
+			</ng-template>
+		</nav>
+	</div>
+	<div class="navSide-bottomSection" *ngIf="withBottomSection">
+		<div class="navSide-item">
+			<a href="#" class="navSide-item-link" (click)="$event.preventDefault()">
+				<span aria-hidden="true" class="lucca-icon icon-help"></span>
+				<span class="navSide-item-link-title">Help</span>
+			</a>
+		</div>
+	</div>
+</aside>

--- a/stories/scss/navSideLegacy/navSideLegacy.stories.ts
+++ b/stories/scss/navSideLegacy/navSideLegacy.stories.ts
@@ -1,0 +1,52 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'navSideLegacy-stories',
+	templateUrl: './navSideLegacy.stories.html',
+}) class NavSideLegacyStory {
+	@Input() withBanner: boolean = false;
+	@Input() compact: boolean = false;
+	@Input() mobileMenuOpened: boolean = false;
+	@Input() withBottomSection: boolean = false;
+	@Input() mobileToggle: boolean = false;
+	@Input() firstSubMenuOpened: boolean = false;
+	@Input() secondSubMenuOpened: boolean = false;
+	@Input() loading: boolean = false;
+	@Input() loadingInverted: boolean = false;
+}
+
+export default {
+	title: 'SCSS/NavSideLegacy',
+	component: NavSideLegacyStory,
+	argTypes: {
+		
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [NavSideLegacyStory],
+			imports: [BrowserModule, CommonModule],
+		})
+	]
+} as Meta;
+
+const template: Story<NavSideLegacyStory> = (args: NavSideLegacyStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+
+basic.args = {	
+	firstSubMenuOpened: false,
+	secondSubMenuOpened: true,
+	withBanner: false,
+	compact: false,
+	withBottomSection: true,
+	mobileMenuOpened: true,
+	mobileToggle: true,
+	loading: false,
+	loadingInverted: false,
+};


### PR DESCRIPTION
# LF 7.2

## Navside

To facilitate the pending release of @lucca/ngx-sitemap, some adjustments have been made on the navside
- No breaking change for @lucca/sitemap (stencil component)
- Reflect updates on the @lucca/ngx-sitemap component to preserve current look and feel, mostly on the responsive side of things

### Visual changes

- On mobile, the `Menu` open button doesn't have rounded edges anymore.

### Fixes

- On mobile, the `Menu` is now in `position: fixed`. The page's content's position is shifted downwards accordingly. You may need to remove some `shame` code regarding `main-content`'s `margin-top` property.

### Technical changes

- Unit standardization: everything is now in `em`.