### PR TITLE
[Table] Fix handlers position

### DIFF
--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -181,7 +181,8 @@
 		}
 	}
 
-	[class*='-row-cell'] {
+	.table-body-row-cell,
+	.table-head-row-cell {
 		&:first-child {
 			padding-left: 2rem;
 			position: relative;


### PR DESCRIPTION
`[class*='-row-cell']` was also targeting `.table-body-row-cell-handler `

<img width="827" alt="image" src="https://user-images.githubusercontent.com/25581936/182576519-9c9675a4-86af-41a1-8b37-bef8ca5be041.png">
