### PR TITLE
fix: eslint on VSCode was broken

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,7 +5,7 @@
 		{
 			"files": ["*.ts"],
 			"parserOptions": {
-				"project": ["tsconfig.json", "packages/ng/tsconfig.lib.json"],
+				"project": ["tsconfig.json", "packages/ng/tsconfig.json"],
 				"createDefaultProgram": true
 			},
 			"extends": [

--- a/packages/ng/tsconfig.json
+++ b/packages/ng/tsconfig.json
@@ -1,0 +1,29 @@
+{
+	"compilerOptions": {
+		"declaration": true,
+		"module": "es2020",
+		"target": "es2017",
+		"baseUrl": "./",
+		"stripInternal": true,
+		"emitDecoratorMetadata": false,
+		"experimentalDecorators": true,
+		"moduleResolution": "node",
+		"outDir": "../build",
+		"rootDirs": ["."],
+		"lib": ["es2020", "dom"],
+		"skipLibCheck": true,
+		"types": [],
+		"paths": {
+			"@lucca-front/ng/*": ["packages/ng/*/src/public-api.ts"]
+		}
+	},
+	"angularCompilerOptions": {
+		"preserveSymlinks": true,
+		"annotateForClosureCompiler": false,
+		"strictMetadataEmit": true,
+		"skipTemplateCodegen": true,
+		"enableI18nLegacyMessageIdFormat": false,
+		"strictInjectionParameters": true,
+		"strictTemplates": true
+	}
+}

--- a/packages/ng/tsconfig.lib.json
+++ b/packages/ng/tsconfig.lib.json
@@ -1,30 +1,4 @@
 {
-	"compilerOptions": {
-		"declaration": true,
-		"module": "es2020",
-		"target": "es2017",
-		"baseUrl": "./",
-		"stripInternal": true,
-		"emitDecoratorMetadata": false,
-		"experimentalDecorators": true,
-		"moduleResolution": "node",
-		"outDir": "../build",
-		"rootDirs": ["."],
-		"lib": ["es2020", "dom"],
-		"skipLibCheck": true,
-		"types": [],
-		"paths": {
-			"@lucca-front/ng/*": ["packages/ng/*/src/public-api.ts"]
-		}
-	},
-	"angularCompilerOptions": {
-		"preserveSymlinks": true,
-		"annotateForClosureCompiler": false,
-		"strictMetadataEmit": true,
-		"skipTemplateCodegen": true,
-		"enableI18nLegacyMessageIdFormat": false,
-		"strictInjectionParameters": true,
-		"strictTemplates": true
-	},
+	"extends": "./tsconfig.json",
 	"files": ["./public_api.ts"]
 }


### PR DESCRIPTION
## Description
Eslint for VSCode was broken due to a tsconfig targeting only one file.

-----