### PR TITLE
[Font size] fix standard

### DIFF
--- a/packages/scss/src/theming/_sizes.scss
+++ b/packages/scss/src/theming/_sizes.scss
@@ -12,7 +12,7 @@ $sizes: (
   ),
   standard: (
 		font-size: 1rem, // 16px
-		line-height: 1.25rem, // 20px
+		line-height: 1.5rem, // 24px
     vertical-padding: 0.125rem, // 2px
   ),
   big: (
@@ -25,7 +25,7 @@ $sizes: (
 		line-height: 1.75rem, // 28px
     vertical-padding: 0.375rem, // 6px
   ),
-  biggest: ( 
+  biggest: (
 		font-size: 1.75rem, // 28px
 		line-height: 2rem, // 32px
     vertical-padding: 0.25rem, // 4px


### PR DESCRIPTION
Standard size is used as H4 and Body 1 (which lately diverged in Figma). 
Reducing the standard line height on LF impacted the height of multiple components (buttons, selects...)

For now we are reverting the standard line height but we should have 2 specifics values in the future. 