### PR TITLE
LF 7.3

### DIFF
--- a/packages/scss/src/components/_button.scss
+++ b/packages/scss/src/components/_button.scss
@@ -5,29 +5,24 @@
 	background-color: _color($palette);
 	color: _color($palette, "text");
 
-	&:hover:not([disabled]) {
-		background-color: _color($palette, "600");
-		box-shadow: _theme('commons.box-shadow.xs');
+	&:not([disabled], .is-disabled) {
+		&:hover {
+			background-color: _color($palette, "600");
+			box-shadow: _theme('commons.box-shadow.xs');
+		}
+
+		&:focus {
+			box-shadow: _theme('commons.box-shadow.xs'), 0 0 0 4px _color($palette, "200");
+			outline: none;
+			background-color: _color($palette, "600");
+		}
+
+		&:active {
+			background-color: _color($palette, "800");
+			box-shadow: 0 0 0 4px _color($palette, "300");
+		}
 	}
 
-	&:focus {
-		box-shadow: _theme('commons.box-shadow.xs'), 0 0 0 4px _color($palette, "200");
-		outline: none;
-		background-color: _color($palette, "600");
-	}
-
-	&:active:not([disabled]) {
-		background-color: _color($palette, "800");
-		box-shadow: 0 0 0 4px _color($palette, "300");
-	}
-
-	&[disabled],
-	&.is-disabled {
-		background-color: _color($palette, "500");
-		color: _color($palette, "300");
-		cursor: default;
-		pointer-events: none;
-	}
 
 	.button-counter {
 		background-color: _color($palette, "500");
@@ -35,33 +30,37 @@
 }
 
 @mixin buttonLinkColoring($palette) {
-	&:focus:not([disabled]) {
-		box-shadow: 0 0 0 4px _color($palette, "100"), inset 0 0 0 1px _color($palette, "300");
-		background: _color($palette, "100");
+	&:not([disabled], .is-disabled) {
+		&:focus {
+			box-shadow: 0 0 0 4px _color($palette, "100"), inset 0 0 0 1px _color($palette, "300");
+			background: _color($palette, "100");
+		}
 	}
 }
 
 @mixin buttonOutlineColoring($palette) {
-	box-shadow: inset 0 0 0 1px _color($palette, "400");
-	color: _color($palette);
-
-	&:hover:not([disabled]) {
-		background-color: _color($palette, "100");
+	&:not([disabled], .is-disabled) {
 		color: _color($palette);
-		box-shadow: 0 2px 8px rgba(19, 29, 53, .04), 0 1px 2px rgba(19, 29, 53, .06), inset 0 0 0 1px _color($palette, "400");
-	}
+		box-shadow: inset 0 0 0 1px _color($palette, "400");
 
-	&:focus:not([disabled]) {
-		background-color: _color($palette, "100");
-		color: _color($palette);
-		box-shadow: 0 2px 8px rgba(19, 29, 53, .04), 0 1px 2px rgba(19, 29, 53, .06), 0 0 0 4px _color($palette, "100"), inset 0 0 0 1px _color($palette, "400");
-		outline: none;
-	}
+		&:hover {
+			background-color: _color($palette, "100");
+			color: _color($palette);
+			box-shadow: _theme('commons.elevations.elevation-1'), inset 0 0 0 1px _color($palette, "400");
+		}
 
-	&:active:not([disabled]) {
-		background-color: _color($palette, "200");
-		color: _color($palette);
-		box-shadow: 0 2px 8px rgba(19, 29, 53, .04), 0 1px 2px rgba(19, 29, 53, .06), 0 0 0 4px _color($palette, "200"), inset 0 0 0 1px _color($palette, "500");
+		&:focus {
+			background-color: _color($palette, "100");
+			color: _color($palette);
+			box-shadow: _theme('commons.elevations.elevation-1'), 0 0 0 4px _color($palette, "100"), inset 0 0 0 1px _color($palette, "400");
+			outline: none;
+		}
+
+		&:active {
+			background-color: _color($palette, "200");
+			color: _color($palette);
+			box-shadow: _theme('commons.elevations.elevation-1'), 0 0 0 4px _color($palette, "200"), inset 0 0 0 1px _color($palette, "500");
+		}
 	}
 
 	.button-counter {
@@ -188,17 +187,17 @@
 		}
 
 		&.mod-invert {
-			color: white;
+			color: _color('white');
 
-			&:hover, &:focus {
-				&:not([disabled]) {
+			&:not([disabled], .is-disabled) {
+				&:hover, &:focus {
 					background-color: rgba(255, 255, 255, .1);
-					color: white;
+					color: _color('white');
 				}
-			}
 
-			&:focus {
-				box-shadow: 0 0 0 4px rgba(0, 0, 0, .1);
+				&:focus {
+					box-shadow: 0 0 0 4px rgba(0, 0, 0, .1);
+				}
 			}
 		}
 	}
@@ -209,8 +208,8 @@
 		width: 2rem;
 
 		&::before {
-			content: "";
 			@include makeIcon("arrow_south");
+			content: "";
 			height: 0;
 			vertical-align: text-top;
 		}
@@ -220,37 +219,41 @@
 		}
 	}
 
-	&.mod-outline,
-	&.mod-outlined {
+	&.mod-outlined,
+	&.mod-outline { // legacy
 		background-color: _color("white");
 		box-shadow: inset 0 0 0 1px _color("grey", "400");
 		color: _color("text.default");
 
-		&:hover:not([disabled]) {
-			background-color: _color("grey", "100");
-			color: _color("text.default");
-			box-shadow: 0 2px 8px rgba(19, 29, 53, .04), 0 1px 2px rgba(19, 29, 53, .06), inset 0 0 0 1px _color("grey", "400");
+		&:not([disabled], .is-disabled) {
+			&:hover {
+				background-color: _color("grey", "100");
+				color: _color("text.default");
+				box-shadow: _theme('commons.elevations.elevation-1'), inset 0 0 0 1px _color("grey", "400");
+			}
+
+			&:focus {
+				background-color: _color("grey", "100");
+				color: _color("text.default");
+				box-shadow: _theme('commons.elevations.elevation-1'), 0 0 0 4px _color("primary", "100"), inset 0 0 0 1px _color("primary", "400");
+				outline: none;
+			}
+
+			&:active {
+				background-color: _color("grey", "200");
+				color: _color("text.default");
+				box-shadow: _theme('commons.elevations.elevation-1'), 0 0 0 4px _color("primary", "200"), inset 0 0 0 1px _color("primary", "500");
+			}
 		}
-	
-		&:focus:not([disabled]) {
-			background-color: _color("grey", "100");
-			color: _color("text.default");
-			box-shadow: 0 2px 8px rgba(19, 29, 53, .04), 0 1px 2px rgba(19, 29, 53, .06), 0 0 0 4px _color("primary", "100"), inset 0 0 0 1px _color("primary", "400");
-			outline: none;
-		}
-	
-		&:active:not([disabled]) {
-			background-color: _color("grey", "200");
-			color: _color("text.default");
-			box-shadow: 0 2px 8px rgba(19, 29, 53, .04), 0 1px 2px rgba(19, 29, 53, .06), 0 0 0 4px _color("primary", "200"), inset 0 0 0 1px _color("primary", "500");
-		}
+
+
 
 		// TODO delete this class ?
 		&.mod-white {
 			background-color: _color("white");
 			color: _color("grey", "700");
 		}
-		
+
 		// palette colors
 		@each $name, $palette in _getMap("palettes") {
 			&.palette-#{$name} {
@@ -312,6 +315,26 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .button {
+	/* Disabled */
+
+	&.is-disabled,
+	&[disabled] {
+		outline: none;
+		background-color: _color('grey', 100);
+		color: _color('grey', 500);
+		cursor: default;
+
+		&.mod-outlined,
+		&.mod-outline { // legacy
+			background-color: _color('white');
+			border-color: _color('grey', 200);
+		}
+
+		&.mod-link {
+			color: _color('grey', 500);
+			background-color: transparent;
+		}
+	}
 
 	/* Loading */
 
@@ -385,7 +408,7 @@
 	}
 
 	.button {
-		@include buttonColoring("button.default-palette");
+		// @include buttonColoring("button.default-palette");
 
 		border-radius: 0;
 		display: block;
@@ -393,7 +416,10 @@
 		padding-left: _theme("spacings.small");
 		padding-right: _theme("spacings.small");
 		position: relative;
-		border-right: 1px solid rgba(0, 0, 0, .1);
+
+		&:not(.mod-outline, .mod-outlined) {
+			border-right: _theme('commons.divider.width') solid rgba(0, 0, 0, .1);
+		}
 
 		&:first-child {
 			border-radius: _component("button.border.radius") 0 0 _component("button.border.radius");
@@ -404,13 +430,22 @@
 			border-right: 0;
 		}
 
-		&:hover, &:focus {
-			z-index: 1;
+		&:not(:first-child) {
+			&.mod-outline,
+			&.mod-outlined {
+				margin-left: -1px;
+			}
 		}
 
-		&:focus {
-			background-color: _color("primary", "600");
-			box-shadow: none;
+		&:not([disabled], .is-disabled) {
+			&:hover, &:focus {
+				z-index: 1;
+			}
+
+			&:focus {
+				background-color: _color("primary", "600");
+				box-shadow: none;
+			}
 		}
 	}
 

--- a/packages/scss/src/components/_form.scss
+++ b/packages/scss/src/components/_form.scss
@@ -140,14 +140,19 @@
 		clear: both;
 	}
 
-	&:not(.is-disabled):hover {
-		background-color: _component("field.framed.color50");
-	}
+	&:not(.is-disabled, :disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+		&:hover,
+		&:focus {
+			position: relative;
+			z-index: 1;
+			background-color: _color("white");
+			box-shadow: fakeborderoverlay(_component("field.framed.color"));
+		}
 
-	&:focus-within {
-		position: relative;
-		z-index: 1;
-		box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
+		&:focus {
+			z-index: 4;
+			box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
+		}
 	}
 
 	.radiosfield, .checkboxesfield {

--- a/packages/scss/src/components/_form.scss
+++ b/packages/scss/src/components/_form.scss
@@ -140,7 +140,7 @@
 		clear: both;
 	}
 
-	&:not(.is-disabled, :disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+	&:not(.is-disabled, :disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid) {
 		&:hover,
 		&:focus {
 			position: relative;

--- a/packages/scss/src/components/_form.scss
+++ b/packages/scss/src/components/_form.scss
@@ -124,6 +124,7 @@
 .checkboxesfield.mod-framed,
 .radiosfield.mod-framed,
 .form.mod-framed .fieldsetWrapper {
+	background-color: _color("white");
 	padding: 0;
 	box-shadow: fakeborderoverlay(_component("field.framed.border"));
 	transition: background-color _theme("commons.animations.durations.standard");
@@ -139,7 +140,7 @@
 		clear: both;
 	}
 
-	&:hover {
+	&:not(.is-disabled):hover {
 		background-color: _component("field.framed.color50");
 	}
 
@@ -169,10 +170,6 @@
 
 	&.is-disabled, &.is-readonly {
 		background-color: _theme("commons.disabled.background");
-
-		.radio-label, .checkbox-label {
-			cursor: not-allowed;
-		}
 	}
 
 	&.is-loading {

--- a/packages/scss/src/components/inputs/checkbox/_checkbox.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkbox.scss
@@ -17,30 +17,31 @@
 	cursor: pointer;
 	display: inline-flex;
 	align-items: flex-start;
-	transition: color _theme("commons.animations.durations.fast") ease;
+	transition: color _theme('commons.animations.durations.fast') ease;
 
 	&::before {
-		@include makeIcon("tick");
-		border-radius: _component("checkbox.input.border-radius");
-		border: 2px solid _component("checkbox.input.border.color");
+		@include makeIcon('tick');
+		background-color: _color("white");
+		border-radius: _component('checkbox.input.border-radius');
+		border: 2px solid _component('checkbox.input.border.color');
 		color: transparent;
 		display: block;
 		flex: 0 0 auto;
-		font-size: .8rem;
-		height: _component("checkbox.input.size");
+		font-size: 0.8rem;
+		height: _component('checkbox.input.size');
 		line-height: 1;
-		margin-right: _component("checkbox.input.margin-right");
-		margin-top: _component("checkbox.input.margin-top");
+		margin-right: _component('checkbox.input.margin-right');
+		margin-top: _component('checkbox.input.margin-top');
 		text-align: center;
-		transition: all _theme("commons.animations.durations.fast") ease;
-		width: _component("checkbox.input.size");
+		transition: all _theme('commons.animations.durations.fast') ease;
+		width: _component('checkbox.input.size');
 	}
 
 	&:hover {
-		color: _color("text.light");
+		color: _color('text.light');
 
 		&::before {
-			border-color: _component("checkbox.input.border.hover");
+			border-color: _component('checkbox.input.border.hover');
 		}
 	}
 }
@@ -61,53 +62,55 @@
 		.checkbox-input:not(:disabled):checked ~ .checkbox-label {
 			&:hover {
 				&::before {
-					background-color: _color($palette, "600");
-					border-color: _color($palette, "600");
+					background-color: _color($palette, '600');
+					border-color: _color($palette, '600');
 				}
 			}
 		}
 
 		.checkbox-input:focus ~ .checkbox-label {
 			&::before {
-				box-shadow: 0 0 0 4px _color($palette, "200");
+				box-shadow: 0 0 0 4px _color($palette, '200');
 			}
 		}
 	}
 
 	// default color
-	@include checkboxColoring("checkbox.default-palette");
+	@include checkboxColoring('checkbox.default-palette');
 
 	// Status and associated palettes
-	&.palette-error, &.is-error {
+	&.palette-error,
+	&.is-error {
 		.checkbox-label {
 			&::before {
-				border-color: _color("error", "600");
+				border-color: _color('error', '600');
 			}
 		}
 	}
-	&.palette-warning, &.is-warning {
+	&.palette-warning,
+	&.is-warning {
 		.checkbox-label {
 			&::before {
-				border-color: _color("warning", "600");
+				border-color: _color('warning', '600');
 			}
 		}
 	}
-	&.palette-success, &.is-success {
+	&.palette-success,
+	&.is-success {
 		.checkbox-label {
 			&::before {
-				border-color: _color("success", "600");
+				border-color: _color('success', '600');
 			}
 		}
 	}
 
 	// palette colors
-	@each $name, $palette in _getMap("palettes") {
+	@each $name, $palette in _getMap('palettes') {
 		&.palette-#{$name} {
 			@include checkboxColoring($name);
 		}
 	}
 }
-
 
 // MODS
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
@@ -134,14 +137,14 @@
 
 	&.mod-small {
 		.checkbox-label {
-			font-size: _theme("sizes.small.font-size");
-			line-height: _theme("sizes.small.line-height");
+			font-size: _theme('sizes.small.font-size');
+			line-height: _theme('sizes.small.line-height');
 
 			&::before {
-				width: _theme("sizes.small.font-size");
-				height: _theme("sizes.small.font-size");
-				font-size: _theme("sizes.smaller.font-size");
-				margin-top: _component("checkbox.input.small-top");
+				width: _theme('sizes.small.font-size');
+				height: _theme('sizes.small.font-size');
+				font-size: _theme('sizes.smaller.font-size');
+				margin-top: _component('checkbox.input.small-top');
 			}
 		}
 	}
@@ -162,22 +165,23 @@
 // STATES
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
-
 .checkbox .checkbox-input {
-	&[disabled] {
+	&[disabled],
+	&[read-only] {
 		~ .checkbox-label {
-			color: _color("grey");
+			color: _color('grey', '500');
 			cursor: default;
 
 			&::before {
-				border: 2px solid _color("grey", "500");
+				border: 2px solid _color('grey', '500');
 			}
 		}
 
 		&:checked ~ .checkbox-label {
 			&::before {
-				background-color: _color("grey", "500");
-				border: 2px solid _color("grey", "500");
+				color: _color('grey', '500');
+				background-color: _color('grey', '200');
+				border: 2px solid _color('grey', '200');
 			}
 		}
 	}
@@ -185,7 +189,7 @@
 	~ .checkbox-mixed ~ .checkbox-label,
 	&.is-incomplete ~ .checkbox-label {
 		&::before {
-			@include makeIcon("partial");
+			@include makeIcon('partial');
 		}
 	}
 }

--- a/packages/scss/src/components/inputs/field/_field.framed.scss
+++ b/packages/scss/src/components/inputs/field/_field.framed.scss
@@ -35,10 +35,14 @@
 	}
 
 	.#{$fieldname}-input {
-		&:not(:disabled) {
+		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+			background-color: _color("white");
+
 			&:focus, &:hover {
 				position: relative;
 				z-index: 1;
+				background-color: _color("white");
+				box-shadow: fakeborderoverlay(_component("field.framed.color"));
 
 				~ .#{$fieldname}-messages {
 					transform: translateY(100%);
@@ -47,6 +51,7 @@
 
 			&:focus {
 				z-index: 4;
+				box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
 			}
 		}
 	}

--- a/packages/scss/src/components/inputs/field/_field.framed.scss
+++ b/packages/scss/src/components/inputs/field/_field.framed.scss
@@ -35,7 +35,7 @@
 	}
 
 	.#{$fieldname}-input {
-		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid) {
 			background-color: _color("white");
 
 			&:focus, &:hover {

--- a/packages/scss/src/components/inputs/radio-buttons/_radio-buttons.scss
+++ b/packages/scss/src/components/inputs/radio-buttons/_radio-buttons.scss
@@ -23,12 +23,14 @@
 .radioButtons-item-input {
 	@include mask;
 
-	&:checked ~ .radioButtons-item-label {
+	&:checked ~ .radioButtons-item-label, 
+	&:focus ~ .radioButtons-item-label {
 		z-index: 2;
 	}
 }
 
 .radioButtons-item-label {
+	background-color: _color("white");
 	cursor: pointer;
 	display: block;
 	overflow: hidden;
@@ -41,45 +43,51 @@
 // PALETTES
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 @mixin radioLabelColoring($palette) {
-	color: _color($palette, "800");
-	box-shadow: inset 0 0 0 1px _color($palette, "200");
+	color: _color($palette, 700);
+	box-shadow: inset 0 0 0 1px _color($palette, 200);
 
 	&:hover {
-		background-color: _color($palette, "50");
-		box-shadow: inset 0 0 0 1px _color($palette, "200");
+		background-color: _color($palette, 50);
+		box-shadow: _theme('commons.elevations.elevation-1'), inset 0 0 0 1px _color($palette, 200);
 	}
 }
 
 @mixin radioInputColoring($palette) {
+
 	&:checked ~ .radioButtons-item-label {
-		background-color: _color($palette, "50");
-		box-shadow: inset 0 0 0 1px _color($palette, "200");
-		color: _color($palette, "700");
+		background-color: _color($palette, 50);
+		box-shadow: inset 0 0 0 1px _color($palette, 400);
+		color: _color($palette, 700);
 
 		&:hover {
-			background-color: _color($palette, "100");
-			box-shadow: inset 0 0 0 1px _color($palette, "400");
-		}
-
-		&:focus {
-			box-shadow: 0 0 0 4px _color($palette, "200"), inset 0 0 0 1px _color($palette, "400");
+			box-shadow: _theme('commons.elevations.elevation-1'), inset 0 0 0 1px _color($palette, 400);
 		}
 	}
 
 	&:focus ~ .radioButtons-item-label {
-		box-shadow: 0 0 0 4px _color($palette, "200"), inset 0 0 0 1px _color($palette, "400");
+		box-shadow: 0 0 0 4px _color($palette, 200), inset 0 0 0 1px _color($palette, 400);
+	}
+
+	&:focus:checked ~ .radioButtons-item-label {
+		background-color: _color($palette, 100);
+		box-shadow: 0 0 0 4px _color($palette, 200), inset 0 0 0 1px _color($palette, 600);
+	}
+
+	&:focus:not(:checked) ~ .radioButtons-item-label {
+		background-color: _color("grey", 50);
 	}
 }
 
 .radioButtons {
 	@each $name, $palette in _getMap("palettes") {
 		&.palette-#{$name} {
-			.radioButtons-item-label {
-				@include radioLabelColoring($name);
-			}
 
-			.radioButtons-item-input {
+			.radioButtons-item-input:not(:disabled, .is-disabled) {
 				@include radioInputColoring($name);
+				
+				~ .radioButtons-item-label {
+					@include radioLabelColoring($name);
+				}
 			}
 		}
 	}
@@ -97,7 +105,7 @@
 	}
 }
 
-.radioButtons-item-input {
+.radioButtons-item-input:not(:disabled, .is-disabled) {
 	// default color
 	@include radioInputColoring("radioButtons.default-palette");
 
@@ -111,7 +119,6 @@
 
 // MODS
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
-
 .radioButtons {
 	&.mod-small {
 		.radioButtons-item-label {
@@ -119,5 +126,23 @@
 			line-height: _component("radioButtons.small.line-height");
 			padding: _component("radioButtons.small.padding");
 		}
+	}
+}
+
+// STATES
+// ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
+.radioButtons-item-input {
+
+	&:disabled ~ .radioButtons-item-label,
+	&.is-disabled ~ .radioButtons-item-label { // legacy
+		box-shadow: inset 0 0 0 1px _color("grey", 200);
+		color: _color("grey", 500);
+		cursor: default;
+		z-index: -1;
+	}
+
+	&:checked:disabled ~ .radioButtons-item-label,
+	&:checked.is-disabled ~ .radioButtons-item-label { // legacy
+		background-color: _color("grey", 100);
 	}
 }

--- a/packages/scss/src/components/inputs/radio/_radio.scss
+++ b/packages/scss/src/components/inputs/radio/_radio.scss
@@ -14,7 +14,7 @@
 
 	&:checked ~ .radio-label {
 		&::after {
-			transform: scale(.55);
+			transform: scale(0.55);
 		}
 	}
 }
@@ -22,34 +22,35 @@
 .radio-label {
 	cursor: pointer;
 	display: inline-block;
-	line-height: _component("radio.label.line-height");
-	padding: _component("radio.label.padding");
-	transition: color _theme("commons.animations.durations.fast") ease;
+	line-height: _component('radio.label.line-height');
+	padding: _component('radio.label.padding');
+	transition: color _theme('commons.animations.durations.fast') ease;
 
 	&::before {
+		background-color: _color("white");
 		border-radius: 50%;
-		content: "";
+		content: '';
 		display: block;
-		height: _component("radio.input.size");
+		height: _component('radio.input.size');
 		left: 0;
 		position: absolute;
-		top: _component("radio.input.top");
-		transition: all _theme("commons.animations.durations.fast") ease;
-		width: _component("radio.input.size");
+		top: _component('radio.input.top');
+		transition: all _theme('commons.animations.durations.fast') ease;
+		width: _component('radio.input.size');
 	}
 
 	&::after {
 		border-radius: 50%;
 		color: transparent;
-		content: "";
+		content: '';
 		display: block;
-		height: _component("radio.input.size");
+		height: _component('radio.input.size');
 		left: 0;
 		position: absolute;
-		top: _component("radio.input.top");
+		top: _component('radio.input.top');
 		transform: scale(0);
-		transition: all _theme("commons.animations.durations.fast") ease;
-		width: _component("radio.input.size");
+		transition: all _theme('commons.animations.durations.fast') ease;
+		width: _component('radio.input.size');
 	}
 }
 
@@ -58,67 +59,64 @@
 
 .radio {
 	@mixin radioColoring($palette) {
-		.radio-input:checked ~ .radio-label {
-			&::before {
-				border: 2px solid _color($palette, "700");
-			}
-
-			&::after {
-				background-color: _color($palette, "700");
-			}
-
-			&:hover {
-				&::before {
-					border-color: _color($palette, "600");
-				}
-
-				&::after {
-					background-color: _color($palette, "600");
-				}
-			}
-		}
 
 		.radio-label {
 			&::before {
-				border: 2px solid _color($palette, "700");
+				border: 2px solid _color($palette, 700);
 			}
+		}
 
+		.radio-input:checked ~ .radio-label {
+			&::after {
+				background-color: _color($palette, 700);
+			}
+		}
+
+		.radio-input:not(:disabled):checked ~ .radio-label {
 			&:hover {
-				&::after {
-					background-color: _color($palette, "600");
+				&::before {
+					border-color: _color($palette, 600);
 				}
 
-				&::before {
-					border-color: _color($palette, "600");
+				&::after {
+					background-color: _color($palette, '600');
 				}
 			}
 		}
+		
+		.radio-input:not(:disabled) ~ .radio-label {
+			&:hover {
+				&::before {
+					border-color: _color($palette, 600);
+				}
+			}
+		}
+
 
 		.radio-input {
 			&:focus ~ .radio-label {
 				&::before {
-					box-shadow: 0 0 0 4px _color($palette, "200");
-					border-color: _color($palette, "600");
+					box-shadow: 0 0 0 4px _color($palette, '200');
+					border-color: _color($palette, '600');
 				}
 
 				&::after {
-					background-color: _color($palette, "600");
+					background-color: _color($palette, '600');
 				}
 			}
 		}
 	}
 
 	// default color
-	@include radioColoring("radio.default-palette");
+	@include radioColoring('radio.default-palette');
 
 	// palette colors
-	@each $name, $palette in _getMap("palettes") {
+	@each $name, $palette in _getMap('palettes') {
 		&.palette-#{$name} {
 			@include radioColoring($name);
 		}
 	}
 }
-
 
 // MODS
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
@@ -132,14 +130,15 @@
 	}
 
 	&.mod-small .radio-label {
-		line-height: _theme("sizes.small.line-height");
-		font-size: _theme("sizes.small.font-size");
-		padding: _component("radio.label.small-padding");
+		line-height: _theme('sizes.small.line-height');
+		font-size: _theme('sizes.small.font-size');
+		padding: _component('radio.label.small-padding');
 
-		&::before, &::after {
-			height: _theme("sizes.small.font-size");
-			width: _theme("sizes.small.font-size");
-			top: _component("radio.input.small-top");
+		&::before,
+		&::after {
+			height: _theme('sizes.small.font-size');
+			width: _theme('sizes.small.font-size');
+			top: _component('radio.input.small-top');
 		}
 	}
 }
@@ -148,23 +147,24 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .radio .radio-input {
-	&[disabled] {
+	&[disabled],
+	&[read-only] {
 		~ .radio-label {
-			color: _color("grey");
+			color: _color('grey', '500');
 			cursor: default;
 
 			&::before {
-				border: 2px solid _color("grey", "500");
+				border: 2px solid _color('grey', '500');
 			}
 		}
 
 		&:checked ~ .radio-label {
 			&::before {
-				border: 2px solid _color("grey", "500");
+				border: 2px solid _color('grey', '500');
 			}
 
 			&::after {
-				background-color: _color("grey", "500");
+				background-color: _color('grey', '500');
 			}
 		}
 	}

--- a/packages/scss/src/components/inputs/switch/_switch.scss
+++ b/packages/scss/src/components/inputs/switch/_switch.scss
@@ -1,4 +1,5 @@
 .switch {
+	display: block;
 	position: relative;
 }
 
@@ -143,7 +144,7 @@
 			}
 		}
 
-		&:active ~ .switch-label {
+		&:active:not([disabled], [readonly]) ~ .switch-label {
 			&::before {
 				background-color: _color("secondary", "800");
 				box-shadow: 0 0 0 4px _color("secondary", "300");
@@ -161,22 +162,22 @@
 			cursor: default;
 
 			&::before {
-				background-color: _color("grey", "500");
+				background-color: _color("grey", "200");
 			}
 
 			&::after {
-				background-color: _color("grey", "300");
+				background-color: _color("grey", "500");
 			}
 		}
 
 		&:checked ~ .switch-label {
 			&::before {
-				background-color: _color("secondary", "500");
-				color: _color("secondary", "700");
+				background-color: _color("grey", "200");
+				color: _color("grey", "500");
 			}
 
 			&::after {
-				background-color: _color("secondary", "200");
+				background-color: _color("grey", "500");
 			}
 		}
 	}
@@ -195,7 +196,7 @@
 		Active
 	*/
 
-	&:active ~ .switch-label {
+	&:active:not([disabled], [readonly]) ~ .switch-label {
 		&::before {
 			background-color: _color("grey", "800");
 			box-shadow: 0 0 0 4px _color("grey", "300");

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -60,74 +60,23 @@
 	.textfield-input {
 		width: 100%;
 		border-radius: 0;
-		background-color: _color("white");
 		box-shadow: fakeborderoverlay(_component("field.framed.border"));
 		padding: _component("field.framed.top-padding") _component("field.framed.side-padding") _component("field.framed.bottom-padding");
 		line-height: _theme("sizes.standard.line-height");
 
-		&:not(:disabled) {
-			&:not(.is-error) {
-				&:not(.is-success) {
-					&:not(.is-valid) {
-						&:not(.is-warning) {
-							&:not(.is-invalid) {
-								&:not(.ng-invalid) {
-									background-color: white;
+		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+			
+			background-color: _color("white");
 
-									&:hover {
-										background-color: _component("field.framed.color50");
-									}
-
-									&:focus {
-										background-color: white;
-										box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
-									}
-								}
-							}
-						}
-					}
-				}
+			&:hover {
+				background-color: _component("field.framed.color50");
 			}
 
-			&.is-error {
-				box-shadow: fakeborderoverlay(_color("error"));
-				z-index: 3;
-
-				&:hover {
-					background-color: _color("error", "100");
-				}
-
-				&:focus {
-					background-color: white;
-					box-shadow: fakeborderoverlay(_color("error")), 0 0 0 4px _color("error", "50");
-				}
+			&:focus {
+				background-color: _color("white");
+				box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
 			}
 
-			&.is-warning {
-				background-color: white;
-
-				&:hover {
-					background-color: _color("warning", "50");
-				}
-
-				&:focus {
-					background-color: white;
-					box-shadow: fakeborderoverlay(_color("warning")), 0 0 0 4px _color("warning", "50");
-				}
-			}
-
-			&.is-valid, &.is-success {
-				background-color: white;
-
-				&:hover {
-					background-color: _color("success", "50");
-				}
-
-				&:focus {
-					background-color: white;
-					box-shadow: fakeborderoverlay(_color("success")), 0 0 0 4px _color("success", "50");
-				}
-			}
 		}
 
 		&:invalid {

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -64,7 +64,7 @@
 		padding: _component("field.framed.top-padding") _component("field.framed.side-padding") _component("field.framed.bottom-padding");
 		line-height: _theme("sizes.standard.line-height");
 
-		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
+		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid) {
 			background-color: _color("white");
 
 			&:hover,

--- a/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.framed.scss
@@ -65,15 +65,18 @@
 		line-height: _theme("sizes.standard.line-height");
 
 		&:not(:disabled, .is-error, .is-success, .is-valid, .is-warning, .is-invalid, .ng-invalid) {
-			
 			background-color: _color("white");
 
-			&:hover {
-				background-color: _component("field.framed.color50");
+			&:hover,
+			&:focus {
+				position: relative;
+				z-index: 1;
+				background-color: _color("white");
+				box-shadow: fakeborderoverlay(_component("field.framed.color"));
 			}
 
 			&:focus {
-				background-color: _color("white");
+				z-index: 4;
 				box-shadow: fakeborderoverlay(_component("field.framed.color")), 0 0 0 4px _component("field.framed.color50");
 			}
 

--- a/packages/scss/src/components/inputs/textfield/_textfield.outlined.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.outlined.scss
@@ -17,7 +17,7 @@
 		.textfield-input:focus {
 			&:not([disabled], &[readonly], &.is-disabled, &.is-readonly) {
 				background-color: _color("white");
-				box-shadow: 0 0 0 4px _color($palette, textfield-input200), inset 0 0 0 _component("textfield.outlined.border.width") _color($palette, 600);
+				box-shadow: 0 0 0 4px _color($palette, 200), inset 0 0 0 _component("textfield.outlined.border.width") _color($palette, 600);
 			}
 		}
 	}

--- a/packages/scss/src/components/inputs/textfield/_textfield.outlined.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.outlined.scss
@@ -4,16 +4,21 @@
 			box-shadow: inset 0 0 0 _component("textfield.outlined.border.width") _component("textfield.outlined.border.default-color");
 			background-color: _color("white");
 		}
+
 		&:hover .textfield-input {
-			box-shadow: inset 0 0 0 _component("textfield.outlined.border.width") _color($palette, 200);
-			background-color: _color($palette, 50);
+			&:not([disabled], &[readonly], &.is-disabled, &.is-readonly) {
+				box-shadow: inset 0 0 0 _component("textfield.outlined.border.width") _color($palette, 200);
+				background-color: _color($palette, 50);
+			}
 		}
 
 		&.is-focused .textfield-input,
 		.textfield-input.is-focused,
 		.textfield-input:focus {
-			background-color: _color("white");
-			box-shadow: 0 0 0 4px _color($palette, 200), inset 0 0 0 _component("textfield.outlined.border.width") _color($palette, 600);
+			&:not([disabled], &[readonly], &.is-disabled, &.is-readonly) {
+				background-color: _color("white");
+				box-shadow: 0 0 0 4px _color($palette, textfield-input200), inset 0 0 0 _component("textfield.outlined.border.width") _color($palette, 600);
+			}
 		}
 	}
 
@@ -42,7 +47,9 @@
 			&,
 			&:focus,
 			&.is-focused {
-				background-color: _theme("commons.disabled.background");
+				background-color: _component("textfield.disabled.background");
+				color: _component("textfield.disabled.color");
+				cursor: default;
 				box-shadow: none;
 			}
 		}
@@ -53,7 +60,9 @@
 		&[readonly],
 		&.is-disabled,
 		&.is-readonly {
-			background-color: _theme("commons.disabled.background");
+			background-color: _component("textfield.disabled.background");
+			color: _component("textfield.disabled.color");
+			cursor: default;
 			box-shadow: none;
 		}
 	}

--- a/packages/scss/src/components/inputs/textfield/_textfield.scss
+++ b/packages/scss/src/components/inputs/textfield/_textfield.scss
@@ -111,7 +111,7 @@
 
 		.textfield-input {
 			padding-right: _theme("spacings.bigger") !important;
-			
+
 			&::-ms-reveal {
 				display: none;
 			}
@@ -387,12 +387,13 @@
 	@include field-input("textfield");
 
 	&[disabled], &[readonly], &.is-disabled, &.is-readonly {
-		background-color: _theme("commons.disabled.background");
-		color: _theme("commons.disabled.color");
-		cursor: not-allowed;
+		background-color: _component("textfield.disabled.background");
+		box-shadow: none;
+		color: _component("textfield.disabled.color");
+		cursor: default;
 
 		&::placeholder {
-			color: _theme("commons.disabled.placeholder");
+			color: _component("textfield.disabled.color");
 		}
 	}
 }

--- a/packages/scss/src/mixins/_forms.scss
+++ b/packages/scss/src/mixins/_forms.scss
@@ -1,33 +1,35 @@
 @import "../mixins/utilities";
 
 @mixin fieldState($fieldname, $state) {
-	background-color: _color($state, "50");
+	&:not(:disabled, .is-disabled) {
+		background-color: _color($state, "50");
 
-	~ .#{$fieldname}-label, ~ .#{$fieldname}-suffix {
-		color: _color($state);
-	}
-
-	&::placeholder {
-		color: _color($state, "400");
-	}
-
-	&:focus {
-		&::placeholder {
-			color: _color($state, "300");
+		~ .#{$fieldname}-label, ~ .#{$fieldname}-suffix {
+			color: _color($state);
 		}
-	}
 
-	&:focus ~ .#{$fieldname}-label, &.is-focused ~ .#{$fieldname}-label {
-		color: _color($state);
-	}
+		&::placeholder {
+			color: _color($state, "400");
+		}
 
-	&:focus {
-		background-color: white;
-		box-shadow: 0 0 0 4px _color($state, "200"), 0 0 0 1px _color($state) inset;
-	}
+		&:focus {
+			&::placeholder {
+				color: _color($state, "300");
+			}
+		}
 
-	@if ($state == "error") {
-		box-shadow: 0 0 0 1px _color($state);
+		&:focus ~ .#{$fieldname}-label, &.is-focused ~ .#{$fieldname}-label {
+			color: _color($state);
+		}
+
+		&:focus {
+			background-color: white;
+			box-shadow: 0 0 0 4px _color($state, "200"), 0 0 0 1px _color($state) inset;
+		}
+
+		@if ($state == "error") {
+			box-shadow: 0 0 0 1px _color($state);
+		}
 	}
 }
 
@@ -160,10 +162,12 @@
 	}
 
 	@if ($fieldname == "radiosfield") {
-		~ .radio-label,
-		~ .checkbox-label {
-			&::before {
-				border-color: _color("error");
+		&:not(:disabled) {
+			~ .radio-label,
+			~ .checkbox-label {
+				&::before {
+					border-color: _color("error");
+				}
 			}
 		}
 	}

--- a/packages/scss/src/theming/_commons.scss
+++ b/packages/scss/src/theming/_commons.scss
@@ -15,7 +15,7 @@ $commons: (
 	),
 	disabled: (
 		opacity: .4,
-		background: #E5E5E5,
+		background: _color("grey", 100),
 		color: #999999,
 		placeholder: #BBBBBB
 	),

--- a/packages/scss/src/theming/components/_radio.theme.scss
+++ b/packages/scss/src/theming/components/_radio.theme.scss
@@ -1,6 +1,6 @@
 $radio: (
   // theming
-  default-palette: _getMap("palettes.primary"),
+  default-palette: _getMap("palettes.grey"),
   label: (
     line-height: 1.5rem,
     padding: 0 0 0 1.5rem,

--- a/packages/scss/src/theming/components/_switch.theme.scss
+++ b/packages/scss/src/theming/components/_switch.theme.scss
@@ -1,6 +1,6 @@
 $switch: (
   // theming
-  top: -1px,
+  top: 1px,
   small-top: 2px,
   icon-top: 1px,
   icon-left: 1px,

--- a/packages/scss/src/theming/components/_textfield.theme.scss
+++ b/packages/scss/src/theming/components/_textfield.theme.scss
@@ -20,13 +20,13 @@ $textfield: (
 	),
 
 	disabled: (
-		background: #F5F5F5,
-		color: #999999
+		background: _color("grey", "100"),
+		color: _color("grey", "400")
 	),
 
 	suffix: (
 		top: 2rem,
-		padding-right: 1.5rem 
+		padding-right: 1.5rem
 	),
 
 	sizes: (

--- a/stories/scss/button/button-basic.stories.html
+++ b/stories/scss/button/button-basic.stories.html
@@ -1,1 +1,9 @@
-<button class="button {{mod}} {{state}} {{palette}} {{size}}">{{label}}</button>
+<div class="u-paddingStandard" [attr.style]="mod === 'mod-link mod-invert' ? 'background-color: black' : null">
+    <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
+</div>
+
+<div class="u-paddingStandard button-group">
+    <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
+    <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
+    <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
+</div>

--- a/stories/scss/button/button-basic.stories.ts
+++ b/stories/scss/button/button-basic.stories.ts
@@ -12,6 +12,8 @@ import { Story, Meta, moduleMetadata } from '@storybook/angular';
 	@Input() palette: string = '';
 	@Input() state: string = '';
 	@Input() size: string = '';
+	@Input() disabled: boolean = false;
+	// @Input() more: boolean = false; // lucca-icons needed
 }
 
 export default {
@@ -21,7 +23,7 @@ export default {
 		mod: {
 			control: {
 				type: 'radio',
-				options: ['', ' mod-outline', 'mod-link']
+				options: ['', ' mod-outline', 'mod-link', 'mod-link mod-invert']
 			}
 		},
 		palette: {
@@ -57,11 +59,5 @@ const template: Story<ButtonBasicStory> = (args: ButtonBasicStory) => ({
 });
 
 export const def = template.bind({});
-def.args = { label: 'label', mod: '', size: '', state: '', palette: '' };
-
-export const outline = template.bind({});
-outline.args = { label: 'label', mod: 'mod-outline', size: '', state: '', palette: '' };
-
-export const loading = template.bind({});
-loading.args = { label: 'label', mod: '', size: '', state: 'is-loading', palette: '' };
+def.args = { label: 'label', mod: '', size: '', state: '', palette: '', disabled: false };
 

--- a/stories/scss/form/checkbox/checkbox.stories.html
+++ b/stories/scss/form/checkbox/checkbox.stories.html
@@ -1,5 +1,10 @@
-<label class="checkbox">
-	<input class="checkbox-input" type="checkbox" [attr.aria-hidden]="isAriaHidden" [ngModel]="isChecked" (ngModelChange)="toggle($event)"/>
+<label class="checkbox {{ palette }}">
+	<input class="checkbox-input" 
+		type="checkbox" 
+		[attr.aria-hidden]="isAriaHidden" 
+		[ngModel]="isChecked" 
+		(ngModelChange)="toggle($event)" 
+		[disabled]="disabled"/>
 	<span *ngIf="isMixed" class="checkbox-mixed" role="checkbox" aria-checked="mixed"></span>
-	<span class="checkbox-label">{{state}}</span>
+	<span class="checkbox-label">Checkbox input</span>
 </label>

--- a/stories/scss/form/checkbox/checkbox.stories.ts
+++ b/stories/scss/form/checkbox/checkbox.stories.ts
@@ -9,17 +9,18 @@ import { Story, Meta, moduleMetadata } from '@storybook/angular';
 	selector: 'checkbox-stories',
 	templateUrl: './checkbox.stories.html',
 }) class CheckboxStory {
-	@Input() state: string = 'unchecked';
-	get isMixed(): boolean { return this.state === 'mixed'; }
-	get isChecked(): boolean { return this.state === 'checked' || this.state === 'mixed'; }
+	@Input() disabled: boolean = false;
+	@Input() checked: string = 'unchecked';
+	get isMixed(): boolean { return this.checked === 'mixed'; }
+	get isChecked(): boolean { return this.checked === 'checked' || this.checked === 'mixed'; }
 	get isAriaHidden(): boolean | null {
 		return this.isMixed ? true : null;
 	}
 	toggle(flag: boolean) {
 		if (flag) {
-			this.state = 'checked';
+			this.checked = 'checked';
 		} else {
-			this.state = 'unchecked';
+			this.checked = 'unchecked';
 		}
 	}
 }
@@ -28,10 +29,21 @@ export default {
 	title: 'SCSS/Form/Checkboxes',
 	component: CheckboxStory,
 	argTypes: {
-		state: {
+		checked: {
 			control: {
 				type: 'radio',
 				options: ['checked', 'unchecked', 'mixed']
+			}
+		},
+		palette: {
+			control: {
+				type: 'radio',
+				options: [
+					'',
+					'palette-success', 
+					'palette-warning',
+					'palette-error'
+				]
 			}
 		},
 	},
@@ -48,3 +60,4 @@ const template: Story<CheckboxStory> = (args: CheckboxStory) => ({
 });
 
 export const basic = template.bind({});
+basic.args = { checked: 'unchecked', palette: '', disabled: false };

--- a/stories/scss/form/framed/framed.stories.html
+++ b/stories/scss/form/framed/framed.stories.html
@@ -1,0 +1,40 @@
+<form class="form mod-framed">
+	<div class="form-group-line">
+		<div class="form-group-line-col">
+			<label class="textfield">
+				<input class="textfield-input {{ state }}" type="text" placeholder="placeholder" [disabled]="disabled"/>
+				<span class="textfield-label">Label textfield</span>
+			</label>
+		</div>
+	</div>
+	<div class="form-group-line">
+		<div class="form-group-line-col">
+			<label class="textfield mod-multiline ">
+				<textarea class="textfield-input {{ state }}" placeholder="Placeholder" [disabled]="disabled"></textarea>
+				<span class="textfield-label">Label textfield</span>
+			</label>
+		</div>
+	</div>
+	<div class="form-group-line">
+		<div class="form-group-line-col">
+			<div class="checkboxesfield mod-framed"
+				[class.is-disabled]="disabled">
+				<label class="checkbox">
+					<input type="checkbox" class="checkbox-input {{ state }}" [disabled]="disabled">
+					<span class="checkbox-label">Checkbox</span>
+				</label>
+			</div>
+		</div>
+	</div>
+	<div class="form-group-line">
+		<div class="form-group-line-col">
+			<div class="radiosfield mod-framed"
+				[class.is-disabled]="disabled">
+				<label class="radio">
+					<input type="radio" class="radio-input {{ state }}" [disabled]="disabled">
+					<span class="radio-label">Radio</span>
+				</label>
+			</div>
+		</div>
+	</div>
+</form>

--- a/stories/scss/form/framed/framed.stories.ts
+++ b/stories/scss/form/framed/framed.stories.ts
@@ -1,0 +1,38 @@
+import { Component, Input } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'framed-stories',
+	templateUrl: './framed.stories.html',
+}) class FramedStory {
+	@Input() state: string = '';
+	@Input() disabled: boolean = false;
+}
+
+export default {
+	title: 'SCSS/Form/FramedStory',
+	component: FramedStory,
+	argTypes: {
+		state: {
+			control: {
+				type: 'radio',
+				options: ['', 'is-error', 'is-warning', 'is-success']
+			}
+		}		
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [FramedStory],
+			imports: [BrowserModule],
+		})
+	]
+} as Meta;
+
+const template: Story<FramedStory> = (args: FramedStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+basic.args = { state: '', disabled: false };

--- a/stories/scss/form/radio-button/radio-button.stories.html
+++ b/stories/scss/form/radio-button/radio-button.stories.html
@@ -1,0 +1,11 @@
+<div class="radioButtons {{palette}}" [ngClass]="{'mod-small': isModSmall}">
+	<label *ngFor="let button of buttonsArray, let index = index"
+		class="radioButtons-item">
+		<input type="radio" 
+			name="radioButtonsId" 
+			class="radioButtons-item-input"
+			[checked]="indexChecked === index + 1"
+			[disabled]="indexDisabled === index + 1"/>
+		<span class="radioButtons-item-label">Button {{ index + 1 }}</span>
+	</label>
+</div>

--- a/stories/scss/form/radio-button/radio-button.stories.ts
+++ b/stories/scss/form/radio-button/radio-button.stories.ts
@@ -1,0 +1,53 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'radioButton-stories',
+	templateUrl: './radio-button.stories.html',
+}) class RadioButtonStory {
+	@Input() buttonsCount: number;
+	@Input() indexDisabled: number;
+	@Input() indexChecked: number;
+	@Input() palette: string = '';
+	@Input() isModSmall: boolean;
+	get buttonsArray () {
+		return Array(this.buttonsCount).keys();
+	}
+}
+
+export default {
+	title: 'SCSS/Form/radioButtons',
+	component: RadioButtonStory,
+	argTypes: {
+		palette: {
+			control: {
+				type: 'radio',
+				options: ['', 'palette-primary', 'palette-secondary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error']
+			}
+		}
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [RadioButtonStory],
+			imports: [BrowserModule, FormsModule, CommonModule],
+		})
+	]
+} as Meta;
+
+
+const template: Story<RadioButtonStory> = (args: RadioButtonStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+basic.args = {
+	buttonsCount: 3,
+	indexChecked: 0,
+	indexDisabled: 0,
+	palette: '',
+	isModSmall: false
+};

--- a/stories/scss/form/radio/radio.stories.html
+++ b/stories/scss/form/radio/radio.stories.html
@@ -1,0 +1,8 @@
+<label class="radio {{ palette }}">
+	<input class="radio-input" 
+		type="radio"
+		[attr.aria-hidden]="isAriaHidden"
+		[checked]="checked"
+		[disabled]="disabled"/>
+	<span class="radio-label">Radio input</span>
+</label>

--- a/stories/scss/form/radio/radio.stories.ts
+++ b/stories/scss/form/radio/radio.stories.ts
@@ -1,0 +1,45 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'radio-stories',
+	templateUrl: './radio.stories.html',
+}) class RadioStory {
+	@Input() disabled: boolean = false;
+	@Input() checked: boolean = false;
+}
+
+export default {
+	title: 'SCSS/Form/Radios',
+	component: RadioStory,
+	argTypes: {
+		palette: {
+			control: {
+				type: 'radio',
+				options: [
+					'',
+					'palette-success', 
+					'palette-warning',
+					'palette-error'
+				]
+			}
+		},
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [RadioStory],
+			imports: [BrowserModule, FormsModule, CommonModule],
+		})
+	]
+} as Meta;
+
+const template: Story<RadioStory> = (args: RadioStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+basic.args = { checked: false, palette: '', disabled: false };

--- a/stories/scss/form/switch/switch.stories.html
+++ b/stories/scss/form/switch/switch.stories.html
@@ -1,0 +1,27 @@
+<div class="grid">
+	<div class="grid-xxxs4">
+		<div class="form-group">
+			<label class="switch" [ngClass]="{'mod-small': isSmall, 'mod-inline': isInline}">
+				<input class="switch-input" id="switch1" type="checkbox" [checked]="isChecked" [disabled]="isDisabled"/>
+				<span for="switch1" class="switch-label">Switch 1</span>
+			</label>
+			<label class="switch" [ngClass]="{'mod-small': isSmall, 'mod-inline': isInline}">
+				<input class="switch-input" id="switch2" type="checkbox" [checked]="isChecked" [disabled]="isDisabled"/>
+				<span for="switch2" class="switch-label">Switch 2</span>
+			</label>
+		</div>
+	</div>
+	<!-- legacy syntax -->
+	<div class="grid-xxxs4">
+		<div class="form-group">
+			<div class="switch" [ngClass]="{'mod-small': isSmall, 'mod-inline': isInline}">
+				<input class="switch-input" id="switch3" type="checkbox" [checked]="isChecked" [disabled]="isDisabled"/>
+				<label for="switch3" class="switch-label">Switch 3</label>
+			</div>
+			<div class="switch" [ngClass]="{'mod-small': isSmall, 'mod-inline': isInline}">
+				<input class="switch-input" id="switch4" type="checkbox" [checked]="isChecked" [disabled]="isDisabled"/>
+				<label for="switch4" class="switch-label">Switch 4</label>
+			</div>
+		</div>
+	</div>
+</div>

--- a/stories/scss/form/switch/switch.stories.ts
+++ b/stories/scss/form/switch/switch.stories.ts
@@ -1,0 +1,61 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'switch-stories',
+	templateUrl: './switch.stories.html',
+}) class SwitchStory {
+	@Input() isChecked: boolean = false;
+	@Input() isDisabled: boolean = false;
+	@Input() isSmall: boolean = false;
+	@Input() isInline: boolean = false;
+}
+
+export default {
+	title: 'SCSS/Form/Switches',
+	component: SwitchStory,
+	argTypes: {
+		isChecked: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		isDisabled: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		isSmall: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		isInline: {
+			control: {
+				type: 'boolean',
+			},
+		}
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [SwitchStory],
+			imports: [BrowserModule, FormsModule, CommonModule],
+		})
+	]
+} as Meta;
+
+const template: Story<SwitchStory> = (args: SwitchStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+basic.args = {
+	isChecked: false,
+	isDisabled: false,
+	isSmall: false,
+	isInline: false
+};

--- a/stories/scss/form/textfields/textfield.stories.html
+++ b/stories/scss/form/textfields/textfield.stories.html
@@ -1,0 +1,4 @@
+<label class="textfield {{ palette }}">
+	<input class="textfield-input {{ state }}" type="text" placeholder="placeholder" [disabled]="disabled"/>
+	<span class="textfield-label">Textfield label</span>
+</label>

--- a/stories/scss/form/textfields/textfield.stories.ts
+++ b/stories/scss/form/textfields/textfield.stories.ts
@@ -1,0 +1,57 @@
+import { Component, Input } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { Story, Meta, moduleMetadata } from '@storybook/angular';
+
+
+@Component({
+	selector: 'textfield-stories',
+	templateUrl: './textfield.stories.html',
+}) class TextfieldStory {
+	@Input() state: string = '';
+	@Input() palette: string = '';
+	@Input() disabled: boolean = false;
+}
+
+export default {
+	title: 'SCSS/Form/Textfields',
+	component: TextfieldStory,
+	argTypes: {
+		state: {
+			control: {
+				type: 'radio',
+				options: [
+					'', 
+					'is-success',
+					'is-warning',
+					'is-error'
+				]
+			}
+		},
+		palette: {
+			control: {
+				type: 'radio',
+				options: [
+					'',
+					'palette-primary',
+					'palette-secondary',
+					'palette-success',
+					'palette-warning',
+					'palette-error'
+				]
+			}
+		},
+	},
+	decorators: [
+		moduleMetadata({
+			entryComponents: [TextfieldStory],
+			imports: [BrowserModule],
+		})
+	]
+} as Meta;
+
+const template: Story<TextfieldStory> = (args: TextfieldStory) => ({
+	props: args,
+});
+
+export const basic = template.bind({});
+basic.args = { state: '', palette: '', disabled: false };


### PR DESCRIPTION
# LF 7.3

## Disabled inputs and buttons

Updates disabled inputs and buttons to use the grey palette and match the design system

See PR https://github.com/LuccaSA/lucca-front/pull/1478 for full details

### Visual changes

- Disabled buttons use the grey palette
- Disabled buttons and inputs use a dark on light color scheme

### Breaking changes

- For radio and checkbox inputs in framed forms, the `.is-disabled` class must be placed on the parent `.radiosfield` or `.checkboxesfield` element to set the correct background color.

### Fixes

- Removes hover animations on buttons and inputs