### PR TITLE
fix(modal): better return type when ModalComponent has no submitAction method

### DIFF
--- a/packages/ng/modal/src/lib/modal.model.ts
+++ b/packages/ng/modal/src/lib/modal.model.ts
@@ -10,4 +10,4 @@ export interface ILuModalContent<T = unknown> {
 	cancelLabel?: string | Observable<string>;
 }
 
-export type LuModalContentResult<T extends ILuModalContent> = T extends ILuModalContent<infer R> ? R : never;
+export type LuModalContentResult<T extends ILuModalContent> = T extends ILuModalContent<infer R> & { submitAction: unknown } ? R : never;

--- a/packages/ng/modal/src/lib/modal.service.spec.ts
+++ b/packages/ng/modal/src/lib/modal.service.spec.ts
@@ -39,7 +39,9 @@ export class ModalOpenerComponent {
 /**
  * Compiles when _input is of type T. Otherwise, throws a compile error.
  */
-function assertOfType<T>(_input: T): void {}
+function assertOfType<T>(_input: T): void {
+	return;
+}
 
 describe('LuModal', () => {
 	let spectator: Spectator<ModalOpenerComponent>;


### PR DESCRIPTION
## Description

* 🐛 fix(modal): better return type when ModalComponent has no submitAction method

-----

