### PR TITLE
feat(schematics): handle _color(text)

### DIFF
--- a/packages/ng/schematics/migrations/css-vars/tests/colors-white.input.scss
+++ b/packages/ng/schematics/migrations/css-vars/tests/colors-white.input.scss
@@ -7,4 +7,7 @@
   color: _color("grey", "default");
   color: _color("grey.default");
   color: lighten(_color("primary", "lighter"), 10%);
+
+  color: _color('text');
+  color: _color('text.dark');
 }

--- a/packages/ng/schematics/migrations/css-vars/tests/colors-white.output.scss
+++ b/packages/ng/schematics/migrations/css-vars/tests/colors-white.output.scss
@@ -8,4 +8,7 @@
   color: var(--palettes-grey-700);
   // [LF NEXT] Fonctions de couleur + variables scss ne sont pas gérées.
   // color: lighten(var(--palettes-primary-200), 10%)
+
+  color: var(--palettes-grey-800);
+  color: var(--palettes-grey-900);
 }

--- a/packages/ng/schematics/migrations/css-vars/updaters/color.ts
+++ b/packages/ng/schematics/migrations/css-vars/updaters/color.ts
@@ -14,6 +14,13 @@ const legacyLevelToLevel: Partial<Record<string, string>> = {
 	default: '700',
 };
 
+const textLevelToLevel: Partial<Record<string, string>> = {
+	dark: '900',
+	default: '800',
+	light: '600',
+	placeholder: '400',
+};
+
 export function updateColorMixin(root: Root, postcssValueParser: ValueParser) {
 	root.walkDecls((decl) => {
 		const valueNode = new ScssValueAst(decl.value, postcssValueParser);
@@ -24,6 +31,9 @@ export function updateColorMixin(root: Root, postcssValueParser: ValueParser) {
 
 			if (color === 'white') {
 				funcNode.nodes = new ScssValueAst(`--colors-${color}-color`, postcssValueParser).nodes;
+			} else if (color === 'text') {
+				const level = textLevelToLevel[legacyLevel] ?? textLevelToLevel['default'];
+				funcNode.nodes = new ScssValueAst(`--palettes-grey-${level}`, postcssValueParser).nodes;
 			} else {
 				let level = legacyLevel ?? funcNode.nodes[2]?.value ?? '700';
 				level = legacyLevelToLevel[level] ?? level;


### PR DESCRIPTION
* Automatic migration of `_color(text)`