### PR TITLE
Update config with default parameters

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -42,7 +42,7 @@ $success: (
 	700: #3c9933,
 	800: #1b7d12,
 	900: #0e6b06,
-);
+) !default;
 
 $warning: (
 	text: #ffffff,
@@ -56,7 +56,7 @@ $warning: (
 	700: #e55006,
 	800: #cc3d00,
 	900: #b23000,
-);
+) !default;
 
 $error: (
 	text: #ffffff,
@@ -70,7 +70,7 @@ $error: (
 	700: #e51a3b,
 	800: #af0e29,
 	900: #91081f,
-);
+) !default;
 
 $grey: (
 	text: #ffffff,
@@ -84,17 +84,17 @@ $grey: (
 	700: #445473,
 	800: #2a3551,
 	900: #131d35,
-);
+) !default;
 
 $colors: (
 	'white': #ffffff,
 	'black': #121212,
-);
+) !default;
 
 $colorsRgb: (
 	'white': '255, 255, 255',
 	'grey-900': '19, 29, 53',
-);
+) !default;
 
 $breakpoints: (
 	xxxs: 320px,


### PR DESCRIPTION
## Description

By adding the keyword "default", we allow overloads on the colours in the products.

It will be useful to apply the new colour charts progressively in the products before doing it again here in a global way.

-----


-----
