### PR TITLE
fix(callout): title => heading renaming, hidden now a two way binding

### DIFF
--- a/packages/ng/callout/callout.component.html
+++ b/packages/ng/callout/callout.component.html
@@ -3,7 +3,7 @@
 		<span aria-hidden="true" class="lucca-icon icon-{{icon}}"></span>
 	</div>
 	<div class="callout-content">
-		<strong class="callout-content-title" *ngIf="title">{{title}}</strong>
+		<strong class="callout-content-title" *ngIf="heading">{{heading}}</strong>
 		<div class="callout-content-description">
 			<ng-content></ng-content>
 		</div>

--- a/packages/ng/callout/callout.component.html
+++ b/packages/ng/callout/callout.component.html
@@ -1,4 +1,4 @@
-<div class="callout palette-{{palette}} mod-{{size}}" [class.mod-tiny]="tiny">
+<div class="callout palette-{{palette}} mod-{{size}}" [class.mod-tiny]="tiny" *ngIf="!hidden">
 	<div class="callout-icon" *ngIf="icon">
 		<span aria-hidden="true" class="lucca-icon icon-{{icon}}"></span>
 	</div>
@@ -8,7 +8,7 @@
 			<ng-content></ng-content>
 		</div>
 	</div>
-	<button *ngIf="removable" type="button" class="callout-kill" (click)="hide()">
+	<button *ngIf="removable" type="button" class="callout-kill" (click)="hidden = true; hiddenChange.emit(true)">
 		<span class="u-mask">{{ intl.close }}</span>
 	</button>
 </div>

--- a/packages/ng/callout/callout.component.ts
+++ b/packages/ng/callout/callout.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { getIntl, Palette } from '@lucca-front/ng/core';
 import { LU_CALLOUT_TRANSLATIONS } from './callout.translate';
@@ -57,19 +57,15 @@ export class CalloutComponent {
 	 */
 	tiny: boolean;
 
-	@Output()
+	@Input({ transform: booleanAttribute })
 	/**
-	 * Emits void when the callout's close button is clicked.
+	 * Is the callout hidden? Works with two way binding too.
 	 *
 	 */
-	hidden: EventEmitter<void> = new EventEmitter<void>();
+	hidden = false;
+
+	@Output()
+	hiddenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
 	public intl = getIntl(LU_CALLOUT_TRANSLATIONS);
-
-	/**
-	 * Emits the hidden event for the consumer to hide the callout.
-	 */
-	hide(): void {
-		this.hidden.emit();
-	}
 }

--- a/packages/ng/callout/callout.component.ts
+++ b/packages/ng/callout/callout.component.ts
@@ -16,7 +16,7 @@ export class CalloutComponent {
 	/**
 	 * The title of the callout
 	 */
-	title: string;
+	heading: string;
 
 	@Input()
 	/**

--- a/stories/documentation/feedback/callout/callout-basic.stories.ts
+++ b/stories/documentation/feedback/callout/callout-basic.stories.ts
@@ -6,10 +6,10 @@ export default {
 	title: 'Documentation/Feedback/Callout/Basic',
 	component: CalloutComponent,
 	render: (args: CalloutComponent & { description: string }) => {
-		const { description, title, palette, size, removable, tiny, icon } = args;
+		const { description, heading, palette, size, removable, tiny, icon } = args;
 		return {
 			template: `
-        <lu-callout title="${title}" palette="${palette}" size="${size}" [removable]="${removable}" [tiny]="${tiny}" icon="${icon}">
+        <lu-callout heading="${heading}" palette="${palette}" size="${size}" [removable]="${removable}" [tiny]="${tiny}" icon="${icon}">
           ${description}
         </lu-callout>
       `,
@@ -40,7 +40,7 @@ export default {
 
 export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	args: {
-		title: 'Feedback or informations',
+		heading: 'Feedback or informations',
 		tiny: false,
 		icon: 'info',
 		palette: 'none',

--- a/stories/documentation/feedback/callout/callout-icons.stories.ts
+++ b/stories/documentation/feedback/callout/callout-icons.stories.ts
@@ -10,7 +10,7 @@ export default {
 
 export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	args: {
-		title: 'Feedback or informations',
+		heading: 'Feedback or informations',
 		tiny: false,
 		icon: 'info',
 		palette: 'none',
@@ -21,7 +21,7 @@ export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	argTypes: {
 		description: HiddenArgType,
 		tiny: HiddenArgType,
-		title: HiddenArgType,
+		heading: HiddenArgType,
 		size: HiddenArgType,
 		removable: HiddenArgType,
 		palette: HiddenArgType,

--- a/stories/documentation/feedback/callout/callout-killable.stories.ts
+++ b/stories/documentation/feedback/callout/callout-killable.stories.ts
@@ -10,7 +10,7 @@ export default {
 
 export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	args: {
-		title: 'Feedback or informations',
+		heading: 'Feedback or informations',
 		tiny: false,
 		icon: 'info',
 		palette: 'none',
@@ -21,7 +21,7 @@ export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	argTypes: {
 		description: HiddenArgType,
 		tiny: HiddenArgType,
-		title: HiddenArgType,
+		heading: HiddenArgType,
 		size: HiddenArgType,
 		icon: HiddenArgType,
 		palette: HiddenArgType,

--- a/stories/documentation/feedback/callout/callout-tiny.stories.ts
+++ b/stories/documentation/feedback/callout/callout-tiny.stories.ts
@@ -10,7 +10,7 @@ export default {
 
 export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	args: {
-		title: '',
+		heading: '',
 		tiny: true,
 		icon: 'info',
 		palette: 'none',
@@ -21,7 +21,7 @@ export const Template: StoryObj<CalloutComponent & { description: string }> = {
 	argTypes: {
 		description: HiddenArgType,
 		removable: HiddenArgType,
-		title: HiddenArgType,
+		heading: HiddenArgType,
 		size: HiddenArgType,
 		icon: HiddenArgType,
 		palette: HiddenArgType,


### PR DESCRIPTION
## Description

`title` input has been renamed to `heading` to avoid DX issues with title also being an html attribute (even tho it'd be bound using `attr.title`, it can easily create confusion among devs).

This PR also changes `hidden` for a two-way binding, meaning that clicking the hide icon now closes the callout, and then sends the updated value on a `hiddenChange` event emitter, making it possible to bind hidden using `[(hidden)]="mybool"`.

-----
