### PR TITLE
feat(ng-toast) add toast generation

### DIFF
--- a/packages/ng/toast/ng-package.json
+++ b/packages/ng/toast/ng-package.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "src/public-api.ts",
+		"styleIncludePaths": ["../style", "../style/overrides"]
+	}
+}

--- a/packages/ng/toast/src/public-api.ts
+++ b/packages/ng/toast/src/public-api.ts
@@ -6,4 +6,6 @@ export { LuToastsComponent as ɵɵLuToatsComponent } from './toasts.component';
 export * from './toasts.model';
 export * from './toasts.module';
 export * from './toasts.service';
-
+export * from './toasts.intl';
+export * from './toasts.translate';
+export * from './toasts.token';

--- a/packages/ng/toast/src/public-api.ts
+++ b/packages/ng/toast/src/public-api.ts
@@ -1,0 +1,9 @@
+/*
+ * Public API Surface of toast
+ */
+
+export { LuToastsComponent as ɵɵLuToatsComponent } from './toasts.component';
+export * from './toasts.model';
+export * from './toasts.module';
+export * from './toasts.service';
+

--- a/packages/ng/toast/src/toasts.component.html
+++ b/packages/ng/toast/src/toasts.component.html
@@ -1,16 +1,13 @@
 <div class="toasts" aria-live="polite" [class.mod-bottom]="bottom">
-
-	<div *ngFor="let toast of toasts$ | async; trackBy: trackToast"
-			 class="toasts-item"
-			 [ngClass]="paletteClassByToastType[toast.type]">
-        <span *ngIf="toast.type"
-							class="lucca-icon size-small u-marginRightSmaller"
-							aria-hidden="true"
-							[ngClass]="iconClassByToastType[toast.type]">
-				</span>
-
+	<div *ngFor="let toast of toasts$ | async; trackBy: trackToast" class="toasts-item" [ngClass]="paletteClassByToastType[toast.type]">
+		<span
+			*ngIf="toast.type"
+			class="lucca-icon size-small u-marginRightSmaller"
+			aria-hidden="true"
+			[ngClass]="iconClassByToastType[toast.type]"
+		>
+		</span>
 		<span [innerHtml]="toast.message"> </span>
-
 		<button type="button" class="toasts-item-kill mod-withCircularGauge" (click)="removeToast(toast)" (animationend)="removeToast(toast)">
 			<span class="lucca-icon icon-cross size-smaller" aria-hidden="true"></span>
 			<div class="circularGauge" *ngIf="!isOnlyDismissibleManually(toast) && toast.duration > 0">
@@ -20,7 +17,5 @@
 			</div>
 			<span class="u-mask">{{ intl.close }}</span>
 		</button>
-
 	</div>
-
 </div>

--- a/packages/ng/toast/src/toasts.component.html
+++ b/packages/ng/toast/src/toasts.component.html
@@ -1,4 +1,4 @@
-<div class="toasts" aria-live="polite">
+<div class="toasts" aria-live="polite" [class.mod-bottom]="bottom">
 
 	<div *ngFor="let toast of toasts$ | async; trackBy: trackToast"
 			 class="toasts-item"

--- a/packages/ng/toast/src/toasts.component.html
+++ b/packages/ng/toast/src/toasts.component.html
@@ -1,4 +1,4 @@
-<div class="toasts" aria-live="polite" [class.mod-bottom]="bottom">
+<div class="toasts mod-withCircularGauge" aria-live="polite" [class.mod-bottom]="bottom">
 	<div *ngFor="let toast of toasts$ | async; trackBy: trackToast" class="toasts-item" [ngClass]="paletteClassByToastType[toast.type]">
 		<span
 			*ngIf="toast.type"
@@ -8,7 +8,7 @@
 		>
 		</span>
 		<span [innerHtml]="toast.message"> </span>
-		<button type="button" class="toasts-item-kill mod-withCircularGauge" (click)="removeToast(toast)" (animationend)="removeToast(toast)">
+		<button type="button" class="toasts-item-kill" (click)="removeToast(toast)" (animationend)="removeToast(toast)">
 			<span class="lucca-icon icon-cross size-smaller" aria-hidden="true"></span>
 			<div class="circularGauge" *ngIf="!isOnlyDismissibleManually(toast) && toast.duration > 0">
 				<svg viewBox="0 0 32 32">

--- a/packages/ng/toast/src/toasts.component.html
+++ b/packages/ng/toast/src/toasts.component.html
@@ -11,7 +11,16 @@
 
 		<span [innerHtml]="toast.message"> </span>
 
-		<button type="button" class="toasts-item-kill" (click)="removeToast(toast)"></button>
+		<button type="button" class="toasts-item-kill mod-withCircularGauge" (click)="removeToast(toast)" (animationend)="removeToast(toast)">
+			<span class="lucca-icon icon-cross size-smaller" aria-hidden="true"></span>
+			<div class="circularGauge" *ngIf="!isOnlyDismissibleManually(toast) && toast.duration > 0">
+				<svg viewBox="0 0 32 32">
+					<circle r="16" cx="16" cy="16" [style.animation-duration]="toast.duration + 'ms'" />
+				</svg>
+			</div>
+			<span class="u-mask">Fermer</span>
+		</button>
+
 	</div>
 
 </div>

--- a/packages/ng/toast/src/toasts.component.html
+++ b/packages/ng/toast/src/toasts.component.html
@@ -1,0 +1,17 @@
+<div class="toasts" aria-live="polite">
+
+	<div *ngFor="let toast of toasts$ | async; trackBy: trackToast"
+			 class="toasts-item"
+			 [ngClass]="paletteClassByToastType[toast.type]">
+        <span *ngIf="toast.type"
+							class="lucca-icon size-small u-marginRightSmaller"
+							aria-hidden="true"
+							[ngClass]="iconClassByToastType[toast.type]">
+				</span>
+
+		<span [innerHtml]="toast.message"> </span>
+
+		<button type="button" class="toasts-item-kill" (click)="removeToast(toast)"></button>
+	</div>
+
+</div>

--- a/packages/ng/toast/src/toasts.component.html
+++ b/packages/ng/toast/src/toasts.component.html
@@ -18,7 +18,7 @@
 					<circle r="16" cx="16" cy="16" [style.animation-duration]="toast.duration + 'ms'" />
 				</svg>
 			</div>
-			<span class="u-mask">Fermer</span>
+			<span class="u-mask">{{ intl.close }}</span>
 		</button>
 
 	</div>

--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -12,6 +12,7 @@ import { ILuToastLabel } from "./toasts.translate";
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LuToastsComponent implements OnDestroy {
+	@Input() public bottom = false;
 	@Input() public set sources(sources: Array<Observable<LuToastInput>>) {
 		merge(...sources)
 			.pipe(takeUntil(this.destroy$))

--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -33,4 +33,8 @@ export class LuToastsComponent {
 	public trackToast(_index: number, toast: LuToast): string {
 		return toast.id;
 	}
+
+	public isOnlyDismissibleManually(toast: LuToast): boolean {
+		return this.toastsService.isOnlyDismissibleManually(toast);
+	}
 }

--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component, Inject, Input, OnDestroy } from '@angular/core';
 import { LuToast, LuToastInput, LuToastType } from './toasts.model';
 import { LuToastsService } from './toasts.service';
-import { merge, Observable, Subject } from "rxjs";
-import { takeUntil } from "rxjs/operators";
-import { LuToastIntl } from "./toasts.intl";
-import { ILuToastLabel } from "./toasts.translate";
+import { merge, Observable, Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+import { LuToastIntl } from './toasts.intl';
+import { ILuToastLabel } from './toasts.translate';
 
 @Component({
 	selector: 'lu-toasts',
@@ -16,17 +16,14 @@ export class LuToastsComponent implements OnDestroy {
 	@Input() public set sources(sources: Array<Observable<LuToastInput>>) {
 		merge(...sources)
 			.pipe(takeUntil(this.destroy$))
-			.subscribe(toast => this.toastsService.addToast(toast));
+			.subscribe((toast) => this.toastsService.addToast(toast));
 	}
 
 	public toasts$ = this.toastsService.toasts$;
 
-	private destroy$ = new Subject<void>()
+	private destroy$ = new Subject<void>();
 
-	constructor(
-		@Inject(LuToastIntl) public intl: ILuToastLabel,
-		private toastsService: LuToastsService
-	) {}
+	constructor(@Inject(LuToastIntl) public intl: ILuToastLabel, private toastsService: LuToastsService) {}
 
 	public ngOnDestroy(): void {
 		this.destroy$.next();
@@ -38,14 +35,14 @@ export class LuToastsComponent implements OnDestroy {
 		Success: 'icon-success',
 		Error: 'icon-error',
 		Warning: 'icon-warning',
-	}
+	};
 
 	public paletteClassByToastType: Record<LuToastType, string> = {
 		Info: '',
 		Success: 'palette-success',
 		Error: 'palette-error',
 		Warning: 'palette-warning',
-	}
+	};
 
 	public removeToast(toast: LuToast): void {
 		this.toastsService.removeToast(toast);

--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -1,0 +1,36 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { LuToast, LuToastType } from './toasts.model';
+import { LuToastsService } from './toasts.service';
+
+@Component({
+	selector: 'lu-toasts',
+	templateUrl: './toasts.component.html',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LuToastsComponent {
+	public toasts$ = this.toastsService.toasts$;
+
+	constructor(private toastsService: LuToastsService) {}
+
+	public iconClassByToastType: Record<LuToastType, string> = {
+		Info: 'icon-info',
+		Success: 'icon-success',
+		Error: 'icon-error',
+		Warning: 'icon-warning',
+	}
+
+	public paletteClassByToastType: Record<LuToastType, string> = {
+		Info: '',
+		Success: 'palette-success',
+		Error: 'palette-error',
+		Warning: 'palette-warning',
+	}
+
+	public removeToast(toast: LuToast): void {
+		this.toastsService.removeToast(toast);
+	}
+
+	public trackToast(_index: number, toast: LuToast): string {
+		return toast.id;
+	}
+}

--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -1,8 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, Input, OnDestroy } from '@angular/core';
 import { LuToast, LuToastInput, LuToastType } from './toasts.model';
 import { LuToastsService } from './toasts.service';
 import { merge, Observable, Subject } from "rxjs";
 import { takeUntil } from "rxjs/operators";
+import { LuToastIntl } from "./toasts.intl";
+import { ILuToastLabel } from "./toasts.translate";
 
 @Component({
 	selector: 'lu-toasts',
@@ -20,7 +22,10 @@ export class LuToastsComponent implements OnDestroy {
 
 	private destroy$ = new Subject<void>()
 
-	constructor(private toastsService: LuToastsService) {}
+	constructor(
+		@Inject(LuToastIntl) public intl: ILuToastLabel,
+		private toastsService: LuToastsService
+	) {}
 
 	public ngOnDestroy(): void {
 		this.destroy$.next();

--- a/packages/ng/toast/src/toasts.intl.ts
+++ b/packages/ng/toast/src/toasts.intl.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 import { ALuIntl, ILuTranslation } from '@lucca-front/ng/core';
 import { ILuToastLabel } from './toasts.translate';
-import { LU_TOAST_TRANSLATIONS } from "./toasts.token";
+import { LU_TOAST_TRANSLATIONS } from './toasts.token';
 
 @Injectable()
 export class LuToastIntl extends ALuIntl<ILuToastLabel> {

--- a/packages/ng/toast/src/toasts.intl.ts
+++ b/packages/ng/toast/src/toasts.intl.ts
@@ -1,0 +1,15 @@
+import { Inject, Injectable, LOCALE_ID } from '@angular/core';
+import { ALuIntl, ILuTranslation } from '@lucca-front/ng/core';
+import { ILuToastLabel } from './toasts.translate';
+import { LU_TOAST_TRANSLATIONS } from "./toasts.token";
+
+@Injectable()
+export class LuToastIntl extends ALuIntl<ILuToastLabel> {
+	constructor(
+		@Inject(LU_TOAST_TRANSLATIONS)
+		translations: ILuTranslation<ILuToastLabel>,
+		@Inject(LOCALE_ID) locale: string,
+	) {
+		super(translations, locale);
+	}
+}

--- a/packages/ng/toast/src/toasts.model.ts
+++ b/packages/ng/toast/src/toasts.model.ts
@@ -10,7 +10,6 @@ export interface LuToastInput {
 	 * Null means manual dismiss only
 	 */
 	duration?: number | null;
-	onClose?: () => void;
 }
 
 export interface LuToast extends LuToastInput {

--- a/packages/ng/toast/src/toasts.model.ts
+++ b/packages/ng/toast/src/toasts.model.ts
@@ -1,0 +1,18 @@
+export type LuToastType = 'Info' | 'Error' | 'Success' | 'Warning';
+
+export const defaultToastDuration = 5000;
+
+export interface LuToastInput {
+	message: string;
+	type?: LuToastType;
+	/**
+	 * Auto kill default duration is 5000ms
+	 * Null means manual dismiss only
+	 */
+	duration?: number | null;
+	onClose?: () => void;
+}
+
+export interface LuToast extends LuToastInput {
+	id: string;
+}

--- a/packages/ng/toast/src/toasts.module.ts
+++ b/packages/ng/toast/src/toasts.module.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { LuToastsComponent } from './toasts.component';
-import { LuToastIntl } from "./toasts.intl";
-import { LU_TOAST_TRANSLATIONS } from "./toasts.token";
-import { luToastTranslations } from "./toasts.translate";
+import { LuToastIntl } from './toasts.intl';
+import { LU_TOAST_TRANSLATIONS } from './toasts.token';
+import { luToastTranslations } from './toasts.translate';
 
 @NgModule({
 	declarations: [LuToastsComponent],
@@ -15,6 +15,6 @@ import { luToastTranslations } from "./toasts.translate";
 			provide: LU_TOAST_TRANSLATIONS,
 			useValue: luToastTranslations,
 		},
-	]
+	],
 })
 export class LuToastsModule {}

--- a/packages/ng/toast/src/toasts.module.ts
+++ b/packages/ng/toast/src/toasts.module.ts
@@ -1,10 +1,20 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { LuToastsComponent } from './toasts.component';
+import { LuToastIntl } from "./toasts.intl";
+import { LU_TOAST_TRANSLATIONS } from "./toasts.token";
+import { luToastTranslations } from "./toasts.translate";
 
 @NgModule({
 	declarations: [LuToastsComponent],
 	imports: [CommonModule],
 	exports: [LuToastsComponent],
+	providers: [
+		LuToastIntl,
+		{
+			provide: LU_TOAST_TRANSLATIONS,
+			useValue: luToastTranslations,
+		},
+	]
 })
 export class LuToastsModule {}

--- a/packages/ng/toast/src/toasts.module.ts
+++ b/packages/ng/toast/src/toasts.module.ts
@@ -1,0 +1,10 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { LuToastsComponent } from './toasts.component';
+
+@NgModule({
+	declarations: [LuToastsComponent],
+	imports: [CommonModule],
+	exports: [LuToastsComponent],
+})
+export class LuToastsModule {}

--- a/packages/ng/toast/src/toasts.service.ts
+++ b/packages/ng/toast/src/toasts.service.ts
@@ -1,0 +1,47 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, interval } from 'rxjs';
+import { take } from 'rxjs/operators';
+import { defaultToastDuration, LuToast, LuToastInput } from './toasts.model';
+
+@Injectable({providedIn: 'root'})
+export class LuToastsService {
+	public toasts$ = new BehaviorSubject<LuToast[]>([]);
+
+	public addToast(toastInput: LuToastInput): LuToast {
+		const toast = this.getToast(toastInput);
+
+		this.toasts$.next([...this.toasts$.value, toast]);
+
+		if (!this.isOnlyDismissibleManually(toast)) {
+			interval(toast.duration)
+				.pipe(take(1))
+				.subscribe(() => this.removeToast(toast));
+		}
+
+		return toast;
+	}
+
+	public removeToast(toast: LuToast): void {
+		const updatedToasts = this.toasts$.value.filter(t => t.id !== toast.id);
+		this.toasts$.next(updatedToasts);
+		toast.onClose?.();
+	}
+
+	private isOnlyDismissibleManually(toast: LuToastInput): boolean {
+		return toast.duration === null;
+	}
+
+	private getToast(toastInput: LuToastInput): LuToast {
+		const id = this.generateId();
+		const duration = this.isOnlyDismissibleManually(toastInput)
+			? toastInput.duration
+			: toastInput.duration ?? defaultToastDuration;
+
+		return {...toastInput, id, duration};
+	}
+
+	private generateId(): string {
+		const randomString = Math.random().toString(36).substring(2, 9);
+		return `_${randomString}`;
+	}
+}

--- a/packages/ng/toast/src/toasts.service.ts
+++ b/packages/ng/toast/src/toasts.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, interval } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { defaultToastDuration, LuToast, LuToastInput } from './toasts.model';
 
-@Injectable({providedIn: 'root'})
+@Injectable({ providedIn: 'root' })
 export class LuToastsService {
 	public toasts$ = new BehaviorSubject<LuToast[]>([]);
 
@@ -22,7 +22,7 @@ export class LuToastsService {
 	}
 
 	public removeToast(toast: LuToast): void {
-		const updatedToasts = this.toasts$.value.filter(t => t.id !== toast.id);
+		const updatedToasts = this.toasts$.value.filter((t) => t.id !== toast.id);
 		this.toasts$.next(updatedToasts);
 	}
 
@@ -32,11 +32,9 @@ export class LuToastsService {
 
 	private getToast(toastInput: LuToastInput): LuToast {
 		const id = this.generateId();
-		const duration = this.isOnlyDismissibleManually(toastInput)
-			? toastInput.duration
-			: toastInput.duration ?? defaultToastDuration;
+		const duration = this.isOnlyDismissibleManually(toastInput) ? toastInput.duration : toastInput.duration ?? defaultToastDuration;
 
-		return {...toastInput, id, duration};
+		return { ...toastInput, id, duration };
 	}
 
 	private generateId(): string {

--- a/packages/ng/toast/src/toasts.service.ts
+++ b/packages/ng/toast/src/toasts.service.ts
@@ -24,7 +24,6 @@ export class LuToastsService {
 	public removeToast(toast: LuToast): void {
 		const updatedToasts = this.toasts$.value.filter(t => t.id !== toast.id);
 		this.toasts$.next(updatedToasts);
-		toast.onClose?.();
 	}
 
 	public isOnlyDismissibleManually(toast: LuToastInput): boolean {

--- a/packages/ng/toast/src/toasts.service.ts
+++ b/packages/ng/toast/src/toasts.service.ts
@@ -27,7 +27,7 @@ export class LuToastsService {
 		toast.onClose?.();
 	}
 
-	private isOnlyDismissibleManually(toast: LuToastInput): boolean {
+	public isOnlyDismissibleManually(toast: LuToastInput): boolean {
 		return toast.duration === null;
 	}
 

--- a/packages/ng/toast/src/toasts.service.ts
+++ b/packages/ng/toast/src/toasts.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, interval } from 'rxjs';
-import { take } from 'rxjs/operators';
+import { BehaviorSubject } from 'rxjs';
 import { defaultToastDuration, LuToast, LuToastInput } from './toasts.model';
 
 @Injectable({ providedIn: 'root' })
@@ -11,12 +10,6 @@ export class LuToastsService {
 		const toast = this.getToast(toastInput);
 
 		this.toasts$.next([...this.toasts$.value, toast]);
-
-		if (!this.isOnlyDismissibleManually(toast)) {
-			interval(toast.duration)
-				.pipe(take(1))
-				.subscribe(() => this.removeToast(toast));
-		}
 
 		return toast;
 	}

--- a/packages/ng/toast/src/toasts.token.ts
+++ b/packages/ng/toast/src/toasts.token.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_TOAST_TRANSLATIONS = new InjectionToken('LuToastTranslations');

--- a/packages/ng/toast/src/toasts.translate.ts
+++ b/packages/ng/toast/src/toasts.translate.ts
@@ -1,0 +1,20 @@
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+export interface ILuToastLabel {
+	close: string;
+}
+export abstract class ALuToastLabel {
+	close: string;
+}
+
+export const luToastTranslations: ILuTranslation<ILuToastLabel> = {
+	en: {
+		close: 'Close',
+	},
+	fr: {
+		close: 'Fermer',
+	},
+	es: {
+		close: 'Cerrar',
+	},
+};

--- a/packages/scss/src/components/_toasts.scss
+++ b/packages/scss/src/components/_toasts.scss
@@ -111,6 +111,80 @@
 	}
 }
 
+.toasts-item-kill {
+	&.mod-withCircularGauge {
+		transition: transform 100ms, opacity 100ms;
+		top: 0.625rem;
+		bottom: auto;
+
+		.lucca-icon {
+			position: absolute;
+			inset: 0;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			z-index: 2;
+		}
+
+		&::after {
+			content: none;
+		}
+
+		&:hover,
+		&:focus {
+			outline: 0;
+			opacity: 0.66;
+		}
+
+		.circularGauge {
+			color: transparent;
+			height: 1.25rem;
+			pointer-events: none;
+			position: relative;
+			width: 1.25rem;
+
+			&::after {
+				content: '';
+				position: absolute;
+				left: 2px;
+				top: 2px;
+				width: calc(100% - 4px);
+				height: calc(100% - 4px);
+				background-color: transparent;
+				z-index: 1;
+				border-radius: 50%;
+			}
+
+			svg {
+				width: 100%;
+				height: auto;
+				transform: rotate(-90deg);
+				border-radius: 50%;
+				display: block;
+			}
+
+			circle {
+				fill: currentColor;
+				stroke: white;
+				stroke-width: 20%;
+				stroke-dasharray: 100.5, 100.5;
+				animation-name: stroke;
+				animation-timing-function: linear;
+				animation-fill-mode: forwards;
+
+				@keyframes stroke {
+					from {
+						stroke-dashoffset: 100.5;
+					}
+					to {
+						stroke-dashoffset: 0;
+					}
+				}
+			}
+		}
+	}
+}
+
 @keyframes toast {
 	from {
 		transform: translateY(1rem);
@@ -121,3 +195,4 @@
 		opacity: 1;
 	}
 }
+

--- a/packages/scss/src/components/_toasts.scss
+++ b/packages/scss/src/components/_toasts.scss
@@ -22,6 +22,12 @@
 	padding: _component("toasts.padding");
 	position: relative;
 	transform-origin: top;
+
+	@each $name, $palette in _getMap("palettes") {
+		&.palette-#{$name} {
+			background-color: _safeGet($palette,"800");
+		}
+	}
 }
 
 .toasts-item-kill {
@@ -52,7 +58,6 @@
 // ▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒▒
 
 .toasts {
-
 	&.mod-commInApp {
 		top: inherit;
 		left: _component("toasts.left");

--- a/packages/scss/src/components/_toasts.scss
+++ b/packages/scss/src/components/_toasts.scss
@@ -109,6 +109,11 @@
 			top: _theme("spacings.smaller");
 		}
 	}
+
+	&.mod-bottom {
+		top: auto;
+		bottom: _theme('spacings.standard');
+	}
 }
 
 .toasts-item-kill {

--- a/packages/scss/src/components/_toasts.scss
+++ b/packages/scss/src/components/_toasts.scss
@@ -114,81 +114,92 @@
 		top: auto;
 		bottom: _theme('spacings.standard');
 	}
-}
 
-.toasts-item-kill {
 	&.mod-withCircularGauge {
-		transition: transform 100ms, opacity 100ms;
-		top: 0.625rem;
-		bottom: auto;
-
-		.lucca-icon {
-			position: absolute;
-			inset: 0;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			z-index: 2;
-		}
-
-		&::after {
-			content: none;
-		}
 
 		&:hover,
-		&:focus {
-			outline: 0;
-			opacity: 0.66;
+		&:focus-within {
+			.circularGauge {
+				circle {
+					animation-play-state: paused;
+				}
+			}
 		}
 
-		.circularGauge {
-			color: transparent;
-			height: 1.25rem;
-			pointer-events: none;
-			position: relative;
-			width: 1.25rem;
+		.toasts-item-kill {
+			transition: transform 100ms, opacity 100ms;
+			top: 0.625rem;
+			bottom: auto;
+
+			.lucca-icon {
+				position: absolute;
+				inset: 0;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				z-index: 2;
+			}
 
 			&::after {
-				content: '';
-				position: absolute;
-				left: 2px;
-				top: 2px;
-				width: calc(100% - 4px);
-				height: calc(100% - 4px);
-				background-color: transparent;
-				z-index: 1;
-				border-radius: 50%;
+				content: none;
 			}
 
-			svg {
-				width: 100%;
-				height: auto;
-				transform: rotate(-90deg);
-				border-radius: 50%;
-				display: block;
+			&:hover,
+			&:focus {
+				outline: 0;
+				opacity: 0.66;
 			}
 
-			circle {
-				fill: currentColor;
-				stroke: white;
-				stroke-width: 20%;
-				stroke-dasharray: 100.5, 100.5;
-				animation-name: stroke;
-				animation-timing-function: linear;
-				animation-fill-mode: forwards;
+			.circularGauge {
+				color: transparent;
+				height: 1.25rem;
+				pointer-events: none;
+				position: relative;
+				width: 1.25rem;
 
-				@keyframes stroke {
-					from {
-						stroke-dashoffset: 100.5;
-					}
-					to {
-						stroke-dashoffset: 0;
+				&::after {
+					content: '';
+					position: absolute;
+					left: 2px;
+					top: 2px;
+					width: calc(100% - 4px);
+					height: calc(100% - 4px);
+					background-color: transparent;
+					z-index: 1;
+					border-radius: 50%;
+				}
+
+				svg {
+					width: 100%;
+					height: auto;
+					transform: rotate(-90deg);
+					border-radius: 50%;
+					display: block;
+				}
+
+				circle {
+					fill: currentColor;
+					stroke: white;
+					stroke-width: 20%;
+					stroke-dasharray: 100.5, 100.5;
+					animation-name: stroke;
+					animation-timing-function: linear;
+					animation-fill-mode: forwards;
+
+					@keyframes stroke {
+						from {
+							stroke-dashoffset: 100.5;
+						}
+						to {
+							stroke-dashoffset: 0;
+						}
 					}
 				}
 			}
 		}
 	}
 }
+
 
 @keyframes toast {
 	from {

--- a/stories/documentation/overlays/toasts/toasts.stories.html
+++ b/stories/documentation/overlays/toasts/toasts.stories.html
@@ -3,7 +3,8 @@
 <!-- Basics -->
 <section class="contentSection">
 	<p>Toasts allow you to show callback on a corner of your app.</p>
-	<p><span aria-hidden="true" class="lucca-icon u-textWarning">warning</span><span class="u-mask">Warning:</span> You have to manually create and kill your toasts for now, they will be added in the NG package in the future.
-	<div class="toasts" id="toastsBox"></div>
-	<button type="button" class="button palette-primary" id="toastGenerate" (click)="toast()">Generate toast</button>
+	<lu-toasts></lu-toasts>
+	<button type="button" class="button palette-primary" (click)="toast('Warning')">Generate warning toast with default auto kill</button>
+	<button type="button" class="button palette-primary" (click)="toast('Success', 2000)">Generate success toast with auto kill</button>
+	<button type="button" class="button palette-primary" (click)="toast('Error', null)">Generate error toast without auto kill</button>
 </section>

--- a/stories/documentation/overlays/toasts/toasts.stories.html
+++ b/stories/documentation/overlays/toasts/toasts.stories.html
@@ -3,8 +3,9 @@
 <!-- Basics -->
 <section class="contentSection">
 	<p>Toasts allow you to show callback on a corner of your app.</p>
-	<lu-toasts></lu-toasts>
-	<button type="button" class="button palette-primary" (click)="toast('Warning')">Generate warning toast with default auto kill</button>
-	<button type="button" class="button palette-primary" (click)="toast('Success', 2000)">Generate success toast with auto kill</button>
-	<button type="button" class="button palette-primary" (click)="toast('Error', null)">Generate error toast without auto kill</button>
+	<lu-toasts [sources]="[toastError$]"></lu-toasts>
+	<button type="button" class="button palette-primary" (click)="createToast('Warning')">Generate warning toast with default auto kill</button>
+	<button type="button" class="button palette-primary" (click)="createToast('Success', 2000)">Generate success toast with auto kill</button>
+	<button type="button" class="button palette-primary" (click)="createToast('Info', null)">Generate info toast without auto kill</button>
+	<button type="button" class="button palette-primary" (click)="createToastSource()">Generate error toast with observable source</button>
 </section>

--- a/stories/documentation/overlays/toasts/toasts.stories.html
+++ b/stories/documentation/overlays/toasts/toasts.stories.html
@@ -3,7 +3,8 @@
 <!-- Basics -->
 <section class="contentSection">
 	<p>Toasts allow you to show callback on a corner of your app.</p>
-	<lu-toasts [sources]="[toastError$]"></lu-toasts>
+	<lu-toasts [sources]="[toastError$]" [bottom]="isBottom"></lu-toasts>
+
 	<h4>Generate them thanks to a button</h4>
 	<button type="button" class="button palette-warning" (click)="createToast('Warning')">
 		Warning toast with default auto kill ({{ defaultToastDuration }}ms)
@@ -14,5 +15,12 @@
 	<h4 class="u-marginTopStandard">Generate them thanks to observable creations</h4>
 	<button type="button" class="button palette-primary" (click)="notifyError()">Notify error</button>
 	The notified error is "{{ error$ | async}}"
+
+	<h4 class="u-marginTopStandard">Change the toast position (bottom or top by default)</h4>
+	<label class="checkbox">
+		<input class="checkbox-input" type="checkbox" name="checkboxList1" [(ngModel)]="isBottom" #ctrl="ngModel">
+		<span class="checkbox-label">Bottom position</span>
+	</label>
+
 
 </section>

--- a/stories/documentation/overlays/toasts/toasts.stories.html
+++ b/stories/documentation/overlays/toasts/toasts.stories.html
@@ -4,8 +4,15 @@
 <section class="contentSection">
 	<p>Toasts allow you to show callback on a corner of your app.</p>
 	<lu-toasts [sources]="[toastError$]"></lu-toasts>
-	<button type="button" class="button palette-primary" (click)="createToast('Warning')">Generate warning toast with default auto kill</button>
-	<button type="button" class="button palette-primary" (click)="createToast('Success', 2000)">Generate success toast with auto kill</button>
-	<button type="button" class="button palette-primary" (click)="createToast('Info', null)">Generate info toast without auto kill</button>
-	<button type="button" class="button palette-primary" (click)="createToastSource()">Generate error toast with observable source</button>
+	<h4>Generate them thanks to a button</h4>
+	<button type="button" class="button palette-warning" (click)="createToast('Warning')">
+		Warning toast with default auto kill ({{ defaultToastDuration }}ms)
+	</button>
+	<button type="button" class="button palette-success" (click)="createToast('Success', 2000)">Success toast with auto kill</button>
+	<button type="button" class="button palette-primary" (click)="createToast('Info', null)">Info toast without auto kill</button>
+
+	<h4 class="u-marginTopStandard">Generate them thanks to observable creations</h4>
+	<button type="button" class="button palette-primary" (click)="notifyError()">Notify error</button>
+	The notified error is "{{ error$ | async}}"
+
 </section>

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -1,30 +1,30 @@
 import { Component } from '@angular/core';
+import { LuToastsModule, LuToastsService, LuToastType } from '@lucca-front/ng/toast';
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
 
 @Component({
 	selector: 'toasts-stories',
 	templateUrl: './toasts.stories.html',
 }) class ToastsStory {
-	toast() {
-		var toastsBox = document.getElementById("toastsBox");
-		var toast = document.createElement("div");
-		var toastsValues = [
+
+	constructor(private toastsService: LuToastsService) {}
+
+	public toast(type: LuToastType, duration?: number | null): void {
+		const toastsValues = [
 			'Oh yeah! Something good happened :)',
 			'Oops, something looks wrong :(',
 			'Marked as done',
 			'Please check <a href="#">this thing</a>',
 			'Here <ins>is</ins> <em>some</em> <strong>HTML</strong>'
 		];
-		var r = Math.floor(Math.random() * Math.floor(toastsValues.length));
-		toast.className = "toasts-item";
-		toast.innerHTML = toastsValues[r];
-		var close = document.createElement('button');
-		close.className = "toasts-item-kill";
-		close.addEventListener('click', function () {
-			this.parentElement.remove();
-		}, false);
-		toast.appendChild(close);
-		toastsBox.appendChild(toast);
+
+		const random = Math.floor(Math.random() * toastsValues.length);
+
+		this.toastsService.addToast({
+			type,
+			message: toastsValues[random],
+			duration,
+		});
 	}
 }
 
@@ -33,7 +33,8 @@ export default {
 	component: ToastsStory,
 	decorators: [
 		moduleMetadata({
-			entryComponents: [ToastsStory]
+			imports: [LuToastsModule],
+			declarations: [ToastsStory]
 		})
 	]
 } as Meta;

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -1,9 +1,11 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { defaultToastDuration, LuToastInput, LuToastsModule, LuToastsService, LuToastType } from '@lucca-front/ng/toast';
-import { Meta, moduleMetadata, Story } from '@storybook/angular';
+import { componentWrapperDecorator, Meta, moduleMetadata, Story } from '@storybook/angular';
 import { Observable, ReplaySubject, Subject } from "rxjs";
 import { map } from "rxjs/operators";
-import { FormsModule } from "@angular/forms";
+import { LuToastsComponent } from '../../../../packages/ng/toast/src/toasts.component';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
 
 @Component({
 	selector: 'toasts-stories',
@@ -56,15 +58,56 @@ class ToastsStory implements OnInit, OnDestroy {
 
 export default {
 	title: 'Documentation/Overlays/Toasts',
-	component: ToastsStory,
+	component: LuToastsComponent,
 	decorators: [
+		componentWrapperDecorator(ToastsStory),
 		moduleMetadata({
-			imports: [LuToastsModule, FormsModule],
+			imports: [LuToastsModule, FormsModule, BrowserAnimationsModule],
 			declarations: [ToastsStory]
 		})
 	]
 } as Meta;
 
-const template: Story<ToastsStory> = () => ({});
+const template: Story<ToastsStory> = (args: ToastsStory) => ({
+	props: args,
+});
+
+const code = () => `
+/* Ajouter l'encre <lu-toasts></lu-toasts> dans le app.component.html */
+<lu-toasts [bottom]="true" [sources]="[]"></lu-toasts>
+
+/* Ajouter un toast avec la méthode addToast(..) du LuToastsService */
+@Component({
+  selector: 'toasts-stories',
+  templateUrl: './toasts.stories.html',
+})
+class ToastsStory implements OnInit, OnDestroy {
+
+  /* Par défaut la durée de vie d'un toast est de 5000ms */
+  public defaultToastDuration = defaultToastDuration;
+
+  constructor(private toastsService: LuToastsService) {}
+
+  public createToast(type: LuToastType, duration?: number | null): void {
+    const message = 'random-message';
+    this.toastsService.addToast({
+    	type, /* LuToastType peut être : 'Info' | 'Error' | 'Success' | 'Warning' */
+    	message,
+    	duration /* Pour activer la suppression manuel du toast, il faut setter la durée à null (et pas undefined) */
+    });
+  }
+}
+
+`
 
 export const basic = template.bind({});
+basic.args = {}
+basic.parameters = {
+	docs: {
+		source: {
+			language: 'ts',
+			code: code(),
+		}
+	},
+	controls: { include: [] },
+};

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -72,7 +72,7 @@ const template: Story<ToastsStory> = (args: ToastsStory) => ({
 	props: args,
 });
 
-const code = () => `
+const code = `
 /* Ajouter l'encre <lu-toasts></lu-toasts> dans le app.component.html */
 <lu-toasts [bottom]="true" [sources]="[]"></lu-toasts>
 

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -106,7 +106,7 @@ basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
-			code: code(),
+			code,
 		}
 	},
 	controls: { include: [] },

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -3,12 +3,15 @@ import { defaultToastDuration, LuToastInput, LuToastsModule, LuToastsService, Lu
 import { Meta, moduleMetadata, Story } from '@storybook/angular';
 import { Observable, ReplaySubject, Subject } from "rxjs";
 import { map } from "rxjs/operators";
+import { FormsModule } from "@angular/forms";
 
 @Component({
 	selector: 'toasts-stories',
 	templateUrl: './toasts.stories.html',
 })
 class ToastsStory implements OnInit, OnDestroy {
+
+	public isBottom = false;
 
 	public defaultToastDuration = defaultToastDuration;
 	public toastError$: Observable<LuToastInput>;
@@ -56,7 +59,7 @@ export default {
 	component: ToastsStory,
 	decorators: [
 		moduleMetadata({
-			imports: [LuToastsModule],
+			imports: [LuToastsModule, FormsModule],
 			declarations: [ToastsStory]
 		})
 	]


### PR DESCRIPTION
## Description

Generate toasts (with different types info, error, success, warning) thank to a service or input observables directly on the `lu-toast` . You can also switch the toast position (bottom, or top by default).

-----

## Demo

https://user-images.githubusercontent.com/35571450/158795727-1215113b-ca2b-432d-b5a2-4c7681094305.mp4

-----