### PR TITLE
Status badge font weight

### DIFF
--- a/packages/scss/src/components/statusBadge/component.scss
+++ b/packages/scss/src/components/statusBadge/component.scss
@@ -8,6 +8,7 @@
 	line-height: var(--components-statusBadge-lineHeight);
 	padding: calc(var(--spacings-XXS) / 2) var(--spacings-XS) calc(var(--spacings-XXS) / 2) .375rem;
 	white-space: nowrap;
+	font-weight: normal;
 
 	&::before {
 		background-color: var(--palettes-700, var(--palettes-primary-700));


### PR DESCRIPTION
## Description

We set the font to normal to avoid inheriting any bolding.

-----


-----
