### PR TITLE
chore(tech): use lucca.tech url in PRs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ node(label: CI.getSelectedNode(script:this)) {
 
 				if (isPR) {
 					// post PR comment
-					def deployUrl = "http://lucca-front.lucca.local/${branchName}/storybook"
+					def deployUrl = "https://lucca-front.lucca.tech/${branchName}/storybook"
 					withCredentials([string(credentialsId: 'ux-comment-token', variable: 'githubToken')]) {
 						powershell """
 							[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12


### PR DESCRIPTION
## Description

`lucca.local` is deprecated, we update the reference to `lucca.tech` urls in PR comments pointing us to storybook

-----
