### PR TITLE
fontVariable option

### DIFF
--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -4,18 +4,20 @@
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/core';
 
-@import url('//fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
-
-// @font-face {
-// 	font-family: 'Source Sans Pro';
-// 	font-weight: 200 900;
-// 	font-style: normal;
-// 	font-stretch: normal;
-// 	font-display: swap;
-// 	src: url('//cdn.lucca.fr/fonts/SourceSans/SourceSans3VF-Roman.ttf.woff2') format('woff2'),
-// 		url('//cdn.lucca.fr/fonts/SourceSans/SourceSans3VF-Roman.ttf.woff') format('woff'),
-// 		url('//cdn.lucca.fr/fonts/SourceSans/SourceSans3VF-Roman.ttf') format('truetype');
-// }
+@if config.$fontVariable {
+	@import url('//fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap');
+} @else {
+	@font-face {
+		font-family: 'Source Sans Pro';
+		font-weight: 200 900;
+		font-style: normal;
+		font-stretch: normal;
+		font-display: swap;
+		src: url('//cdn.lucca.fr/fonts/SourceSans/SourceSans3VF-Roman.ttf.woff2') format('woff2'),
+			url('//cdn.lucca.fr/fonts/SourceSans/SourceSans3VF-Roman.ttf.woff') format('woff'),
+			url('//cdn.lucca.fr/fonts/SourceSans/SourceSans3VF-Roman.ttf') format('truetype');
+	}
+}
 
 *,
 ::after,

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,6 +1,7 @@
 $prefix: 'u-' !default;
 $states: 'error', 'warning', 'success' !default;
 $palettes: 'primary', 'secondary', 'grey' !default;
+$fontVariable: false !default;
 
 $primary: (
 	text: #ffffff,


### PR DESCRIPTION
We can now use font variable with this syntax: 
```
@forward '@lucca-front/scss/src/commons/config' with (
  $fontVariable: true
);
```