### PR TITLE
Update Jenkins shared library version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('Lucca@v0.42.0') _
+@Library('Lucca@v0.58.3') _
 
 import hudson.Util
 import fr.lucca.CI


### PR DESCRIPTION
## Description

Update Jenkins shared library version to v0.58.3 allowing us to publish pre-releases to npm using the specified channel in git tags i.e.

`v16.0.0-rc.1` -> release channel `rc` instead of `next`

-----

