### PR TITLE
Enh allow default user display format override

### DIFF
--- a/packages/ng/user/src/lib/display/display-format.model.ts
+++ b/packages/ng/user/src/lib/display/display-format.model.ts
@@ -1,3 +1,5 @@
+import { InjectionToken } from '@angular/core';
+
 export enum LuDisplayFullname {
 	firstlast = 'fl',
 	lastfirst = 'lf',
@@ -20,3 +22,6 @@ export enum LuDisplayHybrid {
 }
 
 export type LuDisplayFormat = LuDisplayFullname | LuDisplayInitials | LuDisplayHybrid;
+
+/** Injection token that can be used to change the default displayed user format. */
+export const LU_DEFAULT_DISPLAY_POLICY = new InjectionToken<LuDisplayFormat>('LuDisplayFormat', { factory: () => LuDisplayFullname.lastfirst });

--- a/packages/ng/user/src/lib/display/user-display.pipe.spec.ts
+++ b/packages/ng/user/src/lib/display/user-display.pipe.spec.ts
@@ -1,6 +1,7 @@
-import { LuUserDisplayPipe } from './user-display.pipe';
+import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';
 import { ILuUser } from '../user.model';
-import { LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
+import { LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials, LU_DEFAULT_DISPLAY_POLICY } from './display-format.model';
+import { luUserDisplay, LuUserDisplayPipe } from './user-display.pipe';
 
 describe('UserNamePipe', () => {
 	let user: ILuUser;
@@ -8,68 +9,78 @@ describe('UserNamePipe', () => {
 		user = <ILuUser>{ firstName: 'John', lastName: 'Doe' };
 	});
 
-	it('create an instance', () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe).toBeTruthy();
+	describe('luUserDisplay()', () => {
+		it("should return the right value with 'lf' format", () => {
+			expect(luUserDisplay(user, LuDisplayFullname.lastfirst)).toBe('Doe John');
+		});
+
+		it("should return the right value with 'Lf' format", () => {
+			expect(luUserDisplay(user, LuDisplayHybrid.lastIfirstFull)).toBe('D. John');
+		});
+
+		it("should return the right value with 'LF' format", () => {
+			expect(luUserDisplay(user, LuDisplayInitials.lastfirst)).toBe('DJ');
+		});
+
+		it("should return the right value with 'lF' format", () => {
+			expect(luUserDisplay(user, LuDisplayHybrid.lastFullfirstI)).toBe('Doe J.');
+		});
+
+		it("should return the right value with 'l' format", () => {
+			expect(luUserDisplay(user, LuDisplayFullname.last)).toBe('Doe');
+		});
+
+		it("should return the right value with 'L' format", () => {
+			expect(luUserDisplay(user, LuDisplayInitials.last)).toBe('D');
+		});
+
+		it("should return the right value with 'fl' format", () => {
+			expect(luUserDisplay(user, LuDisplayFullname.firstlast)).toBe('John Doe');
+		});
+
+		it("should return the right value with 'Fl' format", () => {
+			expect(luUserDisplay(user, LuDisplayHybrid.firstIlastFull)).toBe('J. Doe');
+		});
+
+		it("should return the right value with 'FL' format", () => {
+			expect(luUserDisplay(user, LuDisplayInitials.firstlast)).toBe('JD');
+		});
+
+		it("should return the right value with 'fL' format", () => {
+			expect(luUserDisplay(user, LuDisplayHybrid.firstFulllastI)).toBe('John D.');
+		});
+
+		it("should return the right value with 'f' format", () => {
+			expect(luUserDisplay(user, LuDisplayFullname.first)).toBe('John');
+		});
+
+		it("should return the right value with 'F' format", () => {
+			expect(luUserDisplay(user, LuDisplayInitials.first)).toBe('J');
+		});
 	});
 
-	it("should return the right value with 'lf' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayFullname.lastfirst)).toBe('Doe John');
-	});
+	describe('| luUserDisplay', () => {
+		let spectator: SpectatorPipe<LuUserDisplayPipe>;
+		const createPipe = createPipeFactory(LuUserDisplayPipe);
 
-	it("should return the right value with 'Lf' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayHybrid.lastIfirstFull)).toBe('D. John');
-	});
+		it(`should return the right value with 'lf' format`, () => {
+			spectator = createPipe(`{{ user | luUserDisplay }}`, {
+				hostProps: {
+					user,
+				},
+			});
+			expect(spectator.element).toHaveText('Doe John');
+		});
 
-	it("should return the right value with 'LF' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayInitials.lastfirst)).toBe('DJ');
-	});
-
-	it("should return the right value with 'lF' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayHybrid.lastFullfirstI)).toBe('Doe J.');
-	});
-
-	it("should return the right value with 'l' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayFullname.last)).toBe('Doe');
-	});
-
-	it("should return the right value with 'L' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayInitials.last)).toBe('D');
-	});
-
-	it("should return the right value with 'fl' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayFullname.firstlast)).toBe('John Doe');
-	});
-
-	it("should return the right value with 'Fl' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayHybrid.firstIlastFull)).toBe('J. Doe');
-	});
-
-	it("should return the right value with 'FL' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayInitials.firstlast)).toBe('JD');
-	});
-
-	it("should return the right value with 'fL' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayHybrid.firstFulllastI)).toBe('John D.');
-	});
-
-	it("should return the right value with 'f' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayFullname.first)).toBe('John');
-	});
-
-	it("should return the right value with 'F' format", () => {
-		const pipe = new LuUserDisplayPipe();
-		expect(pipe.transform(user, LuDisplayInitials.first)).toBe('J');
+		it(`should return the right value with 'fl' format`, () => {
+			const provider = { provide: LU_DEFAULT_DISPLAY_POLICY, useValue: LuDisplayFullname.firstlast };
+			spectator = createPipe(`{{ user | luUserDisplay }}`, {
+				hostProps: {
+					user,
+				},
+				providers: [provider],
+			});
+			expect(spectator.element).toHaveText('John Doe');
+		});
 	});
 });

--- a/packages/ng/user/src/lib/display/user-display.pipe.ts
+++ b/packages/ng/user/src/lib/display/user-display.pipe.ts
@@ -1,6 +1,6 @@
-import { Pipe, PipeTransform } from '@angular/core';
+import { inject, Pipe, PipeTransform } from '@angular/core';
 import { ILuUser } from '../user.model';
-import { LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
+import { LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials, LU_DEFAULT_DISPLAY_POLICY } from './display-format.model';
 
 /**
  * Displays a user name according to specified format. Supported formats: f for first name,
@@ -59,7 +59,9 @@ export function luUserDisplay(user: ILuUser, format: LuDisplayFormat = LuDisplay
  */
 @Pipe({ name: 'luUserDisplay', standalone: true })
 export class LuUserDisplayPipe implements PipeTransform {
-	transform(user: ILuUser, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
+	private readonly defaultFormat = inject(LU_DEFAULT_DISPLAY_POLICY);
+
+	public transform(user: ILuUser, format: LuDisplayFormat = this.defaultFormat): string {
 		return luUserDisplay(user, format);
 	}
 }


### PR DESCRIPTION
## Description

Allow the override of default user display policy

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
