### PR TITLE
Fix invalid label color

### DIFF
--- a/packages/scss/src/components/textfield/states.scss
+++ b/packages/scss/src/components/textfield/states.scss
@@ -78,7 +78,7 @@
 
 @mixin framedInputInvalid {
 	~ .textfield-label {
-		color: var(--palettes-primary-700);
+		color: var(--palettes-error-700);
 	}
 }
 


### PR DESCRIPTION
## Description

Fix of the label color when the input is invalid.
Color : changed from primary to error.

-----
