### PR TITLE
feat(ng) ADD Title service

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -58,7 +58,7 @@
 				"no-restricted-imports": [
 					"error",
 					{
-						"paths": ["rxjs/Rx"]
+						"paths": ["rxjs/Rx", "@ngneat/spectator"]
 					}
 				],
 				"max-classes-per-file": "off",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
 				"@angular/compiler-cli": "^13.2.4",
 				"@compodoc/compodoc": "^1.1.19",
 				"@delagen/eslint-plugin-deprecation": "^1.3.2",
+				"@ngneat/spectator": "^10.0.1",
 				"@storybook/addon-a11y": "6.4.19",
 				"@storybook/addon-actions": "^6.4.19",
 				"@storybook/addon-docs": "^6.4.19",
@@ -5196,6 +5197,26 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
 			"integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
+		},
+		"node_modules/@ngneat/spectator": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@ngneat/spectator/-/spectator-10.0.1.tgz",
+			"integrity": "sha512-ukyEYoK/wCIpe8IFHR+Lx7NfcBzFuYWsvwyFgRbIAinBDyqmzCarr9DKm1n3UejLIuVR3vJakumfHhdblhEmEw==",
+			"dev": true,
+			"dependencies": {
+				"@testing-library/dom": "^8.11.0",
+				"jquery": "3.6.0",
+				"replace-in-file": "6.2.0",
+				"tslib": "^2.1.0"
+			},
+			"bin": {
+				"spectator-migrate": "migrate.js"
+			},
+			"peerDependencies": {
+				"@angular/animations": ">= 13.0.0",
+				"@angular/common": ">= 13.0.0",
+				"@angular/router": ">= 13.0.0"
+			}
 		},
 		"node_modules/@ngtools/webpack": {
 			"version": "13.2.5",
@@ -12629,6 +12650,86 @@
 				"react-dom": "^16.8.0 || ^17.0.0"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+			"integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^5.0.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.4.4",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/aria-query": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+			"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+			"dev": true,
+			"engines": {
+				"node": ">=6.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -12672,6 +12773,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
 			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+			"dev": true
+		},
+		"node_modules/@types/aria-query": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
 			"dev": true
 		},
 		"node_modules/@types/babel__core": {
@@ -18644,6 +18751,12 @@
 			"engines": {
 				"node": ">=6.0.0"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.14",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+			"dev": true
 		},
 		"node_modules/dom-converter": {
 			"version": "0.2.0",
@@ -28589,6 +28702,12 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/jquery": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+			"dev": true
+		},
 		"node_modules/js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -29584,6 +29703,15 @@
 			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
 			"dev": true
+		},
+		"node_modules/lz-string": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
+			"dev": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
 		},
 		"node_modules/macos-release": {
 			"version": "2.5.0",
@@ -34863,6 +34991,102 @@
 			},
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/replace-in-file": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.2.0.tgz",
+			"integrity": "sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^4.1.0",
+				"glob": "^7.1.6",
+				"yargs": "^16.2.0"
+			},
+			"bin": {
+				"replace-in-file": "bin/cli.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/yargs": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+			"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+			"dev": true,
+			"dependencies": {
+				"cliui": "^7.0.2",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.0",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^20.2.2"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/replace-in-file/node_modules/yargs-parser": {
+			"version": "20.2.9",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+			"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/require-directory": {
@@ -44487,6 +44711,18 @@
 				}
 			}
 		},
+		"@ngneat/spectator": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/@ngneat/spectator/-/spectator-10.0.1.tgz",
+			"integrity": "sha512-ukyEYoK/wCIpe8IFHR+Lx7NfcBzFuYWsvwyFgRbIAinBDyqmzCarr9DKm1n3UejLIuVR3vJakumfHhdblhEmEw==",
+			"dev": true,
+			"requires": {
+				"@testing-library/dom": "^8.11.0",
+				"jquery": "3.6.0",
+				"replace-in-file": "6.2.0",
+				"tslib": "^2.1.0"
+			}
+		},
 		"@ngtools/webpack": {
 			"version": "13.2.5",
 			"resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-13.2.5.tgz",
@@ -50204,6 +50440,64 @@
 				"store2": "^2.12.0"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "8.13.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+			"integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^4.2.0",
+				"aria-query": "^5.0.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.4.4",
+				"pretty-format": "^27.0.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"aria-query": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.0.0.tgz",
+					"integrity": "sha512-V+SM7AbUwJ+EBnB8+DXs0hPZHO0W6pqBcc0dW90OwtVG02PswOu/teuARoLQjdDOH+t9pJgGnW5/Qmouf3gPJg==",
+					"dev": true
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"@tootallnate/once": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -50244,6 +50538,12 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
 			"integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+			"dev": true
+		},
+		"@types/aria-query": {
+			"version": "4.2.2",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+			"integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
 			"dev": true
 		},
 		"@types/babel__core": {
@@ -55034,6 +55334,12 @@
 			"requires": {
 				"esutils": "^2.0.2"
 			}
+		},
+		"dom-accessibility-api": {
+			"version": "0.5.14",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.14.tgz",
+			"integrity": "sha512-NMt+m9zFMPZe0JcY9gN224Qvk6qLIdqex29clBvc/y75ZBX9YA9wNK3frsYvu2DI1xcCIwxwnX+TlsJ2DSOADg==",
+			"dev": true
 		},
 		"dom-converter": {
 			"version": "0.2.0",
@@ -62553,6 +62859,12 @@
 				}
 			}
 		},
+		"jquery": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
+			"integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==",
+			"dev": true
+		},
 		"js-string-escape": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -63331,6 +63643,12 @@
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
 			"integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+			"dev": true
+		},
+		"lz-string": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+			"integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=",
 			"dev": true
 		},
 		"macos-release": {
@@ -67397,6 +67715,74 @@
 				"homedir-polyfill": "^1.0.1",
 				"is-absolute": "^1.0.0",
 				"remove-trailing-separator": "^1.1.0"
+			}
+		},
+		"replace-in-file": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/replace-in-file/-/replace-in-file-6.2.0.tgz",
+			"integrity": "sha512-Im2AF9G/qgkYneOc9QwWwUS/efyyonTUBvzXS2VXuxPawE5yQIjT/e6x4CTijO0Quq48lfAujuo+S89RR2TP2Q==",
+			"dev": true,
+			"requires": {
+				"chalk": "^4.1.0",
+				"glob": "^7.1.6",
+				"yargs": "^16.2.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
+				"yargs": {
+					"version": "16.2.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+					"integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+					"dev": true,
+					"requires": {
+						"cliui": "^7.0.2",
+						"escalade": "^3.1.1",
+						"get-caller-file": "^2.0.5",
+						"require-directory": "^2.1.1",
+						"string-width": "^4.2.0",
+						"y18n": "^5.0.5",
+						"yargs-parser": "^20.2.2"
+					}
+				},
+				"yargs-parser": {
+					"version": "20.2.9",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+					"integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+					"dev": true
+				}
 			}
 		},
 		"require-directory": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"@angular/compiler-cli": "^13.2.4",
 		"@compodoc/compodoc": "^1.1.19",
 		"@delagen/eslint-plugin-deprecation": "^1.3.2",
+		"@ngneat/spectator": "^10.0.1",
 		"@storybook/addon-a11y": "6.4.19",
 		"@storybook/addon-actions": "^6.4.19",
 		"@storybook/addon-docs": "^6.4.19",

--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -1,3 +1,96 @@
 # Page titles
+## Usage
 
-## TODO
+Add `title` properties in your routes config:
+
+```typescript
+const routes: Routes = [
+	{
+		path: '',
+		data: {
+			title: 'Parent title'
+		},
+		children: [
+			{
+				path: ':requestId',
+				data: {
+					title: 'Sub route title'
+				},
+			}
+		]
+	}
+]
+```
+
+The service should now be able to collect all `title` properties defined for the current url. Each time a new `title` is found for a child, il will be translated and prepended, ending with `YourAppName - Lucca`.
+
+ex: `Sub route title - Parent title - YourAppName - Lucca`
+
+For dynamic titles, the `prependTitle` method from `TitleService` enables you to add a custom title. 
+In a component you could do the following:
+
+```typescript
+const userName: string = this.userService.getCurrentUser();
+this.titleService.prependTitle(userName);
+```
+
+## Quickstart
+
+You will need to :
+* `@lucca-front/ng` > 8.5.0
+* Create a service (`YourAppNameTranslateService`) that implements the `ILuTitleTranslateService`
+* Provide this service in the `app.module.ts` and import `LuTitleModule`
+* Init the `TitleService` in your `app.component.ts`
+
+### Let's start by creating the service:
+
+`YourAppNameTranslateService` be used in combination with the token `LU_TITLE_TRANSLATE_SERVICE`.
+
+This service should implements the `ILuTitleTranslateService` interface that allows you to use any translation service (`ngx-translate`, `transloco`, ...etc).
+
+You should end up with the following if you are using `ngx-translate`:
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class CoreRhTranslateService implements ILuTitleTranslateService {
+	constructor(private translateService: TranslateService) {}
+	translate(key: string, args: unknown): string {
+		return this.translateService.instant(key, args);
+	}
+}
+```
+
+or if you are using `transloco`:
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class CoreRhTranslateService implements ILuTitleTranslateService {
+	constructor(private translateService: TranslocoService) {}
+	translate(key: string, args: HashMap): string {
+		return this.translateService.translate(key, args);
+	}
+}
+```
+
+### Adapt `app.module.ts` config:
+
+Import the `LuTitleModule` and provide the service you just created to the token `LU_TITLE_TRANSLATE_SERVICE` in the `app.module.ts` :
+```typescript
+@NgModule({
+	imports: [
+		LuTitleModule
+	],
+	provide: [
+		{
+			provide: LU_TITLE_TRANSLATE_SERVICE,
+			useExisting: YourAppNameTranslateService
+		}
+	]
+```
+
+### Init the `titleService`:
+
+In the the `app.component.ts`, init the titleService by passing the name of you app:
+```typescript
+this.titleService.init('**YourAppName**');
+```

--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -1,0 +1,3 @@
+# Page titles
+
+## TODO

--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -1,4 +1,5 @@
 # Page titles
+
 ## Usage
 
 Add `title` properties in your routes config:
@@ -8,45 +9,46 @@ const routes: Routes = [
 	{
 		path: '',
 		data: {
-			title: 'Parent title'
+			title: 'Parent title',
 		},
 		children: [
 			{
 				path: ':requestId',
 				data: {
-					title: 'Sub route title'
+					title: 'Sub route title',
 				},
-			}
-		]
-	}
-]
+			},
+		],
+	},
+];
 ```
 
-The service should now be able to collect all `title` properties defined for the current url. Each time a new `title` is found for a child, il will be translated and prepended, ending with `YourAppName - Lucca`.
+The service should now be able to collect all `title` properties defined for the current url. Each time a new `title` is found for a child, it will be translated and prepended, ending with `YourAppName - Lucca`.
 
 ex: `Sub route title - Parent title - YourAppName - Lucca`
 
-For dynamic titles, the `prependTitle` method from `TitleService` enables you to add a custom title. 
-In a component you could do the following:
+For dynamic titles, the `prependTitle` method from `LuTitleService` enables you to add a custom title.
+In a component, you could do the following:
 
 ```typescript
 const userName: string = this.userService.getCurrentUser();
-this.titleService.prependTitle(userName);
+this.luTitleService.prependTitle(userName);
 ```
 
 ## Quickstart
 
-You will need to :
-* `@lucca-front/ng` > 8.5.0
-* Create a service (`YourAppNameTranslateService`) that implements the `ILuTitleTranslateService`
-* Provide this service in the `app.module.ts` and import `LuTitleModule`
-* Init the `TitleService` in your `app.component.ts`
+You will need to:
 
-### Let's start by creating the service:
+- Install `@lucca-front/ng`
+- Create a service (`YourAppNameTranslateService`) that implements the `ILuTitleTranslateService`
+- Provide this service in the `app.module.ts` and import `LuTitleModule`
+- Init the `LuTitleService` in your `app.component.ts`
+
+### Let's start by creating the service
 
 `YourAppNameTranslateService` be used in combination with the token `LU_TITLE_TRANSLATE_SERVICE`.
 
-This service should implements the `ILuTitleTranslateService` interface that allows you to use any translation service (`ngx-translate`, `transloco`, ...etc).
+This service should implement the `ILuTitleTranslateService` interface. It allows you to use any translation service (`ngx-translate`, `transloco`, ...etc).
 
 You should end up with the following if you are using `ngx-translate`:
 
@@ -72,25 +74,27 @@ export class CoreRhTranslateService implements ILuTitleTranslateService {
 }
 ```
 
-### Adapt `app.module.ts` config:
+### Adapt `app.module.ts` config
 
 Import the `LuTitleModule` and provide the service you just created to the token `LU_TITLE_TRANSLATE_SERVICE` in the `app.module.ts` :
+
 ```typescript
 @NgModule({
-	imports: [
-		LuTitleModule
-	],
-	provide: [
-		{
-			provide: LU_TITLE_TRANSLATE_SERVICE,
-			useExisting: YourAppNameTranslateService
-		}
-	]
+ imports: [
+  LuTitleModule
+ ],
+ provide: [
+  {
+   provide: LU_TITLE_TRANSLATE_SERVICE,
+   useExisting: YourAppNameTranslateService
+  }
+ ]
 ```
 
-### Init the `titleService`:
+### Init the `LuTitleService`
 
-In the the `app.component.ts`, init the titleService by passing the name of you app:
+In the the `app.component.ts`, init the LuTitleService by passing the name of you app:
+
 ```typescript
-this.titleService.init('**YourAppName**');
+this.luTitleService.init('**YourAppName**');
 ```

--- a/packages/ng/title/ng-package.json
+++ b/packages/ng/title/ng-package.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "src/public-api.ts",
+		"styleIncludePaths": ["../style", "../style/overrides"]
+	}
+}

--- a/packages/ng/title/src/index.ts
+++ b/packages/ng/title/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib';

--- a/packages/ng/title/src/lib/index.ts
+++ b/packages/ng/title/src/lib/index.ts
@@ -1,0 +1,3 @@
+export * from './title-translate.service';
+export * from './title.module';
+export * from './title.service';

--- a/packages/ng/title/src/lib/title-translate.service.ts
+++ b/packages/ng/title/src/lib/title-translate.service.ts
@@ -1,0 +1,7 @@
+import { InjectionToken } from '@angular/core';
+
+export const LU_TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('TITLE_TRANSLATE_SERVICE');
+
+export interface ILuTitleTranslateService {
+	translate(key: string, args?: { [arg: string]: unknown }): string;
+}

--- a/packages/ng/title/src/lib/title-translate.service.ts
+++ b/packages/ng/title/src/lib/title-translate.service.ts
@@ -3,5 +3,5 @@ import { InjectionToken } from '@angular/core';
 export const LU_TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('LU_TITLE_TRANSLATE_SERVICE');
 
 export interface ILuTitleTranslateService {
-	translate(key: string, args?: { [arg: string]: unknown }): string;
+	translate(key: string, args?: Record<string, unknown>): string;
 }

--- a/packages/ng/title/src/lib/title-translate.service.ts
+++ b/packages/ng/title/src/lib/title-translate.service.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 
-export const LU_TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('TITLE_TRANSLATE_SERVICE');
+export const LU_TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('LU_TITLE_TRANSLATE_SERVICE');
 
 export interface ILuTitleTranslateService {
 	translate(key: string, args?: { [arg: string]: unknown }): string;

--- a/packages/ng/title/src/lib/title.module.ts
+++ b/packages/ng/title/src/lib/title.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { TitleService } from './title.service';
+import { LuTitleService } from './title.service';
 
 @NgModule({
 	imports: [RouterModule],
-	providers: [TitleService],
+	providers: [LuTitleService],
 })
 export class LuTitleModule {}

--- a/packages/ng/title/src/lib/title.module.ts
+++ b/packages/ng/title/src/lib/title.module.ts
@@ -1,0 +1,9 @@
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { TitleService } from './title.service';
+
+@NgModule({
+	imports: [RouterModule],
+	providers: [TitleService],
+})
+export class LuTitleModule {}

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -1,8 +1,8 @@
+import { Location } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-import { ActivatedRouteSnapshot, ActivationEnd, Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
-import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
-import { of } from 'rxjs';
+import { createRoutingFactory, mockProvider, SpectatorRouting } from '@ngneat/spectator/jest';
+import { skip } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
 import { TitleService } from './title.service';
 
@@ -14,38 +14,110 @@ class TranslateService implements ILuTitleTranslateService {
 
 const translationKey = 'Home';
 
-describe('TitleService', () => {
-	let spectator: SpectatorService<TitleService>;
-	const route = new ActivatedRouteSnapshot();
-	// eslint-disable-next-line
-	(route as any).snapshot = { children: [], data: { title: translationKey } };
+@Component({
+	selector: 'lu-app',
+	template: `<router-outlet></router-outlet>
+		<a class="link-2" [routerLink]="['/first']">Stub</a>
+		<a class="link-3" [routerLink]="['/first/1']">Stub</a>
+		<a class="link-4" [routerLink]="['/first/1/last']">Stub</a> `,
+})
+export class AppComponent {
+	constructor(private titleService: TitleService) {
+		this.titleService.init('BU');
+	}
+}
 
-	const createService = createServiceFactory({
-		service: TitleService,
-		imports: [RouterTestingModule.withRoutes([])],
+@Component({
+	selector: 'lu-stub',
+	template: `<router-outlet></router-outlet>`,
+})
+export class StubComponent {}
+
+@Component({
+	selector: 'lu-override-title',
+	template: `<div></div>`,
+})
+export class OverrideTitleComponent implements OnInit {
+	constructor(private titleService: TitleService) {}
+	ngOnInit() {
+		this.titleService.prependTitle('Overridden title');
+	}
+}
+
+describe('TitleService', () => {
+	let spectator: SpectatorRouting<AppComponent>;
+
+	const createComponent = createRoutingFactory({
+		component: AppComponent,
 		providers: [
-			mockProvider(Router, {
-				events: of(new ActivationEnd(route)),
-			}),
+			TitleService,
 			mockProvider(Title),
 			{
 				provide: LU_TITLE_TRANSLATE_SERVICE,
 				useClass: TranslateService,
 			},
 		],
+		declarations: [StubComponent, OverrideTitleComponent],
+		stubsEnabled: false,
+		routes: [
+			{
+				path: '',
+				data: { title: 'Stub' },
+				component: StubComponent,
+				children: [
+					{
+						path: 'first',
+						data: { title: `` },
+						component: StubComponent,
+						children: [
+							{
+								path: ':id',
+								data: { title: `Stubs' child` },
+								component: StubComponent,
+								children: [
+									{
+										path: 'last',
+										data: { title: `` },
+										component: OverrideTitleComponent,
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		],
 	});
 
-	beforeEach(() => (spectator = createService()));
+	beforeEach(() => (spectator = createComponent()));
 
-	it('should be defined', () => {
-		expect(spectator.service).toBeDefined();
+	it('should set title', async () => {
+		let resultTitle = '';
+		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
+
+		// wait for promises to resolve...
+		await spectator.fixture.whenStable();
+		expect(spectator.inject(Location).path()).toBe('/');
+
+		spectator.click('.link-2');
+		await spectator.fixture.whenStable();
+		expect(resultTitle).toEqual('Stub – BU – Lucca');
+
+		spectator.click('.link-3');
+		await spectator.fixture.whenStable();
+		expect(resultTitle).toEqual(`Stubs' child – Stub – BU – Lucca`);
 	});
 
-	xit('should set title', () => {
-		const mockTitle = spectator.inject(Title);
+	it('prepend', async () => {
+		let resultTitle = '';
+		spectator
+			.inject(TitleService)
+			// We need to skip first value because the title is overridden by the component's ngOnInit
+			.title$.pipe(skip(1))
+			.subscribe((title) => (resultTitle = title));
 
-		spectator.service.init(translationKey);
-		expect(mockTitle.setTitle).toHaveBeenCalled();
-		expect(mockTitle.setTitle).toHaveBeenCalledWith(translationKey);
+		spectator.click('.link-4');
+		await spectator.fixture.whenStable();
+		expect(resultTitle).toEqual(`Overridden title – Stubs' child – Stub – BU – Lucca`);
 	});
 });

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -7,7 +7,12 @@ import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-tr
 import { TitleSeparator, TitleService } from './title.service';
 
 class TranslateService implements ILuTitleTranslateService {
-	translate(key: string, _args?: { [arg: string]: unknown }): string {
+	translate(key: string, args: Record<string, unknown> = null): string {
+		if (args !== null) {
+			Object.entries(args).forEach(([argKey, value]) => {
+				key = key.replace(`{{${argKey}}}`, value as string);
+			});
+		}
 		return key;
 	}
 }
@@ -70,7 +75,7 @@ describe('TitleService', () => {
 						children: [
 							{
 								path: ':id',
-								data: { title: `Stubs' child` },
+								data: { title: `Stubs' child {{id}}` },
 								component: StubComponent,
 								children: [
 									{
@@ -103,7 +108,7 @@ describe('TitleService', () => {
 
 		spectator.click('.link-3');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Stubs' child${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('prepend', async () => {
@@ -116,6 +121,6 @@ describe('TitleService', () => {
 
 		spectator.click('.link-4');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 });

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -4,15 +4,13 @@ import { Title } from '@angular/platform-browser';
 import { createRoutingFactory, mockProvider, SpectatorRouting } from '@ngneat/spectator/jest';
 import { skip } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
-import { TitleService } from './title.service';
+import { TitleSeparator, TitleService } from './title.service';
 
 class TranslateService implements ILuTitleTranslateService {
 	translate(key: string, _args?: { [arg: string]: unknown }): string {
 		return key;
 	}
 }
-
-const translationKey = 'Home';
 
 @Component({
 	selector: 'lu-app',
@@ -101,11 +99,11 @@ describe('TitleService', () => {
 
 		spectator.click('.link-2');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual('Stub – BU – Lucca');
+		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 
 		spectator.click('.link-3');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Stubs' child – Stub – BU – Lucca`);
+		expect(resultTitle).toEqual(`Stubs' child${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('prepend', async () => {
@@ -118,6 +116,6 @@ describe('TitleService', () => {
 
 		spectator.click('.link-4');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Overridden title – Stubs' child – Stub – BU – Lucca`);
+		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 });

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -1,0 +1,57 @@
+import { Title } from '@angular/platform-browser';
+import { ActivatedRouteSnapshot, ActivationEnd, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
+import { of } from 'rxjs';
+import { ILuTitleTranslateService } from './title-translate.service';
+import { TitleService, TITLE_TRANSLATE_SERVICE } from './title.service';
+
+class TranslateService implements ILuTitleTranslateService {
+	translate(key: string, args?: { [arg: string]: unknown }): string {
+		return key;
+	}
+	getAvailableLangs(): string[] {
+		return [];
+	}
+	setActiveLang(lang: string): void {
+		return;
+	}
+}
+
+const translationKey = 'Home';
+
+describe('TitleService', () => {
+	let spectator: SpectatorService<TitleService>;
+	const route = new ActivatedRouteSnapshot();
+	// eslint-disable-next-line
+	(route as any).snapshot = { children: [], data: { title: translationKey } };
+
+	const createService = createServiceFactory({
+		service: TitleService,
+		imports: [RouterTestingModule.withRoutes([])],
+		providers: [
+			mockProvider(Router, {
+				events: of(new ActivationEnd(route)),
+			}),
+			mockProvider(Title),
+			{
+				provide: TITLE_TRANSLATE_SERVICE,
+				useClass: TranslateService,
+			},
+		],
+	});
+
+	beforeEach(() => (spectator = createService()));
+
+	it('should be defined', () => {
+		expect(spectator.service).toBeDefined();
+	});
+
+	xit('should set title', () => {
+		const mockTitle = spectator.inject(Title);
+
+		spectator.service.init(translationKey);
+		expect(mockTitle.setTitle).toHaveBeenCalled();
+		expect(mockTitle.setTitle).toHaveBeenCalledWith(translationKey);
+	});
+});

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -70,7 +70,6 @@ describe('TitleService', () => {
 				children: [
 					{
 						path: 'first',
-						data: { title: `` },
 						component: StubComponent,
 						children: [
 							{
@@ -98,20 +97,30 @@ describe('TitleService', () => {
 		let resultTitle = '';
 		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
 
-		// wait for promises to resolve...
 		await spectator.fixture.whenStable();
 		expect(spectator.inject(Location).path()).toBe('/');
+		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+	});
+
+	it('should ignore empty or absent titles', async () => {
+		let resultTitle = '';
+		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
 
 		spectator.click('.link-2');
 		await spectator.fixture.whenStable();
 		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+	});
+
+	it('should include named params in title', async () => {
+		let resultTitle = '';
+		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
 
 		spectator.click('.link-3');
 		await spectator.fixture.whenStable();
 		expect(resultTitle).toEqual(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
-	it('prepend', async () => {
+	it('should prepend title when a component forces its own title', async () => {
 		let resultTitle = '';
 		spectator
 			.inject(TitleService)

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -4,7 +4,7 @@ import { Title } from '@angular/platform-browser';
 import { createRoutingFactory, mockProvider, SpectatorRouting } from '@ngneat/spectator/jest';
 import { skip } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
-import { TitleSeparator, TitleService } from './title.service';
+import { LuTitleService, TitleSeparator } from './title.service';
 
 class TranslateService implements ILuTitleTranslateService {
 	translate(key: string, args: Record<string, unknown> = null): string {
@@ -25,7 +25,7 @@ class TranslateService implements ILuTitleTranslateService {
 		<a class="link-4" [routerLink]="['/first/1/last']">Stub</a> `,
 })
 export class AppComponent {
-	constructor(private titleService: TitleService) {
+	constructor(private titleService: LuTitleService) {
 		this.titleService.init('BU');
 	}
 }
@@ -41,7 +41,7 @@ export class StubComponent {}
 	template: `<div></div>`,
 })
 export class OverrideTitleComponent implements OnInit {
-	constructor(private titleService: TitleService) {}
+	constructor(private titleService: LuTitleService) {}
 	ngOnInit() {
 		this.titleService.prependTitle('Overridden title');
 	}
@@ -53,7 +53,7 @@ describe('TitleService', () => {
 	const createComponent = createRoutingFactory({
 		component: AppComponent,
 		providers: [
-			TitleService,
+			LuTitleService,
 			mockProvider(Title),
 			{
 				provide: LU_TITLE_TRANSLATE_SERVICE,
@@ -95,7 +95,7 @@ describe('TitleService', () => {
 
 	it('should set title', async () => {
 		let resultTitle = '';
-		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
+		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
 		await spectator.fixture.whenStable();
 		expect(spectator.inject(Location).path()).toBe('/');
@@ -104,7 +104,7 @@ describe('TitleService', () => {
 
 	it('should ignore empty or absent titles', async () => {
 		let resultTitle = '';
-		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
+		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
 		spectator.click('.link-2');
 		await spectator.fixture.whenStable();
@@ -113,7 +113,7 @@ describe('TitleService', () => {
 
 	it('should include named params in title', async () => {
 		let resultTitle = '';
-		spectator.inject(TitleService).title$.subscribe((title) => (resultTitle = title));
+		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
 		spectator.click('.link-3');
 		await spectator.fixture.whenStable();
@@ -123,7 +123,7 @@ describe('TitleService', () => {
 	it('should prepend title when a component forces its own title', async () => {
 		let resultTitle = '';
 		spectator
-			.inject(TitleService)
+			.inject(LuTitleService)
 			// We need to skip first value because the title is overridden by the component's ngOnInit
 			.title$.pipe(skip(1))
 			.subscribe((title) => (resultTitle = title));

--- a/packages/ng/title/src/lib/title.service.spec.ts
+++ b/packages/ng/title/src/lib/title.service.spec.ts
@@ -3,18 +3,12 @@ import { ActivatedRouteSnapshot, ActivationEnd, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { createServiceFactory, mockProvider, SpectatorService } from '@ngneat/spectator/jest';
 import { of } from 'rxjs';
-import { ILuTitleTranslateService } from './title-translate.service';
-import { TitleService, TITLE_TRANSLATE_SERVICE } from './title.service';
+import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
+import { TitleService } from './title.service';
 
 class TranslateService implements ILuTitleTranslateService {
-	translate(key: string, args?: { [arg: string]: unknown }): string {
+	translate(key: string, _args?: { [arg: string]: unknown }): string {
 		return key;
-	}
-	getAvailableLangs(): string[] {
-		return [];
-	}
-	setActiveLang(lang: string): void {
-		return;
 	}
 }
 
@@ -35,7 +29,7 @@ describe('TitleService', () => {
 			}),
 			mockProvider(Title),
 			{
-				provide: TITLE_TRANSLATE_SERVICE,
+				provide: LU_TITLE_TRANSLATE_SERVICE,
 				useClass: TranslateService,
 			},
 		],

--- a/packages/ng/title/src/lib/title.service.ts
+++ b/packages/ng/title/src/lib/title.service.ts
@@ -6,6 +6,7 @@ import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
 
 export type PageTitle = { title: string; params: { [param: string]: string } };
+export const TitleSeparator = ' – ';
 
 @Injectable()
 export class TitleService {
@@ -23,7 +24,7 @@ export class TitleService {
 				map((event: ActivationEnd) => getPageTitleParts(event.snapshot)),
 				map((titleParts) => uniqTitle(titleParts)),
 				map((titleParts) => titleParts.filter(({ title }) => title !== '').map(({ title, params }) => this.translateService.translate(title, params))),
-				map((titles: Array<string>) => [...titles, this.translateService.translate(applicationNameTranslationKey, {}), 'Lucca'].filter((x) => !!x).join(' – ')),
+				map((titles: Array<string>) => [...titles, this.translateService.translate(applicationNameTranslationKey, {}), 'Lucca'].filter((x) => !!x).join(TitleSeparator)),
 				distinctUntilChanged(),
 				tap((title) => this.titleSubject.next(title)),
 			)
@@ -33,7 +34,7 @@ export class TitleService {
 	}
 
 	prependTitle(title: string) {
-		this.titleSubject.next(`${title} – ${this.titleSubject.value}`);
+		this.titleSubject.next(`${title}${TitleSeparator}${this.titleSubject.value}`);
 	}
 }
 

--- a/packages/ng/title/src/lib/title.service.ts
+++ b/packages/ng/title/src/lib/title.service.ts
@@ -9,7 +9,7 @@ export type PageTitle = { title: string; params: { [param: string]: string } };
 export const TitleSeparator = ' – ';
 
 @Injectable()
-export class TitleService {
+export class LuTitleService {
 	private titleSubject = new BehaviorSubject<string>('Lucca');
 	title$ = this.titleSubject.asObservable();
 

--- a/packages/ng/title/src/lib/title.service.ts
+++ b/packages/ng/title/src/lib/title.service.ts
@@ -9,7 +9,7 @@ export type PageTitle = { title: string; params: { [param: string]: string } };
 
 @Injectable()
 export class TitleService {
-	private titleSubject = new BehaviorSubject<string>('');
+	private titleSubject = new BehaviorSubject<string>('Lucca');
 	title$ = this.titleSubject.asObservable();
 
 	constructor(private router: Router, private title: Title, @Inject(LU_TITLE_TRANSLATE_SERVICE) private translateService: ILuTitleTranslateService) {}
@@ -22,13 +22,18 @@ export class TitleService {
 				}),
 				map((event: ActivationEnd) => getPageTitleParts(event.snapshot)),
 				map((titleParts) => uniqTitle(titleParts)),
-				map((titleParts) => titleParts.map(({ title, params }) => this.translateService.translate(title, params))),
+				map((titleParts) => titleParts.filter(({ title }) => title !== '').map(({ title, params }) => this.translateService.translate(title, params))),
 				map((titles: Array<string>) => [...titles, this.translateService.translate(applicationNameTranslationKey, {}), 'Lucca'].filter((x) => !!x).join(' – ')),
 				distinctUntilChanged(),
-				tap((title) => this.title.setTitle(title)),
 				tap((title) => this.titleSubject.next(title)),
 			)
 			.subscribe();
+
+		this.title$.pipe(tap((title) => this.title.setTitle(title))).subscribe();
+	}
+
+	preprendTitle(title: string) {
+		this.titleSubject.next(`${title} – ${this.titleSubject.value}`);
 	}
 }
 

--- a/packages/ng/title/src/lib/title.service.ts
+++ b/packages/ng/title/src/lib/title.service.ts
@@ -1,20 +1,18 @@
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { Inject, Injectable } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, ActivationEnd, Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
 import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
-import { ILuTitleTranslateService } from './title-translate.service';
+import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
 
 export type PageTitle = { title: string; params: { [param: string]: string } };
-
-export const TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('TITLE_TRANSLATE_SERVICE');
 
 @Injectable()
 export class TitleService {
 	private titleSubject = new BehaviorSubject<string>('');
 	title$ = this.titleSubject.asObservable();
 
-	constructor(private router: Router, private title: Title, @Inject(TITLE_TRANSLATE_SERVICE) private translateService: ILuTitleTranslateService) {}
+	constructor(private router: Router, private title: Title, @Inject(LU_TITLE_TRANSLATE_SERVICE) private translateService: ILuTitleTranslateService) {}
 
 	init(applicationNameTranslationKey: string) {
 		this.router.events

--- a/packages/ng/title/src/lib/title.service.ts
+++ b/packages/ng/title/src/lib/title.service.ts
@@ -1,0 +1,47 @@
+import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { ActivatedRouteSnapshot, ActivationEnd, Router } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { distinctUntilChanged, filter, map, tap } from 'rxjs/operators';
+import { ILuTitleTranslateService } from './title-translate.service';
+
+export type PageTitle = { title: string; params: { [param: string]: string } };
+
+export const TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('TITLE_TRANSLATE_SERVICE');
+
+@Injectable()
+export class TitleService {
+	private titleSubject = new BehaviorSubject<string>('');
+	title$ = this.titleSubject.asObservable();
+
+	constructor(private router: Router, private title: Title, @Inject(TITLE_TRANSLATE_SERVICE) private translateService: ILuTitleTranslateService) {}
+
+	init(applicationNameTranslationKey: string) {
+		this.router.events
+			.pipe(
+				filter((event) => {
+					return event instanceof ActivationEnd && event.snapshot.children.length === 0;
+				}),
+				map((event: ActivationEnd) => getPageTitleParts(event.snapshot)),
+				map((titleParts) => uniqTitle(titleParts)),
+				map((titleParts) => titleParts.map(({ title, params }) => this.translateService.translate(title, params))),
+				map((titles: Array<string>) => [...titles, this.translateService.translate(applicationNameTranslationKey, {}), 'Lucca'].filter((x) => !!x).join(' – ')),
+				distinctUntilChanged(),
+				tap((title) => this.title.setTitle(title)),
+				tap((title) => this.titleSubject.next(title)),
+			)
+			.subscribe();
+	}
+}
+
+function getPageTitleParts(snapshot: ActivatedRouteSnapshot): Array<PageTitle> {
+	const pageTitle: PageTitle = {
+		title: (snapshot.data?.['title'] || '') as string,
+		params: snapshot.params,
+	};
+	return snapshot.parent ? [pageTitle, ...getPageTitleParts(snapshot.parent)] : [pageTitle];
+}
+
+function uniqTitle(titleParts: Array<PageTitle>): Array<PageTitle> {
+	return titleParts.filter(({ title }, index) => titleParts.findIndex((pageTitle) => pageTitle.title === title) === index);
+}

--- a/packages/ng/title/src/lib/title.service.ts
+++ b/packages/ng/title/src/lib/title.service.ts
@@ -32,7 +32,7 @@ export class TitleService {
 		this.title$.pipe(tap((title) => this.title.setTitle(title))).subscribe();
 	}
 
-	preprendTitle(title: string) {
+	prependTitle(title: string) {
 		this.titleSubject.next(`${title} – ${this.titleSubject.value}`);
 	}
 }

--- a/packages/ng/title/src/public-api.ts
+++ b/packages/ng/title/src/public-api.ts
@@ -1,0 +1,1 @@
+export * from './index';


### PR DESCRIPTION
Adds utility service that sets the page title according to routing rules. It respects Lucca's rules for page titles ("Current page title - Current app - Lucca" i.e. "Purchases - Cleemy Procurement - Lucca")

Inspired from https://github.com/LuccaSA/Cleemy.Front/blob/master/projects/cleemy/page-title/src/page-title.service.ts#L11
Thanks to @belabb-z @jbosi @mathieu-bellange @JeSuisCharlie1 @LucasPerrault @albangranger 

fixes https://github.com/LuccaSA/Guildes/issues/48