### PR TITLE
[Button] Fix disabled + outlined + palette style

### DIFF
--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -16,7 +16,7 @@
 
 @mixin disabledOutlined {
 	background-color: var(--colors-white-color);
-	box-shadow: inset 0 0 0 1px var(--palettes-400, var(--palettes-grey-400));
+	box-shadow: inset 0 0 0 1px var(--palettes-grey-400);
 	color: var(--palettes-grey-500);
 	cursor: default;
 }


### PR DESCRIPTION
## Description

Fix disabled + outlined + palette style

-----

Before
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/8b8196c7-859d-467f-934e-839cba3d8d30)

After
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/242d97ea-16f2-4d55-80b5-0ef53f4fb723)


-----
