### PR TITLE
@root param for components

### DIFF
--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -3,8 +3,8 @@
 
 @use '@lucca-front/scss/src/commons/config';
 
-@mixin base {
-	@at-root {
+@mixin base($atRoot: 'without: rule') {
+	@at-root ($atRoot) {
 		@if config.$fontVariable {
 			@font-face {
 				font-family: 'Source Sans Pro';

--- a/packages/scss/src/components/box/component.scss
+++ b/packages/scss/src/components/box/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	border-radius: var(--components-box-border-radius);
 	margin: var(--components-box-margin);
 	padding: var(--components-box-padding);
@@ -6,7 +6,7 @@
 	display: block;
 	position: relative;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.box-close {
 			position: absolute;
 			font-size: var(--sizes-standard-font-size);

--- a/packages/scss/src/components/breadcrumbs/component.scss
+++ b/packages/scss/src/components/breadcrumbs/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
-	@at-root {
+@mixin component($atRoot: 'without: rule') {
+	@at-root ($atRoot) {
 		.breadcrumbs-list {
 			display: flex;
 			flex-wrap: wrap;

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -82,7 +82,7 @@
 	width: 100%;
 }
 
-@mixin icon {
+@mixin icon($atRoot: 'without: rule') { {
 	--components-button-padding: var(--spacings-smaller) calc(var(--spacings-smaller) + var(--spacings-smallest));
 }
 
@@ -123,10 +123,10 @@
 	min-width: 1.75rem;
 }
 
-@mixin counter {
+@mixin counter($atRoot: 'without: rule') { {
 	--components-button-padding: var(--spacings-smaller) calc(var(--spacings-smaller) + var(--spacings-smallest)) var(--spacings-smaller) var(--spacings-small);
 
-	@at-root {
+	@at-root ($atRoot) {
 		.button-counter {
 			background-color: var(--palettes-500, var(--palettes-primary-500));
 			border-radius: 1rem;

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -82,7 +82,7 @@
 	width: 100%;
 }
 
-@mixin icon($atRoot: 'without: rule') { {
+@mixin icon($atRoot: 'without: rule') {
 	--components-button-padding: var(--spacings-smaller) calc(var(--spacings-smaller) + var(--spacings-smallest));
 }
 
@@ -123,7 +123,7 @@
 	min-width: 1.75rem;
 }
 
-@mixin counter($atRoot: 'without: rule') { {
+@mixin counter($atRoot: 'without: rule') {
 	--components-button-padding: var(--spacings-smaller) calc(var(--spacings-smaller) + var(--spacings-smallest)) var(--spacings-smaller) var(--spacings-small);
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/callout/component.scss
+++ b/packages/scss/src/components/callout/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	border-radius: var(--commons-border-radius);
 	background-color: var(--palettes-100, var(--components-callout-background));
 	color: var(--palettes-grey-800);
@@ -9,7 +9,8 @@
 	border-style: solid;
 	position: relative;
 
-	a, .link {
+	a,
+	.link {
 		color: var(--palettes-grey-800);
 
 		&:hover {
@@ -18,7 +19,7 @@
 		}
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.callout-title {
 			font-weight: 600;
 			margin-bottom: var(--spacings-smallest);

--- a/packages/scss/src/components/callout/mods.scss
+++ b/packages/scss/src/components/callout/mods.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin icon {
+@mixin icon($atRoot: 'without: rule') {
 	padding-left: var(--spacings-bigger);
 
-	@at-root {
+	@at-root ($atRoot) {
 		.callout-icon {
 			top: 0.4rem;
 			left: 0.75rem;
@@ -39,10 +39,10 @@
 	}
 }
 
-@mixin killable {
+@mixin killable($atRoot: 'without: rule') {
 	padding-right: 2.5rem;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.callout-kill {
 			right: var(--spacings-small);
 			background-color: transparent;

--- a/packages/scss/src/components/card/component.scss
+++ b/packages/scss/src/components/card/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	background-color: var(--colors-white-color);
 	border-radius: var(--commons-border-radius-big);
 	border-color: var(--commons-divider-color);
@@ -10,7 +10,7 @@
 	transition-duration: var(--commons-animations-durations-fast);
 	transition-property: background-color, box-shadow, color;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.card-content {
 			padding: var(--components-card-content-padding);
 		}

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -1,11 +1,11 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: block;
 	position: relative;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.checkbox-label {
 			transition-duration: var(--commons-animations-durations-fast);
 			transition-property: color;

--- a/packages/scss/src/components/chip/component.scss
+++ b/packages/scss/src/components/chip/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	background-color: var(--palettes-primary-700);
 	border-radius: var(--commons-border-radius);
 	color: var(--colors-white-color);
@@ -11,7 +11,7 @@
 	margin: 0 0.2rem 0.3rem 0;
 	padding: 0.15rem 1.8rem 0.15rem 0.75rem;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.chip-kill {
 			background-color: var(--colors-white-color);
 			color: var(--palettes-primary-700);

--- a/packages/scss/src/components/collapse/component.scss
+++ b/packages/scss/src/components/collapse/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: block;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.collapse-title {
 			margin-bottom: var(--spacings-smallest);
 			display: inline-flex;

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,9 +1,9 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	margin: 6rem auto var(--spacings-biggest);
 	text-align: center;
 	max-width: 30rem;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.emptyState-title {
 			color: var(--palettes-grey-600);
 		}

--- a/packages/scss/src/components/field/component.scss
+++ b/packages/scss/src/components/field/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;
@@ -25,7 +25,7 @@
 		color: var(--components-field-label-color);
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.textfield-input,
 		.radiosfield-input,
 		.checkboxesfield-input {

--- a/packages/scss/src/components/filters/component.scss
+++ b/packages/scss/src/components/filters/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	box-shadow: var(--commons-elevations-elevation-1);
 	background-color: var(--components-filters-background);
 	min-height: var(--components-filters-height);
@@ -7,7 +7,7 @@
 	position: relative;
 	z-index: 99;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.filters-sectionLeft {
 			align-items: center;
 			display: flex;

--- a/packages/scss/src/components/form/component.scss
+++ b/packages/scss/src/components/form/component.scss
@@ -1,12 +1,12 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	padding: 0;
 	border: 0;
 	margin: 0 0 var(--components-form-group-margin-bottom);
 	position: relative;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.form-group-label,
 		.form-group-legend,
 		.form-group-title {

--- a/packages/scss/src/components/gauge/component.scss
+++ b/packages/scss/src/components/gauge/component.scss
@@ -1,11 +1,11 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	border-radius: var(--commons-border-radius);
 	height: var(--components-gauge-height);
 	overflow: hidden;
 	position: relative;
 	background-color: rgba(var(--colors-grey-900-rgb), 0.05);
 
-	@at-root {
+	@at-root ($atRoot) {
 		.gauge-bar {
 			color: var(--palettes-700, var(--palettes-primary-700));
 			border-bottom-width: var(--components-gauge-height);

--- a/packages/scss/src/components/header/component.scss
+++ b/packages/scss/src/components/header/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	box-shadow: var(--commons-elevations-elevation-1);
 	background-color: var(--components-header-background);
 	min-height: var(--components-header-height);
@@ -10,7 +10,7 @@
 	align-items: center;
 	z-index: 99;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.header-contentLeft {
 			display: flex;
 		}

--- a/packages/scss/src/components/layout/component.scss
+++ b/packages/scss/src/components/layout/component.scss
@@ -4,7 +4,7 @@
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/config';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	min-height: 100vh;
 	display: grid;
 
@@ -35,7 +35,7 @@
 			'aside';
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.layout-content-container {
 			max-width: math.div(map.get(config.$breakpoints, 'm'), 16px) * 1rem;
 		}

--- a/packages/scss/src/components/list/component.scss
+++ b/packages/scss/src/components/list/component.scss
@@ -1,11 +1,11 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	background-color: var(--colors-white-color);
 	box-shadow: var(--commons-elevations-elevation-1);
 	margin-bottom: var(--components-list-margin-bottom);
 	list-style: none;
 	padding: 0;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.list-item {
 			border-bottom-width: var(--commons-divider-width);
 			border-bottom-color: var(--commons-divider-color);

--- a/packages/scss/src/components/menu/component.scss
+++ b/packages/scss/src/components/menu/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	background-color: var(--components-menu-background);
 	column-gap: var(--spacings-big);
 	align-items: center;
@@ -28,7 +28,7 @@
 		color: var(--palettes-grey-700);
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.menu-list {
 			@include reset.list;
 

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/loading';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	bottom: 0;
 	left: 0;
 	top: 0;
@@ -12,7 +12,7 @@
 	padding-top: var(--components-navSide-padding-top);
 	width: var(--commons-navSide-width);
 
-	@at-root {
+	@at-root ($atRoot) {
 		.navSide-wrapper {
 			display: flex;
 			flex-direction: column;

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -1,5 +1,5 @@
-@mixin vars {
-	@at-root {
+@mixin vars($atRoot: 'without: rule') {
+	@at-root ($atRoot) {
 		:root {
 			--commons-navSide-width: 15rem;
 			--commons-navSide-compact-width: 7.5rem;

--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	box-shadow: var(--commons-box-shadow-xs);
 	padding: var(--spacings-big) 2.5rem var(--spacings-standard);
 	background-color: var(--colors-white-color);
@@ -11,7 +11,7 @@
 		}
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.pageHeader-content {
 			display: flex;
 			justify-content: space-between;

--- a/packages/scss/src/components/pagination/component.scss
+++ b/packages/scss/src/components/pagination/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: flex;
 	flex-wrap: wrap;
 	margin: var(--spacings-small) 0;
@@ -7,7 +7,7 @@
 		margin-right: var(--spacings-smaller);
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.pagination-count,
 		.pagination-navigation,
 		.pagination-scrolling {

--- a/packages/scss/src/components/progress/component.scss
+++ b/packages/scss/src/components/progress/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/scss/src/components/keyframe/exports' as keyframe;
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	@keyframes progress {
 		0% {
 			transform: scale(0, 1);
@@ -19,7 +19,7 @@
 	position: relative;
 	overflow: hidden;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.progress-bar {
 			background-color: var(--components-progress-bar-background);
 			transition-duration: var(--commons-animations-durations-fast);

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: flex;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.radioButtons-item {
 			margin-left: -1px;
 
@@ -65,8 +65,7 @@
 						color: var(--components-radioButtons-default-palette-700);
 
 						&:hover {
-							box-shadow: var(--commons-elevations-elevation-1),
-								inset 0 0 0 1px var(--components-radioButtons-default-palette-400);
+							box-shadow: var(--commons-elevations-elevation-1), inset 0 0 0 1px var(--components-radioButtons-default-palette-400);
 						}
 					}
 				}

--- a/packages/scss/src/components/skipLinks/component.scss
+++ b/packages/scss/src/components/skipLinks/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	position: fixed;
 	list-style-type: none;
 	justify-content: center;
@@ -12,7 +12,7 @@
 	inset: 0.75rem;
 	bottom: auto;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.skipLinks-action {
 			border: 0;
 			margin: 0;

--- a/packages/scss/src/components/status/component.scss
+++ b/packages/scss/src/components/status/component.scss
@@ -1,9 +1,9 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: inline-flex;
 	align-items: center;
 	white-space: nowrap;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.status-dot {
 			aspect-ratio: 1;
 			width: var(--spacings-smaller);

--- a/packages/scss/src/components/switch/component.scss
+++ b/packages/scss/src/components/switch/component.scss
@@ -1,11 +1,11 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	display: block;
 	position: relative;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.switch-input {
 			@include a11y.mask;
 		}

--- a/packages/scss/src/components/table/component.scss
+++ b/packages/scss/src/components/table/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	font-size: var(--components-table-font-size);
 	line-height: var(--components-table-line-height);
 	border-spacing: 0;
@@ -8,7 +8,7 @@
 	text-align: left;
 	width: 100%;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.table-head {
 			display: table-header-group;
 			vertical-align: bottom;

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -164,8 +164,8 @@
 	}
 }
 
-@mixin draggable {
-	@at-root {
+@mixin draggable($atRoot: 'without: rule') {
+	@at-root ($atRoot) {
 		.table-body-row-cell-handler,
 		.table-foot-row-cell-handler {
 			top: 0;
@@ -215,12 +215,8 @@
 	}
 }
 
-@mixin twoLines(
-	$headCell: '.table-head-row-cell',
-	$secondLine: '.table-head-row-cell-secondLine',
-	$wrapper: '.table-head-row-cell-wrapper'
-) {
-	@at-root {
+@mixin twoLines($atRoot: 'without: rule') {
+	@at-root ($atRoot) {
 		.table-head-row-cell-secondLine {
 			margin-top: var(--spacings-smallest);
 			display: block;

--- a/packages/scss/src/components/tableOfContent/component.scss
+++ b/packages/scss/src/components/tableOfContent/component.scss
@@ -1,12 +1,12 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	align-items: flex-start;
 	display: flex;
 	flex-direction: column;
 	position: sticky;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.tableOfContent-list {
 			@include reset.list;
 		}

--- a/packages/scss/src/components/textfield/component.scss
+++ b/packages/scss/src/components/textfield/component.scss
@@ -1,8 +1,8 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	vertical-align: middle;
 	width: var(--components-textfield-sizes-default);
 
-	@at-root {
+	@at-root ($atRoot) {
 		.textfield-input {
 			min-width: 0;
 			border: 0;
@@ -20,8 +20,8 @@
 				transition-duration: var(--commons-animations-durations-fast);
 				opacity: 1;
 			}
-			
-			&[type="search"] {
+
+			&[type='search'] {
 				&::-webkit-search-cancel-button,
 				&::-webkit-search-decoration {
 					appearance: none;

--- a/packages/scss/src/components/timeline/component.scss
+++ b/packages/scss/src/components/timeline/component.scss
@@ -1,13 +1,13 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	list-style-type: none;
 	padding: 0;
 	margin: var(--spacings-small) 0;
 	display: flex;
 	align-items: center;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.timeline-step {
 			flex-grow: 1;
 			display: flex;

--- a/packages/scss/src/components/timepicker/component.scss
+++ b/packages/scss/src/components/timepicker/component.scss
@@ -1,4 +1,4 @@
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	margin: var(--spacings-smaller);
 	padding: var(--spacings-smallest) var(--spacings-smaller);
 	border: 0;
@@ -12,10 +12,10 @@
 		background-color: transparent;
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.timepicker-field {
-	    position: relative;
-	    display: inline-block;
+			position: relative;
+			display: inline-block;
 		}
 
 		.timepicker-field-input {
@@ -35,7 +35,9 @@
 				margin: 0;
 			}
 
-			&:hover, &:focus, &:focus-visible {
+			&:hover,
+			&:focus,
+			&:focus-visible {
 				background-color: var(--palettes-100, var(--palettes-primary-100));
 				outline: none;
 			}
@@ -44,7 +46,7 @@
 		.timepicker-field-increment {
 			cursor: pointer;
 			position: absolute;
-			bottom: calc(100% + .5rem);
+			bottom: calc(100% + 0.5rem);
 			left: 0;
 			border: 0;
 			height: 1.25rem;
@@ -58,7 +60,7 @@
 			padding: 0;
 
 			&:last-child {
-				top: calc(100% + .5rem);
+				top: calc(100% + 0.5rem);
 				bottom: auto;
 			}
 
@@ -80,7 +82,7 @@
 		.timepicker-separator {
 			margin: 0 var(--spacings-smallest);
 			text-align: center;
-			width: .5rem;
+			width: 0.5rem;
 		}
 	}
 }

--- a/packages/scss/src/components/titleSection/component.scss
+++ b/packages/scss/src/components/titleSection/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/scss/src/commons/config';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	margin-bottom: 1.2rem;
 
 	.titleSection-title,
@@ -22,7 +22,7 @@
 		margin-bottom: 0 !important;
 	}
 
-	@at-root {
+	@at-root ($atRoot) {
 		.titleSection-sub {
 			color: var(--palettes-grey-600);
 			font-size: var(--sizes-standard-font-size);

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 
-@mixin component {
+@mixin component($atRoot: 'without: rule') {
 	@keyframes toast {
 		0% {
 			transform: translateY(var(--spacings-small));
@@ -21,7 +21,7 @@
 	position: fixed;
 	z-index: 9999;
 
-	@at-root {
+	@at-root ($atRoot) {
 		.toasts-item {
 			display: flex;
 			gap: .75rem;


### PR DESCRIPTION
## Description

We can now override the behaviour of @at-root in tables.
Example `@include table.component($atRoot: 'with: rule media')`

Co-authored with @audreylemercier and @jeremie-lucca.

-----


-----
