### PR TITLE
New Toasts mobile styles

### DIFF
--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -36,7 +36,7 @@ export class LuToastsComponent implements OnDestroy {
 	}
 
 	public iconClassByToastType: Record<LuToastType, string> = {
-		Info: 'icon-info',
+		Info: 'icon-lucca',
 		Success: 'icon-success',
 		Error: 'icon-error',
 		Warning: 'icon-warning',

--- a/packages/ng/toast/src/toasts.component.ts
+++ b/packages/ng/toast/src/toasts.component.ts
@@ -37,7 +37,7 @@ export class LuToastsComponent implements OnDestroy {
 
 	public iconClassByToastType: Record<LuToastType, string> = {
 		Info: 'icon-lucca',
-		Success: 'icon-success',
+		Success: 'icon-confirm',
 		Error: 'icon-error',
 		Warning: 'icon-warning',
 	};

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/media';
 
 @mixin component($atRoot: 'without: rule') {
 	@keyframes toast {
@@ -36,10 +37,28 @@
 			overflow: hidden;
 			position: relative;
 			transform-origin: top;
+
+			@include media.max('S') {
+				border-radius: calc(var(--commons-borderRadius-M) + var(--commons-borderRadius-L));
+				background-color: var(--palettes-grey-900);
+			}
 		}
 
 		.toast-item-icon {
 			margin-top: 2px;
+
+			@include media.max('S') {
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				flex-shrink: 0;
+				align-self: flex-start;
+				width: 1.25rem;
+				height: 1.25rem;
+				border-radius: 50%;
+				font-size: var(--sizes-XS-lineHeight);
+				background-color: var(--palettes-700, var(--palettes-primary-700));
+			}
 		}
 
 		.toast-item-content {
@@ -67,6 +86,12 @@
 
 			&::after {
 				@include icon.generate('cross');
+			}
+
+			.lucca-icon {
+				@include media.max('S') {
+					font-size: var(--sizes-L-lineHeight);
+				}
 			}
 		}
 	}

--- a/packages/scss/src/components/toast/mods.scss
+++ b/packages/scss/src/components/toast/mods.scss
@@ -1,6 +1,20 @@
+@use '@lucca-front/scss/src/commons/utils/media';
+
 @mixin bottom {
 	top: auto;
 	bottom: var(--spacings-M);
+
+	@include media.max('S') {
+		right: 0;
+		left: 0;
+		pointer-events: none;
+
+		.toasts-item {
+			align-self: center;
+			margin-bottom: var(--spacings-S);
+			pointer-events: auto;
+		}
+	}
 }
 
 @mixin circularGauge {


### PR DESCRIPTION
## Description

New UI for Toasts on mobile devices when they're placed at the bottom (`.mod-bottom`).


![CleanShot 2023-05-16 at 18 01 25](https://github.com/LuccaSA/lucca-front/assets/128475140/26666754-06f4-4b75-82d2-f2f24087927e)


-----

- All elements have the same background color.
- Only the background of the icon changes depending on the state.
- The rounded border is larger.
- The 'x' icon is also bigger.
- `icon-info` has been replaced by `icon-lucca` (⚠️  Breaking change on desktop!)
- `icon-success` has been replaced by `icon-confirm` (⚠️  Breaking change on desktop!)
- Still work on multilines.

-----
