### PR TITLE
fix(scss) breadcrumbs sizing and spacing

### DIFF
--- a/packages/scss/src/components/_breadcrumbs.scss
+++ b/packages/scss/src/components/_breadcrumbs.scss
@@ -11,8 +11,10 @@
 }
 
 .breadcrumbs-list-item {
-	display: flex;
 	align-items: center;
+	display: flex;
+	font-size: _theme("sizes.small.font-size");
+	line-height: _theme("sizes.small.line-height");
 
 	&:not(:first-child) {
 		&::before {

--- a/packages/scss/src/components/_breadcrumbs.scss
+++ b/packages/scss/src/components/_breadcrumbs.scss
@@ -1,7 +1,3 @@
-.breadcrumbs {
-	margin-bottom: _theme("spacings.smaller");
-}
-
 .breadcrumbs-list {
 	display: flex;
 	flex-wrap: wrap;
@@ -62,8 +58,6 @@
 // ▒▒▒▒
 
 .breadcrumbs.mod-compact {
-	margin-bottom: 0;
-
 	.breadcrumbs-list-item {
 		// two items
 		&:nth-last-child(2):first-child,


### PR DESCRIPTION
## Description

Sets correct `font-size` and `line-height` values for breadcrumbs links and removes `margin-bottom`.

-----

### Before

![image](https://user-images.githubusercontent.com/5755913/147672989-394dd6f1-bd83-49ee-94a5-9535545d5ce5.png)

### After

![image](https://user-images.githubusercontent.com/5755913/147672940-28688369-9eb4-465e-bb9c-7c151c7c18bd.png)
