### PR TITLE
fix(scss) .button.mod-more

### DIFF
--- a/packages/scss/src/components/_button.scss
+++ b/packages/scss/src/components/_button.scss
@@ -209,7 +209,6 @@
 
 		&::before {
 			@include makeIcon("arrow_south");
-			content: "";
 			height: 0;
 			vertical-align: text-top;
 		}

--- a/stories/scss/button/button-basic.stories.html
+++ b/stories/scss/button/button-basic.stories.html
@@ -1,8 +1,8 @@
-<div class="u-paddingStandard" [attr.style]="mod === 'mod-link mod-invert' ? 'background-color: black' : null">
+<div class="u-marginStandard" [attr.style]="mod === 'mod-link mod-invert' ? 'background-color: black' : null">
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
 </div>
 
-<div class="u-paddingStandard button-group">
+<div class="u-marginStandard button-group">
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>

--- a/stories/scss/button/button-basic.stories.html
+++ b/stories/scss/button/button-basic.stories.html
@@ -6,4 +6,5 @@
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
     <button class="button {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null">{{label}}</button>
+    <button class="button mod-more {{mod}} {{state}} {{palette}} {{size}}" [attr.disabled]="disabled ? 'disabled' : null"></button>
 </div>


### PR DESCRIPTION
## Description

Fixes display for the `arrowSouth` icon in the `.button.mod-more` button.

-----

![image](https://user-images.githubusercontent.com/5755913/147671056-70070e21-3c11-42cf-bfaf-cdc2501b9424.png)
