### PR TITLE
Fix selection lost in picker advanced

### DIFF
--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -1,20 +1,45 @@
 import { rest } from 'msw';
-import { mockAxisSectionsV3, mockDepartmentsTree, mockEstablishments, mockGenericCount, mockJobQualifications, mockMe, mockProjectUsers, mockUsers } from './mocks';
+import {
+	mockAxisSectionsV3,
+	mockDepartmentsTree,
+	mockEstablishments,
+	mockEstablishmentsCount,
+	mockGenericCount,
+	mockJobQualifications,
+	mockMe,
+	mockProjectUsers,
+	mockUsers,
+} from './mocks';
 
 export const handlers = [
 	rest.get('/organization/structure/api/legal-units', (_, res, ctx) => res(ctx.delay(300), ctx.json(mockGenericCount))),
 
 	rest.get('/organization/structure/api/establishments', (req, res, ctx) => {
 		if (req.url.searchParams.get('fields.root') === 'count') {
-			return res(ctx.delay(300), ctx.json(mockGenericCount));
+			return res(ctx.delay(300), ctx.json(mockEstablishmentsCount));
 		}
 
+		const page = req.url.searchParams.get('page');
+		const legalUnitId = req.url.searchParams.get('legalUnitId');
 		const search = req.url.searchParams.get('search');
+
+		let items = [];
+		if(!page || page === '1') {
+			if(search) {
+				items = [mockEstablishments[0]];
+			}
+			else if(legalUnitId) {
+				items = mockEstablishments.filter(e => e.legalUnitId === +legalUnitId) ?? []
+			}
+			else {
+				items = mockEstablishments;
+			}
+		}
 
 		return res(
 			ctx.delay(300),
 			ctx.json({
-				items: search ? [mockEstablishments[0]] : mockEstablishments,
+				items,
 			}),
 		);
 	}),

--- a/.storybook/msw/mocks.ts
+++ b/.storybook/msw/mocks.ts
@@ -1,4 +1,5 @@
 export const mockGenericCount = { items: [], count: 3 };
+export const mockEstablishmentsCount = { items: [], count: 4 };
 export const mockEstablishments = [
 	{
 		id: 3,
@@ -17,8 +18,23 @@ export const mockEstablishments = [
 	},
 	{
 		id: 1,
-		name: 'Lucca FR',
-		code: 'Lucca FR',
+		name: 'Lucca Paris FR',
+		code: 'Lucca Paris FR',
+		legalUnitId: 1,
+		legalUnit: { id: 1, name: 'Lucca FR', code: 'Lucca FR' },
+		legalIdentificationNumber: null,
+		activityCode: null,
+		calendarId: 52,
+		address: null,
+		timeZoneId: 'Europe/Paris',
+		usersCount: 40,
+		createdAt: '2020-08-13T22:23:09.59',
+		isArchived: false,
+	},
+	{
+		id: 4,
+		name: 'Lucca Nantes FR',
+		code: 'Lucca Nantes FR',
 		legalUnitId: 1,
 		legalUnit: { id: 1, name: 'Lucca FR', code: 'Lucca FR' },
 		legalIdentificationNumber: null,

--- a/packages/ng/option/src/lib/picker/option-picker-advanced.component.ts
+++ b/packages/ng/option/src/lib/picker/option-picker-advanced.component.ts
@@ -98,6 +98,7 @@ export abstract class ALuOptionPickerAdvancedComponent<T, O extends import('../i
 		this._subs.add(
 			selectors$.subscribe((selectors) => {
 				this._selectors = selectors;
+				this._selectors.forEach((s) => s.setValue(this._value));
 				this._subs.add(
 					merge(this._selectors.map((s) => s.onSelectValue))
 						.pipe(mergeAll())


### PR DESCRIPTION
## Description

Fix for https://github.com/LuccaSA/lucca-front/issues/1938

-----

Selected items where lost if user :

1. check some items in the picker
2. scroll to the bottom of the picker -> new query triggered -> new selectors created without existing values (checked items)
3. one selector (who has an empty value) is clicked

-----
