### PR TITLE
[Dropdown] Cover icons on options

### DIFF
--- a/packages/ng/styles/components/_dropdown.scss
+++ b/packages/ng/styles/components/_dropdown.scss
@@ -22,16 +22,21 @@
 }
 
 .lu-dropdown-options-item-action {
-	display: block;
+	display: flex;
 	background-color: transparent;
 	border: 0;
 	padding: var(--spacings-smaller) var(--spacings-small);
-	margin: var(--spacings-smallest) 0;
 	cursor: pointer;
+	line-height: var(--sizes-standard-line-height);
 	width: 100%;
 	text-align: left;
 	transition: background-color var(--commons-animations-durations-standard);
 	text-decoration: none;
+
+	.lucca-icon {
+		font-size: 1rem;
+		margin: var(--spacings-smallest) var(--spacings-smaller) 0 0;
+	}
 
 	&,
 	&:hover,
@@ -51,6 +56,15 @@
 		&:hover,
 		&:focus {
 			background-color: var(--colors-white-color);
+		}
+	}
+
+	&.mod-delete {
+		color: var(--palettes-error-800);
+
+		&:focus,
+		&:hover {
+			background-color: var(--palettes-error-50);
 		}
 	}
 }

--- a/stories/documentation/overlays/dropdown/dropdown-basic.stories.html
+++ b/stories/documentation/overlays/dropdown/dropdown-basic.stories.html
@@ -1,15 +1,21 @@
-<button type="button" class="button" [luDropdown]="dropdown">Open dropdown</button>
+<button type="button" class="button" [luDropdown]="dropdown">Dropdown with options</button>
 <lu-dropdown #dropdown>
 	<li class="lu-dropdown-options-item">
-		<a routerLink="." fragment="link1" class="lu-dropdown-options-item-action is-disabled" luDropdownItem>Link 1</a>
+		<a routerLink="." fragment="link1" class="lu-dropdown-options-item-action is-disabled" luDropdownItem>
+			<span aria-hidden="true" class="lucca-icon icon-watch"></span>
+			Prévisualiser
+		</a>
 	</li>
 	<li class="lu-dropdown-options-item">
-		<a routerLink="." fragment="link2" class="lu-dropdown-options-item-action" luDropdownItem>Link 2</a>
+		<a routerLink="." fragment="link2" class="lu-dropdown-options-item-action" luDropdownItem>
+			<span aria-hidden="true" class="lucca-icon icon-edit"></span>
+			Editer
+		</a>
 	</li>
 	<li class="lu-dropdown-options-item">
-		<a routerLink="." fragment="link3" class="lu-dropdown-options-item-action" luDropdownItem>Link 3</a>
-	</li>
-	<li class="lu-dropdown-options-item">
-		<button type="button" class="lu-dropdown-options-item-action" luDropdownItem>Button 4</button>
+		<button type="button" class="lu-dropdown-options-item-action mod-delete" luDropdownItem>
+			<span aria-hidden="true" class="lucca-icon icon-trash"></span>
+			Supprimer
+		</button>
 	</li>
 </lu-dropdown>

--- a/stories/documentation/overlays/dropdown/dropdown-basic.stories.ts
+++ b/stories/documentation/overlays/dropdown/dropdown-basic.stories.ts
@@ -41,16 +41,22 @@ class DropdownStoriesModule {}
 /* 3. Ajouter le composant <lu-dropdown #dropdown></lu-dropdown> avec la référence de la directive */
 <lu-dropdown #dropdown>
 	<li class="lu-dropdown-options-item">
-		<a routerLink="." fragment="link1" class="lu-dropdown-options-item-action is-disabled" luDropdownItem>Link 1</a>
+		<a routerLink="." fragment="link1" class="lu-dropdown-options-item-action is-disabled" luDropdownItem>
+			<span aria-hidden="true" class="lucca-icon icon-watch"></span>
+			Prévisualiser
+		</a>
 	</li>
 	<li class="lu-dropdown-options-item">
-		<a routerLink="." fragment="link2" class="lu-dropdown-options-item-action" luDropdownItem>Link 2</a>
+		<a routerLink="." fragment="link2" class="lu-dropdown-options-item-action" luDropdownItem>
+			<span aria-hidden="true" class="lucca-icon icon-edit"></span>
+			Editer
+		</a>
 	</li>
 	<li class="lu-dropdown-options-item">
-		<a routerLink="." fragment="link3" class="lu-dropdown-options-item-action" luDropdownItem>Link 3</a>
-	</li>
-	<li class="lu-dropdown-options-item">
-		<button type="button" class="lu-dropdown-options-item-action" luDropdownItem>Button 4</button>
+		<button type="button" class="lu-dropdown-options-item-action mod-delete" luDropdownItem>
+			<span aria-hidden="true" class="lucca-icon icon-trash"></span>
+			Supprimer
+		</button>
 	</li>
 </lu-dropdown>
 `;


### PR DESCRIPTION
## Description

Cover icons for dropdown options

-----

- Option's display switched to a display flex to handle (or not) icons
- Bonus: add a mod-delete to options

![Capture d’écran 2022-10-18 à 17 06 47](https://user-images.githubusercontent.com/25581936/196470778-988f110e-08a0-4e50-aafa-05722f9058c3.png)
![Capture d’écran 2022-10-18 à 17 06 41](https://user-images.githubusercontent.com/25581936/196470796-c0bd16eb-658e-497b-b730-5cdc239e316a.png)

-----
