### PR TITLE
fix(storybook): use type code to avoid using "angular" language in prettier

### DIFF
--- a/stories/documentation/forms/api/select/api-select.stories.ts
+++ b/stories/documentation/forms/api/select/api-select.stories.ts
@@ -93,6 +93,7 @@ Basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	}

--- a/stories/documentation/forms/date/calendar/calendar.stories.ts
+++ b/stories/documentation/forms/date/calendar/calendar.stories.ts
@@ -73,6 +73,7 @@ Calendar.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		},
 	},

--- a/stories/documentation/forms/date/select/date-select.stories.ts
+++ b/stories/documentation/forms/date/select/date-select.stories.ts
@@ -78,6 +78,7 @@ Select.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		},
 	},

--- a/stories/documentation/forms/department/department-select.stories.ts
+++ b/stories/documentation/forms/department/department-select.stories.ts
@@ -70,6 +70,7 @@ Select.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		},
 	},

--- a/stories/documentation/forms/establishment-select/establishment-select.stories.ts
+++ b/stories/documentation/forms/establishment-select/establishment-select.stories.ts
@@ -66,6 +66,7 @@ basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		},
 	},

--- a/stories/documentation/forms/qualification/qualification-select.stories.ts
+++ b/stories/documentation/forms/qualification/qualification-select.stories.ts
@@ -70,6 +70,7 @@ Select.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code
 		}
 	}

--- a/stories/documentation/forms/select/select.stories.ts
+++ b/stories/documentation/forms/select/select.stories.ts
@@ -154,6 +154,7 @@ Basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		},
 	},

--- a/stories/documentation/overlays/dropdown/dropdown-basic.stories.ts
+++ b/stories/documentation/overlays/dropdown/dropdown-basic.stories.ts
@@ -62,6 +62,7 @@ Basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		},
 	},

--- a/stories/documentation/overlays/dropdown/dropdown-component.stories.ts
+++ b/stories/documentation/overlays/dropdown/dropdown-component.stories.ts
@@ -57,6 +57,7 @@ Component.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	}

--- a/stories/documentation/overlays/dropdown/dropdown-directive.stories.ts
+++ b/stories/documentation/overlays/dropdown/dropdown-directive.stories.ts
@@ -48,6 +48,7 @@ Directive.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	},

--- a/stories/documentation/overlays/modal/modal.stories.ts
+++ b/stories/documentation/overlays/modal/modal.stories.ts
@@ -51,6 +51,7 @@ Basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code: `
 /* 1. Importer LuModalModule */
 import { LuModalModule } from '@lucca-front/ng/modal';

--- a/stories/documentation/overlays/popover/popover.stories.ts
+++ b/stories/documentation/overlays/popover/popover.stories.ts
@@ -80,6 +80,7 @@ basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	}

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -105,6 +105,7 @@ basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	},

--- a/stories/documentation/users/select/user-homonyms.stories.ts
+++ b/stories/documentation/users/select/user-homonyms.stories.ts
@@ -81,6 +81,7 @@ homonyms.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	}

--- a/stories/documentation/users/select/user-select.stories.ts
+++ b/stories/documentation/users/select/user-select.stories.ts
@@ -71,6 +71,7 @@ basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	}

--- a/stories/documentation/users/tile/user-tile-format.stories.ts
+++ b/stories/documentation/users/tile/user-tile-format.stories.ts
@@ -45,6 +45,7 @@ format.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code: '',
 		}
 	}

--- a/stories/documentation/users/tile/user-tile.stories.ts
+++ b/stories/documentation/users/tile/user-tile.stories.ts
@@ -63,6 +63,7 @@ basic.parameters = {
 	docs: {
 		source: {
 			language: 'ts',
+			type: 'code',
 			code,
 		}
 	}


### PR DESCRIPTION
## Description
After Angular 14 migration, Storybook forced "Angular" type in prettier. "Angular" type is only for HTML files. Our "Typescript" had broken format.

-----