### PR TITLE
Fix department select with appInstanceId + operations attributes

### DIFF
--- a/packages/ng/department/src/lib/service/department-v3.service.ts
+++ b/packages/ng/department/src/lib/service/department-v3.service.ts
@@ -34,7 +34,7 @@ export class LuDepartmentV3Service extends LuApiV3Service<ILuDepartment> impleme
 		let call: Observable<ILuApiResponse<IApiDepartment>>;
 		if (this._appInstanceId && this._operations?.length) {
 			call = this._http.get<ILuApiResponse<IApiDepartment>>(
-				`/api/v3/departments/scopedtree?fields=id,name&${[`appInstanceId=${this.appInstanceId}`, `operations=${this._operations.join(',')}`, this._filters.join(',')].filter((f) => !!f).join('&')}`,
+				`/api/v3/departments/scopedtree?fields=id,name&${[`appInstanceId=${this._appInstanceId}`, `operations=${this._operations.join(',')}`, this._filters.join(',')].filter((f) => !!f).join('&')}`,
 			);
 		} else {
 			call = this._http.get<ILuApiResponse<IApiDepartment>>(`/api/v3/departments/tree?fields=id,name&${this._filters.join(',')}`);
@@ -46,6 +46,7 @@ export class LuDepartmentV3Service extends LuApiV3Service<ILuDepartment> impleme
 			}),
 		);
 	}
+
 	private format(t: IApiDepartment): ILuTree<ILuDepartment> {
 		return { value: t.node, children: t.children.map((c) => this.format(c)) };
 	}


### PR DESCRIPTION
Fixes a typo in `LuDepartmentV3Service` : a non existing getter was referenced by mistake and was always resolved as `undefined`