### PR TITLE
Better.modal.typings

### DIFF
--- a/packages/ng/modal/src/lib/modal-config.default.ts
+++ b/packages/ng/modal/src/lib/modal-config.default.ts
@@ -11,3 +11,9 @@ export const luDefaultModalConfig: LuModalConfig = {
 	size: 'standard',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 };
+
+export const luDefaultSidepanelConfig: LuModalConfig = {
+	...luDefaultModalConfig,
+	mode: 'sidepanel',
+	position: 'right',
+};

--- a/packages/ng/modal/src/lib/modal-config.model.ts
+++ b/packages/ng/modal/src/lib/modal-config.model.ts
@@ -21,3 +21,8 @@ export type LuModalConfig = ILuPopupConfig &
 	LuModalModeWithPosition & {
 		changeDetection: ChangeDetectionStrategy;
 	};
+
+/**
+ * @deprecated Use LuModalConfig instead.
+ */
+export type ILuModalConfig = LuModalConfig;

--- a/packages/ng/modal/src/lib/modal-config.model.ts
+++ b/packages/ng/modal/src/lib/modal-config.model.ts
@@ -15,7 +15,7 @@ export const luModalClasses: Record<LuModalMode, LuModalClasses> = {
 	sidepanel: { panel: 'lu-sidepanel-panel', panelInner: 'lu-sidepanel-panel-inner', overlayPane: 'mod-sidepanel', panelContainer: 'lu-sidepanel-container' },
 };
 
-type LuModalModeWithPosition = { mode: 'modal'; position: undefined | 'center' } | { mode: 'sidepanel'; position: 'left' | 'right' };
+type LuModalModeWithPosition = { mode?: 'modal'; position: undefined | 'center' } | { mode: 'sidepanel'; position: 'left' | 'right' };
 
 export type LuModalConfig = ILuPopupConfig &
 	LuModalModeWithPosition & {

--- a/packages/ng/modal/src/lib/modal-ref.model.ts
+++ b/packages/ng/modal/src/lib/modal-ref.model.ts
@@ -1,5 +1,5 @@
 import { ALuPopupRef, ILuPopupRef } from '@lucca-front/ng/popup';
-import { LuModalMode, LuModalConfig, LuModalClasses, luModalClasses } from './modal-config.model';
+import { LuModalClasses, luModalClasses, LuModalConfig, LuModalMode } from './modal-config.model';
 import { ILuModalContent } from './modal.model';
 
 export interface ILuModalRef<T extends ILuModalContent = ILuModalContent, D = unknown, R = unknown> extends ILuPopupRef<T, D, R> {
@@ -11,10 +11,10 @@ export abstract class ALuModalRef<T extends ILuModalContent = ILuModalContent, D
 	implements ILuModalRef<T, D, R>
 {
 	public get mode(): LuModalMode {
-		return this._config.mode;
+		return this._config.mode || 'modal';
 	}
 
 	public get modalClasses(): LuModalClasses {
-		return luModalClasses[this._config.mode];
+		return luModalClasses[this.mode];
 	}
 }

--- a/packages/ng/sidepanel/src/lib/sidepanel.model.ts
+++ b/packages/ng/sidepanel/src/lib/sidepanel.model.ts
@@ -42,6 +42,11 @@ export const luSidepanelTranslations: ILuTranslation<ILuSidepanelLabel> = luModa
 export type LuSidepanelConfig = LuModalConfig;
 
 /**
+ * @deprecated Use LuModalConfig from @lucca-front/ng/modal instead.
+ */
+export type ILuSidepanelConfig = LuModalConfig;
+
+/**
  * @deprecated Use ILuModalContent from @lucca-front/ng/modal instead.
  */
 export type ILuSidepanelContent<T = unknown> = ILuModalContent<T>;

--- a/packages/ng/sidepanel/src/lib/sidepanel.model.ts
+++ b/packages/ng/sidepanel/src/lib/sidepanel.model.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
 import { ILuTranslation } from '@lucca-front/ng/core';
-import { ILuModalContent, ILuModalLabel, ILuModalRef, luDefaultModalConfig, LuModalConfig, luModalTranslations, LU_MODAL_DATA } from '@lucca-front/ng/modal';
+import { ILuModalContent, ILuModalLabel, ILuModalRef, luDefaultSidepanelConfig, LuModalConfig, luModalTranslations, LU_MODAL_DATA } from '@lucca-front/ng/modal';
 
 /**
  * For backward compatibility, we re-export modal tokens as sidepanel tokens.
@@ -11,11 +11,7 @@ import { ILuModalContent, ILuModalLabel, ILuModalRef, luDefaultModalConfig, LuMo
  * @deprecated Use LU_MODAL_CONFIG from @lucca-front/ng/modal instead.
  */
 export const LU_SIDEPANEL_CONFIG = new InjectionToken<LuSidepanelConfig>('LuSidepanelDefaultConfig', {
-	factory: () => ({
-		...luDefaultModalConfig,
-		mode: 'sidepanel',
-		position: 'right',
-	}),
+	factory: () => luDefaultSidepanelConfig,
 });
 
 /**


### PR DESCRIPTION
## Description

* 🔨 ref(modal): mode is optional (default to modal)
* ✨ feat(modal): expose luDefaultSidepanelConfig
* 🐛 fix(modal): bring back config interface to avoid breaking change and deprecate them

-----

