### PR TITLE
fix(front) : 1897 - inconsistent items height when text-wrap

### DIFF
--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -43,6 +43,7 @@
 			display: block;
 			overflow: hidden;
 			position: relative;
+			height: 100%;
 			cursor: pointer;
 		}
 
@@ -62,20 +63,23 @@
 						color: var(--components-radioButtons-default-palette-700);
 
 						&:hover {
-							box-shadow: var(--commons-elevations-elevation-1), inset 0 0 0 1px var(--components-radioButtons-default-palette-400);
+							box-shadow: var(--commons-elevations-elevation-1),
+								inset 0 0 0 1px var(--components-radioButtons-default-palette-400);
 						}
 					}
 				}
 
 				&:focus {
 					~ .radioButtons-item-label {
-						box-shadow: 0 0 0 4px var(--components-radioButtons-default-palette-200), inset 0 0 0 1px var(--components-radioButtons-default-palette-400);
+						box-shadow: 0 0 0 4px var(--components-radioButtons-default-palette-200),
+							inset 0 0 0 1px var(--components-radioButtons-default-palette-400);
 					}
 
 					&:checked {
 						~ .radioButtons-item-label {
 							background-color: var(--components-radioButtons-default-palette-100);
-							box-shadow: 0 0 0 4px var(--components-radioButtons-default-palette-200), inset 0 0 0 1px var(--components-radioButtons-default-palette-500);
+							box-shadow: 0 0 0 4px var(--components-radioButtons-default-palette-200),
+								inset 0 0 0 1px var(--components-radioButtons-default-palette-500);
 						}
 					}
 


### PR DESCRIPTION
## Description

Fix for https://github.com/LuccaSA/lucca-front/issues/1897

![image](https://user-images.githubusercontent.com/65592565/196967114-5ef0cc04-d3b5-4e1a-bb21-db9ab92ef197.png)


-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
