### PR TITLE
16.1 Fixes

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -18,16 +18,16 @@ $primary: (
 
 $secondary: (
 	text: #ffffff,
-	50: #e2ebfd,
-	100: #ccddff,
-	200: #b3ccff,
-	300: #9ebeff,
-	400: #85aeff,
-	500: #6699ff,
-	600: #4280fa,
-	700: #2067f3,
-	800: #0a48c2,
-	900: #083691,
+	50: #fff1eb,
+	100: #ffe0d1,
+	200: #ffccb3,
+	300: #ffbe9e,
+	400: #ffaa80,
+	500: #ff9361,
+	600: #ff7b3d,
+	700: #e06029,
+	800: #b43409,
+	900: #611405,
 ) !default;
 
 $success: (

--- a/packages/scss/src/components/breadcrumbs/mods.scss
+++ b/packages/scss/src/components/breadcrumbs/mods.scss
@@ -11,13 +11,14 @@
 
 			&:first-child {
 				.breadcrumbs-list-item-action {
-					display: flex;
-					align-items: center;
-
 					&::before {
 						@include icon.generate('format_undo');
 
 						padding-right: var(--spacings-XXS);
+						font-size: var(--sizes-XS-lineHeight);
+						line-height: var(--sizes-S-lineHeight);
+						text-decoration: none;
+						vertical-align: top;
 					}
 				}
 			}

--- a/packages/scss/src/components/buttonGroup/component.scss
+++ b/packages/scss/src/components/buttonGroup/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin component {
-	gap: var(--commons-divider-width);
 	border-radius: var(--commons-borderRadius-M);
+	gap: var(--commons-divider-width);
 	display: inline-flex;
 	list-style-type: none;
 	padding: 0;
@@ -12,8 +12,6 @@
 		border-radius: 0;
 		display: block;
 		margin: 0;
-		padding-left: var(--spacings-S);
-		padding-right: var(--spacings-S);
 		position: relative;
 		flex-grow: 1;
 		white-space: normal;
@@ -50,6 +48,18 @@
 		.button {
 			width: 100%;
 			border-radius: 0;
+		}
+
+		&:first-child {
+			.button {
+				border-radius: var(--commons-borderRadius-M) 0 0 var(--commons-borderRadius-M);
+			}
+		}
+
+		&:last-child {
+			.button {
+				border-radius: 0 var(--commons-borderRadius-M) var(--commons-borderRadius-M) 0;
+			}
 		}
 	}
 

--- a/packages/scss/src/components/field/component.scss
+++ b/packages/scss/src/components/field/component.scss
@@ -11,8 +11,10 @@
 	.textfield-input,
 	.radiosfield-input,
 	.checkboxesfield-input {
-		display: block;
+		display: flex;
+		flex-direction: column;
 		background-color: var(--colors-white-color);
+		row-gap: var(--spacings-XXS);
 
 		&.palette-error {
 			box-shadow: 0 0 0 1px var(--palettes-700);

--- a/packages/scss/src/components/field/mods.scss
+++ b/packages/scss/src/components/field/mods.scss
@@ -331,12 +331,7 @@
 
 @mixin field-row {
 	display: flex;
+	flex-direction: row;
 	flex-wrap: wrap;
-
-	.checkbox,
-	.radio {
-		margin-top: 0;
-		margin-bottom: 0;
-		margin-right: var(--components-field-horizontal-spacing);
-	}
+	column-gap: var(--components-field-horizontal-spacing);
 }

--- a/packages/scss/src/components/link/index.scss
+++ b/packages/scss/src/components/link/index.scss
@@ -8,10 +8,6 @@
 		@include icon;
 	}
 
-	&.mod-decorationNone {
-		@include decorationNone;
-	}
-
 	&.mod-decorationHover {
 		@include decorationHover;
 	}

--- a/packages/scss/src/components/link/mods.scss
+++ b/packages/scss/src/components/link/mods.scss
@@ -7,10 +7,6 @@
 	}
 }
 
-@mixin decorationNone {
-	text-decoration: none;
-}
-
 @mixin decorationHover {
 	text-decoration: none;
 

--- a/packages/scss/src/components/radio/component.scss
+++ b/packages/scss/src/components/radio/component.scss
@@ -2,7 +2,7 @@
 
 @mixin component {
 	position: relative;
-	display: block;
+	display: flex;
 
 	.radio-input {
 		@include a11y.mask;

--- a/packages/scss/src/components/switch/component.scss
+++ b/packages/scss/src/components/switch/component.scss
@@ -39,7 +39,7 @@
 				top: var(--components-switch-offset-top);
 				transition-duration: var(--commons-animations-durations-fast);
 				transition-timing-function: ease;
-				transition-property: background-color, box-shadow, padding;
+				transition-property: background-color, box-shadow;
 				width: var(--components-switch-width);
 			}
 

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -5,7 +5,7 @@
 	margin-bottom: var(--spacings-S);
 
 	// suffix here
-	font-weight: var(--components-title-weight) #{$suffix};
+	font-weight: 600 #{$suffix};
 	font-size: var(--sizes-fontSize) #{$suffix};
 	line-height: var(--sizes-lineHeight) #{$suffix};
 	padding-top: var(--sizes-verticalPadding) #{$suffix};

--- a/stories/documentation/actions/button/button-group.stories.ts
+++ b/stories/documentation/actions/button/button-group.stories.ts
@@ -1,12 +1,25 @@
 import { Meta, Story } from '@storybook/angular';
 
 interface ButtonGroupStory {
+	outlined: boolean;
+	size: string;
 	noFlexWrap: boolean;
 }
 
 export default {
 	title: 'Documentation/Actions/Button/Group',
 	argTypes: {
+		outlined: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		size: {
+			options: ['', 'mod-S', 'mod-XS'],
+			control: {
+				type: 'select',
+			},
+		},
 		noFlexWrap: {
 			description: 'Désactive la réorganisation des butons en cas de manque de place.',
 			control: {
@@ -17,15 +30,17 @@ export default {
 } as Meta;
 
 function getTemplate(args: ButtonGroupStory): string {
+	const classes = [args.size].filter(Boolean).join(' ');
 	const noFlexWrap = args.noFlexWrap ? `u-flexWrapNowrap` : '';
+	const outlined = args.outlined ? `mod-outlined` : '';
 
 	return `
-	<ul class="button-group ${noFlexWrap}">
-		<li class="button-group-item"><button type="button" class="button">Bouton</button></li>
-		<li class="button-group-item"><button type="button" class="button">Bouton</button></li>
-		<li class="button-group-item"><button type="button" class="button">Bouton</button></li>
+	<ul class="button-group ${outlined} ${noFlexWrap}">
+		<li class="button-group-item"><button type="button" class="button ${outlined} ${classes}">Bouton</button></li>
+		<li class="button-group-item"><button type="button" class="button ${outlined} ${classes}">Bouton</button></li>
+		<li class="button-group-item"><button type="button" class="button ${outlined} ${classes}">Bouton</button></li>
 		<li class="button-group-item">
-			<button type="button" class="button mod-more">
+			<button type="button" class="button ${outlined} ${classes} mod-more">
 				<span class="lucca-icon icon-chevronSouth" aria-hidden="true"></span>
 				<span class="u-mask">Plus d'actions</span>
 			</button>
@@ -40,4 +55,4 @@ const Template: Story<ButtonGroupStory> = (args: ButtonGroupStory) => ({
 });
 
 export const GroupButton = Template.bind({});
-GroupButton.args = { noFlexWrap: false };
+GroupButton.args = { noFlexWrap: false, outlined: false, size: '' };

--- a/stories/documentation/actions/links/link-basic.stories.ts
+++ b/stories/documentation/actions/links/link-basic.stories.ts
@@ -2,7 +2,7 @@ import { Meta, Story } from '@storybook/angular';
 
 interface LinkBasicStory {
 		disabled: boolean;
-		decoration: string;
+		decorationHover: boolean;
 }
 
 export default {
@@ -14,22 +14,21 @@ export default {
 				type: 'boolean',
 			},
 		},
-		decoration: {
-			options: ['', 'mod-decorationNone', 'mod-decorationHover'],
+		decorationHover: {
 			control: {
-				type: 'select',
+				type: 'boolean',
 			},
 		},
 	},
 } as Meta;
 
 function getTemplate(args: LinkBasicStory): string {
-	const classes = [args.decoration].filter(Boolean).join(' ');
 	const disabled = args.disabled ? `is-disabled` : '';
+	const decorationHover = args.decorationHover ? `mod-decorationHover` : '';
 
 	return `
-<a href="#" class="link ${classes} ${disabled}">Lien</a>
-<a class="link mod-icon ${classes} ${disabled}" href="#" target="_blank">Lien externe<span aria-hidden="true" class="lucca-icon icon-outside"></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span></a>
+<a href="#" class="link ${decorationHover} ${disabled}">Lien</a>
+<a class="link mod-icon ${decorationHover} ${disabled}" href="#" target="_blank">Lien externe<span aria-hidden="true" class="lucca-icon icon-outside"></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span></a>
 	`;
 }
 
@@ -48,4 +47,4 @@ const Template: Story<LinkBasicStory> = (args: LinkBasicStory) => ({
 });
 
 export const BasicLink = Template.bind({});
-BasicLink.args = { disabled: false, decoration: '' };
+BasicLink.args = { disabled: false, decorationHover: false };

--- a/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
+++ b/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
@@ -48,7 +48,7 @@ function getTemplate(args: CheckboxBasicStory): string {
 				<label class="checkbox ${s}">
 					<input class="checkbox-input" type="checkbox" name="checkboxList1" ${disabled} ${required} checked>
 					<span class="checkbox-label">Label</span>
-				</label>g
+				</label>
 			</div>
 			<div>
 				<label class="checkbox ${s}">

--- a/stories/qa/button/button.stories.html
+++ b/stories/qa/button/button.stories.html
@@ -66,17 +66,31 @@
 <!-- Groups -->
 <section class="contentSection">
 	<h2>Group of buttons</h2>
-	<div class="button-group">
-		<button type="button" class="button">default</button>
-		<button type="button" class="button">default</button>
-		<button type="button" class="button">default</button>
-		<button type="button" class="button">default</button>
-	</div><br><br>
-	<div class="button-group mod-outlined">
-		<button type="button" class="button mod-outlined">default</button>
-		<button type="button" class="button mod-outlined">default</button>
-		<button type="button" class="button mod-outlined">default</button>
-		<button type="button" class="button mod-outlined">default</button>
+	<div class="u-marginBottomXS">
+		<ul class="button-group">
+			<li class="button-group-item"><button type="button" class="button">Bouton</button></li>
+			<li class="button-group-item"><button type="button" class="button">Bouton</button></li>
+			<li class="button-group-item"><button type="button" class="button">Bouton</button></li>
+			<li class="button-group-item">
+				<button type="button" class="button mod-more">
+					<span class="lucca-icon icon-chevronSouth" aria-hidden="true"></span>
+					<span class="u-mask">Plus d'actions</span>
+				</button>
+			</li>
+		</ul>
+	</div>
+	<div>
+		<ul class="button-group mod-outlined">
+			<li class="button-group-item"><button type="button" class="button mod-outlined">Bouton</button></li>
+			<li class="button-group-item"><button type="button" class="button mod-outlined">Bouton</button></li>
+			<li class="button-group-item"><button type="button" class="button mod-outlined">Bouton</button></li>
+			<li class="button-group-item">
+				<button type="button" class="button mod-outlined mod-more">
+					<span class="lucca-icon icon-chevronSouth" aria-hidden="true"></span>
+					<span class="u-mask">Plus d'actions</span>
+				</button>
+			</li>
+		</ul>
 	</div>
 </section>
 

--- a/stories/qa/links/links.stories.html
+++ b/stories/qa/links/links.stories.html
@@ -11,8 +11,6 @@
 	<br />
 	<a class="link is-disabled" href="#">link custom</a>
 	<br />
-	<a class="link mod-decorationNone" href="#">link with no decoration</a>
-	<br />
 	<a class="link mod-decorationHover" href="#">link with decoration on hover</a>
 	<br />
 	<em><b>Tip:</b> You can use link's style (e.g. for buttons) with a <code class="code">link</code> class.</em>


### PR DESCRIPTION
## Description

- Apply primary on secondary palette
- Add radio/checkbox gap on fields
- Fix button group (previously applied en deprecated code)
- Remove link decorationNone (keep only decorationHover) 
- Remove translation animation on switch icon
- Fix hover on breadcrumb compact
- Set radio as flex (instead of block) to fix `.textfield.mod-radio`
- Delay new title weights on next release

-----