### PR TITLE
FIX(scss) Hover states for fields in mod-framed

### DIFF
--- a/packages/scss/src/components/_form.scss
+++ b/packages/scss/src/components/_form.scss
@@ -140,14 +140,19 @@
 		clear: both;
 	}
 
-	&:not(.is-disabled):hover {
-		background-color: _component("field.framed.color50");
-	}
+	&:not(.is-disabled, :disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+		&:hover,
+		&:focus {
+			position: relative;
+			z-index: 1;
+			background-color: _color("white");
+			box-shadow: fakeborderoverlay(_component("field.framed.color"));
+		}
 
-	&:focus-within {
-		position: relative;
-		z-index: 1;
-		box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
+		&:focus {
+			z-index: 4;
+			box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
+		}
 	}
 
 	.radiosfield, .checkboxesfield {

--- a/packages/scss/src/components/inputs/field/_field.framed.scss
+++ b/packages/scss/src/components/inputs/field/_field.framed.scss
@@ -35,10 +35,14 @@
 	}
 
 	.#{$fieldname}-input {
-		&:not(:disabled) {
+		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+			background-color: _color("white");
+
 			&:focus, &:hover {
 				position: relative;
 				z-index: 1;
+				background-color: _color("white");
+				box-shadow: fakeborderoverlay(_component("field.framed.color"));
 
 				~ .#{$fieldname}-messages {
 					transform: translateY(100%);
@@ -47,6 +51,7 @@
 
 			&:focus {
 				z-index: 4;
+				box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
 			}
 		}
 	}

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -65,15 +65,18 @@
 		line-height: _theme("sizes.standard.line-height");
 
 		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
-			
 			background-color: _color("white");
 
-			&:hover {
-				background-color: _component("field.framed.color50");
+			&:hover,
+			&:focus {
+				position: relative;
+				z-index: 1;
+				background-color: _color("white");
+				box-shadow: fakeborderoverlay(_component("field.framed.color"));
 			}
 
 			&:focus {
-				background-color: _color("white");
+				z-index: 4;
 				box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
 			}
 


### PR DESCRIPTION
The grid background on the hover was not in accordance with the design system.
It is replaced by a more pronounced border color. 

A white background is also added to override the inherited background color of the fields outside the mod-framed.

-----

![Capture d’écran 2021-12-20 à 17 18 21](https://user-images.githubusercontent.com/64789527/146798925-e06cbc4b-9e2b-4bb8-bbc1-95c8948995b2.png)

![Capture d’écran 2021-12-20 à 17 18 42](https://user-images.githubusercontent.com/64789527/146798928-5cdf547d-8a53-47f2-b937-0744fc56b4da.png)
