### PR TITLE
[Establishment] Fix categories alignment

### DIFF
--- a/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.scss
+++ b/packages/ng/establishment/src/lib/select/input/establishment-select-input.component.scss
@@ -22,7 +22,7 @@
 	border-top: var(--commons-divider-width) solid var(--commons-divider-color);
 	font-size: var(--sizes-S-fontSize);
 	width: 100%;
-	text-align: left;
+	justify-content: flex-start;
 
 	&.mod-readonly {
 		color: var(--palettes-grey-600);


### PR DESCRIPTION
## Description

Fix establishment categories alignement

-----

![image](https://user-images.githubusercontent.com/25581936/221162888-c93ccc9c-a4d3-44b7-b25a-ccb6930255c5.png)

As we set button as `inline-flex`, `text-align: left` was not working anymore

-----
