### PR TITLE
Fix warning

### DIFF
--- a/packages/scss/src/components/pagination/component.scss
+++ b/packages/scss/src/components/pagination/component.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	padding: var(--spacings-XS) .75rem;
-	justify-content: end;
+	justify-content: flex-end;
 
 	> *:not(:last-child) {
 		margin-right: var(--spacings-XS);


### PR DESCRIPTION
## Description

Fix build warning generated by use of `end` instead of `flex-end`

-----
