### PR TITLE
fix(schematic): CRLF/LF issue on some projects

### DIFF
--- a/packages/ng/schematics/lib/angular-template.ts
+++ b/packages/ng/schematics/lib/angular-template.ts
@@ -53,7 +53,7 @@ export function extractNgTemplates(fileNameOrSourceFile: string | SourceFile, co
 					.map((initializer) => ({
 						offsetStart: initializer.getStart(sourcefile) + initializer.getLeadingTriviaWidth(sourcefile),
 						offsetEnd: initializer.getEnd(),
-						content: initializer.text,
+						content: 'rawText' in initializer && initializer.rawText ? initializer.rawText : initializer.text,
 					})),
 			);
 		}),


### PR DESCRIPTION
## Description

When a file use CRLF line endings (hey Windows !), the replaced content is broken because typescript normalize line endings with only LF.

-----

