### PR TITLE
[FIX] Fix LF9 -> LF10 migration script

### DIFF
--- a/packages/ng/schematics/lib/scss-ast.ts
+++ b/packages/ng/schematics/lib/scss-ast.ts
@@ -26,7 +26,7 @@ export function removeContainerIfEmpty(node: Container | undefined): void {
 			}
 		}
 
-		if (!parent || parent.type === 'docment') {
+		if (!parent || parent.type === 'document') {
 			return;
 		}
 
@@ -34,7 +34,7 @@ export function removeContainerIfEmpty(node: Container | undefined): void {
 	}
 }
 
-export function addMixinImport(root: Root, mixin: string, postCss: PostCssLib, namespace = ''): void {
+export function addMixinImport(root: Root, mixin: string, postCss: PostCssLib, namespace = ''): AtRule {
 	let lastImportRule: AtRule | undefined;
 
 	root.walkAtRules(/(import|use)/, (rule) => {
@@ -49,10 +49,10 @@ export function addMixinImport(root: Root, mixin: string, postCss: PostCssLib, n
 
 	const newImportRule = new postCss.AtRule({ name: 'use', params: importStr });
 
-	addImport(root, newImportRule, lastImportRule);
+	return addImport(root, newImportRule, lastImportRule);
 }
 
-export function addImport(root: Root, atRule: AtRule, afterNode?: Node) {
+export function addImport(root: Root, atRule: AtRule, afterNode?: Node): AtRule {
 	if (afterNode) {
 		atRule.raws.before = '\n';
 		afterNode.after(atRule);
@@ -66,22 +66,21 @@ export function addImport(root: Root, atRule: AtRule, afterNode?: Node) {
 			root.append(atRule);
 		}
 	}
+	return atRule;
 }
 
-export function addForwardRule(root: Root, name: string, postCss: PostCssLib) {
-	let lastForwardRule: AtRule | undefined;
-
-	root.walkAtRules('forward', (rule) => {
-		lastForwardRule = rule;
-	});
-
-	let afterNode: Node | undefined = lastForwardRule;
+export function addForwardRule(root: Root, name: string, postCss: PostCssLib, afterNode?: Node): AtRule {
+	if (!afterNode) {
+		root.walkAtRules('forward', (rule) => {
+			afterNode = rule;
+		});
+	}
 
 	if (!afterNode && root.first?.type === 'comment') {
 		afterNode = root.first;
 	}
 
-	addImport(root, new postCss.AtRule({ name: 'forward', params: `'${name}'` }), afterNode);
+	return addImport(root, new postCss.AtRule({ name: 'forward', params: `'${name}'` }), afterNode);
 }
 
 /**

--- a/packages/ng/schematics/migrations/css-vars/css-class-registry.ts
+++ b/packages/ng/schematics/migrations/css-vars/css-class-registry.ts
@@ -1,60 +1,59 @@
 const classWithImports = [
-	{ cssClass: ['actionIcon'], cssImport: ['@lucca-front/scss/src/components/actionIcon'] },
-	{ cssClass: ['box'], cssImport: ['@lucca-front/scss/src/components/box'] },
-	{ cssClass: ['breadcrumbs'], cssImport: ['@lucca-front/scss/src/components/breadcrumbs'] },
-	{ cssClass: ['button'], cssImport: ['@lucca-front/scss/src/components/button'] },
-	{ cssClass: ['button-group'], cssImport: ['@lucca-front/scss/src/components/buttonGroup'] },
-	{ cssClass: ['callout'], cssImport: ['@lucca-front/scss/src/components/callout'] },
-	{ cssClass: ['card'], cssImport: ['@lucca-front/scss/src/components/card'] },
-	{ cssClass: ['checkbox'], cssImport: ['@lucca-front/scss/src/components/checkbox'] },
-	{ cssClass: ['chip'], cssImport: ['@lucca-front/scss/src/components/chip'] },
-	{ cssClass: ['code'], cssImport: ['@lucca-front/scss/src/components/code'] },
-	{ cssClass: ['collapse'], cssImport: ['@lucca-front/scss/src/components/collapse'] },
-	{ cssClass: ['container'], cssImport: ['@lucca-front/scss/src/components/container'] },
-	{ cssClass: ['contentSection'], cssImport: ['@lucca-front/scss/src/components/contentSection'] },
-	{ cssClass: ['titleSection'], cssImport: ['@lucca-front/scss/src/components/titleSection'] },
-	{ cssClass: ['divider'], cssImport: ['@lucca-front/scss/src/components/divider'] },
-	{ cssClass: ['emptyState'], cssImport: ['@lucca-front/scss/src/components/emptyState'] },
-	{ cssClass: ['errorPage'], cssImport: ['@lucca-front/scss/src/components/errorPage'] },
-	{ cssClass: ['textfield'], cssImport: ['@lucca-front/scss/src/components/field', '@lucca-front/scss/src/components/textfield'] },
-	{ cssClass: ['radiosfield'], cssImport: ['@lucca-front/scss/src/components/field', '@lucca-front/scss/src/components/radio'] },
-	{ cssClass: ['checkboxesfield'], cssImport: ['@lucca-front/scss/src/components/field', '@lucca-front/scss/src/components/checkbox'] },
-	{ cssClass: ['file'], cssImport: ['@lucca-front/scss/src/components/file'] },
-	{ cssClass: ['filters'], cssImport: ['@lucca-front/scss/src/components/filters'] },
-	{ cssClass: ['form-group'], cssImport: ['@lucca-front/scss/src/components/form'] },
-	{ cssClass: ['gauge'], cssImport: ['@lucca-front/scss/src/components/gauge'] },
-	{ cssClass: ['grid'], cssImport: ['@lucca-front/scss/src/components/grid'] },
-	{ cssClass: ['header'], cssImport: ['@lucca-front/scss/src/components/header'] },
-	{ cssClass: ['label'], cssImport: ['@lucca-front/scss/src/components/label'] },
-	{ cssClass: ['layout'], cssImport: ['@lucca-front/scss/src/components/layout'] },
-	{ cssClass: ['link'], cssImport: ['@lucca-front/scss/src/components/link'] },
-	{ cssClass: ['list'], cssImport: ['@lucca-front/scss/src/components/list'] },
-	{ cssClass: ['loading'], cssImport: ['@lucca-front/scss/src/components/loading'] },
-	{ cssClass: ['main-content'], cssImport: ['@lucca-front/scss/src/components/main'] },
-	{ cssClass: ['menu'], cssImport: ['@lucca-front/scss/src/components/menu'] },
-	{ cssClass: ['navSide'], cssImport: ['@lucca-front/scss/src/components/navside'], elements: ['lucca-sitemap'] },
-	{ cssClass: ['pageHeader'], cssImport: ['@lucca-front/scss/src/components/pageHeader'] },
-	{ cssClass: ['pagination'], cssImport: ['@lucca-front/scss/src/components/pagination'] },
-	{ cssClass: ['progress'], cssImport: ['@lucca-front/scss/src/components/progress'] },
-	{ cssClass: ['radio'], cssImport: ['@lucca-front/scss/src/components/radio'] },
-	{ cssClass: ['radioButtons'], cssImport: ['@lucca-front/scss/src/components/radioButtons'] },
-	{ cssClass: ['section'], cssImport: ['@lucca-front/scss/src/components/section'] },
-	{ cssClass: ['switch'], cssImport: ['@lucca-front/scss/src/components/switch'] },
-	{ cssClass: ['table'], cssImport: ['@lucca-front/scss/src/components/table'] },
-	{ cssClass: [/^mod-layoutFixed-.*/], cssImport: ['@lucca-front/scss/src/components/tableFixed'] },
-	{ cssClass: ['mod-sortable', 'table-head-row-cell-sortableButton'], cssImport: ['@lucca-front/scss/src/components/tableSorted'] },
-	{ cssClass: ['mod-stickyColumn', 'mod-stickyHeader'], cssImport: ['@lucca-front/scss/src/components/tableSticked'] },
-	{ cssClass: ['tag'], cssImport: ['@lucca-front/scss/src/components/tag'] },
-	{ cssClass: ['textfield'], cssImport: ['@lucca-front/scss/src/components/textfield'] },
-	{ cssClass: ['timeline'], cssImport: ['@lucca-front/scss/src/components/timeline'] },
 	{
-		cssClass: ['u-h1', 'u-h2', 'u-h3', 'u-h4', 'u-h5', 'u-h6'],
-		cssImport: ['@lucca-front/scss/src/components/title'],
+		cssClasses: ['u-h1', 'u-h2', 'u-h3', 'u-h4', 'u-h5', 'u-h6'],
+		cssImports: ['@lucca-front/scss/src/components/title'],
 		elements: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 	},
-	{ cssClass: ['toasts'], cssImport: ['@lucca-front/scss/src/components/toast'] },
-	{ cssClass: ['tableOfContent'], cssImport: ['@lucca-front/scss/src/components/tableOfContent'] },
-	{ cssClass: [/^u-.*/], cssImport: ['@lucca-front/scss/src/components/util'] },
+	{ cssClasses: ['actionIcon'], cssImports: ['@lucca-front/scss/src/components/actionIcon'] },
+	{ cssClasses: ['box'], cssImports: ['@lucca-front/scss/src/components/box'] },
+	{ cssClasses: ['breadcrumbs'], cssImports: ['@lucca-front/scss/src/components/breadcrumbs'] },
+	{ cssClasses: ['button-group'], cssImports: ['@lucca-front/scss/src/components/buttonGroup'] },
+	{ cssClasses: ['button'], cssImports: ['@lucca-front/scss/src/components/button'] },
+	{ cssClasses: ['callout'], cssImports: ['@lucca-front/scss/src/components/callout'] },
+	{ cssClasses: ['card'], cssImports: ['@lucca-front/scss/src/components/card'] },
+	{ cssClasses: ['checkbox'], cssImports: ['@lucca-front/scss/src/components/checkbox'] },
+	{ cssClasses: ['checkboxesfield'], cssImports: ['@lucca-front/scss/src/components/field', '@lucca-front/scss/src/components/checkbox'] },
+	{ cssClasses: ['chip'], cssImports: ['@lucca-front/scss/src/components/chip'] },
+	{ cssClasses: ['code'], cssImports: ['@lucca-front/scss/src/components/code'] },
+	{ cssClasses: ['collapse'], cssImports: ['@lucca-front/scss/src/components/collapse'] },
+	{ cssClasses: ['container'], cssImports: ['@lucca-front/scss/src/components/container'] },
+	{ cssClasses: ['contentSection'], cssImports: ['@lucca-front/scss/src/components/contentSection'] },
+	{ cssClasses: ['divider'], cssImports: ['@lucca-front/scss/src/components/divider'], elements: ['hr'] },
+	{ cssClasses: ['emptyState'], cssImports: ['@lucca-front/scss/src/components/emptyState'] },
+	{ cssClasses: ['errorPage'], cssImports: ['@lucca-front/scss/src/components/errorPage'] },
+	{ cssClasses: ['file'], cssImports: ['@lucca-front/scss/src/components/file'] },
+	{ cssClasses: ['filters'], cssImports: ['@lucca-front/scss/src/components/filters'] },
+	{ cssClasses: ['form-group'], cssImports: ['@lucca-front/scss/src/components/form'] },
+	{ cssClasses: ['gauge'], cssImports: ['@lucca-front/scss/src/components/gauge'] },
+	{ cssClasses: ['grid'], cssImports: ['@lucca-front/scss/src/components/grid'] },
+	{ cssClasses: ['header'], cssImports: ['@lucca-front/scss/src/components/header'] },
+	{ cssClasses: ['label'], cssImports: ['@lucca-front/scss/src/components/label'] },
+	{ cssClasses: ['layout'], cssImports: ['@lucca-front/scss/src/components/layout'] },
+	{ cssClasses: ['link'], cssImports: ['@lucca-front/scss/src/components/link'] },
+	{ cssClasses: ['list'], cssImports: ['@lucca-front/scss/src/components/list'] },
+	{ cssClasses: ['loading'], cssImports: ['@lucca-front/scss/src/components/loading'] },
+	{ cssClasses: ['main-content'], cssImports: ['@lucca-front/scss/src/components/main'] },
+	{ cssClasses: ['menu'], cssImports: ['@lucca-front/scss/src/components/menu'] },
+	{ cssClasses: ['mod-sortable', 'table-head-row-cell-sortableButton'], cssImports: ['@lucca-front/scss/src/components/tableSorted'] },
+	{ cssClasses: ['mod-stickyColumn', 'mod-stickyHeader'], cssImports: ['@lucca-front/scss/src/components/tableSticked'] },
+	{ cssClasses: ['navSide'], cssImports: ['@lucca-front/scss/src/components/navside'], elements: ['lucca-sitemap'] },
+	{ cssClasses: ['pageHeader'], cssImports: ['@lucca-front/scss/src/components/pageHeader'] },
+	{ cssClasses: ['pagination'], cssImports: ['@lucca-front/scss/src/components/pagination'] },
+	{ cssClasses: ['progress'], cssImports: ['@lucca-front/scss/src/components/progress'] },
+	{ cssClasses: ['radio'], cssImports: ['@lucca-front/scss/src/components/radio'] },
+	{ cssClasses: ['radioButtons'], cssImports: ['@lucca-front/scss/src/components/radioButtons'] },
+	{ cssClasses: ['radiosfield'], cssImports: ['@lucca-front/scss/src/components/field', '@lucca-front/scss/src/components/radio'] },
+	{ cssClasses: ['section'], cssImports: ['@lucca-front/scss/src/components/section'] },
+	{ cssClasses: ['switch'], cssImports: ['@lucca-front/scss/src/components/switch'] },
+	{ cssClasses: ['table'], cssImports: ['@lucca-front/scss/src/components/table'] },
+	{ cssClasses: ['tableOfContent'], cssImports: ['@lucca-front/scss/src/components/tableOfContent'] },
+	{ cssClasses: ['tag'], cssImports: ['@lucca-front/scss/src/components/tag'] },
+	{ cssClasses: ['textfield'], cssImports: ['@lucca-front/scss/src/components/field', '@lucca-front/scss/src/components/textfield'] },
+	{ cssClasses: ['timeline'], cssImports: ['@lucca-front/scss/src/components/timeline'] },
+	{ cssClasses: ['titleSection'], cssImports: ['@lucca-front/scss/src/components/titleSection'] },
+	{ cssClasses: ['toasts'], cssImports: ['@lucca-front/scss/src/components/toast'] },
+	{ cssClasses: [/^mod-layoutFixed-.*/], cssImports: ['@lucca-front/scss/src/components/tableFixed'] },
+	{ cssClasses: [/^u-.*/], cssImports: ['@lucca-front/scss/src/components/util'] },
 ];
 
 export function getCssImports(allVisitedClasses: string[], allVisitedElements: string[]): string[] {
@@ -64,16 +63,16 @@ export function getCssImports(allVisitedClasses: string[], allVisitedElements: s
 
 	// Pre-compute classWithImports for performance optimization
 	for (const classWithImport of classWithImports) {
-		for (const cssClass of classWithImport.cssClass) {
+		for (const cssClass of classWithImport.cssClasses) {
 			if (typeof cssClass === 'string') {
-				exactCssClasses[cssClass] = classWithImport.cssImport;
+				exactCssClasses[cssClass] = classWithImport.cssImports;
 			} else {
-				regexpCssTests.push((css) => (css.match(cssClass) ? classWithImport.cssImport : null));
+				regexpCssTests.push((css) => (css.match(cssClass) ? classWithImport.cssImports : null));
 			}
 		}
 
 		for (const element of classWithImport.elements || []) {
-			exactCssElements[element] = classWithImport.cssImport;
+			exactCssElements[element] = classWithImport.cssImports;
 		}
 	}
 

--- a/packages/ng/schematics/migrations/css-vars/migration.spec.ts
+++ b/packages/ng/schematics/migrations/css-vars/migration.spec.ts
@@ -128,7 +128,7 @@ describe('CSS Vars Migration', () => {
 		tree.create('app.component.html', '<button type="button" class="button">Test</button>');
 		tree.create('table.component.html', '<table class="table mod-sortable" [class.mod-stickyColumn]="true"></table>');
 		tree.create('util.component.html', '<div class="u-marginTopStandard">LOL</div>');
-		tree.create('styles.scss', "@import '@lucca-front/scss/src/main.overridable';");
+		tree.create('styles.scss', "@import '@lucca-front/scss/src/main.overridable';\n@import '@lucca-front/ng/style/main.overridable';");
 
 		const schematicRunner = new SchematicTestRunner('migrations', collectionPath);
 		// migration-v10-css-vars is the name of the migration, which is defined in the migration.json file
@@ -144,6 +144,7 @@ describe('CSS Vars Migration', () => {
 			`@forward '@lucca-front/scss/src/components/tableSorted';`,
 			`@forward '@lucca-front/scss/src/components/tableSticked';`,
 			`@forward '@lucca-front/scss/src/components/util';`,
+			`@forward '@lucca-front/ng/src/main';`,
 		];
 
 		expect(tree.readContent('styles.scss')).toBe(expectedImports.join('\n'));

--- a/packages/ng/schematics/migrations/css-vars/migration.ts
+++ b/packages/ng/schematics/migrations/css-vars/migration.ts
@@ -1,3 +1,4 @@
+import { Node } from 'postcss';
 import type { ValueParser } from 'postcss-value-parser';
 import { AngularTemplate } from '../../lib/angular-template';
 import { applyUpdates, FileUpdate } from '../../lib/file-update.js';
@@ -65,17 +66,17 @@ export function migrateScssFile(content: string, postCss: PostCssLib, postCssScs
 
 export function optimizeScssGlobalImport(content: string, cssImports: string[], postCss: PostCssLib, postCssScss: PostCssScssLib): string {
 	const root = postCssScss.parse(content);
-	let hasGlobalImport = false;
+	let startImport: Node | null = null;
 
 	root.walkAtRules('forward', (rule) => {
 		if (rule.params.includes('@lucca-front/scss/src/main')) {
-			hasGlobalImport = true;
+			startImport = rule;
 		}
 	});
 
-	if (hasGlobalImport) {
+	if (startImport) {
 		for (const cssImport of cssImports) {
-			addForwardRule(root, cssImport, postCss);
+			startImport = addForwardRule(root, cssImport, postCss, startImport);
 		}
 	}
 
@@ -86,6 +87,8 @@ const classMigrationMap = {
 	'u-fontWeightBold': 'u-fontWeight600',
 	'u-order1': 'u-flexOrder1',
 	'u-order-1': 'u-flexOrderMinus1',
+	'u-right': 'u-floatRight',
+	'u-left': 'u-floatLeft',
 };
 
 export function migrateHTMLFile(path: string, content: string, angularCompiler: AngularCompilerLib): string {

--- a/stories/documentation/integration/utilities/float.stories.ts
+++ b/stories/documentation/integration/utilities/float.stories.ts
@@ -8,8 +8,8 @@ export default {
 
 function getTemplate(args: FloatStory): string {
 	return `
-		<div class="u-left"><code class="code">u-left</code></div>
-		<div class="u-right"><code class="code">u-right</code></div>
+		<div class="u-floatLeft"><code class="code">u-floatLeft</code></div>
+		<div class="u-floatRight"><code class="code">u-floatRight</code></div>
 	`;
 }
 


### PR DESCRIPTION
## Description

Corrige:
- Quand on importe textfield, checkbox ou radio, il faut aussi importer field
- Divider est aussi un composant (à importer si utilisé, donc)
- La source src/ng doit être appelé après la liste des composants SCSS sinon il y a des soucis de spécification
- u-right / u-left deviennent u-floatRight / u-floatLeft
-----