### PR TITLE
Aria-required support

### DIFF
--- a/packages/scss/src/components/_form.scss
+++ b/packages/scss/src/components/_form.scss
@@ -206,3 +206,15 @@
 		}
 	}
 }
+
+.radiosfield-label,
+.checkboxesfield-label,
+.textfield-label {
+	&.is-required {
+		&:not(:empty) {
+			&::after {
+				@extend %isRequired;
+			}
+		}
+	}
+}

--- a/packages/scss/src/components/inputs/checkbox/_checkbox.scss
+++ b/packages/scss/src/components/inputs/checkbox/_checkbox.scss
@@ -3,8 +3,24 @@
 	position: relative;
 
 	&.is-required {
-		&::after {
-			@extend %isRequired;
+		.checkbox-label {
+			&:not(:empty) {
+				&::after {
+					@extend %isRequired;
+				}
+			}
+		}
+	}
+
+	.checkbox-input {
+		&[aria-required] {
+			~ .checkbox-label {
+				&:not(:empty) {
+					&::after {
+						@extend %isRequired;
+					}
+				}
+			}
 		}
 	}
 }

--- a/packages/scss/src/components/inputs/field/_field.scss
+++ b/packages/scss/src/components/inputs/field/_field.scss
@@ -120,6 +120,18 @@
 			}
 		}
 
+		.#{$fieldname}-input {
+			&[aria-required] {
+				~ .#{$fieldname}-label {
+					&:not(:empty) {
+						&::after {
+							@extend %isRequired;
+						}
+					}
+				}
+			}
+		}
+
 		// Inline validation
 		&.is-loading {
 			@include loading(1rem);

--- a/packages/scss/src/components/inputs/radio/_radio.scss
+++ b/packages/scss/src/components/inputs/radio/_radio.scss
@@ -5,8 +5,11 @@
 	&.is-required {
 		&::after {
 			@extend %isRequired;
-		}
+		}			
 	}
+
+	// we can't use the ::after like on checkboxes because
+	// the pseudo element is already used to skin the radio buttons
 }
 
 .radio-input {

--- a/packages/scss/src/mixins/_forms.scss
+++ b/packages/scss/src/mixins/_forms.scss
@@ -182,7 +182,14 @@
 
 %isRequired {
 	color: _color("error");
-	content: "*";
 	display: inline-block;
 	margin-left: .2em;
+
+	@supports (content: "*" / "") {
+		content: "*" / "";
+	}
+
+	@supports not (content: "*" / "") {
+		content: "*";
+	}
 }

--- a/stories/scss/form/checkbox/checkbox.stories.html
+++ b/stories/scss/form/checkbox/checkbox.stories.html
@@ -1,7 +1,8 @@
-<label class="checkbox {{ palette }}">
+<label [class.is-required]="isRequiredLegacy" class="checkbox {{ palette }}">
 	<input class="checkbox-input" 
 		type="checkbox" 
 		[attr.aria-hidden]="isAriaHidden" 
+		[attr.aria-required]="isRequired ? true : null"
 		[ngModel]="isChecked" 
 		(ngModelChange)="toggle($event)" 
 		[disabled]="disabled"/>

--- a/stories/scss/form/checkbox/checkbox.stories.ts
+++ b/stories/scss/form/checkbox/checkbox.stories.ts
@@ -10,6 +10,8 @@ import { Meta, moduleMetadata, Story } from '@storybook/angular';
 	templateUrl: './checkbox.stories.html',
 }) class CheckboxStory {
 	@Input() disabled: boolean = false;
+	@Input() isRequiredLegacy: boolean = false;
+	@Input() isRequired: boolean = false;
 	@Input() checked: string = 'unchecked';
 	get isMixed(): boolean { return this.checked === 'mixed'; }
 	get isChecked(): boolean { return this.checked === 'checked' || this.checked === 'mixed'; }
@@ -60,4 +62,4 @@ const template: Story<CheckboxStory> = (args: CheckboxStory) => ({
 });
 
 export const basic = template.bind({});
-basic.args = { checked: 'unchecked', palette: '', disabled: false };
+basic.args = { checked: 'unchecked', palette: '', disabled: false, isRequiredLegacy: false, isRequired: false };

--- a/stories/scss/form/framed/framed.stories.html
+++ b/stories/scss/form/framed/framed.stories.html
@@ -2,15 +2,15 @@
 	<div class="form-group-line">
 		<div class="form-group-line-col">
 			<label class="textfield">
-				<input class="textfield-input {{ state }}" type="text" placeholder="placeholder" [disabled]="disabled"/>
+				<input [attr.aria-required]="isRequired ? true : null" class="textfield-input {{ state }}" type="text" placeholder="placeholder" [disabled]="disabled"/>
 				<span class="textfield-label">Label textfield</span>
 			</label>
 		</div>
 	</div>
 	<div class="form-group-line">
 		<div class="form-group-line-col">
-			<label class="textfield mod-multiline ">
-				<textarea class="textfield-input {{ state }}" placeholder="Placeholder" [disabled]="disabled"></textarea>
+			<label class="textfield mod-multiline" >
+				<textarea [attr.aria-required]="isRequired ? true : null" class="textfield-input {{ state }}" placeholder="Placeholder" [disabled]="disabled"></textarea>
 				<span class="textfield-label">Label textfield</span>
 			</label>
 		</div>
@@ -20,7 +20,7 @@
 			<div class="checkboxesfield mod-framed"
 				[class.is-disabled]="disabled">
 				<label class="checkbox">
-					<input type="checkbox" class="checkbox-input {{ state }}" [disabled]="disabled">
+					<input [attr.aria-required]="isRequired ? true : null" type="checkbox" class="checkbox-input {{ state }}" [disabled]="disabled">
 					<span class="checkbox-label">Checkbox</span>
 				</label>
 			</div>
@@ -30,8 +30,8 @@
 		<div class="form-group-line-col">
 			<div class="radiosfield mod-framed"
 				[class.is-disabled]="disabled">
-				<label class="radio">
-					<input type="radio" class="radio-input {{ state }}" [disabled]="disabled">
+				<label class="radio" [class.is-required]="isRequired">
+					<input [attr.aria-required]="isRequired ? true : null" type="radio" class="radio-input {{ state }}" [disabled]="disabled">
 					<span class="radio-label">Radio</span>
 				</label>
 			</div>
@@ -42,7 +42,7 @@
 			<div class="radiosfield mod-framed"
 				[class.is-disabled]="disabled">
 				<fieldset>
-					<legend class="radiosfield-label">Radios label</legend>
+					<legend class="radiosfield-label" [class.is-required]="isRequired">Radios label</legend>
 					<div class="radiosfield-input">
 						<label class="radio">
 							<input type="radio" name="radioframedlist" class="radio-input {{ state }}" [disabled]="disabled">
@@ -66,7 +66,7 @@
 			<div class="checkboxesfield mod-framed"
 				[class.is-disabled]="disabled">
 				<fieldset>
-					<legend class="checkboxesfield-label">Checkboxes legend</legend>
+					<legend class="checkboxesfield-label" [class.is-required]="isRequired">Checkboxes legend</legend>
 					<div class="checkboxesfield-input">
 						<label class="checkbox">
 							<input type="checkbox" name="checkboxframedlist" class="checkbox-input {{ state }}" [disabled]="disabled">

--- a/stories/scss/form/framed/framed.stories.ts
+++ b/stories/scss/form/framed/framed.stories.ts
@@ -9,6 +9,7 @@ import { Story, Meta, moduleMetadata } from '@storybook/angular';
 }) class FramedStory {
 	@Input() state: string = '';
 	@Input() disabled: boolean = false;
+	@Input() isRequired: boolean = false;
 }
 
 export default {
@@ -35,4 +36,4 @@ const template: Story<FramedStory> = (args: FramedStory) => ({
 });
 
 export const basic = template.bind({});
-basic.args = { state: '', disabled: false };
+basic.args = { state: '', disabled: false, isRequired: false };

--- a/stories/scss/form/radio/radio.stories.html
+++ b/stories/scss/form/radio/radio.stories.html
@@ -1,7 +1,8 @@
-<label class="radio {{ palette }}">
+<label [class.is-required]="isRequired" class="radio {{ palette }}">
 	<input class="radio-input" 
 		type="radio"
 		[attr.aria-hidden]="isAriaHidden"
+		[attr.aria-required]="isRequired ? true : null"
 		[checked]="checked"
 		[disabled]="disabled"/>
 	<span class="radio-label">Radio input</span>

--- a/stories/scss/form/radio/radio.stories.ts
+++ b/stories/scss/form/radio/radio.stories.ts
@@ -11,6 +11,7 @@ import { Meta, moduleMetadata, Story } from '@storybook/angular';
 }) class RadioStory {
 	@Input() disabled: boolean = false;
 	@Input() checked: boolean = false;
+	@Input() isRequired: boolean = false;
 }
 
 export default {
@@ -42,4 +43,4 @@ const template: Story<RadioStory> = (args: RadioStory) => ({
 });
 
 export const basic = template.bind({});
-basic.args = { checked: false, palette: '', disabled: false };
+basic.args = { checked: false, palette: '', disabled: false, isRequired: false };

--- a/stories/scss/form/textfields/textfield.stories.html
+++ b/stories/scss/form/textfields/textfield.stories.html
@@ -1,4 +1,4 @@
-<label class="textfield {{ palette }}">
-	<input class="textfield-input {{ state }}" type="text" placeholder="placeholder" [disabled]="disabled"/>
+<label [class.is-required]="isRequiredLegacy" class="textfield {{ palette }}">
+	<input [attr.aria-required]="isRequired ? true : null" class="textfield-input {{ state }}" type="text" placeholder="placeholder" [disabled]="disabled"/>
 	<span class="textfield-label">Textfield label</span>
 </label>

--- a/stories/scss/form/textfields/textfield.stories.ts
+++ b/stories/scss/form/textfields/textfield.stories.ts
@@ -10,6 +10,8 @@ import { Meta, moduleMetadata, Story } from '@storybook/angular';
 	@Input() state: string = '';
 	@Input() palette: string = '';
 	@Input() disabled: boolean = false;
+	@Input() isRequiredLegacy: boolean = false;
+	@Input() isRequired: boolean = false;
 }
 
 export default {
@@ -54,4 +56,4 @@ const template: Story<TextfieldStory> = (args: TextfieldStory) => ({
 });
 
 export const basic = template.bind({});
-basic.args = { state: '', palette: '', disabled: false };
+basic.args = { state: '', palette: '', disabled: false, isRequiredLegacy: false, isRequired: false };


### PR DESCRIPTION
Added support for the aria-required attribute in addition to the is-required class.

⚠️ No breaking change but it is still necessary to add the `is-required` class for the radio buttons.

Close #1540 

![2022-02-23 18 58 30](https://user-images.githubusercontent.com/64789527/155379101-7003bc53-3177-4e7a-9fc8-4267dc504010.gif)

![2022-02-23 18 59 16](https://user-images.githubusercontent.com/64789527/155379107-a3656ecd-f098-4fa7-bc15-a09a22207d4b.gif)

![2022-02-23 18 59 35](https://user-images.githubusercontent.com/64789527/155379108-bca04e36-92e3-4840-9c1b-4d08f7b6db69.gif)

![2022-02-23 18 58 58](https://user-images.githubusercontent.com/64789527/155379103-a68e1a48-1074-42b5-bdc5-5f606a6b441a.gif)
