### PR TITLE
16.3 fixes

### DIFF
--- a/packages/ng/new-badge/new-badge.component.scss
+++ b/packages/ng/new-badge/new-badge.component.scss
@@ -1,1 +1,5 @@
 @use '@lucca-front/scss/src/components/newBadge';
+
+:host {
+  display: inline-flex;
+}

--- a/packages/ng/numeric-badge/numeric-badge/numeric-badge.component.scss
+++ b/packages/ng/numeric-badge/numeric-badge/numeric-badge.component.scss
@@ -1,1 +1,5 @@
 @use "@lucca-front/scss/src/components/numericBadge";
+
+:host {
+  display: inline-flex;
+}

--- a/packages/scss/src/components/callout/component.scss
+++ b/packages/scss/src/components/callout/component.scss
@@ -51,6 +51,10 @@
 			transition-property: background-color;
 			width: auto;
 
+			&:focus-visible {
+				@include a11y.focusVisible($borderRadius: var(--commons-borderRadius-M));
+			}
+
 			&::before {
 				@include icon.generate('cross');
 				font-size: var(--sizes-S-lineHeight);

--- a/packages/scss/src/components/field/vars.scss
+++ b/packages/scss/src/components/field/vars.scss
@@ -6,7 +6,7 @@
 	--components-field-label-color: var(--palettes-grey-800);
 	--components-field-label-margin-bottom: var(--spacings-XXS);
 	--components-field-message-font-size: var(--sizes-XS-fontSize);
-	--components-field-message-margin-top: 0.35rem;
+	--components-field-message-margin-top: var(--spacings-XXS);
 
 	--components-field-sizes-default: 13rem;
 

--- a/packages/scss/src/components/textfield/component.scss
+++ b/packages/scss/src/components/textfield/component.scss
@@ -59,7 +59,7 @@
 
 		.textField-label-input {
 		  grid-column: 1 / span 4;
-		  border: 1px solid var(--component-textField-input-border);
+		  box-shadow: 0 0 0 1px var(--component-textField-input-border);
 		  grid-row: 2;
 		  pointer-events: none;
 		  border-radius: calc(var(--commons-borderRadius-M) + 1px);

--- a/packages/scss/src/components/textfield/component.scss
+++ b/packages/scss/src/components/textfield/component.scss
@@ -120,7 +120,7 @@
 		  &:focus-visible {
 		    ~ .textField-label {
 		      .textField-label-input {
-		        @include a11y.focusVisible;
+		        @include a11y.focusVisible($offset: 3px);
 		      }
 		    }
 		  }

--- a/packages/scss/src/components/textfield/component.scss
+++ b/packages/scss/src/components/textfield/component.scss
@@ -8,6 +8,18 @@
 	font-size: var(--component-textField-label-fontSize);
 	line-height: var(--component-textField-label-lineHeight);
 
+	.formLabel {
+		@include formLabel.label;
+		grid-column-start: 1;
+		grid-column-end: -1;
+		grid-row: 1;
+	}
+
+	.inlineMessage {
+		grid-column-start: 1;
+		grid-column-end: -1;
+	}
+
 	@at-root ($atRoot) {
 		.textField-label {
 		  display: contents;
@@ -112,18 +124,6 @@
 		      }
 		    }
 		  }
-		}
-
-		.formLabel {
-			@include formLabel.label;
-			grid-column-start: 1;
-			grid-column-end: -1;
-			grid-row: 1;
-		}
-
-		.inlineMessage {
-			grid-column-start: 1;
-			grid-column-end: -1;
 		}
 	}
 }

--- a/packages/scss/src/components/textfields/mods.scss
+++ b/packages/scss/src/components/textfields/mods.scss
@@ -31,10 +31,37 @@
 		bottom: .75rem;
 		right: var(--spacings-XS);
 	}
+
+	.textfield-actionClear { // deprecated
+		text-align: center;
+		position: absolute;
+		bottom: .75rem;
+		right: var(--spacings-XS);
+		width: 1rem;
+		height: 1rem;
+		padding: 0;
+		line-height: 0;
+		background-color: var(--palettes-grey-700);
+		border-radius: 50%;
+
+		.lucca-icon {
+			font-size: var(--sizes-XS-lineHeight);
+			color: white;
+		}
+
+		&:hover {
+			background-color: var(--palettes-grey-600) !important;
+		}
+	}
 }
 
 @mixin clearableS {
 	.textfield-clear {
+		bottom: var(--spacings-XXS);
+		right: var(--spacings-XXS);
+	}
+
+	.textfield-actionClear { // deprecated
 		bottom: var(--spacings-XXS);
 		right: var(--spacings-XXS);
 	}
@@ -45,11 +72,26 @@
 		bottom: var(--spacings-XXS);
 		right: var(--spacings-XXS);
 	}
+
+	.textfield-actionClear { // deprecated
+		bottom: var(--spacings-XXS);
+		right: var(--spacings-XXS);
+		height: 1rem;
+		width: 1rem;
+
+		.lucca-icon {
+			font-size: 1rem;
+		}
+	}
 }
 
 @mixin suffix {
 	.textfield-input {
 		padding-right: var(--components-textfield-suffix-padding-right);
+	}
+
+	.textfield-actionClear { // deprecated
+		right: 2rem;
 	}
 }
 
@@ -189,6 +231,10 @@
 			}
 		}
 	}
+
+	.textfield-actionClear { // deprecated
+		right: 2.5rem;
+	}
 }
 
 @mixin searchClearable {
@@ -199,6 +245,10 @@
 	.textfield-clear {
 		right: 2.5rem;
 	}
+
+	.textfield-actionClear { // deprecated
+		right: 2.5rem;
+	}
 }
 
 @mixin searchS {
@@ -207,6 +257,17 @@
 		font-size: var(--sizes-S-lineHeight);
 		bottom: .375rem;
 		right: .375rem;
+	}
+
+	.textfield-actionClear { // deprecated
+		right: 2.125rem;
+		bottom: .625rem;
+		width: .75rem;
+		height: .75rem;
+
+		.lucca-icon {
+			font-size: .75rem;
+		}
 	}
 }
 
@@ -222,6 +283,11 @@
 		right: 2.125rem;
 		bottom: .625rem;
 	}
+
+	.textfield-actionClear { // deprecated
+		right: 2.125rem;
+		bottom: .625rem;
+	}
 }
 
 @mixin searchXS {
@@ -230,6 +296,17 @@
 		font-size: var(--sizes-XS-lineHeight);
 		bottom: var(--spacings-XXS);
 		right: var(--spacings-XXS);
+	}
+
+	.textfield-actionClear { // deprecated
+		right: 1.75rem;
+		bottom: .375rem;
+		width: .75rem;
+		height: .75rem;
+
+		.lucca-icon {
+			font-size: .75rem;
+		}
 	}
 }
 
@@ -244,6 +321,17 @@
 
 		right: 1.75rem;
 		bottom: .375rem;
+	}
+
+	.textfield-actionClear { // deprecated
+		right: 1.75rem;
+		bottom: .375rem;
+		width: .75rem;
+		height: .75rem;
+
+		.lucca-icon {
+			font-size: .75rem;
+		}
 	}
 }
 

--- a/packages/scss/src/components/textfields/states.scss
+++ b/packages/scss/src/components/textfields/states.scss
@@ -23,6 +23,11 @@
 		color: var(--palettes-grey-500) !important;
 		pointer-events: none;
 	}
+
+	~ .textfield-actionClear { // deprecated
+		color: var(--palettes-grey-500) !important;
+		pointer-events: none;
+	}
 }
 
 @mixin filterHover {

--- a/packages/scss/src/components/timeline/mods.scss
+++ b/packages/scss/src/components/timeline/mods.scss
@@ -73,6 +73,10 @@
 		margin: var(--spacings-XS) 0;
 		min-height: var(--spacings-M);
 		min-width: 0;
+
+		&:before {
+			top: .75rem;
+		}
 	}
 
 	.timeline-step-description {

--- a/stories/documentation/forms/textfield/textfield-basic.stories.ts
+++ b/stories/documentation/forms/textfield/textfield-basic.stories.ts
@@ -88,7 +88,7 @@ function getTemplate(args: TextfieldBasicStory): string {
 		<input type="text" id="${id}" class="textField-input" aria-labelledby="${id}prefix ${id}label ${id}suffix" aria-describedby="${id}message" placeholder="Placeholder" aria-invalid="false" value="Value" ${disabled} ${required} ${invalid} />
 		<label for="${id}" class="textField-label">
 			<div class="textField-label-input"></div>
-			<span class="textField-label-prefix" id="${id}label">
+			<span class="textField-label-prefix" id="${id}prefix">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
 			<span class="formLabel" id="${id}label">

--- a/stories/documentation/forms/textfield/textfield-basic.stories.ts
+++ b/stories/documentation/forms/textfield/textfield-basic.stories.ts
@@ -87,7 +87,7 @@ function getTemplate(args: TextfieldBasicStory): string {
 	<div class="textField ${size}">
 		<input type="text" id="${id}" class="textField-input" aria-labelledby="${id}prefix ${id}label ${id}suffix" aria-describedby="${id}message" placeholder="Placeholder" aria-invalid="false" value="Value" ${disabled} ${required} ${invalid} />
 		<label for="${id}" class="textField-label">
-			<div class="textField-label-input"></div>
+			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="${id}prefix">
 				<span class="textField-label-prefix-item">$</span>
 			</span>

--- a/stories/qa/forms/textfield-legacy.stories.html
+++ b/stories/qa/forms/textfield-legacy.stories.html
@@ -502,6 +502,32 @@
 					<span class="u-mask">Clear</span>
 				</a>
 			</label>
+
+			<h3>Legacy clearer</h3>
+			<label class="textfield mod-block mod-search mod-clearable">
+			  <input class="textfield-input" type="text" placeholder="Placeholder" />
+			  <span class="textfield-label">Label</span>
+			  <a role="button" href="#" class="actionIcon textfield-actionClear">
+			    <span aria-hidden="true" class="lucca-icon icon-thinCross"></span>
+			    <span class="u-mask">Clear</span>
+			  </a>
+			</label>
+			<label class="textfield mod-block mod-search mod-clearable mod-S">
+			  <input class="textfield-input" type="text" placeholder="Placeholder" />
+			  <span class="textfield-label">Label</span>
+			  <a role="button" href="#" class="actionIcon textfield-actionClear">
+			    <span aria-hidden="true" class="lucca-icon icon-thinCross"></span>
+			    <span class="u-mask">Clear</span>
+			  </a>
+			</label>
+			<label class="textfield mod-block mod-search mod-clearable mod-XS">
+			  <input class="textfield-input" type="text" placeholder="Placeholder" />
+			  <span class="textfield-label">Label</span>
+			  <a role="button" href="#" class="actionIcon textfield-actionClear">
+			    <span aria-hidden="true" class="lucca-icon icon-thinCross"></span>
+			    <span class="u-mask">Clear</span>
+			  </a>
+			</label>
 		</div>
 	</div>
 	<div class="grid u-marginBottomS">

--- a/stories/qa/forms/textfield.stories.html
+++ b/stories/qa/forms/textfield.stories.html
@@ -4,7 +4,7 @@
     <input type="text" id="field1" class="textField-input" aria-labelledby="field1prefix field1label field1suffix" aria-describedby="field1message" placeholder="Placeholder" aria-invalid="false" value="Value" />
     <label for="field1" class="textField-label">
       <div class="textField-label-input"></div>
-      <span class="textField-label-prefix" id="field1label">
+      <span class="textField-label-prefix" id="field1prefix">
         <span class="textField-label-prefix-item">$</span>
       </span>
 			<span class="formLabel" id="field1label">
@@ -26,7 +26,7 @@
 		<input type="text" id="field2" class="textField-input" aria-labelledby="field2prefix field2label field2suffix" aria-describedby="field2message" placeholder="Placeholder" aria-invalid="false" />
 		<label for="field2" class="textField-label">
 			<div class="textField-label-input"></div>
-			<span class="textField-label-prefix" id="field2label">
+			<span class="textField-label-prefix" id="field2prefix">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
 			<span class="formLabel" id="field2label">

--- a/stories/qa/forms/textfield.stories.html
+++ b/stories/qa/forms/textfield.stories.html
@@ -3,7 +3,7 @@
 	<div class="textField">
     <input type="text" id="field1" class="textField-input" aria-labelledby="field1prefix field1label field1suffix" aria-describedby="field1message" placeholder="Placeholder" aria-invalid="false" value="Value" />
     <label for="field1" class="textField-label">
-      <div class="textField-label-input"></div>
+      <span class="textField-label-input"></span>
       <span class="textField-label-prefix" id="field1prefix">
         <span class="textField-label-prefix-item">$</span>
       </span>
@@ -25,7 +25,7 @@
 	<div class="textField">
 		<input type="text" id="field2" class="textField-input" aria-labelledby="field2prefix field2label field2suffix" aria-describedby="field2message" placeholder="Placeholder" aria-invalid="false" />
 		<label for="field2" class="textField-label">
-			<div class="textField-label-input"></div>
+			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="field2prefix">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
@@ -50,7 +50,7 @@
 	<div class="textField mod-S">
 		<input type="text" id="fieldS" class="textField-input" aria-labelledby="fieldSprefix fieldSlabel fieldSsuffix" aria-describedby="fieldSmessage" placeholder="Placeholder" aria-invalid="false" value="Value" />
 		<label for="fieldS" class="textField-label">
-			<div class="textField-label-input"></div>
+			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="fieldSlabel">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
@@ -73,7 +73,7 @@
 	<div class="textField mod-XS">
 		<input type="text" id="fieldXS" class="textField-input" aria-labelledby="fieldXSprefix fieldXSlabel fieldXSsuffix" aria-describedby="fieldXSmessage" placeholder="Placeholder" aria-invalid="false" value="Value" />
 		<label for="fieldXS" class="textField-label">
-			<div class="textField-label-input"></div>
+			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="fieldXSlabel">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
@@ -98,7 +98,7 @@
 	<div class="textField">
     <input type="text" id="fieldDisabled1" class="textField-input" aria-labelledby="fieldDisabled1prefix fieldDisabled1label fieldDisabled1suffix" aria-describedby="fieldDisabled1message" placeholder="Placeholder" aria-invalid="false" value="Value" disabled />
     <label for="fieldDisabled1" class="textField-label">
-      <div class="textField-label-input"></div>
+      <span class="textField-label-input"></span>
       <span class="textField-label-prefix" id="fieldDisabled1label">
         <span class="textField-label-prefix-item">$</span>
       </span>
@@ -114,7 +114,7 @@
 	<div class="textField">
 		<input type="text" id="fieldDisabled2" class="textField-input" aria-labelledby="fieldDisabled2prefix fieldDisabled2label fieldDisabled2suffix" aria-describedby="fieldDisabled2message" placeholder="Placeholder" aria-invalid="false" disabled />
 		<label for="fieldDisabled2" class="textField-label">
-			<div class="textField-label-input"></div>
+			<span class="textField-label-input"></span>
 			<span class="textField-label-prefix" id="fieldDisabled2label">
 				<span class="textField-label-prefix-item">$</span>
 			</span>
@@ -133,7 +133,7 @@
 	<div class="textField">
     <input type="text" id="fieldInvalid1" class="textField-input" aria-labelledby="fieldInvalid1prefix fieldInvalid1label fieldInvalid1suffix" aria-describedby="fieldInvalid1message" placeholder="Placeholder" aria-invalid="true" value="Value" />
     <label for="fieldInvalid1" class="textField-label">
-      <div class="textField-label-input"></div>
+      <span class="textField-label-input"></span>
       <span class="textField-label-prefix" id="fieldInvalid1label">
         <span class="textField-label-prefix-item">$</span>
       </span>
@@ -149,7 +149,7 @@
 	<div class="textField">
     <input type="text" id="fieldInvalid2" class="textField-input" aria-labelledby="fieldInvalid2prefix fieldInvalid2label fieldInvalid2suffix" aria-describedby="fieldInvalid2message" placeholder="Placeholder" aria-invalid="true" />
     <label for="fieldInvalid2" class="textField-label">
-      <div class="textField-label-input"></div>
+      <span class="textField-label-input"></span>
       <span class="textField-label-prefix" id="fieldInvalid2label">
         <span class="textField-label-prefix-item">$</span>
       </span>


### PR DESCRIPTION
## Description

- Fix vertical timeline dot position
- Fix new textfield prefix ID
- Replace textfield borders by boxshadow to fit with DS & legacy components & fix focus offset
- `.textfield-label-input` as `span` 
- Fix legacy textfield messages margin
- Wrap _formLabel_ & _inlineMessage_ override inside `.textfield`
- Fix callout clear focus style
- Revert deprecated classes for legacy textfields with clearer
- Fix wrapped _newBadge_ & _numericBadge_ height

-----