### PR TITLE
Move scrollbar-gutter from body to html

### DIFF
--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -63,6 +63,7 @@
 
 		html {
 			height: -webkit-fill-available;
+			scrollbar-gutter: stable;
 		}
 
 		body {
@@ -71,7 +72,6 @@
 			font-family: var(--commons-font-family);
 			font-size: var(--sizes-M-fontSize);
 			line-height: var(--sizes-M-lineHeight);
-			scrollbar-gutter: stable;
 
 			@supports (-webkit-touch-callout: none) {
 				min-height: -webkit-fill-available;


### PR DESCRIPTION
## Description

After [some tests](https://codepen.io/vincent-valentin/pen/YzdaZgX/fe0e7858936497970a169d9f0da63424), I noticed that you have to put the property on the `html` for a working behaviour. 

-----

Reminder: This avoids seeing the layout move depending on whether or not the content overflows from the viewport, better for performance and ux.

-----
