### PR TITLE
[BREAKING] Ref modal typings

### DIFF
--- a/packages/ng/modal/src/lib/modal-ref.factory.ts
+++ b/packages/ng/modal/src/lib/modal-ref.factory.ts
@@ -9,7 +9,7 @@ import { ILuModalContent } from './modal.model';
 import { LU_MODAL_DATA } from './modal.token';
 import { setAriaHiddenOnApplicationRoot } from './modal.utils';
 
-class LuModalRef<T extends ILuModalContent = ILuModalContent, D = unknown, R = unknown, C extends LuModalConfig = LuModalConfig> extends ALuModalRef<T, D, R, C> implements ILuModalRef<T, D, R> {
+class LuModalRef<T extends ILuModalContent = ILuModalContent, D = unknown, R = unknown, C extends LuModalConfig = LuModalConfig> extends ALuModalRef<T, D, R, C> implements ILuModalRef<D, R> {
 	protected _containerRef: ComponentRef<ALuModalPanelComponent<T>>;
 	constructor(
 		protected override _overlay: Overlay,

--- a/packages/ng/modal/src/lib/modal-ref.model.ts
+++ b/packages/ng/modal/src/lib/modal-ref.model.ts
@@ -1,20 +1,20 @@
 import { ComponentType } from '@angular/cdk/portal';
 import { ALuPopupRef, ILuPopupRef } from '@lucca-front/ng/popup';
 import { LuModalClasses, luModalClasses, LuModalConfig, LuModalMode } from './modal-config.model';
-import { ILuModalContent } from './modal.model';
+import { ILuModalContent, LuModalContentResult } from './modal.model';
 
-export interface ILuModalRef<T extends ILuModalContent = ILuModalContent, D = unknown, R = unknown> extends ILuPopupRef<T, D, R> {
+export interface ILuModalRef<D = unknown, R = unknown> extends ILuPopupRef<D, R> {
 	mode: LuModalMode;
 	modalClasses: LuModalClasses;
 }
 
-export interface IModalRefFactory<TComponent extends ILuModalContent = ILuModalContent, TConfig extends LuModalConfig = LuModalConfig> {
-	forge<T extends TComponent, C extends TConfig, D, R>(component: ComponentType<T>, config: C): ILuModalRef<T, D, R>;
+export interface IModalRefFactory {
+	forge<T extends ILuModalContent, C extends LuModalConfig, D>(component: ComponentType<T>, config: C): ILuModalRef<D, LuModalContentResult<T>>;
 }
 
 export abstract class ALuModalRef<T extends ILuModalContent = ILuModalContent, D = unknown, R = unknown, C extends LuModalConfig = LuModalConfig>
 	extends ALuPopupRef<T, D, R, C>
-	implements ILuModalRef<T, D, R>
+	implements ILuModalRef<D, R>
 {
 	public get mode(): LuModalMode {
 		return this._config.mode || 'modal';

--- a/packages/ng/modal/src/lib/modal.model.ts
+++ b/packages/ng/modal/src/lib/modal.model.ts
@@ -9,3 +9,5 @@ export interface ILuModalContent<T = unknown> {
 	submitCounter?: number | Observable<number>;
 	cancelLabel?: string | Observable<string>;
 }
+
+export type LuModalContentResult<T extends ILuModalContent> = T extends ILuModalContent<infer R> ? R : never;

--- a/packages/ng/modal/src/lib/modal.service.ts
+++ b/packages/ng/modal/src/lib/modal.service.ts
@@ -2,7 +2,7 @@ import { ComponentType } from '@angular/cdk/portal';
 import { inject, Injectable } from '@angular/core';
 import { LuModalConfig } from './modal-config.model';
 import { ILuModalRef } from './modal-ref.model';
-import { ILuModalContent } from './modal.model';
+import { ILuModalContent, LuModalContentResult } from './modal.model';
 import { LU_MODAL_CONFIG, LU_MODAL_REF_FACTORY } from './modal.token';
 
 @Injectable()
@@ -10,9 +10,9 @@ export class LuModal {
 	protected _factory = inject(LU_MODAL_REF_FACTORY);
 	protected _config = inject(LU_MODAL_CONFIG);
 
-	open<T extends ILuModalContent<R>, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<LuModalConfig> = {}): ILuModalRef<T, D, R> {
+	open<T extends ILuModalContent, D>(component: ComponentType<T>, data: D = undefined, config: Partial<LuModalConfig> = {}): ILuModalRef<D, LuModalContentResult<T>> {
 		const extendedConfig = { ...this._config, ...config } as LuModalConfig;
-		const ref = this._factory.forge<T, LuModalConfig, D, T extends ILuModalContent<infer R> ? R : unknown>(component, extendedConfig);
+		const ref = this._factory.forge<T, LuModalConfig, D>(component, extendedConfig);
 		ref.open(data);
 		return ref;
 	}

--- a/packages/ng/popup/src/lib/popup-ref.model.ts
+++ b/packages/ng/popup/src/lib/popup-ref.model.ts
@@ -6,8 +6,7 @@ import { filter } from 'rxjs/operators';
 import { ILuPopupConfig } from './popup-config.model';
 import { LU_POPUP_DATA } from './popup.token';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export interface ILuPopupRef<T = unknown, D = unknown, R = unknown> {
+export interface ILuPopupRef<D = unknown, R = unknown> {
 	onOpen: Observable<D>;
 	onClose: Observable<R>;
 	onDismiss: Observable<void>;
@@ -17,10 +16,10 @@ export interface ILuPopupRef<T = unknown, D = unknown, R = unknown> {
 	dismiss(): void;
 }
 export interface ILuPopupRefFactory<TComponent = unknown, TConfig extends ILuPopupConfig = ILuPopupConfig> {
-	forge<T extends TComponent, C extends TConfig, D, R>(component: ComponentType<T>, config: C): ILuPopupRef<T, D, R>;
+	forge<T extends TComponent, C extends TConfig, D, R>(component: ComponentType<T>, config: C): ILuPopupRef<D, R>;
 }
 
-export abstract class ALuPopupRef<T = unknown, D = unknown, R = unknown, C extends ILuPopupConfig = ILuPopupConfig> implements ILuPopupRef<T, D, R> {
+export abstract class ALuPopupRef<T = unknown, D = unknown, R = unknown, C extends ILuPopupConfig = ILuPopupConfig> implements ILuPopupRef<D, R> {
 	onOpen = new Subject<D>();
 	onClose = new Subject<R>();
 	onDismiss = new Subject<void>();

--- a/packages/ng/popup/src/lib/popup.service.ts
+++ b/packages/ng/popup/src/lib/popup.service.ts
@@ -9,7 +9,7 @@ export class LuPopup {
 	protected _factory = inject(LU_POPUP_REF_FACTORY);
 	protected _config = inject(LU_POPUP_CONFIG);
 
-	open<T, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<ILuPopupConfig> = {}): ILuPopupRef<T, D, R> {
+	open<T, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<ILuPopupConfig> = {}): ILuPopupRef<D, R> {
 		const extendedConfig = { ...this._config, ...config };
 		const ref = this._factory.forge<T, ILuPopupConfig, D, R>(component, extendedConfig);
 		ref.open(data);

--- a/packages/ng/sidepanel/src/lib/sidepanel.model.ts
+++ b/packages/ng/sidepanel/src/lib/sidepanel.model.ts
@@ -54,4 +54,4 @@ export type ILuSidepanelContent<T = unknown> = ILuModalContent<T>;
 /**
  * @deprecated Use ILuModalRef from @lucca-front/ng/modal instead.
  */
-export type ILuSidepanelRef<T extends ILuSidepanelContent = ILuSidepanelContent, D = unknown, R = unknown> = ILuModalRef<T, D, R>;
+export type ILuSidepanelRef<D = unknown, R = unknown> = ILuModalRef<D, R>;

--- a/packages/ng/sidepanel/src/lib/sidepanel.service.ts
+++ b/packages/ng/sidepanel/src/lib/sidepanel.service.ts
@@ -1,6 +1,6 @@
 import { ComponentType } from '@angular/cdk/overlay';
 import { inject, Injectable } from '@angular/core';
-import { ILuModalContent, LuModal } from '@lucca-front/ng/modal';
+import { ILuModalContent, LuModal, LuModalContentResult } from '@lucca-front/ng/modal';
 import { ILuSidepanelRef, LuSidepanelConfig, LU_SIDEPANEL_CONFIG } from './sidepanel.model';
 
 /**
@@ -13,7 +13,7 @@ export class LuSidepanel extends LuModal {
 	/**
 	 * @deprecated Use LuModal with `modal.open(component, data, { mode: 'sidepanel' })` instead.
 	 */
-	override open<T extends ILuModalContent<R>, D, R>(component: ComponentType<T>, data: D = undefined, config: Partial<LuSidepanelConfig> = {}): ILuSidepanelRef<T, D, R> {
+	override open<T extends ILuModalContent, D>(component: ComponentType<T>, data: D = undefined, config: Partial<LuSidepanelConfig> = {}): ILuSidepanelRef<D, LuModalContentResult<T>> {
 		return super.open(component, data, config);
 	}
 }


### PR DESCRIPTION
## Description

- 🔨 All Modals and Sidepanels has only two generics instead of three. The result is inferred from component type.

-----

```typescript
class TestModalComponent implements ILuModalContent {
	title: 'Test';

	submitAction() {
		return 42;
	}
}


class BeforeThisPrOpenerComponent {
	modal = inject(LuModal);

	open() {
		const ref = this.modal.open(TestModalComponent);
		const result$ = ref.onClose;
		//    ^^^^^^^ inferred as a `Observable<unknown>` 😭
	}

	manualOpen() {
		const ref = this.modal.open<TestModalComponent, void, number>(TestModalComponent);
		const result$ = ref.onClose;
		//    ^^^^^^^ typed manually as a `Observable<number>`  🙁
	}
}

class AfterThisPrOpenerComponent {
	modal = inject(LuModal);

	open() {
		const ref = this.modal.open(TestModalComponent);
		const result$ = ref.onClose;
		//    ^^^^^^^ automatically inferred as a `Observable<number>` 🤩
	}
}
```

-----
