### PR TITLE
[2078] Add multiple users param on LuUserDisplayPipe

### DIFF
--- a/packages/ng/user/display/user-display.pipe.spec.ts
+++ b/packages/ng/user/display/user-display.pipe.spec.ts
@@ -1,21 +1,16 @@
 import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';
-import { ILuUser } from '../user.model';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
 import { luUserDisplay, LuUserDisplayPipe } from './user-display.pipe';
 
-describe('UserNamePipe', () => {
-	let users: ILuUser[];
-	let user: ILuUser;
-	let userFirst: ILuUser;
-	let userLast: ILuUser;
-	beforeEach(() => {
-		users = <ILuUser[]>[
-			{ firstName: 'John', lastName: 'Doe' },
-			{ firstName: 'Michael', lastName: 'Scott' },
-			{ firstName: 'Dwight', lastName: 'Schrute' },
-		];
-		user = users[0];
-	});
+describe(LuUserDisplayPipe.name, () => {
+	const users = [
+		{ firstName: 'John', lastName: 'Doe' },
+		{ firstName: 'Michael', lastName: 'Scott' },
+		{ firstName: 'Dwight', lastName: 'Schrute' },
+	];
+	const user = users[0];
+	const userFirst = { firstName: user.firstName, lastName: '' };
+	const userLast = { firstName: '', lastName: user.lastName };
 
 	describe('luUserDisplay()', () => {
 		it("should return the right value with 'lf' format", () => {
@@ -158,6 +153,17 @@ describe('UserNamePipe', () => {
 				},
 			});
 			expect(spectator.element).toHaveText('J. Doe M. Scott D. Schrute');
+		});
+
+		it(`should return the right multiple value with specify 'fL' format and formatter`, () => {
+			const formatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
+			spectator = createPipe(`{{ users | luUserDisplay:{ format: 'fL', formatter } }}`, {
+				hostProps: {
+					users,
+					formatter,
+				},
+			});
+			expect(spectator.element).toHaveText('John D., Michael S., and Dwight S.');
 		});
 	});
 });

--- a/packages/ng/user/display/user-display.pipe.spec.ts
+++ b/packages/ng/user/display/user-display.pipe.spec.ts
@@ -1,16 +1,20 @@
 import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';
 import { ILuUser } from '../user.model';
-import { LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials, LU_DEFAULT_DISPLAY_POLICY } from './display-format.model';
+import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
 import { luUserDisplay, LuUserDisplayPipe } from './user-display.pipe';
 
 describe('UserNamePipe', () => {
+	let users: ILuUser[];
 	let user: ILuUser;
 	let userFirst: ILuUser;
 	let userLast: ILuUser;
 	beforeEach(() => {
-		user = <ILuUser>{ firstName: 'John', lastName: 'Doe' };
-		userFirst = <ILuUser>{ firstName: 'John', lastName: '' };
-		userLast = <ILuUser>{ firstName: '', lastName: 'Doe' };
+		users = <ILuUser[]>[
+			{ firstName: 'John', lastName: 'Doe' },
+			{ firstName: 'Michael', lastName: 'Scott' },
+			{ firstName: 'Dwight', lastName: 'Schrute' },
+		];
+		user = users[0];
 	});
 
 	describe('luUserDisplay()', () => {
@@ -91,7 +95,7 @@ describe('UserNamePipe', () => {
 		let spectator: SpectatorPipe<LuUserDisplayPipe>;
 		const createPipe = createPipeFactory(LuUserDisplayPipe);
 
-		it(`should return the right value with 'lf' format`, () => {
+		it(`should return the right single value with default 'lf' format`, () => {
 			spectator = createPipe(`{{ user | luUserDisplay }}`, {
 				hostProps: {
 					user,
@@ -100,7 +104,7 @@ describe('UserNamePipe', () => {
 			expect(spectator.element).toHaveText('Doe John');
 		});
 
-		it(`should return the right value with 'fl' format`, () => {
+		it(`should return the right single value with provide 'fl' format`, () => {
 			const provider = { provide: LU_DEFAULT_DISPLAY_POLICY, useValue: LuDisplayFullname.firstlast };
 			spectator = createPipe(`{{ user | luUserDisplay }}`, {
 				hostProps: {
@@ -109,6 +113,51 @@ describe('UserNamePipe', () => {
 				providers: [provider],
 			});
 			expect(spectator.element).toHaveText('John Doe');
+		});
+
+		it(`should return the right single value with specify 'FL' format`, () => {
+			spectator = createPipe(`{{ user | luUserDisplay:'FL' }}`, {
+				hostProps: {
+					user,
+				},
+			});
+			expect(spectator.element).toHaveText('JD');
+		});
+
+		it(`should return the right multiple value with default 'lf' format and default ', ' separator`, () => {
+			spectator = createPipe(`{{ users | luUserDisplay }}`, {
+				hostProps: {
+					users,
+				},
+			});
+			expect(spectator.element).toHaveText('Doe John, Scott Michael, Schrute Dwight');
+		});
+
+		it(`should return the right multiple value with default 'lf' format and '; ' separator`, () => {
+			spectator = createPipe(`{{ users | luUserDisplay:{ separator: '; ' } }}`, {
+				hostProps: {
+					users,
+				},
+			});
+			expect(spectator.element).toHaveText('Doe John; Scott Michael; Schrute Dwight');
+		});
+
+		it(`should return the right multiple value with default 'Lf' format and default ', ' separator`, () => {
+			spectator = createPipe(`{{ users | luUserDisplay:{ format: 'Lf' } }}`, {
+				hostProps: {
+					users,
+				},
+			});
+			expect(spectator.element).toHaveText('D. John, S. Michael, S. Dwight');
+		});
+
+		it(`should return the right multiple value with specify 'Fl' format and ' ' separator`, () => {
+			spectator = createPipe(`{{ users | luUserDisplay:{ format: 'Fl', separator: ' ' } }}`, {
+				hostProps: {
+					users,
+				},
+			});
+			expect(spectator.element).toHaveText('J. Doe M. Scott D. Schrute');
 		});
 	});
 });

--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -1,4 +1,5 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
+import { ILuUser } from '../user.model';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
 
 export interface LuUserDisplayInput {
@@ -6,56 +7,44 @@ export interface LuUserDisplayInput {
 	lastName: string;
 }
 
+function getFirstCharacter([firstCharacter]: string): string {
+	return firstCharacter ?? '';
+}
+
+const formatUser: Record<LuDisplayFormat, (user: ILuUser) => string> = {
+	[LuDisplayFullname.lastfirst]: ({ firstName, lastName }) => `${lastName} ${firstName}`,
+	[LuDisplayFullname.firstlast]: ({ firstName, lastName }) => `${firstName} ${lastName}`,
+	[LuDisplayFullname.first]: ({ firstName }) => firstName,
+	[LuDisplayFullname.last]: ({ lastName }) => lastName,
+	[LuDisplayInitials.lastfirst]: ({ firstName, lastName }) => `${getFirstCharacter(lastName)}${getFirstCharacter(firstName)}`,
+	[LuDisplayInitials.firstlast]: ({ firstName, lastName }) => `${getFirstCharacter(firstName)}${getFirstCharacter(lastName)}`,
+	[LuDisplayInitials.first]: ({ firstName }) => getFirstCharacter(firstName),
+	[LuDisplayInitials.last]: ({ lastName }) => getFirstCharacter(lastName),
+	[LuDisplayHybrid.lastIfirstFull]: ({ firstName, lastName }) => `${getFirstCharacter(lastName)}. ${firstName}`,
+	[LuDisplayHybrid.firstIlastFull]: ({ firstName, lastName }) => `${getFirstCharacter(firstName)}. ${lastName}`,
+	[LuDisplayHybrid.lastFullfirstI]: ({ firstName, lastName }) => `${lastName} ${getFirstCharacter(firstName)}.`,
+	[LuDisplayHybrid.firstFulllastI]: ({ firstName, lastName }) => `${firstName} ${getFirstCharacter(lastName)}.`,
+};
+
 /**
  * Displays a user name according to specified format. Supported formats: f for first name,
  * F for first initial, l for last name, L for last initial.
  */
-export function luUserDisplay(user: LuUserDisplayInput, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
-	let result = '';
-	if (user) {
-		switch (format) {
-			case LuDisplayFullname.lastfirst:
-				result = [user.lastName, user.firstName].filter((v) => !!v).join(' ');
-				break;
-			case LuDisplayFullname.firstlast:
-				result = [user.firstName, user.lastName].filter((v) => !!v).join(' ');
-				break;
-			case LuDisplayFullname.first:
-				result = user.firstName;
-				break;
-			case LuDisplayFullname.last:
-				result = user.lastName;
-				break;
-			case LuDisplayInitials.lastfirst:
-				result = [user.lastName?.charAt(0), user.firstName?.charAt(0)].filter((v) => !!v).join('');
-				break;
-			case LuDisplayInitials.firstlast:
-				result = [user.firstName?.charAt(0), user.lastName?.charAt(0)].filter((v) => !!v).join('');
-				break;
-			case LuDisplayInitials.first:
-				result = user.firstName?.charAt(0) ?? '';
-				break;
-			case LuDisplayInitials.last:
-				result = user.lastName?.charAt(0) ?? '';
-				break;
-			case LuDisplayHybrid.firstIlastFull:
-				result = [user.firstName ? user.firstName.charAt(0) + '.' : '', user.lastName].filter((v) => !!v).join(' ');
-				break;
-			case LuDisplayHybrid.lastIfirstFull:
-				result = [user.lastName ? user.lastName.charAt(0) + '.' : '', user.firstName].filter((v) => !!v).join(' ');
-				break;
-			case LuDisplayHybrid.lastFullfirstI:
-				result = [user.lastName, user.firstName ? user.firstName.charAt(0) + '.' : ''].filter((v) => !!v).join(' ');
-				break;
-			case LuDisplayHybrid.firstFulllastI:
-				result = [user.firstName, user.lastName ? user.lastName.charAt(0) + '.' : ''].filter((v) => !!v).join(' ');
-				break;
-			default:
-				break;
-		}
-	}
-	return result;
+export function luUserDisplay(user: ILuUser, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
+	return formatUser[format](user);
 }
+
+/**
+ * Displays a user name according to specified format. Supported formats: f for first name,
+ * F for first initial, l for last name, L for last initial.
+ */
+export function luUsersDisplay(users: ILuUser[], { format, separator }: LuUserDisplayMultipleOptions): string {
+	return users.map((u) => luUserDisplay(u, format)).join(separator);
+}
+
+export type LuUserDisplaySingleOptions = LuDisplayFormat | { format: LuDisplayFormat };
+
+export type LuUserDisplayMultipleOptions = { format: LuDisplayFormat; separator: string };
 
 /**
  * Displays a user name according to specified format. Supported formats: f for first name,
@@ -65,7 +54,22 @@ export function luUserDisplay(user: LuUserDisplayInput, format: LuDisplayFormat 
 export class LuUserDisplayPipe implements PipeTransform {
 	private readonly defaultFormat = inject(LU_DEFAULT_DISPLAY_POLICY);
 
-	public transform(user: LuUserDisplayInput, format: LuDisplayFormat = this.defaultFormat): string {
-		return luUserDisplay(user, format);
+	public transform<T extends ILuUser>(user: T, options?: Partial<LuUserDisplaySingleOptions>): string;
+	public transform<T extends ILuUser>(users: T[], options?: Partial<LuUserDisplayMultipleOptions>): string;
+	public transform<T extends ILuUser>(userOrUsers: T | T[], options?: Partial<LuUserDisplaySingleOptions> | Partial<LuUserDisplayMultipleOptions>): string {
+		if (userOrUsers == null) {
+			throw new Error("Parameter 'userOrUsers' must be a user or a user array");
+		}
+
+		options = typeof options === 'string' ? { format: options } : options || {};
+
+		const format = options.format ?? this.defaultFormat;
+
+		if (Array.isArray(userOrUsers)) {
+			const separator = ('separator' in options ? options.separator : undefined) ?? ', ';
+			return luUsersDisplay(userOrUsers, { format, separator });
+		}
+
+		return luUserDisplay(userOrUsers, format);
 	}
 }

--- a/stories/documentation/users/display/display.stories.html
+++ b/stories/documentation/users/display/display.stories.html
@@ -1,0 +1,9 @@
+<section class="contentSection">
+	<h4>Un utilisateur</h4>
+	<div>{{ users[0] | luUserDisplay : displayFormat }}</div>
+</section>
+
+<section class="contentSection u-marginTopM">
+	<h4>Plusieurs utilisateurs</h4>
+	<div>{{ users | luUserDisplay : { format: displayformat, separator } }}</div>
+</section>

--- a/stories/documentation/users/display/display.stories.html
+++ b/stories/documentation/users/display/display.stories.html
@@ -5,5 +5,8 @@
 
 <section class="contentSection u-marginTopM">
 	<h4>Plusieurs utilisateurs</h4>
-	<div>{{ users | luUserDisplay : { format: displayformat, separator } }}</div>
+	<div class="u-displayFlex u-flexDirectionColumn u-gapS">
+		<div><label class="u-marginRightM">Avec un séparateur :</label>{{ users | luUserDisplay : { format: displayFormat, separator } }}</div>
+		<div><label class="u-marginRightM">Avec un formatter :</label>{{ users | luUserDisplay : { format: displayFormat, formatter } }}</div>
+	</div>
 </section>

--- a/stories/documentation/users/display/display.stories.ts
+++ b/stories/documentation/users/display/display.stories.ts
@@ -1,17 +1,18 @@
 import { Component, Input } from '@angular/core';
 import { ILuUser, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials, LuUserDisplayModule } from '@lucca-front/ng/user';
 import { Meta, StoryFn } from '@storybook/angular';
-import { bob } from '../user.mocks';
+import { bob, patrick, squidwards } from '../user.mocks';
 
 @Component({
 	selector: 'display-stories',
 	standalone: true,
 	imports: [LuUserDisplayModule],
-	template: `{{ user | luUserDisplay : displayFormat }}`,
+	templateUrl: './display.stories.html',
 })
 class DisplayStory {
-	@Input() user: ILuUser = bob;
+	@Input() users: ILuUser[] = [bob, patrick, squidwards];
 	@Input() displayFormat: LuDisplayFormat = LuDisplayFullname.lastfirst;
+	@Input() separator = ', ';
 }
 
 export default {
@@ -29,16 +30,18 @@ export default {
 				},
 			},
 		},
+		separator: { control: 'text' },
 	},
 } as Meta;
 
-const template: StoryFn<DisplayStory> = (args) => ({
+const template: StoryFn<DisplayStory> = (args: DisplayStory) => ({
 	props: args,
 });
 
 export const Basic = template.bind({});
 Basic.args = {
 	displayFormat: LuDisplayFullname.lastfirst,
+	separator: ', ',
 };
 
 const code = `
@@ -54,11 +57,16 @@ class StoriesModule {}
 {{ user | luUserDisplay }}
 /* Ou utiliser le pipe luUserDisplay avec un format particulier*/
 {{ user | luUserDisplay:'lf' }}
+
+/* On peut également l'utiliser pour afficher un tableau d'utilisateurs*/
+{{ users | luUserDisplay }}
+/* Egalement utilisable avec un format et un séparateur personnalisé */
+{{ users | luUserDisplay: { format: 'Fl', separator: ' ; ' } }}
 `;
 
 Basic.parameters = {
 	// Disable controls as they are not modifiable because of ComponentWrapper
-	controls: { include: ['displayFormat'] },
+	controls: { include: ['displayFormat', 'separator'] },
 	docs: {
 		source: {
 			language: 'ts',

--- a/stories/documentation/users/display/display.stories.ts
+++ b/stories/documentation/users/display/display.stories.ts
@@ -3,6 +3,12 @@ import { ILuUser, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplay
 import { Meta, StoryFn } from '@storybook/angular';
 import { bob, patrick, squidwards } from '../user.mocks';
 
+const formatters = {
+	enLongConjFormatter: new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }),
+	deShortDisjFormatter: new Intl.ListFormat('de', { style: 'short', type: 'disjunction' }),
+	enNarrowUnitormatter: new Intl.ListFormat('en', { style: 'narrow', type: 'unit' }),
+};
+
 @Component({
 	selector: 'display-stories',
 	standalone: true,
@@ -13,6 +19,7 @@ class DisplayStory {
 	@Input() users: ILuUser[] = [bob, patrick, squidwards];
 	@Input() displayFormat: LuDisplayFormat = LuDisplayFullname.lastfirst;
 	@Input() separator = ', ';
+	@Input() formatter = formatters.enLongConjFormatter;
 }
 
 export default {
@@ -31,6 +38,13 @@ export default {
 			},
 		},
 		separator: { control: 'text' },
+		formatter: {
+			options: Object.keys(formatters),
+			mapping: formatters,
+			control: {
+				type: 'select',
+			},
+		},
 	},
 } as Meta;
 
@@ -42,6 +56,7 @@ export const Basic = template.bind({});
 Basic.args = {
 	displayFormat: LuDisplayFullname.lastfirst,
 	separator: ', ',
+	formatter: formatters.enLongConjFormatter,
 };
 
 const code = `
@@ -62,11 +77,13 @@ class StoriesModule {}
 {{ users | luUserDisplay }}
 /* Egalement utilisable avec un format et un séparateur personnalisé */
 {{ users | luUserDisplay: { format: 'Fl', separator: ' ; ' } }}
+/* Egalement utilisable avec un format et un formatter Intl.ListFormat personnalisé */
+{{ users | luUserDisplay: { format: 'Fl', formatter: new Intl.ListFormat('en', { style: 'long', type: 'conjunction' }) } }}
 `;
 
 Basic.parameters = {
 	// Disable controls as they are not modifiable because of ComponentWrapper
-	controls: { include: ['displayFormat', 'separator'] },
+	controls: { include: ['displayFormat', 'separator', 'formatter'] },
 	docs: {
 		source: {
 			language: 'ts',


### PR DESCRIPTION
## Description

Add multiple users param on LuUserDisplayPipe

N.B. Usage with single user param remains the same

-----

Examples : 
- In template: `{{ users | luUserDisplay: { format: 'LF', separator: '; '  } }}`
- With transform: `luUserDisplayPipe.transform(users, { format: 'LF', separator: '; ' });`

Defaut values:
- Format (same as single user): InjectionToken `LU_DEFAULT_DISPLAY_POLICY`
- Separator: `, `

Breaking changes :
- Before: Passing a null user displays an empty string
- After: Passing a null user throws an error

-----

