### PR TITLE
feat(callout): new callout wrapper

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -13,7 +13,8 @@
 		{
 			"files": ["*.html"],
 			"options": {
-				"parser": "html"
+				"parser": "html",
+				"singleQuote": false
 			}
 		},
 		{

--- a/packages/ng/callout/ng-package.json
+++ b/packages/ng/callout/ng-package.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "src/public-api.ts",
+		"styleIncludePaths": ["../styles"]
+	}
+}

--- a/packages/ng/callout/src/lib/callout/callout.component.html
+++ b/packages/ng/callout/src/lib/callout/callout.component.html
@@ -1,0 +1,12 @@
+<div class="callout palette-{{palette}}" [class.mod-S]="size === 's'" [class.mod-tiny]="tiny">
+	<div class="callout-icon" *ngIf="icon">
+		<span aria-hidden="true" class="lucca-icon icon-{{icon}}"></span>
+	</div>
+	<div class="callout-content">
+		<strong class="callout-content-title" *ngIf="title">{{title}}</strong>
+		<div class="callout-content-description">
+			<ng-content></ng-content>
+		</div>
+	</div>
+	<button *ngIf="removable" type="button" class="callout-kill" (click)="hide()"></button>
+</div>

--- a/packages/ng/callout/src/lib/callout/callout.component.scss
+++ b/packages/ng/callout/src/lib/callout/callout.component.scss
@@ -1,0 +1,1 @@
+@use '@lucca-front/scss/src/components/callout';

--- a/packages/ng/callout/src/lib/callout/callout.component.ts
+++ b/packages/ng/callout/src/lib/callout/callout.component.ts
@@ -1,0 +1,71 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Palette, SizeMS } from '@lucca-front/ng/core';
+
+@Component({
+	selector: 'lu-callout',
+	standalone: true,
+	imports: [CommonModule],
+	templateUrl: './callout.component.html',
+	styleUrls: ['./callout.component.scss'],
+})
+export class CalloutComponent {
+	@Input()
+	/**
+	 * The title of the callout
+	 */
+	title: string;
+
+	@Input()
+	/**
+	 * Which palette should be used for the entire callout.
+	 * Defaults to none (inherits parent palette)
+	 */
+	palette: Palette = 'none';
+
+	@Input()
+	/**
+	 * Which size should the callout be? Defaults to medium
+	 */
+	size: SizeMS = 'm';
+
+	@Input()
+	/**
+	 * Should we display the remove icon?
+	 *
+	 * IMPORTANT: the callout won't hide itself, you're responsible for removing
+	 * it using *ngIf as you might want to store the information that it has been
+	 * hidden. Hook on the `hidden` event emitter for that.
+	 */
+	removable = false;
+
+	@Input()
+	/**
+	 * Which icon should we display in the callout if any?
+	 * Defaults to no icon.
+	 */
+	icon: 'info' | 'success' | 'warning' | 'error' | 'help' | string;
+
+	@Input()
+	/**
+	 * Should we use tiny mode?
+	 * WARNING: tiny mode should only be used without a title, there's no runtime
+	 * check for this for performance reasons but make sure to never have both title
+	 * and tiny.
+	 */
+	tiny: boolean;
+
+	@Output()
+	/**
+	 * Emits void when the callout's close button is clicked.
+	 *
+	 */
+	hidden: EventEmitter<void> = new EventEmitter<void>();
+
+	/**
+	 * Emits the hidden event for the consumer to hide the callout.
+	 */
+	hide(): void {
+		this.hidden.emit();
+	}
+}

--- a/packages/ng/callout/src/lib/index.ts
+++ b/packages/ng/callout/src/lib/index.ts
@@ -1,0 +1,1 @@
+export * from './callout/callout.component';

--- a/packages/ng/callout/src/public-api.ts
+++ b/packages/ng/callout/src/public-api.ts
@@ -1,0 +1,1 @@
+export * from './lib/index';

--- a/packages/ng/core/src/lib/index.ts
+++ b/packages/ng/core/src/lib/index.ts
@@ -4,3 +4,4 @@ export * from './translate/index';
 export * from './tree/index';
 export * from './group/index';
 export * from './id/index';
+export * from './type/index';

--- a/packages/ng/core/src/lib/type/index.ts
+++ b/packages/ng/core/src/lib/type/index.ts
@@ -1,0 +1,1 @@
+export * from './style';

--- a/packages/ng/core/src/lib/type/style.ts
+++ b/packages/ng/core/src/lib/type/style.ts
@@ -1,0 +1,9 @@
+/**
+ * Available CSS palettes
+ */
+export type Palette = 'success' | 'warning' | 'error' | 'primary' | 'grey' | 'none';
+
+/**
+ * Size that accepts only medium or small
+ */
+export type SizeMS = 'm' | 's';

--- a/stories/documentation/feedback/callout/callout-basic.stories.ts
+++ b/stories/documentation/feedback/callout/callout-basic.stories.ts
@@ -1,45 +1,55 @@
-import { Meta, Story } from '@storybook/angular';
-
-interface CalloutBasicStory {
-	palette: string;
-	s: boolean;
-}
+import { Meta, StoryObj } from '@storybook/angular';
+import { CalloutComponent } from '@lucca-front/ng/callout';
 
 export default {
 	title: 'Documentation/Feedback/Callout/Basic',
+	component: CalloutComponent,
+	render: (args: CalloutComponent & { description: string }) => {
+		const { description, title, palette, size, removable, tiny, icon } = args;
+		return {
+			template: `
+        <lu-callout title="${title}" palette="${palette}" size="${size}" [removable]="${removable}" [tiny]="${tiny}" icon="${icon}">
+          ${description}
+        </lu-callout>
+      `,
+		};
+	},
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['none', 'primary', 'grey', 'success', 'warning', 'error'],
 			control: {
 				type: 'select',
 			},
 		},
-		s: {
+		icon: {
+			options: ['info', 'success', 'warning', 'error', 'help'],
 			control: {
-				type: 'boolean',
+				type: 'select',
 			},
-			description: 'Taille : Small',
+		},
+		size: {
+			options: ['m', 's'],
+			control: {
+				type: 'select',
+			},
+		},
+		title: {
+			type: 'string',
+		},
+		description: {
+			type: 'string',
 		},
 	},
 } as Meta;
 
-function getTemplate(args: CalloutBasicStory): string {
-	const classes = [args.palette].filter(Boolean).join(' ');
-	const s = args.s ? `mod-S` : '';
-	return `
-	<div class="callout ${classes} ${s}">
-		<div class="callout-content">
-			<strong class="callout-content-title">Feedback or informations</strong>
-			<div class="callout-content-description">Caesarem fama studio memorabili ut latius abscessere amplam Nebridius equitum. <a href="#">En savoir plus</a></div>
-		</div>
-	</div>
-	`;
-}
-
-const Template: Story<CalloutBasicStory> = (args: CalloutBasicStory) => ({
-	props: args,
-	template: getTemplate(args),
-});
-
-export const Basic = Template.bind({});
-Basic.args = { palette: '', s: false };
+export const Template: StoryObj<CalloutComponent & { description: string }> = {
+	args: {
+		title: 'Feedback or informations',
+		tiny: false,
+		icon: 'info',
+		palette: 'none',
+		size: 'm',
+		removable: false,
+		description: `Caesarem fama studio memorabili ut latius abscessere amplam Nebridius equitum. <a href="#">En savoir plus</a>`,
+	},
+};

--- a/stories/documentation/feedback/callout/callout-icons.stories.ts
+++ b/stories/documentation/feedback/callout/callout-icons.stories.ts
@@ -1,71 +1,52 @@
-import { Meta, Story } from '@storybook/angular';
-
-interface CalloutIconStory {
-	s: boolean;
-	palette: string;
-	icon: string;
-}
+import { Meta, StoryObj } from '@storybook/angular';
+import { CalloutComponent } from '@lucca-front/ng/callout';
+import { default as BasicStory } from './callout-basic.stories';
 
 export default {
-	title: 'Documentation/Feedback/Callout/Icon',
-	argTypes: {
-		s: {
-			control: {
-				type: 'boolean',
-			},
-			description: 'Taille : Small',
-		},
-		palette: {
-			options: ['', 'palette-success', 'palette-warning', 'palette-error'],
-			control: {
-				type: 'select',
-			},
-		},
-		icon: {
-			options: ['icon-help', 'icon-success', 'icon-warning', 'icon-error'],
-			control: {
-				type: 'select',
-			},
-		},
-	},
+	...BasicStory,
+	title: 'Documentation/Feedback/Callout/Icon'
 } as Meta;
 
-function getTemplate(args: CalloutIconStory): string {
-	const s = args.s ? `mod-S` : '';
-	const palette = args.palette;
-	const icon = args.icon;
-	let text: { title: string; description: string };
-	switch (args.palette) {
-		case 'palette-success':
-			text = { title: 'Cool!', description: 'Je suis un callout de succès :)' };
-			break;
-		case 'palette-warning':
-			text = { title: 'Hmmm...', description: "Je suis un callout d'alarme :|" };
-			break;
-		case 'palette-error':
-			text = { title: 'Oops!', description: "Je suis un callout d'erreur :(" };
-			break;
-		default:
-			text = { title: "Besoin d'aide ?", description: 'Je suis un callout standard' };
-			break;
+export const Template: StoryObj<CalloutComponent & { description: string }> = {
+	args: {
+		title: 'Feedback or informations',
+		tiny: false,
+		icon: 'info',
+		palette: 'none',
+		size: 'm',
+		removable: false,
+		description: `Caesarem fama studio memorabili ut latius abscessere amplam Nebridius equitum. <a href="#">En savoir plus</a>`,
+	},
+	argTypes: {
+		description: {
+			table: {
+				disable: true
+			}
+		},
+		tiny: {
+			table: {
+				disable: true
+			}
+		},
+		title: {
+			table: {
+				disable: true
+			}
+		},
+		size: {
+			table: {
+				disable: true
+			}
+		},
+		removable: {
+			table: {
+				disable: true
+			}
+		},
+		palette: {
+			table: {
+				disable: true
+			}
+		},
 	}
-	return `
-	<div class="callout ${s} ${palette}">
-		<div class="callout-icon">
-			<span aria-hidden="true" class="lucca-icon ${icon}"></span>
-		</div>
-		<div class="callout-content">
-			<strong class="callout-content-title">${text.title} </strong>
-			<div class="callout-content-description">${text.description}</div>
-		</div>
-	</div>
-	`;
-}
-
-const Template: Story<CalloutIconStory> = (args: CalloutIconStory) => ({
-	props: args,
-	template: getTemplate(args),
-});
-
-export const Icon = Template.bind({});
-Icon.args = { s: false, icon: 'icon-help', palette: '' };
+};

--- a/stories/documentation/feedback/callout/callout-killable.stories.ts
+++ b/stories/documentation/feedback/callout/callout-killable.stories.ts
@@ -1,30 +1,52 @@
-import { Meta, Story } from '@storybook/angular';
-
-interface CalloutKillableStory {
-}
+import { Meta, StoryObj } from '@storybook/angular';
+import { CalloutComponent } from '@lucca-front/ng/callout';
+import { default as BasicStory } from './callout-basic.stories';
 
 export default {
-	title: 'Documentation/Feedback/Callout/Killable',
-	argTypes: {
-	},
+	...BasicStory,
+	title: 'Documentation/Feedback/Callout/Killable'
 } as Meta;
 
-function getTemplate(args: CalloutKillableStory): string {
-	return `
-	<div class="callout">
-		<div class="callout-content">
-			<strong class="callout-content-title">Feedback or informations</strong>
-			<div class="callout-content-description">Caesarem fama studio memorabili ut latius abscessere amplam Nebridius equitum.</div>
-		</div>
-		<button type="button" class="callout-kill"></button>
-	</div>
-	`;
-}
-
-const Template: Story<CalloutKillableStory> = (args: CalloutKillableStory) => ({
-	props: args,
-	template: getTemplate(args),
-});
-
-export const Killable = Template.bind({});
-Killable.args = { };
+export const Template: StoryObj<CalloutComponent & { description: string }> = {
+	args: {
+		title: 'Feedback or informations',
+		tiny: false,
+		icon: 'info',
+		palette: 'none',
+		size: 'm',
+		removable: true,
+		description: `Caesarem fama studio memorabili ut latius abscessere amplam Nebridius equitum. <a href="#">En savoir plus</a>`,
+	},
+	argTypes: {
+		description: {
+			table: {
+				disable: true
+			}
+		},
+		tiny: {
+			table: {
+				disable: true
+			}
+		},
+		title: {
+			table: {
+				disable: true
+			}
+		},
+		size: {
+			table: {
+				disable: true
+			}
+		},
+		icon: {
+			table: {
+				disable: true
+			}
+		},
+		palette: {
+			table: {
+				disable: true
+			}
+		},
+	}
+};

--- a/stories/documentation/feedback/callout/callout-tiny.stories.ts
+++ b/stories/documentation/feedback/callout/callout-tiny.stories.ts
@@ -1,70 +1,52 @@
-import { Meta, Story } from '@storybook/angular';
-
-interface CalloutTinyStory {
-	s: boolean;
-	palette: string;
-	icon: string;
-}
+import { Meta, StoryObj } from '@storybook/angular';
+import { CalloutComponent } from '@lucca-front/ng/callout';
+import { default as BasicStory } from './callout-basic.stories';
 
 export default {
-	title: 'Documentation/Feedback/Callout/Tiny',
-	argTypes: {
-		s: {
-			control: {
-				type: 'boolean',
-			},
-			description: "Taille : Small",
-		},
-		palette: {
-			options: ['', 'palette-success', 'palette-warning', 'palette-error'],
-			control: {
-				type: 'select',
-			},
-		},
-		icon: {
-			options: ['icon-help', 'icon-success', 'icon-warning', 'icon-error'],
-			control: {
-				type: 'select',
-			},
-		},
-	},
+	...BasicStory,
+	title: 'Documentation/Feedback/Callout/Tiny'
 } as Meta;
 
-function getTemplate(args: CalloutTinyStory): string {
-	const s = args.s ? `mod-S` : '';
-	const palette = args.palette;
-	const icon = args.icon;
-	let text: {title: string, description: string};
-	switch (args.palette) {
-		case 'palette-success':
-				text = {title: 'Cool!', description: 'Je suis un callout de succès :)'};
-				break;
-		case 'palette-warning':
-				text = {title: 'Hmmm...', description: 'Je suis un callout d\'alarme :|'};
-				break;
-		case 'palette-error':
-				text = {title: 'Oops!', description: 'Je suis un callout d\'erreur :('};
-				break;
-		default:
-			text = {title: 'Besoin d\'aide ?', description: 'Je suis un callout standard'};
-			break;
-  };
-	return `
-	<div class="callout mod-tiny ${s} ${palette}">
-		<div class="callout-icon">
-			<span aria-hidden="true" class="lucca-icon ${icon}"></span>
-		</div>
-		<div class="callout-content">
-			99
-		</div>
-	</div>
-	`
-}
-
-const Template: Story<CalloutTinyStory> = (args: CalloutTinyStory) => ({
-	props: args,
-	template: getTemplate(args),
-});
-
-export const Tiny = Template.bind({});
-Tiny.args = { s: false, icon: 'icon-help', palette: '' };
+export const Template: StoryObj<CalloutComponent & { description: string }> = {
+	args: {
+		title: '',
+		tiny: true,
+		icon: 'info',
+		palette: 'none',
+		size: 'm',
+		removable: false,
+		description: `Caesarem fama studio memorabili ut latius abscessere amplam Nebridius equitum. <a href="#">En savoir plus</a>`,
+	},
+	argTypes: {
+		description: {
+			table: {
+				disable: true
+			}
+		},
+		removable: {
+			table: {
+				disable: true
+			}
+		},
+		title: {
+			table: {
+				disable: true
+			}
+		},
+		size: {
+			table: {
+				disable: true
+			}
+		},
+		icon: {
+			table: {
+				disable: true
+			}
+		},
+		palette: {
+			table: {
+				disable: true
+			}
+		},
+	}
+};


### PR DESCRIPTION
## Description

First implementation of the callout wrapper, aiming at wrapping the callout structure in an Angular component for better maintainability.

This PR also includes new stories using the new wrapper, as well as using the new CSF3 Storybook system to make it easier to share code between various stories.

-----

Aside from the implementation itself, something that needs to be reviewed is if we want the `hidden` event to hide the callout too (so have the callout `*ngIf` its own template) or not.

One of the main pros is how easy it'd be to use, one of the main cons is that you'll probably want to store this "hidden" flag somewhere like in localstorage or further, and having the component handle it would make it too smart for what it is. Not to mention the fact that it also means adding a `ng-container` to wrap everything while a parent component that handles hidden would just `*ngIf` the callout.

Another approach could be to make it a two-way binding and make it hide itself upon clicking on the X icon, letting the parent component decide whether they want to store that info or not.

-----
