### PR TITLE
fix(callout): rename `hidden` input to `removed` to avoid HTML attribute conflicts

### DIFF
--- a/packages/ng/callout/callout.component.html
+++ b/packages/ng/callout/callout.component.html
@@ -1,4 +1,4 @@
-<div class="callout palette-{{palette}} mod-{{size}}" [class.mod-tiny]="tiny" *ngIf="!hidden">
+<div class="callout palette-{{palette}} mod-{{size}}" [class.mod-tiny]="tiny" *ngIf="!removed">
 	<div class="callout-icon" *ngIf="icon">
 		<span aria-hidden="true" class="lucca-icon icon-{{icon}}"></span>
 	</div>
@@ -8,7 +8,7 @@
 			<ng-content></ng-content>
 		</div>
 	</div>
-	<button *ngIf="removable" type="button" class="callout-kill" (click)="hidden = true; hiddenChange.emit(true)">
+	<button *ngIf="removable" type="button" class="callout-kill" (click)="removed = true; removedChange.emit(true)">
 		<span class="u-mask">{{ intl.close }}</span>
 	</button>
 </div>

--- a/packages/ng/callout/callout.component.ts
+++ b/packages/ng/callout/callout.component.ts
@@ -59,13 +59,13 @@ export class CalloutComponent {
 
 	@Input({ transform: booleanAttribute })
 	/**
-	 * Is the callout hidden? Works with two way binding too.
+	 * Is the callout removed? Works with two way binding too.
 	 *
 	 */
-	hidden = false;
+	removed = false;
 
 	@Output()
-	hiddenChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+	removedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
 
 	public intl = getIntl(LU_CALLOUT_TRANSLATIONS);
 }


### PR DESCRIPTION
## Description

Everything is in the title, pretty much, this is a small one.

-----
