### PR TITLE
Add details for textfields

### DIFF
--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -1,14 +1,16 @@
+@use '@lucca-front/scss/src/commons/utils/a11y';
+
 @mixin component($atRoot: 'without: rule') {
 	color: var(--components-formLabel-color);
 	display: inline-block;
 	font-size: var(--components-formLabel-fontSize);
 	line-height: var(--components-formLabel-lineHeight);
-	display: inline-flex;
+	display: flex;
 	align-items: flex-end;
 	gap: var(--spacings-XXS);
 	width: fit-content;
 
-	&:has(.formLabel-details) {
+	&:has(.formLabel-counter) {
 		width: auto;
 	}
 
@@ -29,10 +31,14 @@
 			color: var(--palettes-error-700);
 		}
 
-		.formLabel-details {
+		.formLabel-counter {
 			margin-left: auto;
 			text-align: right;
 			padding-left: var(--spacings-XS);
+		}
+
+		.formLabel-counter-alternative {
+			@include a11y.mask;
 		}
 	}
 }

--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -1,21 +1,38 @@
 @mixin component($atRoot: 'without: rule') {
-  color: var(--components-formLabel-color);
-  display: inline-block;
-  font-size: var(--components-formLabel-fontSize);
-  line-height: var(--components-formLabel-lineHeight);
-  width: fit-content;
+	color: var(--components-formLabel-color);
+	display: inline-block;
+	font-size: var(--components-formLabel-fontSize);
+	line-height: var(--components-formLabel-lineHeight);
+	display: inline-flex;
+	align-items: flex-end;
+	gap: var(--spacings-XXS);
+	width: fit-content;
 
-  .lucca-icon {
-    color: var(--palettes-grey-600);
-    font-size: var(--components-formLabel-required-fontSize);
-    line-height: var(--components-formLabel-required-lineHeight);
-    margin-left: .125rem;
-    vertical-align: top;
-  }
+	&:has(.formLabel-details) {
+		width: auto;
+	}
+
+	@supports not selector(:has(*)) {
+		width: auto;
+	}
+
+	.lucca-icon {
+		color: var(--palettes-grey-600);
+		font-size: var(--components-formLabel-required-fontSize);
+		line-height: var(--components-formLabel-required-lineHeight);
+		margin-left: 0.125rem;
+		vertical-align: top;
+	}
 
 	@at-root ($atRoot) {
-    .formLabel-required {
-      color: var(--palettes-error-700);
-    }
-  }
+		.formLabel-required {
+			color: var(--palettes-error-700);
+		}
+
+		.formLabel-details {
+			margin-left: auto;
+			text-align: right;
+			padding-left: var(--spacings-XS);
+		}
+	}
 }

--- a/packages/scss/src/components/formLabel/states.scss
+++ b/packages/scss/src/components/formLabel/states.scss
@@ -1,8 +1,8 @@
 @mixin error {
-  --components-formLabel-color: var(--palettes-error-700);
+	--components-formLabel-color: var(--palettes-error-700);
 }
 
 @mixin disabled {
-  --components-formLabel-color: var(--palettes-grey-500);
-  pointer-events: none;
+	--components-formLabel-color: var(--palettes-grey-500);
+	pointer-events: none;
 }

--- a/packages/scss/src/components/textfield/component.scss
+++ b/packages/scss/src/components/textfield/component.scss
@@ -22,7 +22,7 @@
 
 	@at-root ($atRoot) {
 		.textField-label {
-		  display: contents;
+			display: contents;
 		}
 
 		.textField-label-prefix {
@@ -32,7 +32,7 @@
 			cursor: text;
 			line-height: var(--component-textField-input-lineHeight);
 			grid-column: 1;
- 			grid-row: 2;
+			grid-row: 2;
 		}
 
 		.textField-label-suffix {
@@ -42,19 +42,19 @@
 			cursor: text;
 			line-height: var(--component-textField-input-lineHeight);
 			grid-row: 2;
-  		grid-column: 3;
+			grid-column: 3;
 		}
 
 		.textField-label-prefix-item {
-		  padding: var(--component-textField-input-paddingVertical) var(--spacings-XS);
+			padding: var(--component-textField-input-paddingVertical) var(--spacings-XS);
 
-		  &::selection {
-		    background-color: var(--palettes-primary-200);
-		  }
+			&::selection {
+				background-color: var(--palettes-primary-200);
+			}
 
 			&:last-child {
-		    padding-right: 0;
-		  }
+				padding-right: 0;
+			}
 		}
 
 		.textField-label-suffix-item {
@@ -65,65 +65,78 @@
 			}
 
 			&:first-child {
-		    padding-left: 0;
-		  }
+				padding-left: 0;
+			}
 		}
 
 		.textField-label-input {
-		  grid-column: 1 / span 4;
-		  box-shadow: 0 0 0 1px var(--component-textField-input-border);
-		  grid-row: 2;
-		  pointer-events: none;
-		  border-radius: calc(var(--commons-borderRadius-M) + 1px);
-		  background-color: var(--component-textField-input-background);
-		  transition-property: border-color;
-		  transition-duration: var(--commons-animations-durations-fast);
+			grid-column: 1 / span 4;
+			box-shadow: 0 0 0 1px var(--component-textField-input-border);
+			grid-row: 2;
+			pointer-events: none;
+			border-radius: calc(var(--commons-borderRadius-M) + 1px);
+			background-color: var(--component-textField-input-background);
+			transition-property: box-shadow;
+			transition-duration: var(--commons-animations-durations-fast);
 		}
 
 		.textField-action {
-		  display: flex;
+			display: flex;
 			padding-right: var(--spacings-XS);
 			align-items: center;
-		  grid-row: 2;
-		  grid-column: 4;
-		  color: var(--palettes-grey-600);
+			grid-row: 2;
+			grid-column: 4;
+			color: var(--palettes-grey-600);
 		}
 
 		.textField-input {
-		  grid-column: 2;
-		  grid-row: 2;
-		  border: 0;
-		  outline: none;
-		  padding: var(--component-textField-input-paddingVertical) var(--spacings-XS);
-		  min-width: var(--spacings-M);
-		  font: inherit;
-		  color: var(--component-textField-input-color);
-		  background-color: transparent;
-		  z-index: 1;
-		  line-height: var(--component-textField-input-lineHeight);
+			grid-column: 2;
+			grid-row: 2;
+			border: 0;
+			outline: none;
+			padding: var(--component-textField-input-paddingVertical) var(--spacings-XS);
+			min-width: var(--spacings-M);
+			font: inherit;
+			color: var(--component-textField-input-color);
+			background-color: transparent;
+			z-index: 1;
+			line-height: var(--component-textField-input-lineHeight);
 
-		  &::selection {
-		    background-color: var(--palettes-primary-200);
-		  }
+			&::selection {
+				background-color: var(--palettes-primary-200);
+			}
 
-		  &::placeholder {
-		    color: var(--component-textField-input-placeholder);
-		    opacity: 1;
-		  }
+			&::placeholder {
+				color: var(--component-textField-input-placeholder);
+				opacity: 1;
+			}
 
-		  &:hover {
-		    ~ .textField-label {
+			&:hover {
+				~ .textField-label {
 					--component-textField-input-border: var(--palettes-grey-400);
-		    }
-		  }
+				}
+			}
 
-		  &:focus-visible {
-		    ~ .textField-label {
-		      .textField-label-input {
-		        @include a11y.focusVisible($offset: 3px);
-		      }
-		    }
-		  }
+			&:focus-visible {
+				~ .textField-label {
+					.textField-label-input {
+						@include a11y.focusVisible($offset: 3px);
+					}
+				}
+			}
+		}
+
+		.formLabel {
+			@include formLabel.label;
+
+			grid-column-start: 1;
+			grid-column-end: -1;
+			grid-row: 1;
+		}
+
+		.inlineMessage {
+			grid-column-start: 1;
+			grid-column-end: -1;
 		}
 	}
 }

--- a/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
+++ b/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
@@ -87,7 +87,7 @@ function getTemplate(args: CheckboxBasicStory): string {
 	const required = args.required ? ` aria-required="true"` : '';
 	const mixed = args.mixed ? ` aria-checked="mixed"` : '';
 	const invalid = args.invalid ? ` aria-invalid="true"` : '';
-	const help = args.help;
+	const help = args.help ? `<span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>` : ``;
 	const messageState = args.messageState ? ' is-' + args.messageState : '';
 
 	return `<div class="checkboxField${s}">
@@ -98,7 +98,8 @@ function getTemplate(args: CheckboxBasicStory): string {
 		</span>
 		<span class="formLabel" id="${id}label">
 			<span class="formLabel-content">
-				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline" *ngIf="help"></span>
+				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup>
+				${help}
 			</span>
 		</span>
 	</label>

--- a/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
+++ b/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
@@ -97,7 +97,9 @@ function getTemplate(args: CheckboxBasicStory): string {
 			<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 		</span>
 		<span class="formLabel" id="${id}label">
-			Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline" *ngIf="help"></span>
+			<span class="formLabel-content">
+				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline" *ngIf="help"></span>
+			</span>
 		</span>
 	</label>
 	<div class="inlineMessage${messageState}" id="${id}message" *ngIf="message"><span aria-hidden="true" class="lucca-icon"></span>${message}</div>
@@ -110,4 +112,4 @@ const Template: StoryFn<CheckboxBasicStory> = (args: CheckboxBasicStory) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { checked: false, s: false, disabled: false, required: false, mixed: false, invalid: false, help: false, messageState: '', id: 'field1', label: 'Label', message: 'Helper text', };
+Basic.args = { checked: false, s: false, disabled: false, required: false, mixed: false, invalid: false, help: false, messageState: '', id: 'field1', label: 'Label', message: 'Helper text' };

--- a/stories/documentation/forms/form-label/form-label.stories.ts
+++ b/stories/documentation/forms/form-label/form-label.stories.ts
@@ -3,6 +3,7 @@ import { Meta, Story } from '@storybook/angular';
 interface FormLabelBasicStory {
 	size: string;
 	error: boolean;
+	counter: boolean;
 }
 
 export default {
@@ -19,13 +20,34 @@ export default {
 				type: 'boolean',
 			},
 		},
+		counter: {
+			control: {
+				type: 'boolean',
+			},
+		},
 	},
 } as Meta;
 
 function getTemplate(args: FormLabelBasicStory): string {
 	const size = args.size ? ` ${args.size}` : '';
 	const error = args.error ? ` is-error` : '';
-	return `<label class="formLabel${size}${error}">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>`;
+	const counter = args.counter
+		? `<span class="formLabel-counter">
+	<span class="formLabel-counter-display" aria-hidden="true">0/20</span>
+	<span class="formLabel-counter-alternative">
+		Le texte fait 0 caractère de long.
+		20 caractères sont autorisés.
+	</span>
+</span>`
+		: ``;
+	return `
+		<label class="formLabel${size}${error}">
+			<span class="formLabel-content">
+				Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+			</span>
+			${counter}
+		</label>
+	`;
 }
 
 const Template: Story<FormLabelBasicStory> = (args: FormLabelBasicStory) => ({
@@ -34,4 +56,4 @@ const Template: Story<FormLabelBasicStory> = (args: FormLabelBasicStory) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { size: false, error: false };
+Basic.args = { size: false, error: false, counter: false };

--- a/stories/documentation/forms/radio/radio-basic.stories.ts
+++ b/stories/documentation/forms/radio/radio-basic.stories.ts
@@ -90,7 +90,9 @@ function getTemplate(args: RadioBasicStory): string {
       <span class="radioField-label-input-icon" aria-hidden="true"></span>
     </span>
 		<span class="formLabel" id="${id}label">
-			${label}<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline" *ngIf="help"></span>
+			<span class="formLabel-content">
+				${label}<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline" *ngIf="help"></span>
+			</span>
 		</span>
   </label>
 	<div class="inlineMessage${messageState}" id="${id}message" *ngIf="message"><span aria-hidden="true" class="lucca-icon"></span>${message}</div>
@@ -103,4 +105,4 @@ const Template: Story<RadioBasicStory> = (args: RadioBasicStory) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { checked: false, s: false, disabled: false, required: false, invalid: false, help: false, messageState: '', id: 'field1', label: 'Label', message: 'Helper text', };
+Basic.args = { checked: false, s: false, disabled: false, required: false, invalid: false, help: false, messageState: '', id: 'field1', label: 'Label', message: 'Helper text' };

--- a/stories/documentation/forms/radio/radio-basic.stories.ts
+++ b/stories/documentation/forms/radio/radio-basic.stories.ts
@@ -80,7 +80,7 @@ function getTemplate(args: RadioBasicStory): string {
 	const checked = args.checked ? ` checked="checked"` : '';
 	const required = args.required ? ` aria-required="true"` : '';
 	const invalid = args.invalid ? ` aria-invalid="true"` : '';
-	const help = args.help;
+	const help = args.help ? `<span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>` : ``;
 	const messageState = args.messageState ? ' is-' + args.messageState : '';
 
 	return `<div class="radioField${s}">
@@ -91,7 +91,8 @@ function getTemplate(args: RadioBasicStory): string {
     </span>
 		<span class="formLabel" id="${id}label">
 			<span class="formLabel-content">
-				${label}<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline" *ngIf="help"></span>
+				${label}<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup>
+				${help}
 			</span>
 		</span>
   </label>

--- a/stories/documentation/forms/switch/switch-basic.stories.ts
+++ b/stories/documentation/forms/switch/switch-basic.stories.ts
@@ -80,7 +80,7 @@ function getTemplate(args: SwitchBasicStory): string {
 	const checked = args.checked ? ` checked="checked"` : '';
 	const required = args.required ? ` aria-required="true"` : '';
 	const invalid = args.invalid ? ` aria-invalid="true"` : '';
-	const help = args.help;
+	const help = args.help ? `<span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>` : ``;
 	const messageState = args.messageState ? ' is-' + args.messageState : '';
 
 	return `<div class="switchField${s}">
@@ -91,7 +91,8 @@ function getTemplate(args: SwitchBasicStory): string {
     </span>
 		<span class="formLabel" id="${id}Label">
 			<span class="formLabel-content">
-				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup>
+				${help}
 			</span>
 		</span>
   </label>

--- a/stories/documentation/forms/switch/switch-basic.stories.ts
+++ b/stories/documentation/forms/switch/switch-basic.stories.ts
@@ -90,7 +90,9 @@ function getTemplate(args: SwitchBasicStory): string {
       <span class="switchField-label-input-icon" aria-hidden="true"></span>
     </span>
 		<span class="formLabel" id="${id}Label">
-			Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+			<span class="formLabel-content">
+				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+			</span>
 		</span>
   </label>
 	<div class="inlineMessage${messageState}" *ngIf="message" id="${id}message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>

--- a/stories/documentation/forms/textfield/textfield-basic.stories.ts
+++ b/stories/documentation/forms/textfield/textfield-basic.stories.ts
@@ -4,13 +4,17 @@ interface TextfieldBasicStory {
 	disabled: boolean;
 	size: string;
 	required: boolean;
-	id: Text;
-	label: Text;
-	message: Text;
+	id: string;
+	label: string;
+	message: string;
 	invalid: false;
-	help: false;
-	clear: false;
+	help: boolean;
+	clear: boolean;
 	messageState: '';
+	counter: boolean;
+	value: string;
+	maxlength: number;
+	maxlengthAttribute: boolean;
 }
 
 export default {
@@ -62,6 +66,22 @@ export default {
 				type: 'text',
 			},
 		},
+		value: {
+			control: {
+				type: 'text',
+			},
+		},
+		maxlength: {
+			control: {
+				type: 'number',
+				min: 1,
+			},
+		},
+		maxlengthAttribute: {
+			control: {
+				type: 'boolean',
+			},
+		},
 		messageState: {
 			options: ['', 'error', 'warning', 'success'],
 			control: {
@@ -79,12 +99,24 @@ function getTemplate(args: TextfieldBasicStory): string {
 	const disabled = args.disabled ? ` disabled="disabled"` : '';
 	const required = args.required ? ` aria-required="true"` : '';
 	const invalid = args.invalid ? ` aria-invalid="true"` : '';
-	const help = args.help;
-	const clear = args.help;
+	const maxlengthAttribute = args.maxlengthAttribute ? ` maxlength="${args.maxlength}"` : '';
+	const maxlength = args.maxlength;
+	const help = args.help ? `<span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>` : ``;
+	const clear = args.clear;
+	const value = args.value;
 	const messageState = args.messageState ? ' is-' + args.messageState : '';
+	const counter = args.counter
+		? `<span class="formLabel-counter">
+				<span class="formLabel-counter-display" aria-hidden="true">${value.length}/${maxlength}</span>
+				<span class="formLabel-counter-alternative">
+					Le texte fait ${value.length} ${value.length > 1 ? 'caractères de long.' : 'caractère de long.'}
+					${maxlength} ${maxlength > 1 ? 'caractères sont autorisés.' : 'caractère est autorisé.'}
+				</span>
+			</span>`
+		: ``;
 
 	return `<div class="textField${size}">
-	<input type="text" id="${id}" class="textField-input" aria-labelledby="${id}prefix ${id}label ${id}suffix" aria-describedby="${id}message" placeholder="Placeholder" aria-invalid="false" value="Value"${disabled}${required}${invalid} />
+	<input type="text" id="${id}" class="textField-input" aria-labelledby="${id}label ${id}prefix ${id}suffix" aria-describedby="${id}message" placeholder="Placeholder" aria-invalid="false" value="${value}"${disabled}${required}${invalid}${maxlengthAttribute} />
 	<label for="${id}" class="textField-label">
 		<span class="textField-label-input"></span>
 		<span class="textField-label-prefix" id="${id}prefix">
@@ -92,8 +124,10 @@ function getTemplate(args: TextfieldBasicStory): string {
 		</span>
 		<span class="formLabel" id="${id}label">
 			<span class="formLabel-content">
-				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup>
+				${help}
 			</span>
+			${counter}
 		</span>
 		<span class="textField-label-suffix" id="${id}suffix">
 			<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -115,4 +149,19 @@ const Template: Story<TextfieldBasicStory> = (args: TextfieldBasicStory) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { size: '', disabled: false, required: false, invalid: false, help: false, clear: false, messageState: '', id: 'fieldID', label: 'Label', message: 'Helper text' };
+Basic.args = {
+	size: '',
+	disabled: false,
+	required: false,
+	invalid: false,
+	help: false,
+	clear: false,
+	messageState: '',
+	id: 'fieldID',
+	label: 'Label',
+	message: 'Helper text',
+	counter: false,
+	value: 'Value',
+	maxlength: 20,
+	maxlengthAttribute: false,
+};

--- a/stories/documentation/forms/textfield/textfield-basic.stories.ts
+++ b/stories/documentation/forms/textfield/textfield-basic.stories.ts
@@ -75,7 +75,7 @@ function getTemplate(args: TextfieldBasicStory): string {
 	const id = args.id;
 	const label = args.label;
 	const message = args.message;
-	const size = args.size ? ' '+args.size : '';
+	const size = args.size ? ' ' + args.size : '';
 	const disabled = args.disabled ? ` disabled="disabled"` : '';
 	const required = args.required ? ` aria-required="true"` : '';
 	const invalid = args.invalid ? ` aria-invalid="true"` : '';
@@ -91,7 +91,9 @@ function getTemplate(args: TextfieldBasicStory): string {
 			<span class="textField-label-prefix-item">$</span>
 		</span>
 		<span class="formLabel" id="${id}label">
-			Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+			<span class="formLabel-content">
+				Label<sup *ngIf="required" class="formLabel-required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+			</span>
 		</span>
 		<span class="textField-label-suffix" id="${id}suffix">
 			<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -113,4 +115,4 @@ const Template: Story<TextfieldBasicStory> = (args: TextfieldBasicStory) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { size: '', disabled: false, required: false, invalid: false, help: false, clear: false, messageState: '', id: 'fieldID', label: 'Label', message: 'Helper text', };
+Basic.args = { size: '', disabled: false, required: false, invalid: false, help: false, clear: false, messageState: '', id: 'fieldID', label: 'Label', message: 'Helper text' };

--- a/stories/qa/form-label/form-label.stories.html
+++ b/stories/qa/form-label/form-label.stories.html
@@ -2,12 +2,36 @@
 
 <!-- Basics -->
 <section class="contentSection">
-	<label class="formLabel">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>
-	<label class="formLabel is-error">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>
-	<label class="formLabel mod-S">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>
-	<label class="formLabel mod-S is-error">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>
-	<label class="formLabel mod-XS">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>
-	<label class="formLabel mod-XS is-error">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span></label>
+	<label class="formLabel">
+		<span class="formLabel-content">
+			Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		</span>
+	</label>
+	<label class="formLabel is-error">
+		<span class="formLabel-content">
+			Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		</span>
+	</label>
+	<label class="formLabel mod-S">
+		<span class="formLabel-content">
+			Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		</span>
+	</label>
+	<label class="formLabel mod-S is-error">
+		<span class="formLabel-content">
+			Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		</span>
+	</label>
+	<label class="formLabel mod-XS">
+		<span class="formLabel-content">
+			Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		</span>
+	</label>
+	<label class="formLabel mod-XS is-error">
+		<span class="formLabel-content">
+			Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		</span>
+	</label>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/forms/checkbox.stories.html
+++ b/stories/qa/forms/checkbox.stories.html
@@ -3,49 +3,93 @@
 
 	<h2>Basic</h2>
 	<div class="checkboxField">
-		<input type="checkbox" class="checkboxField-input" id="CB1" aria-labelledby="CB1label" aria-describedby="CB1message" aria-required="true" />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB1"
+			aria-labelledby="CB1label"
+			aria-describedby="CB1message"
+			aria-required="true"
+		/>
 		<label class="checkboxField-label" for="CB1">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB1message">Helper text</div>
 	</div>
 	<div class="checkboxField">
-		<input type="checkbox" class="checkboxField-input" id="CB2" aria-labelledby="CB2label" aria-describedby="CB2message" aria-required="true" checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB2"
+			aria-labelledby="CB2label"
+			aria-describedby="CB2message"
+			aria-required="true"
+			checked
+		/>
 		<label class="checkboxField-label" for="CB2">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB2message">Helper text</div>
 	</div>
 	<div class="checkboxField">
-		<input type="checkbox" class="checkboxField-input" id="CB3" aria-labelledby="CB3label" aria-describedby="CB3message" aria-required="true" disabled />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB3"
+			aria-labelledby="CB3label"
+			aria-describedby="CB3message"
+			aria-required="true"
+			disabled
+		/>
 		<label class="checkboxField-label" for="CB3">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB3label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB3message">Helper text</div>
 	</div>
 	<div class="checkboxField">
-		<input type="checkbox" class="checkboxField-input" id="CB4" aria-labelledby="CB4label" aria-describedby="CB4message" aria-required="true" disabled checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB4"
+			aria-labelledby="CB4label"
+			aria-describedby="CB4message"
+			aria-required="true"
+			disabled
+			checked
+		/>
 		<label class="checkboxField-label" for="CB4">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB4label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB4message">Helper text</div>
@@ -53,25 +97,46 @@
 
 	<h2>Small</h2>
 	<div class="checkboxField mod-S">
-		<input type="checkbox" class="checkboxField-input" id="CB5" aria-labelledby="CB5label" aria-describedby="CB5message" aria-required="true" />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB5"
+			aria-labelledby="CB5label"
+			aria-describedby="CB5message"
+			aria-required="true"
+		/>
 		<label class="checkboxField-label" for="CB5">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB5label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB5message">Helper text</div>
 	</div>
 	<div class="checkboxField mod-S">
-		<input type="checkbox" class="checkboxField-input" id="CB6" aria-labelledby="CB6label" aria-describedby="CB6message" aria-required="true" checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB6"
+			aria-labelledby="CB6label"
+			aria-describedby="CB6message"
+			aria-required="true"
+			checked
+		/>
 		<label class="checkboxField-label" for="CB6">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB6label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB6message">Helper text</div>
@@ -79,25 +144,49 @@
 
 	<h2>Mixed</h2>
 	<div class="checkboxField">
-		<input type="checkbox" class="checkboxField-input" id="CB7" aria-labelledby="CB7label" aria-describedby="CB7message" aria-required="true" aria-checked="mixed" checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB7"
+			aria-labelledby="CB7label"
+			aria-describedby="CB7message"
+			aria-required="true"
+			aria-checked="mixed"
+			checked
+		/>
 		<label class="checkboxField-label" for="CB7">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB7label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB7message">Helper text</div>
 	</div>
 	<div class="checkboxField mod-S">
-		<input type="checkbox" class="checkboxField-input" id="CB8" aria-labelledby="CB8label" aria-describedby="CB8message" aria-required="true" aria-checked="mixed" checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB8"
+			aria-labelledby="CB8label"
+			aria-describedby="CB8message"
+			aria-required="true"
+			aria-checked="mixed"
+			checked
+		/>
 		<label class="checkboxField-label" for="CB8">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB8label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB8message">Helper text</div>
@@ -105,25 +194,49 @@
 
 	<h2>Invalid</h2>
 	<div class="checkboxField">
-		<input type="checkbox" class="checkboxField-input" id="CB9" aria-labelledby="CB9label" aria-describedby="CB9message" aria-required="true" aria-invalid="true" checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB9"
+			aria-labelledby="CB9label"
+			aria-describedby="CB9message"
+			aria-required="true"
+			aria-invalid="true"
+			checked
+		/>
 		<label class="checkboxField-label" for="CB9">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB9label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB9message">Helper text</div>
 	</div>
 	<div class="checkboxField mod-S">
-		<input type="checkbox" class="checkboxField-input" id="CB10" aria-labelledby="CB10label" aria-describedby="CB10message" aria-required="true" aria-invalid="true" checked />
+		<input
+			type="checkbox"
+			class="checkboxField-input"
+			id="CB10"
+			aria-labelledby="CB10label"
+			aria-describedby="CB10message"
+			aria-required="true"
+			aria-invalid="true"
+			checked
+		/>
 		<label class="checkboxField-label" for="CB10">
 			<span class="checkboxField-label-input">
 				<span class="checkboxField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="CB10label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="CB10message">Helper text</div>

--- a/stories/qa/forms/radio.stories.html
+++ b/stories/qa/forms/radio.stories.html
@@ -3,53 +3,101 @@
 
 	<h2>Basic</h2>
 
-  <div class="radioField">
-    <input type="radio" class="radioField-input" id="fieldA1" name="fieldA" aria-labelledby="fieldA1Label" aria-describedby="fieldA1Msg" required="required" checked />
-    <label class="radioField-label" for="fieldA1">
-      <span class="radioField-label-input">
-        <span class="radioField-label-input-icon" aria-hidden="true"></span>
-      </span>
-			<span class="formLabel" id="fieldA1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+	<div class="radioField">
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldA1"
+			name="fieldA"
+			aria-labelledby="fieldA1Label"
+			aria-describedby="fieldA1Msg"
+			required="required"
+			checked
+		/>
+		<label class="radioField-label" for="fieldA1">
+			<span class="radioField-label-input">
+				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
-    </label>
+			<span class="formLabel" id="fieldA1label">
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+			</span>
+		</label>
 		<div class="inlineMessage" id="fieldA1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
-  </div>
+	</div>
 
 	<div class="radioField">
-		<input type="radio" class="radioField-input" id="fieldA2" name="fieldA" aria-labelledby="fieldA2Label" aria-describedby="fieldA2Msg" required="required" />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldA2"
+			name="fieldA"
+			aria-labelledby="fieldA2Label"
+			aria-describedby="fieldA2Msg"
+			required="required"
+		/>
 		<label class="radioField-label" for="fieldA2">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldA2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldA2message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
 
 	<div class="radioField">
-		<input type="radio" class="radioField-input" id="fieldB1" name="fieldB" aria-labelledby="fieldB1Label" aria-describedby="fieldB1Msg" required="required" disabled checked />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldB1"
+			name="fieldB"
+			aria-labelledby="fieldB1Label"
+			aria-describedby="fieldB1Msg"
+			required="required"
+			disabled
+			checked
+		/>
 		<label class="radioField-label" for="fieldB1">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldB1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldB1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
 
 	<div class="radioField">
-		<input type="radio" class="radioField-input" id="fieldB2" name="fieldB" aria-labelledby="fieldB2Label" aria-describedby="fieldB2Msg" disabled required="required" />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldB2"
+			name="fieldB"
+			aria-labelledby="fieldB2Label"
+			aria-describedby="fieldB2Msg"
+			disabled
+			required="required"
+		/>
 		<label class="radioField-label" for="fieldB2">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldB2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldB2message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
@@ -58,26 +106,49 @@
 	<h2>Small</h2>
 
 	<div class="radioField mod-S">
-		<input type="radio" class="radioField-input" id="fieldC1" name="fieldC" aria-labelledby="fieldC1Label" aria-describedby="fieldC1Msg" required="required" checked />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldC1"
+			name="fieldC"
+			aria-labelledby="fieldC1Label"
+			aria-describedby="fieldC1Msg"
+			required="required"
+			checked
+		/>
 		<label class="radioField-label" for="fieldC1">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldC1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldC1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
 
 	<div class="radioField mod-S">
-		<input type="radio" class="radioField-input" id="fieldC2" name="fieldC" aria-labelledby="fieldC2Label" aria-describedby="fieldC2Msg" required="required" />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldC2"
+			name="fieldC"
+			aria-labelledby="fieldC2Label"
+			aria-describedby="fieldC2Msg"
+			required="required"
+		/>
 		<label class="radioField-label" for="fieldC2">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldC2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldC2message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
@@ -86,31 +157,55 @@
 	<h2>Invalid</h2>
 
 	<div class="radioField">
-		<input type="radio" class="radioField-input" id="fieldD1" name="fieldD" aria-labelledby="fieldD1Label" aria-describedby="fieldD1Msg" required="required" aria-invalid="true" checked />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldD1"
+			name="fieldD"
+			aria-labelledby="fieldD1Label"
+			aria-describedby="fieldD1Msg"
+			required="required"
+			aria-invalid="true"
+			checked
+		/>
 		<label class="radioField-label" for="fieldD1">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldD1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldD1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
 
 	<div class="radioField">
-		<input type="radio" class="radioField-input" id="fieldD2" name="fieldD" aria-labelledby="fieldD2Label" aria-describedby="fieldD2Msg" required="required" aria-invalid="true" />
+		<input
+			type="radio"
+			class="radioField-input"
+			id="fieldD2"
+			name="fieldD"
+			aria-labelledby="fieldD2Label"
+			aria-describedby="fieldD2Msg"
+			required="required"
+			aria-invalid="true"
+		/>
 		<label class="radioField-label" for="fieldD2">
 			<span class="radioField-label-input">
 				<span class="radioField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="fieldD2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="fieldD2message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
-
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/forms/switch.stories.html
+++ b/stories/qa/forms/switch.stories.html
@@ -3,79 +3,95 @@
 
 	<h2>Basic</h2>
 	<div class="switchField">
-    <input type="checkbox"
-           class="switchField-input"
-           id="field1"
-           aria-labelledby="field1Label"
-           aria-describedby="field1Msg"
-           required="required"
-           checked="checked"
-           />
-    <label class="switchField-label" for="field1">
-      <span class="switchField-label-input">
-        <span class="switchField-label-input-icon" aria-hidden="true"></span>
-      </span>
-			<span class="formLabel" id="field1Label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		<input
+			type="checkbox"
+			class="switchField-input"
+			id="field1"
+			aria-labelledby="field1Label"
+			aria-describedby="field1Msg"
+			required="required"
+			checked="checked"
+		/>
+		<label class="switchField-label" for="field1">
+			<span class="switchField-label-input">
+				<span class="switchField-label-input-icon" aria-hidden="true"></span>
 			</span>
-    </label>
+			<span class="formLabel" id="field1Label">
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+			</span>
+		</label>
 		<div class="inlineMessage" id="field1Msg"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
-  </div>
+	</div>
 	<div class="switchField">
-		<input type="checkbox"
-					 class="switchField-input"
-					 id="field2"
-					 aria-labelledby="field2Label"
-					 aria-describedby="field2Msg"
-					 required="required"
-					 checked="checked"
-					 disabled
-					 />
+		<input
+			type="checkbox"
+			class="switchField-input"
+			id="field2"
+			aria-labelledby="field2Label"
+			aria-describedby="field2Msg"
+			required="required"
+			checked="checked"
+			disabled
+		/>
 		<label class="switchField-label" for="field2">
 			<span class="switchField-label-input">
 				<span class="switchField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="field2Label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="field2Msg"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
 	<div class="switchField mod-S">
-		<input type="checkbox"
-					 class="switchField-input"
-					 id="field3"
-					 aria-labelledby="field3Label"
-					 aria-describedby="field3Msg"
-					 required="required"
-					 checked="checked"
-					 />
+		<input
+			type="checkbox"
+			class="switchField-input"
+			id="field3"
+			aria-labelledby="field3Label"
+			aria-describedby="field3Msg"
+			required="required"
+			checked="checked"
+		/>
 		<label class="switchField-label" for="field3">
 			<span class="switchField-label-input">
 				<span class="switchField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="field3Label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="field3Msg"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
 	</div>
 	<div class="switchField">
-		<input type="checkbox"
-					 class="switchField-input"
-					 id="field4"
-					 aria-labelledby="field4Label"
-					 aria-describedby="field4Msg"
-					 aria-invalid="true"
-					 required="required"
-					 checked="checked"
-					 />
+		<input
+			type="checkbox"
+			class="switchField-input"
+			id="field4"
+			aria-labelledby="field4Label"
+			aria-describedby="field4Msg"
+			aria-invalid="true"
+			required="required"
+			checked="checked"
+		/>
 		<label class="switchField-label" for="field4">
 			<span class="switchField-label-input">
 				<span class="switchField-label-input-icon" aria-hidden="true"></span>
 			</span>
 			<span class="formLabel" id="field4Label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 		</label>
 		<div class="inlineMessage" id="field4Msg"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>

--- a/stories/qa/forms/textfield.stories.html
+++ b/stories/qa/forms/textfield.stories.html
@@ -1,36 +1,38 @@
 <section class="contentSection">
 	<h1>Text field</h1>
 	<div class="textField">
-    <input type="text" id="field1" class="textField-input" aria-labelledby="field1prefix field1label field1suffix" aria-describedby="field1message" placeholder="Placeholder" aria-invalid="false" value="Value" />
-    <label for="field1" class="textField-label">
-      <span class="textField-label-input"></span>
-      <span class="textField-label-prefix" id="field1prefix">
-        <span class="textField-label-prefix-item">$</span>
-      </span>
+		<input type="text" id="field1" class="textField-input" aria-labelledby="field1label" />
+		<label for="field1" class="textField-label">
+			<span class="textField-label-input"></span>
 			<span class="formLabel" id="field1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">Label</span>
 			</span>
-      <span class="textField-label-suffix" id="field1suffix">
-        <span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
-      </span>
-    </label>
-    <div class="textField-action">
-			<button class="clear">
-			  <span aria-hidden="true" class="lucca-icon icon-close"></span>
-				<span class="u-mask">Vider ce champ</span>
-			</button>
-    </div>
-		<div class="inlineMessage" id="field1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
-  </div>
+		</label>
+	</div>
+</section>
+<section class="contentSection">
 	<div class="textField">
-		<input type="text" id="field2" class="textField-input" aria-labelledby="field2prefix field2label field2suffix" aria-describedby="field2message" placeholder="Placeholder" aria-invalid="false" />
+		<input
+			type="text"
+			id="field2"
+			class="textField-input"
+			aria-labelledby="field2prefix field2label field2suffix"
+			aria-describedby="field2message"
+			placeholder="Placeholder"
+			aria-invalid="false"
+			aria-required="true"
+		/>
 		<label for="field2" class="textField-label">
 			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="field2prefix">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
 			<span class="formLabel" id="field2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+				<span class="formLabel-details">détails</span>
 			</span>
 			<span class="textField-label-suffix" id="field2suffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -48,14 +50,27 @@
 <section class="contentSection">
 	<h2>Sizes</h2>
 	<div class="textField mod-S">
-		<input type="text" id="fieldS" class="textField-input" aria-labelledby="fieldSprefix fieldSlabel fieldSsuffix" aria-describedby="fieldSmessage" placeholder="Placeholder" aria-invalid="false" value="Value" />
+		<input
+			type="text"
+			id="fieldS"
+			class="textField-input"
+			aria-labelledby="fieldSprefix fieldSlabel fieldSsuffix"
+			aria-describedby="fieldSmessage"
+			placeholder="Placeholder"
+			aria-invalid="false"
+			value="Value"
+		/>
 		<label for="fieldS" class="textField-label">
 			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="fieldSlabel">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
 			<span class="formLabel" id="fieldSlabel">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+				<span class="formLabel-details">détails</span>
 			</span>
 			<span class="textField-label-suffix" id="fieldSsuffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -71,14 +86,27 @@
 	</div>
 
 	<div class="textField mod-XS">
-		<input type="text" id="fieldXS" class="textField-input" aria-labelledby="fieldXSprefix fieldXSlabel fieldXSsuffix" aria-describedby="fieldXSmessage" placeholder="Placeholder" aria-invalid="false" value="Value" />
+		<input
+			type="text"
+			id="fieldXS"
+			class="textField-input"
+			aria-labelledby="fieldXSprefix fieldXSlabel fieldXSsuffix"
+			aria-describedby="fieldXSmessage"
+			placeholder="Placeholder"
+			aria-invalid="false"
+			value="Value"
+		/>
 		<label for="fieldXS" class="textField-label">
 			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="fieldXSlabel">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
 			<span class="formLabel" id="fieldXSlabel">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+				<span class="formLabel-details">détails</span>
 			</span>
 			<span class="textField-label-suffix" id="fieldXSsuffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -96,30 +124,55 @@
 <section class="contentSection">
 	<h2>Disabled</h2>
 	<div class="textField">
-    <input type="text" id="fieldDisabled1" class="textField-input" aria-labelledby="fieldDisabled1prefix fieldDisabled1label fieldDisabled1suffix" aria-describedby="fieldDisabled1message" placeholder="Placeholder" aria-invalid="false" value="Value" disabled />
-    <label for="fieldDisabled1" class="textField-label">
-      <span class="textField-label-input"></span>
-      <span class="textField-label-prefix" id="fieldDisabled1label">
-        <span class="textField-label-prefix-item">$</span>
-      </span>
-			<span class="formLabel" id="fieldDisabled1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		<input
+			type="text"
+			id="fieldDisabled1"
+			class="textField-input"
+			aria-labelledby="fieldDisabled1prefix fieldDisabled1label fieldDisabled1suffix"
+			aria-describedby="fieldDisabled1message"
+			placeholder="Placeholder"
+			aria-invalid="false"
+			value="Value"
+			disabled
+		/>
+		<label for="fieldDisabled1" class="textField-label">
+			<span class="textField-label-input"></span>
+			<span class="textField-label-prefix" id="fieldDisabled1label">
+				<span class="textField-label-prefix-item">$</span>
 			</span>
-      <span class="textField-label-suffix" id="fieldDisabled1suffix">
-        <span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
-      </span>
-    </label>
+			<span class="formLabel" id="fieldDisabled1label">
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+			</span>
+			<span class="textField-label-suffix" id="fieldDisabled1suffix">
+				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
+			</span>
+		</label>
 		<div class="inlineMessage" id="fieldDisabled1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
-  </div>
+	</div>
 	<div class="textField">
-		<input type="text" id="fieldDisabled2" class="textField-input" aria-labelledby="fieldDisabled2prefix fieldDisabled2label fieldDisabled2suffix" aria-describedby="fieldDisabled2message" placeholder="Placeholder" aria-invalid="false" disabled />
+		<input
+			type="text"
+			id="fieldDisabled2"
+			class="textField-input"
+			aria-labelledby="fieldDisabled2prefix fieldDisabled2label fieldDisabled2suffix"
+			aria-describedby="fieldDisabled2message"
+			placeholder="Placeholder"
+			aria-invalid="false"
+			disabled
+		/>
 		<label for="fieldDisabled2" class="textField-label">
 			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="fieldDisabled2label">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
 			<span class="formLabel" id="fieldDisabled2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
 			<span class="textField-label-suffix" id="fieldDisabled2suffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -131,37 +184,60 @@
 <section class="contentSection">
 	<h2>Invalid</h2>
 	<div class="textField">
-    <input type="text" id="fieldInvalid1" class="textField-input" aria-labelledby="fieldInvalid1prefix fieldInvalid1label fieldInvalid1suffix" aria-describedby="fieldInvalid1message" placeholder="Placeholder" aria-invalid="true" value="Value" />
-    <label for="fieldInvalid1" class="textField-label">
-      <span class="textField-label-input"></span>
-      <span class="textField-label-prefix" id="fieldInvalid1label">
-        <span class="textField-label-prefix-item">$</span>
-      </span>
+		<input
+			type="text"
+			id="fieldInvalid1"
+			class="textField-input"
+			aria-labelledby="fieldInvalid1prefix fieldInvalid1label fieldInvalid1suffix"
+			aria-describedby="fieldInvalid1message"
+			placeholder="Placeholder"
+			aria-invalid="true"
+			value="Value"
+		/>
+		<label for="fieldInvalid1" class="textField-label">
+			<span class="textField-label-input"></span>
+			<span class="textField-label-prefix" id="fieldInvalid1label">
+				<span class="textField-label-prefix-item">$</span>
+			</span>
 			<span class="formLabel" id="fieldInvalid1label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
 			</span>
-      <span class="textField-label-suffix" id="fieldInvalid1suffix">
-        <span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
-      </span>
-    </label>
+			<span class="textField-label-suffix" id="fieldInvalid1suffix">
+				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
+			</span>
+		</label>
 		<div class="inlineMessage" id="fieldInvalid1message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
-  </div>
+	</div>
 	<div class="textField">
-    <input type="text" id="fieldInvalid2" class="textField-input" aria-labelledby="fieldInvalid2prefix fieldInvalid2label fieldInvalid2suffix" aria-describedby="fieldInvalid2message" placeholder="Placeholder" aria-invalid="true" />
-    <label for="fieldInvalid2" class="textField-label">
-      <span class="textField-label-input"></span>
-      <span class="textField-label-prefix" id="fieldInvalid2label">
-        <span class="textField-label-prefix-item">$</span>
-      </span>
-			<span class="formLabel" id="fieldInvalid2label">
-				Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+		<input
+			type="text"
+			id="fieldInvalid2"
+			class="textField-input"
+			aria-labelledby="fieldInvalid2prefix fieldInvalid2label fieldInvalid2suffix"
+			aria-describedby="fieldInvalid2message"
+			placeholder="Placeholder"
+			aria-invalid="true"
+		/>
+		<label for="fieldInvalid2" class="textField-label">
+			<span class="textField-label-input"></span>
+			<span class="textField-label-prefix" id="fieldInvalid2label">
+				<span class="textField-label-prefix-item">$</span>
 			</span>
-      <span class="textField-label-suffix" id="fieldInvalid2suffix">
-        <span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
-      </span>
-    </label>
+			<span class="formLabel" id="fieldInvalid2label">
+				<span class="formLabel-content">
+					Label<sup class="formLabel-required" aria-hidden="true">*</sup
+					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
+				</span>
+			</span>
+			<span class="textField-label-suffix" id="fieldInvalid2suffix">
+				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
+			</span>
+		</label>
 		<div class="inlineMessage" id="fieldInvalid2message"><span aria-hidden="true" class="lucca-icon"></span>Helper text</div>
-  </div>
+	</div>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/forms/textfield.stories.html
+++ b/stories/qa/forms/textfield.stories.html
@@ -32,7 +32,10 @@
 					Label<sup class="formLabel-required" aria-hidden="true">*</sup
 					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
 				</span>
-				<span class="formLabel-details">détails</span>
+				<span class="formLabel-counter">
+					<span class="formLabel-counter-display" aria-hidden="true">0/20</span>
+					<span class="formLabel-counter-alternative"> Le texte fait 0 caractère de long. 20 caractères sont autorisés. </span>
+				</span>
 			</span>
 			<span class="textField-label-suffix" id="field2suffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -70,7 +73,10 @@
 					Label<sup class="formLabel-required" aria-hidden="true">*</sup
 					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
 				</span>
-				<span class="formLabel-details">détails</span>
+				<span class="formLabel-counter">
+					<span class="formLabel-counter-display" aria-hidden="true">0/20</span>
+					<span class="formLabel-counter-alternative"> Le texte fait 0 caractère de long. 20 caractères sont autorisés. </span>
+				</span>
 			</span>
 			<span class="textField-label-suffix" id="fieldSsuffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>
@@ -106,7 +112,10 @@
 					Label<sup class="formLabel-required" aria-hidden="true">*</sup
 					><span aria-hidden="true" class="lucca-icon icon-helpOutline"></span>
 				</span>
-				<span class="formLabel-details">détails</span>
+				<span class="formLabel-counter">
+					<span class="formLabel-counter-display" aria-hidden="true">0/20</span>
+					<span class="formLabel-counter-alternative"> Le texte fait 0 caractère de long. 20 caractères sont autorisés. </span>
+				</span>
 			</span>
 			<span class="textField-label-suffix" id="fieldXSsuffix">
 				<span class="textField-label-suffix-item" aria-label="euros par jour">€/j</span>


### PR DESCRIPTION
## Description

On ajoute la possibilité d’afficher des informations en haut à droite des champs textes. Ça servira pour les compteur de caractères, mais ça peut aussi servir pour d’autres choses.

-----

Le message ajouté fait alors partie de l’intitulé du champ.

-----

![Capture d’écran 2023-08-25 à 10 15 32](https://github.com/LuccaSA/lucca-front/assets/64789527/0e795760-9043-4986-a3af-90b8e8050127)

