### PR TITLE
[Forms] Fix variables

### DIFF
--- a/packages/scss/src/components/form/index.scss
+++ b/packages/scss/src/components/form/index.scss
@@ -3,6 +3,7 @@
 @use 'exports' as *;
 
 .form {
+	@include vars;
 }
 
 .form-group {


### PR DESCRIPTION
## Description

Fix variables on `.form` scope

-----

Not a perfect solution as we duplicated variables, but it avoids breakings before the form/field refactor. 

-----
