### PR TITLE
fix(scss) display for fieldset in framed forms

### DIFF
--- a/packages/scss/src/components/inputs/checkbox/_checkboxesfield.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkboxesfield.scss
@@ -25,11 +25,15 @@
 }
 
 .form.mod-framed .checkboxesfield, .checkboxesfield.mod-framed {
-	@include field-framed("checkboxesfield");
 	display: block;
 
 	.checkboxesfield-input {
 		@extend %checkboxesfield-row;
+	}
+
+	fieldset {
+		border: none;
+		padding: 0;
 	}
 }
 

--- a/packages/scss/src/components/inputs/radio/_radiosfield.scss
+++ b/packages/scss/src/components/inputs/radio/_radiosfield.scss
@@ -31,12 +31,15 @@
 }
 
 .form.mod-framed .radiosfield, .radiosfield.mod-framed {
-	@include field-framed("radiosfield");
-
 	display: block;
 
 	.radiosfield-input {
 		@extend %radiosfield-row;
+	}
+
+	fieldset {
+		border: none;
+		padding: 0;
 	}
 }
 

--- a/stories/scss/form/framed/framed.stories.html
+++ b/stories/scss/form/framed/framed.stories.html
@@ -37,4 +37,56 @@
 			</div>
 		</div>
 	</div>
+	<div class="form-group-line">
+		<div class="form-group-line-col">
+			<div class="radiosfield mod-framed"
+				[class.is-disabled]="disabled">
+				<fieldset>
+					<legend class="radiosfield-label">Radios label</legend>
+					<div class="radiosfield-input">
+						<label class="radio">
+							<input type="radio" name="radioframedlist" class="radio-input {{ state }}" [disabled]="disabled">
+							<span class="radio-label">Radio</span>
+						</label>
+						<label class="radio">
+							<input type="radio" name="radioframedlist" class="radio-input {{ state }}" [disabled]="disabled">
+							<span class="radio-label">Radio</span>
+						</label>
+						<label class="radio">
+							<input type="radio" name="radioframedlist" class="radio-input {{ state }}" [disabled]="disabled">
+							<span class="radio-label">Radio</span>
+						</label>
+					</div>
+				</fieldset>
+			</div>
+		</div>
+	</div>
+	<div class="form-group-line">
+		<div class="form-group-line-col">
+			<div class="checkboxesfield mod-framed"
+				[class.is-disabled]="disabled">
+				<fieldset>
+					<legend class="checkboxesfield-label">Checkboxes legend</legend>
+					<div class="checkboxesfield-input">
+						<label class="checkbox">
+							<input type="checkbox" name="checkboxframedlist" class="checkbox-input {{ state }}" [disabled]="disabled">
+							<span class="checkbox-label">Checkbox</span>
+						</label>
+						<label class="checkbox">
+							<input type="checkbox" name="checkboxframedlist" class="checkbox-input {{ state }}" [disabled]="disabled">
+							<span class="checkbox-label">Checkbox</span>
+						</label>
+						<label class="checkbox">
+							<input type="checkbox" name="checkboxframedlist" class="checkbox-input {{ state }}" [disabled]="disabled">
+							<span class="checkbox-label">Checkbox</span>
+						</label>
+						<label class="checkbox">
+							<input type="checkbox" name="checkboxframedlist" class="checkbox-input {{ state }}" [disabled]="disabled">
+							<span class="checkbox-label">Checkbox</span>
+						</label>
+					</div>
+				</fieldset>
+			</div>
+		</div>
+	</div>
 </form>


### PR DESCRIPTION
## Description

Adds support for the `fieldset` element in containers with the `.radiosfield` or `.checkboxesfield` classes.

-----
