### PR TITLE
fix(ng) sorting in formly api select

### DIFF
--- a/packages/ng/api/src/lib/service/api-v4.service.ts
+++ b/packages/ng/api/src/lib/service/api-v4.service.ts
@@ -22,7 +22,9 @@ export class LuApiV4Service<T extends ILuApiItem = ILuApiItem> extends ALuApiSer
 
 	protected _sort: string;
 	set sort(sort: string) {
-		this._sort = `sort=${sort}`;
+		if (sort) {
+			this._sort = `sort=${sort}`;
+		}
 	}
 
 	constructor(protected _http: HttpClient) {

--- a/packages/ng/formly/src/lib/types/api.html
+++ b/packages/ng/formly/src/lib/types/api.html
@@ -9,6 +9,7 @@
 	[api]="_api"
 	[filters]="_filters"
 	[orderBy]="_orderBy"
+	[sort]="_sort"
 	[standard]="_standard"
 >
 </lu-api-select>

--- a/packages/ng/formly/src/lib/types/api.ts
+++ b/packages/ng/formly/src/lib/types/api.ts
@@ -19,6 +19,9 @@ export class LuFormlyFieldApi extends FieldType {
 	get _orderBy() {
 		return this.to['orderBy'] as string;
 	}
+	get _sort() {
+		return this.to['sort'] as string;
+	}
 	get _standard() {
 		return (this.to['standard'] || 'v3') as string;
 	}


### PR DESCRIPTION
#### Description

Since the PR : https://github.com/LuccaSA/lucca-front/pull/1512, it is impossible to add api v4 sorting on formly api select because it is not using the `sort` property.

- Add the sort property in the formly api select component,
- Add a protection in api v4 select for nul sorting params

-----