### PR TITLE
fix : add sort input on api-feeder input for set sort on api v4 (align with api-search cmp)

### DIFF
--- a/packages/ng/api/src/lib/select/feeder/api-feeder.component.ts
+++ b/packages/ng/api/src/lib/select/feeder/api-feeder.component.ts
@@ -55,4 +55,7 @@ export class LuApiFeederComponent<T extends ILuApiItem = ILuApiItem> extends ALu
 	@Input() set orderBy(orderBy: string) {
 		this._service.orderBy = orderBy;
 	}
+	@Input() set sort(sort: string) {
+		this._service.sort = sort;
+	}
 }


### PR DESCRIPTION
## Description

Add sort on api feeder

-----

Alignement avec les autres composants (vivement que ça dégage car avoir sort + orderBy sur le même composant, c'est pas ouf)

-----
