### PR TITLE
Add UI diff hub stuff

### DIFF
--- a/e2e/LuccaFront.Tests.e2e/Features/DepartmentSelect.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/DepartmentSelect.feature
@@ -4,5 +4,5 @@ Feature: DepartmentSelect
     Background: Specify storybook actions on department select
         Given storybook forms departmentselect
 
-    Scenario: DepartmentSelect01: I can display basic departmentSelect
+    Scenario: DepartmentSelect-01: I can display basic departmentSelect
         Then take screenshot

--- a/e2e/LuccaFront.Tests.e2e/Features/DepartmentSelect.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/DepartmentSelect.feature
@@ -1,0 +1,8 @@
+@ui-diff
+Feature: DepartmentSelect
+
+    Background: Specify storybook actions on department select
+        Given storybook forms departmentselect
+
+    Scenario: DepartmentSelect01: I can display basic departmentSelect
+        Then take screenshot

--- a/e2e/LuccaFront.Tests.e2e/Features/EstablishmentSelect.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/EstablishmentSelect.feature
@@ -4,5 +4,5 @@ Feature: EstablishmentSelect
     Background: Specify storybook actions on establishment select
         Given storybook forms establishmentselect
 
-    Scenario: EstablishmentSelect01: I can display basic establishmentSelect
+    Scenario: EstablishmentSelect-01: I can display basic establishmentSelect
         Then take screenshot

--- a/e2e/LuccaFront.Tests.e2e/Features/EstablishmentSelect.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/EstablishmentSelect.feature
@@ -1,0 +1,8 @@
+@ui-diff
+Feature: EstablishmentSelect
+
+    Background: Specify storybook actions on establishment select
+        Given storybook forms establishmentselect
+
+    Scenario: EstablishmentSelect01: I can display basic establishmentSelect
+        Then take screenshot

--- a/e2e/LuccaFront.Tests.e2e/Features/QualificationSelect.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/QualificationSelect.feature
@@ -4,5 +4,5 @@ Feature: QualificationSelect
     Background: Specify storybook actions on qualification select
         Given storybook forms qualification
 
-    Scenario: QualificationSelect01: I can display basic qualificationSelect
+    Scenario: QualificationSelect-01: I can display basic qualificationSelect
         Then take screenshot

--- a/e2e/LuccaFront.Tests.e2e/Features/QualificationSelect.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/QualificationSelect.feature
@@ -1,0 +1,8 @@
+@ui-diff
+Feature: QualificationSelect
+
+    Background: Specify storybook actions on qualification select
+        Given storybook forms qualification
+
+    Scenario: QualificationSelect01: I can display basic qualificationSelect
+        Then take screenshot

--- a/e2e/LuccaFront.Tests.e2e/Features/Switches.feature
+++ b/e2e/LuccaFront.Tests.e2e/Features/Switches.feature
@@ -1,0 +1,36 @@
+@ui-diff
+Feature: Switches
+
+    Background: Specify storybook actions on qualification select
+        Given storybook forms switches
+
+    Scenario: Switches-01: I can display basic switches
+        Then take screenshot
+
+    Scenario: Switches-02: I can display <inline> switches
+        When select inline <inline>
+        Then take screenshot
+        Examples:
+        | inline |
+        | true   |
+        | false  |
+
+    Scenario: Switches-03: I can display <small> switches
+        When select small <small>
+        Then take screenshot
+        Examples:
+        | small  |
+        | true   |
+        | false  |
+
+    Scenario: Switches-04: I can display <small> and <inline> switches
+        When select small <small>
+        And select inline <inline>
+        Then take screenshot
+        Examples:
+        | small | inline |
+        | true  | false  |
+        | true  | true   |
+        | false | true   |
+        | false | false  |
+

--- a/e2e/LuccaFront.Tests.e2e/Steps/ModSteps.cs
+++ b/e2e/LuccaFront.Tests.e2e/Steps/ModSteps.cs
@@ -49,6 +49,18 @@ public class ModSteps
         await ClickOnSwitchControlAsync(disabled, "disabled");
     }
 
+    [When(@"select inline (true|false)")]
+    public async Task WhenSelectInlineAsync(string inline)
+    {
+        await ClickOnSwitchControlAsync(inline, "inline");
+    }
+
+    [When(@"select small (true|false)")]
+    public async Task WhenSelectSmallAsync(string small)
+    {
+        await ClickOnSwitchControlAsync(small, "small");
+    }
+
     private async Task ClickOnRadioControlAsync(string value, string controlPrefix, string valuePrefix)
     {
         var selector = $"[for*='control-{controlPrefix}-']";


### PR DESCRIPTION
Ajout de tests e2e basiques pour les stories suivantes : 
+ EstablishmentSelect https://lucca-front.lucca.io/storybook/?path=/story/documentation-forms-establishmentselect--basic
+ QualificationSelect https://lucca-front.lucca.io/storybook/?path=/story/documentation-forms-qualification--select
+ DepartmentSelect https://lucca-front.lucca.io/storybook/?path=/story/documentation-forms-departmentselect--select
+ Switches https://lucca-front.lucca.io/storybook/?path=/story/documentation-forms-switches-basic--basic

Les tests sur les select sont très basiques et ne font que prendre une screenshot sans faire aucune action : il faudrait revoir les stories pour respecter le même formalisme que les autres stories en proposant des switches pour modifier les options des composants