### PR TITLE
allow to override button's icons

### DIFF
--- a/packages/icons/src/icon/component.scss
+++ b/packages/icons/src/icon/component.scss
@@ -2,7 +2,7 @@
 
 @mixin component {
 	font-weight: 400;
-	font-size: 1.3rem;
+	font-size: var(--icon-size, 1.25rem);
 	direction: ltr;
 	display: inline-block;
 	font-family: config.$font-name;

--- a/packages/icons/src/icon/index.scss
+++ b/packages/icons/src/icon/index.scss
@@ -4,6 +4,7 @@
 
 .lucca-icon {
 	@include component;
+	@include vars;
 
 	@each $name, $content in config.$icons {
 		&.icon-#{core.camelize($name)} {
@@ -12,26 +13,26 @@
 	}
 
 	&.size-smaller {
-		@include size('smaller');
+		--icon-size:  calc(var(--sizes-smaller-font-size) * 1.25);
 	}
 
 	&.size-small {
-		@include size('small');
+		--icon-size:  calc(var(--sizes-small-font-size) * 1.25);
 	}
 
 	&.size-standard {
-		@include size('standard');
+		--icon-size:  calc(var(--sizes-standard-font-size) * 1.25);
 	}
 
 	&.size-big {
-		@include size('big');
+		--icon-size:  calc(var(--sizes-big-font-size) * 1.25);
 	}
 
 	&.size-bigger {
-		@include size('bigger');
+		--icon-size:  calc(var(--sizes-bigger-font-size) * 1.25);
 	}
 
 	&.size-biggest {
-		@include size('biggest');
+		--icon-size:  calc(var(--sizes-biggest-font-size) * 1.25);
 	}
 }

--- a/packages/icons/src/icon/mods.scss
+++ b/packages/icons/src/icon/mods.scss
@@ -1,3 +1,0 @@
-@mixin size($size, $ratio: 1.25) {
-	font-size: calc(var(--sizes-#{$size}-font-size) * $ratio);
-}

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -20,8 +20,7 @@
 	cursor: pointer;
 
 	.lucca-icon {
-		font-size: 1.25rem;
-		line-height: 1;
+		font-size: var(--icon-size, 1.25rem);
 	}
 
 	&:first-of-type {

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -1,34 +1,17 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin size {
-	font-size: var(--components-button-font-size);
-	line-height: var(--components-button-line-height);
-	padding: var(--components-button-padding);
-
-	.lucca-icon {
-		font-size: var(--components-button-icon-font-size);
-		line-height: var(--components-button-icon-line-height);
-	}
-}
-
 @mixin small {
-	@include size;
-
 	--components-button-font-size: var(--components-button-small-font-size);
 	--components-button-line-height: var(--components-button-small-line-height);
 	--components-button-padding: var(--components-button-small-padding);
-	--components-button-icon-font-size: var(--sizes-standard-font-size);
-	--components-button-icon-line-height: 1;
+	--icon-size: var(--sizes-standard-font-size);
 }
 
 @mixin smaller {
-	@include size;
-
 	--components-button-font-size: var(--components-button-smaller-font-size);
 	--components-button-line-height: var(--components-button-smaller-line-height);
 	--components-button-padding: var(--components-button-smaller-padding);
-	--components-button-icon-font-size: 0.875rem;
-	--components-button-icon-line-height: 1;
+	--icon-size: 0.875rem;
 }
 
 @mixin text {

--- a/stories/documentation/actions/button/button-icon.stories.ts
+++ b/stories/documentation/actions/button/button-icon.stories.ts
@@ -7,10 +7,8 @@ export default {
 } as Meta;
 
 function getTemplate(args: ButtonIconStory): string {
-	return `
-	<button type="button" class="button mod-icon"><span aria-hidden="true" class="lucca-icon icon-save"></span>Sauvegarder</button>
-	<button type="button" class="button mod-icon">Envoyer<span aria-hidden="true" class="lucca-icon icon-send"></span></button>
-	`;
+	return `<button type="button" class="button mod-icon"><span aria-hidden="true" class="lucca-icon icon-save size-bigger"></span>Sauvegarder</button>
+	<button type="button" class="button mod-icon">Envoyer<span aria-hidden="true" class="lucca-icon icon-send"></span></button>`;
 }
 
 const Template: Story<ButtonIconStory> = (args: ButtonIconStory) => ({


### PR DESCRIPTION
## Description

Rewrite icons size to allow overrides in components

-----

Exemples bellow show buttons with size mods (line 1) and size mods on both buttons and icons (line 2)
![Capture d’écran 2022-12-06 à 12 19 22](https://user-images.githubusercontent.com/25581936/205899232-1fda608e-d264-432b-866c-cc53a31c273d.png)


-----
