### PR TITLE
ref(modal): no more popup inheritance + "open" correct return type

### DIFF
--- a/packages/ng/modal/src/lib/modal-ref.model.ts
+++ b/packages/ng/modal/src/lib/modal-ref.model.ts
@@ -1,3 +1,4 @@
+import { ComponentType } from '@angular/cdk/portal';
 import { ALuPopupRef, ILuPopupRef } from '@lucca-front/ng/popup';
 import { LuModalClasses, luModalClasses, LuModalConfig, LuModalMode } from './modal-config.model';
 import { ILuModalContent } from './modal.model';
@@ -6,6 +7,11 @@ export interface ILuModalRef<T extends ILuModalContent = ILuModalContent, D = un
 	mode: LuModalMode;
 	modalClasses: LuModalClasses;
 }
+
+export interface IModalRefFactory<TComponent extends ILuModalContent = ILuModalContent, TConfig extends LuModalConfig = LuModalConfig> {
+	forge<T extends TComponent, C extends TConfig, D, R>(component: ComponentType<T>, config: C): ILuModalRef<T, D, R>;
+}
+
 export abstract class ALuModalRef<T extends ILuModalContent = ILuModalContent, D = unknown, R = unknown, C extends LuModalConfig = LuModalConfig>
 	extends ALuPopupRef<T, D, R, C>
 	implements ILuModalRef<T, D, R>

--- a/packages/ng/modal/src/lib/modal.service.spec.ts
+++ b/packages/ng/modal/src/lib/modal.service.spec.ts
@@ -35,7 +35,7 @@ describe('LuModal', () => {
 		spectator = createComponent();
 	});
 
-	function openModal<T>(type: Type<T>): T {
+	function openModal<T extends ILuModalContent>(type: Type<T>): T {
 		spectator.component.modal.open(type);
 		return spectator.debugElement.parent.query(By.directive(type)).componentInstance as T;
 	}

--- a/packages/ng/modal/src/lib/modal.service.ts
+++ b/packages/ng/modal/src/lib/modal.service.ts
@@ -1,10 +1,19 @@
+import { ComponentType } from '@angular/cdk/portal';
 import { inject, Injectable } from '@angular/core';
-import { LuPopup } from '@lucca-front/ng/popup';
 import { LuModalConfig } from './modal-config.model';
+import { ILuModalRef } from './modal-ref.model';
+import { ILuModalContent } from './modal.model';
 import { LU_MODAL_CONFIG, LU_MODAL_REF_FACTORY } from './modal.token';
 
 @Injectable()
-export class LuModal<C extends LuModalConfig = LuModalConfig> extends LuPopup<C> {
-	protected override _factory = inject(LU_MODAL_REF_FACTORY);
-	protected override _config = inject<C>(LU_MODAL_CONFIG);
+export class LuModal {
+	protected _factory = inject(LU_MODAL_REF_FACTORY);
+	protected _config = inject(LU_MODAL_CONFIG);
+
+	open<T extends ILuModalContent<R>, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<LuModalConfig> = {}): ILuModalRef<T, D, R> {
+		const extendedConfig = { ...this._config, ...config } as LuModalConfig;
+		const ref = this._factory.forge<T, LuModalConfig, D, T extends ILuModalContent<infer R> ? R : unknown>(component, extendedConfig);
+		ref.open(data);
+		return ref;
+	}
 }

--- a/packages/ng/modal/src/lib/modal.token.ts
+++ b/packages/ng/modal/src/lib/modal.token.ts
@@ -1,17 +1,11 @@
 import { InjectionToken } from '@angular/core';
-import { ILuPopupRefFactory } from '@lucca-front/ng/popup';
 import { luDefaultModalConfig } from './modal-config.default';
 import { LuModalConfig } from './modal-config.model';
+import { IModalRefFactory } from './modal-ref.model';
 
 /** Injection token that can be used to access the data that was passed in to a dialog. */
 export const LU_MODAL_DATA = new InjectionToken<unknown>('LuModalData');
 export const LU_MODAL_CONFIG = new InjectionToken<LuModalConfig>('LuModalDefaultConfig', {
 	factory: () => luDefaultModalConfig,
 });
-export const LU_MODAL_REF_FACTORY = new InjectionToken<ILuPopupRefFactory>('LuModalRefFactory', {
-	factory: () => ({
-		forge() {
-			throw new Error('[LuModalRefFactory] Cannot call forge, LuModalRefFactory needs to be overriden.');
-		},
-	}),
-});
+export const LU_MODAL_REF_FACTORY = new InjectionToken<IModalRefFactory>('LuModalRefFactory');

--- a/packages/ng/popup/src/lib/popup.service.ts
+++ b/packages/ng/popup/src/lib/popup.service.ts
@@ -5,13 +5,13 @@ import { ILuPopupRef } from './popup-ref.model';
 import { LU_POPUP_CONFIG, LU_POPUP_REF_FACTORY } from './popup.token';
 
 @Injectable()
-export class LuPopup<C extends ILuPopupConfig = ILuPopupConfig> {
+export class LuPopup {
 	protected _factory = inject(LU_POPUP_REF_FACTORY);
-	protected _config = inject<C>(LU_POPUP_CONFIG);
+	protected _config = inject(LU_POPUP_CONFIG);
 
-	open<T, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<C> = {}): ILuPopupRef<T, D, R> {
+	open<T, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<ILuPopupConfig> = {}): ILuPopupRef<T, D, R> {
 		const extendedConfig = { ...this._config, ...config };
-		const ref = this._factory.forge<T, C, D, R>(component, extendedConfig);
+		const ref = this._factory.forge<T, ILuPopupConfig, D, R>(component, extendedConfig);
 		ref.open(data);
 		return ref;
 	}

--- a/packages/ng/popup/src/lib/popup.token.ts
+++ b/packages/ng/popup/src/lib/popup.token.ts
@@ -2,13 +2,7 @@ import { InjectionToken } from '@angular/core';
 import { ILuPopupConfig } from './popup-config.model';
 import { ILuPopupRefFactory } from './popup-ref.model';
 
-export const LU_POPUP_REF_FACTORY = new InjectionToken<ILuPopupRefFactory>('LuPopupRefFactory', {
-	factory: () => ({
-		forge() {
-			throw new Error('[LuPopupRefFactory] Cannot call forge, LuPopupRefFactory needs to be overriden.');
-		},
-	}),
-});
+export const LU_POPUP_REF_FACTORY = new InjectionToken<ILuPopupRefFactory>('LuPopupRefFactory');
 
 /** Injection token that can be used to access the data that was passed in to a dialog. */
 export const LU_POPUP_DATA = new InjectionToken<unknown>('LuPopupData');

--- a/packages/ng/sidepanel/src/lib/sidepanel.service.ts
+++ b/packages/ng/sidepanel/src/lib/sidepanel.service.ts
@@ -1,20 +1,19 @@
 import { ComponentType } from '@angular/cdk/overlay';
 import { inject, Injectable } from '@angular/core';
-import { LuModal } from '@lucca-front/ng/modal';
-import { ILuPopupRef } from '@lucca-front/ng/popup';
-import { LuSidepanelConfig, LU_SIDEPANEL_CONFIG } from './sidepanel.model';
+import { ILuModalContent, LuModal } from '@lucca-front/ng/modal';
+import { ILuSidepanelRef, LuSidepanelConfig, LU_SIDEPANEL_CONFIG } from './sidepanel.model';
 
 /**
  * @deprecated Use LuModal with `modal.open(component, data, { mode: 'sidepanel' })` instead.
  */
 @Injectable()
-export class LuSidepanel<C extends LuSidepanelConfig = LuSidepanelConfig> extends LuModal<C> {
-	protected override _config = inject<C>(LU_SIDEPANEL_CONFIG);
+export class LuSidepanel extends LuModal {
+	protected override _config = inject(LU_SIDEPANEL_CONFIG);
 
 	/**
 	 * @deprecated Use LuModal with `modal.open(component, data, { mode: 'sidepanel' })` instead.
 	 */
-	override open<T, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<C> = {}): ILuPopupRef<T, D, R> {
+	override open<T extends ILuModalContent<R>, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<LuSidepanelConfig> = {}): ILuSidepanelRef<T, D, R> {
 		return super.open(component, data, config);
 	}
 }


### PR DESCRIPTION
## Description

* 🔨 no more popup inheritance
* 🔨 Popup/Modal/Sidepanel can no longer have a custom config type.
* 🐛 `modal.open` returns a `ILuModalRef` and not a `ILuPopupRef`

-----

#1918 introduced a richer `ILuModalRef`. `ILuModalRef` and `ILuPopupRef` can no longer be used interchangeably.

I removed CustomConfigType as it is not used across Lucca repositories. `inject` typings does not take default config type : 

```typescript
class AComponent {
        // modal1 has LuModal<any> type
	public modal1 = inject(LuModal);


        // modal2 has LuModal<LuModalConfig> type
	public constructor(public modal2: LuModal) {}
}
```

-----
