### PR TITLE
[Tooltip] Add luTooltipAsHtml input

### DIFF
--- a/packages/ng/tooltip/src/lib/panel/tooltip-panel.component.html
+++ b/packages/ng/tooltip/src/lib/panel/tooltip-panel.component.html
@@ -7,5 +7,8 @@
 	[attr.id]="panelId"
 	[@transformTooltip]="'enter'"
 >
-	<div class="lu-tooltip-content" [ngClass]="contentClassesMap" [innerHtml]="content"></div>
+	<div *ngIf="contentAsHtml; else contentAsString" class="lu-tooltip-content" [ngClass]="contentClassesMap" [innerHtml]="content"></div>
+	<ng-template #contentAsString>
+		<div class="lu-tooltip-content" [ngClass]="contentClassesMap">{{ content }}</div>
+	</ng-template>
 </div>

--- a/packages/ng/tooltip/src/lib/panel/tooltip-panel.component.ts
+++ b/packages/ng/tooltip/src/lib/panel/tooltip-panel.component.ts
@@ -26,6 +26,15 @@ export class LuTooltipPanelComponent extends ALuPopoverPanel implements ILuPopov
 		this._changeDetectorRef.markForCheck();
 	}
 
+	private _contentAsHtml: boolean;
+	get contentAsHtml() {
+		return this._contentAsHtml;
+	}
+	set contentAsHtml(c) {
+		this._contentAsHtml = c;
+		this._changeDetectorRef.markForCheck();
+	}
+
 	//FIXME output event
 	// eslint-disable-next-line @angular-eslint/no-output-native
 	@Output() override close = new EventEmitter<void>();

--- a/packages/ng/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/src/lib/trigger/tooltip-trigger.directive.ts
@@ -41,6 +41,14 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 		this.whenEllipsis = we;
 	}
 
+	@Input('luTooltipAsHtml') public set inputAsHtml(asHtml: boolean) {
+		if (this.panel) {
+			this.panel.contentAsHtml = asHtml;
+		}
+
+		this._contentAsHtml = asHtml;
+	}
+
 	// FIXME output native
 	/** Event emitted when the associated popover is opened. */
 	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
@@ -82,6 +90,7 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 
 	protected override _portal: ComponentPortal<LuTooltipPanelComponent>;
 	protected _tooltipContent: string | SafeHtml = '';
+	protected _contentAsHtml = false;
 
 	constructor(protected override _overlay: Overlay, protected override _elementRef: ElementRef<HTMLElement>, protected override _viewContainerRef: ViewContainerRef) {
 		super(_overlay, _elementRef, _viewContainerRef);
@@ -132,6 +141,7 @@ export class LuTooltipTriggerDirective extends ALuPopoverTrigger<LuTooltipPanelC
 		const componentRef = this._overlayRef.attach(this._portal);
 		this._panel = componentRef.instance;
 		this._panel.content = this._tooltipContent;
+		this._panel.contentAsHtml = this._contentAsHtml;
 	}
 
 	protected override _getPanelScrollStrategy(): LuPopoverScrollStrategy {

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LuPopoverPosition } from '@lucca-front/ng/popover';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { componentWrapperDecorator, Meta, moduleMetadata, Story } from '@storybook/angular';
+import { Meta, Story, componentWrapperDecorator, moduleMetadata } from '@storybook/angular';
 
 @Component({
 	selector: 'tooltip-stories',
@@ -11,12 +11,13 @@ import { componentWrapperDecorator, Meta, moduleMetadata, Story } from '@storybo
 	template: `<button
 		type="button"
 		class="button u-marginL"
-		luTooltip="so you can see me"
+		luTooltip="so <em>you</em> can see me"
 		[luTooltipEnterDelay]="luTooltipEnterDelay"
 		[luTooltipLeaveDelay]="luTooltipLeaveDelay"
 		[luTooltipPosition]="luTooltipPosition"
 		[luTooltipDisabled]="luTooltipDisabled"
 		[luTooltipWhenEllipsis]="luTooltipWhenEllipsis"
+		[luTooltipAsHtml]="luTooltipAsHtml"
 		[class.u-ellipsis]="luTooltipWhenEllipsis"
 		[tabindex]="tabindex"
 		[attr.data-tooltip]="getDataTooltip()"
@@ -37,6 +38,7 @@ class TooltipStory {
 	@Input() luTooltipDisabled: boolean;
 	@Input() luTooltipPosition: LuPopoverPosition;
 	@Input() luTooltipWhenEllipsis: boolean;
+	@Input() luTooltipAsHtml: boolean;
 	@Input() tabindex: number | null;
 
 	getDataTooltip() {
@@ -73,6 +75,9 @@ export default {
 		luTooltipWhenEllipsis: {
 			control: { type: 'boolean' },
 		},
+		luTooltipAsHtml: {
+			control: { type: 'boolean' },
+		},
 		tabindex: {
 			control: { type: 'number' },
 		},
@@ -84,6 +89,7 @@ export default {
 			luTooltipDisabled: props.luTooltipDisabled,
 			luTooltipPosition: props.luTooltipPosition,
 			luTooltipWhenEllipsis: props.luTooltipWhenEllipsis,
+			luTooltipAsHtml: props.luTooltipAsHtml,
 			tabindex: props.tabindex,
 		})),
 		moduleMetadata({
@@ -103,6 +109,7 @@ Basic.args = {
 	luTooltipDisabled: false,
 	luTooltipPosition: 'below',
 	luTooltipWhenEllipsis: false,
+	luTooltipAsHtml: true,
 	tabindex: null,
 };
 
@@ -126,6 +133,7 @@ class StoriesModule {}
 	[luTooltipPosition]="luTooltipPosition"
 	[luTooltipDisabled]="luTooltipDisabled"
 	[luTooltipWhenEllipsis]="luTooltipWhenEllipsis"
+	[luTooltipAsHtml]="luTooltipAsHtml"
 	[class.u-ellipsis]="luTooltipWhenEllipsis">
 		Come over here
 	</button>\`,
@@ -135,11 +143,13 @@ class TooltipStory {
   @Input() luTooltipLeaveDelay: number;
   @Input() luTooltipDisabled: boolean;
   @Input() luTooltipPosition: LuPopoverPosition;
+	@Input() luTooltipWhenEllipsis: boolean;
+	@Input() luTooltipAsHtml: boolean;
 }`;
 
 Basic.parameters = {
 	// Disable controls as they are not modifiable because of ComponentWrapper
-	controls: { include: ['luTooltipEnterDelay', 'luTooltipLeaveDelay', 'luTooltipDisabled', 'luTooltipPosition', 'luTooltipWhenEllipsis', 'tabindex'] },
+	controls: { include: ['luTooltipEnterDelay', 'luTooltipLeaveDelay', 'luTooltipDisabled', 'luTooltipPosition', 'luTooltipWhenEllipsis', 'luTooltipAsHtml', 'tabindex'] },
 	docs: {
 		source: {
 			language: 'ts',

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -143,8 +143,8 @@ class TooltipStory {
   @Input() luTooltipLeaveDelay: number;
   @Input() luTooltipDisabled: boolean;
   @Input() luTooltipPosition: LuPopoverPosition;
-	@Input() luTooltipWhenEllipsis: boolean;
-	@Input() luTooltipAsHtml: boolean;
+  @Input() luTooltipWhenEllipsis: boolean;
+  @Input() luTooltipAsHtml: boolean;
 }`;
 
 Basic.parameters = {


### PR DESCRIPTION
## Description

Add a `luTooltipAsHtml` input for the tooltip component to allow the content to be interpreted as HTML.

-----

The content of the tooltip is now passed in a mustache by default, except when the `luTooltipAsHtml` input is set to `true`.

-----
