### PR TITLE
[callout] button.link support

### DIFF
--- a/packages/scss/src/components/_callout.scss
+++ b/packages/scss/src/components/_callout.scss
@@ -7,7 +7,7 @@
 	position: relative;
 	color: _color('grey', 800);
 
-	a {
+	a, .link {
 		color: _color('grey', 800);
 
 		&:hover {


### PR DESCRIPTION
Supports `<button class="link">` in callouts.
![image](https://user-images.githubusercontent.com/25581936/165475350-3c0c9c94-a3cd-42cf-b1fc-b7e2aa07bf01.png)
