### PR TITLE
[Table/List] Action icons should be visible by default

### DIFF
--- a/packages/scss/src/components/list/component.scss
+++ b/packages/scss/src/components/list/component.scss
@@ -1,5 +1,3 @@
-@use '@lucca-front/scss/src/commons/utils/a11y';
-
 @mixin component {
 	background-color: var(--colors-white-color);
 	box-shadow: var(--commons-elevations-elevation-1);
@@ -20,19 +18,6 @@
 
 			&:last-child {
 				border: 0;
-			}
-
-			// if no hover on list item
-			&:not(:hover) {
-				.actionIcon {
-					// and no focus on action icon
-					&:not(:focus) {
-						// then mask
-						@include a11y.mask;
-
-						opacity: 0;
-					}
-				}
 			}
 		}
 

--- a/packages/scss/src/components/list/index.scss
+++ b/packages/scss/src/components/list/index.scss
@@ -13,4 +13,8 @@
 	&.mod-draggable {
 		@include draggable;
 	}
+
+	&.mod-actionsHidden {
+		@include actionsHidden; // Legacy
+	}
 }

--- a/packages/scss/src/components/list/mods.scss
+++ b/packages/scss/src/components/list/mods.scss
@@ -40,14 +40,13 @@
 
 @mixin actionsHidden {
 	// if no hover on list item
-	&:not(:hover) {
-		.actionIcon {
-			// and no focus on action icon
-			&:not(:focus) {
-				// then mask
-				@include a11y.mask;
-
-				opacity: 0;
+	@media (hover: hover) {
+		&:not(:hover) {
+			.actionIcon {
+				&:not(:focus) {
+					@include a11y.mask;
+					opacity: 0;
+				}
 			}
 		}
 	}

--- a/packages/scss/src/components/list/mods.scss
+++ b/packages/scss/src/components/list/mods.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin clickable {
 	transition-duration: var(--commons-animations-durations-fast);
@@ -33,6 +34,21 @@
 			@include icon.generate('drag');
 
 			vertical-align: middle;
+		}
+	}
+}
+
+@mixin actionsHidden {
+	// if no hover on list item
+	&:not(:hover) {
+		.actionIcon {
+			// and no focus on action icon
+			&:not(:focus) {
+				// then mask
+				@include a11y.mask;
+
+				opacity: 0;
+			}
 		}
 	}
 }

--- a/packages/scss/src/components/table/index.scss
+++ b/packages/scss/src/components/table/index.scss
@@ -86,6 +86,10 @@
 .table-foot-row-cell {
 	&.mod-actions {
 		@include actions;
+
+		&.mod-actionsHidden { // Legacy
+			@include actionsHidden;
+		}
 	}
 
 	&.mod-alignCenter {

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -258,7 +258,9 @@
 	transition-property: opacity;
 	text-align: right;
 	white-space: nowrap;
+}
 
+@mixin actionsHidden {
 	> * {
 		&:not(.is-loading) {
 			opacity: 0;

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -261,25 +261,27 @@
 }
 
 @mixin actionsHidden {
-	> * {
-		&:not(.is-loading) {
-			opacity: 0;
-		}
-	}
-
-	.table-head-row:hover &,
-	.table-body-row:hover &,
-	.table-foot-row:hover & {
+	@media (hover: hover) {
 		> * {
-			opacity: 1;
+			&:not(.is-loading) {
+				opacity: 0;
+			}
 		}
-	}
 
-	.table-head-row:focus-within &,
-	.table-body-row:focus-within &,
-	.table-foot-row:focus-within & {
-		> * {
-			opacity: 1;
+		.table-head-row:hover &,
+		.table-body-row:hover &,
+		.table-foot-row:hover & {
+			> * {
+				opacity: 1;
+			}
+		}
+
+		.table-head-row:focus-within &,
+		.table-body-row:focus-within &,
+		.table-foot-row:focus-within & {
+			> * {
+				opacity: 1;
+			}
 		}
 	}
 }

--- a/stories/documentation/listings/lists/lists-basic.stories.ts
+++ b/stories/documentation/listings/lists/lists-basic.stories.ts
@@ -25,8 +25,8 @@ function getTemplate(args: ListBasicStory): string {
 				<p class="list-item-content-description">Description</p>
 			</div>
 			<div class="list-item-actions">
-				<button type="button" class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
-				<button type="button" class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
+				<button type="button" class="actionIcon mod-small"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
+				<button type="button" class="actionIcon mod-small"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 			</div>
 		</li>
 		<li class="list-item ${clickable}">
@@ -35,8 +35,8 @@ function getTemplate(args: ListBasicStory): string {
 				<p class="list-item-content-description">Description</p>
 			</div>
 			<div class="list-item-actions">
-				<button type="button" class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
-				<button type="button" class="actionIcon"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
+				<button type="button" class="actionIcon mod-small"><span aria-hidden="true" class="lucca-icon icon-edit"></span></button>
+				<button type="button" class="actionIcon mod-small"><span aria-hidden="true" class="lucca-icon icon-trash"></span></button>
 			</div>
 		</li>
 	</ul>

--- a/stories/qa/list/list.stories.html
+++ b/stories/qa/list/list.stories.html
@@ -10,11 +10,11 @@
 				<p class="list-item-content-description">List item description 1</p>
 			</div>
 			<div class="list-item-actions">
- 				<button type="button" class="actionIcon">
+ 				<button type="button" class="actionIcon mod-small">
 					 <span aria-hidden="true" class="lucca-icon icon-edit"></span>
 					 <span class="u-mask">Edit</span>
 				</button>
- 				<button type="button" class="actionIcon">
+ 				<button type="button" class="actionIcon mod-small">
 					 <span aria-hidden="true" class="lucca-icon icon-trash"></span>
 					 <span class="u-mask">Delete</span>
 					</button>
@@ -26,11 +26,11 @@
 				<p class="list-item-content-description">List item description 2</p>
 			</div>
 			<div class="list-item-actions">
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-edit"></span>
 					<span class="u-mask">Edit</span>
 			   </button>
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-trash"></span>
 					<span class="u-mask">Delete</span>
 				   </button>
@@ -42,11 +42,11 @@
 				<p class="list-item-content-description">List item description 3</p>
 			</div>
 			<div class="list-item-actions">
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-edit"></span>
 					<span class="u-mask">Edit</span>
 			   </button>
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-trash"></span>
 					<span class="u-mask">Delete</span>
 				   </button>
@@ -64,11 +64,11 @@
 				<p class="list-item-content-description">List item description 1</p>
 			</div>
 			<div class="list-item-actions">
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-edit"></span>
 					<span class="u-mask">Edit</span>
 			   </button>
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-trash"></span>
 					<span class="u-mask">Delete</span>
 				   </button>
@@ -80,11 +80,11 @@
 				<p class="list-item-content-description">List item description 2</p>
 			</div>
 			<div class="list-item-actions">
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-edit"></span>
 					<span class="u-mask">Edit</span>
 			   </button>
-				<button type="button" class="actionIcon">
+				<button type="button" class="actionIcon mod-small">
 					<span aria-hidden="true" class="lucca-icon icon-trash"></span>
 					<span class="u-mask">Delete</span>
 				   </button>
@@ -93,7 +93,7 @@
 	</ul>
 
 	<em><b>Tip:</b> Put your click on <code class="code">list-item</code>.</em><br>
-	<em><b>Tip:</b> To prevent a double <code class="code">list-item</code> / <code class="code">actionIcon</code> click, you can use <code class="code">.preventDefault()</code> & <code class="code">.stopPropagation()</code> on <code class="code">actionIcon</code> click function.</em><br>
+	<em><b>Tip:</b> To prevent a double <code class="code">list-item</code> / <code class="code">actionIcon</code> click, you can use <code class="code">.preventDefault()</code> & <code class="code">.stopPropagation()</code> on <code class="code">actionIcon mod-small</code> click function.</em><br>
 	<em><b>Tip:</b> You can also use a <code class="code">div</code> / <code class="code">a</code> list structure.</em>
 </section>
 


### PR DESCRIPTION
## Description

Actions icons should be visible by default

-----

![image](https://user-images.githubusercontent.com/25581936/196483527-8197e629-1165-426b-ad2c-0ba13423fd6f.png)

Add a `mod-actionsHidden` to cover legacy behavior just in case

-----
