### PR TITLE
chore(ci): use linux node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ node(label: CI.getSelectedLinuxNode(script:this)) {
 			}
 
 			loggableStage('e2e', !shouldDeploy) {
-				publishE2e(loggableStageName: 'e2e', slnFilepath: 'e2e\\LuccaFront.e2e.sln', framework: "net6.0")
+				publishE2e(loggableStageName: 'e2e', slnFilepath: 'e2e/LuccaFront.e2e.sln', framework: "net6.0")
 				archiveElements(e2e: true)
 			}
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,13 +1,11 @@
-@Library('Lucca@v0.62.0') _
+@Library('Lucca@v0.63.6') _
 
 import hudson.Util
 import fr.lucca.CI
 
 ciBuildProperties script:this
 
-node(label: CI.getSelectedNode(script:this)) {
-	notifyStartStats()
-
+node(label: CI.getSelectedLinuxNode(script:this)) {
 	def projectTechnicalName = 'lucca-front'
 	def repoName = "lucca-front"
 
@@ -24,80 +22,66 @@ node(label: CI.getSelectedNode(script:this)) {
 
 	try {
 		timeout(time: 10, unit: 'MINUTES') {
-			loggableStage('Cleanup') {
-				// storybook static
-				if (fileExists('storybook')) {
-					dir('storybook') {
-						deleteDir()
-					}
-				}
-			}
-
 			loggableStage('Checkout') {
 				scmVars = checkout scm
 			}
 
-			loggableStage('Restore') {
-				npmCi()
-			}
+			npmCi()
 
-			if (!isPR) {
-				loggableStage('Qualif') {
-					// it must be buildable
-					bat "npm run build"
-					// it must break no test
-					bat "npm run jenkins-test"
-					// it must be lint compliant
-					bat "npm run lint"
+			npmScript(script: 'build')
+			npmScript(script: 'jenkins-test', skip: isPR)
+			npmScript(script: 'lint', skip: isPR)
+
+			def shouldDeploy = isPR || isRc || isMaster;
+
+			loggableStage('Deploy', !shouldDeploy) {
+				echo "deploying ${branchName}"
+				npmScript(script: 'build-storybook')
+				npmScript(script: 'build-compodoc')
+
+				// FIXME Deploy with windows node for now
+				stash(name: "storybook-static", includes: "storybook-static/**")
+				stash(name: "compodoc-static", includes: "compodoc-static/**")
+				node("windows") {
+					unstash(name: "storybook-static")
+					powershell "Remove-Item \\\\RBX1-SH1-TECH\\lucca-front\\${env.BRANCH_NAME}\\storybook -Recurse"
+					powershell "Copy-Item storybook-static \\\\RBX1-SH1-TECH\\lucca-front\\${env.BRANCH_NAME}\\storybook -Recurse"
+					unstash(name: "compodoc-static")
+					powershell "Remove-Item \\\\RBX1-SH1-TECH\\lucca-front\\${env.BRANCH_NAME}\\compodoc -Recurse"
+					powershell "Copy-Item compodoc-static \\\\RBX1-SH1-TECH\\lucca-front\\${env.BRANCH_NAME}\\compodoc -Recurse"
 				}
 			}
 
-			if (isPR || isRc || isMaster) {
-				loggableStage('Deploy') {
-					echo "deploying ${branchName}"
-					bat "npm run build-storybook"
-					bat "npm run build-compodoc"
-					powershell "Remove-Item \\\\RBX1-SH1-TECH\\lucca-front\\${branchName}\\storybook -Recurse"
-					powershell "Remove-Item \\\\RBX1-SH1-TECH\\lucca-front\\${branchName}\\compodoc -Recurse"
-					powershell "Copy-Item storybook-static \\\\RBX1-SH1-TECH\\lucca-front\\${branchName}\\storybook -Recurse"
-					powershell "Copy-Item compodoc-static \\\\RBX1-SH1-TECH\\lucca-front\\${branchName}\\compodoc -Recurse"
-				}
-
-				loggableStage('e2e') {
-					publishE2e(loggableStageName: 'e2e', slnFilepath: 'e2e\\LuccaFront.e2e.sln', framework: "net6.0")
-            		archiveElements(e2e: true)
-				}
-
-				commentOnPR(
-						credentialsId: 'ux-comment-token',
-						body: ":woman_cook: https://lucca-front.lucca.tech/${branchName}/storybook",
-						repoName: projectTechnicalName,
-						skip: !isPR
-				)
+			loggableStage('e2e', !shouldDeploy) {
+				publishE2e(loggableStageName: 'e2e', slnFilepath: 'e2e\\LuccaFront.e2e.sln', framework: "net6.0")
+				archiveElements(e2e: true)
 			}
 
-			if (!isPR) {
-				loggableStage('Publish') {
-					def version = env.BRANCH_NAME
+			commentOnPR(
+				credentialsId: 'ux-comment-token',
+				body: ":woman_cook: https://lucca-front.lucca.tech/${branchName}/storybook",
+				repoName: projectTechnicalName,
+				skip: !isPR
+			)
 
-					def iconsPackageJson = readFile(file: 'dist/icons/package.json');
-					def scssPackageJson = readFile(file: 'dist/scss/package.json');
-					def ngPackageJson = readFile(file: 'dist/ng/package.json');
+			loggableStage('Publish', isPR) {
+				def version = env.BRANCH_NAME
 
-					writeFile(file: 'dist/icons/package.json', text: iconsPackageJson.replaceAll('"\\*"', "\"${version}\""));
-					writeFile(file: 'dist/scss/package.json', text: scssPackageJson.replaceAll('"\\*"', "\"${version}\""));
-					writeFile(file: 'dist/ng/package.json', text: ngPackageJson.replaceAll('"\\*"', "\"${version}\""));
+				def iconsPackageJson = readFile(file: 'dist/icons/package.json');
+				def scssPackageJson = readFile(file: 'dist/scss/package.json');
+				def ngPackageJson = readFile(file: 'dist/ng/package.json');
 
-					publishNpmOnReleaseTag(publishFolder: 'dist/icons')
-					publishNpmOnReleaseTag(publishFolder: 'dist/scss')
-					publishNpmOnReleaseTag(publishFolder: 'dist/ng')
-				}
+				writeFile(file: 'dist/icons/package.json', text: iconsPackageJson.replaceAll('"\\*"', "\"${version}\""));
+				writeFile(file: 'dist/scss/package.json', text: scssPackageJson.replaceAll('"\\*"', "\"${version}\""));
+				writeFile(file: 'dist/ng/package.json', text: ngPackageJson.replaceAll('"\\*"', "\"${version}\""));
+
+				publishNpmOnReleaseTag(publishFolder: 'dist/icons')
+				publishNpmOnReleaseTag(publishFolder: 'dist/scss')
+				publishNpmOnReleaseTag(publishFolder: 'dist/ng')
 			}
 		}
 	} catch(err) {
 		println err
 		currentBuild.result = 'failure'
 	}
-
-	notifyEndStats()
 }

--- a/packages/ng/establishment/establishment-select.spec.ts
+++ b/packages/ng/establishment/establishment-select.spec.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
 import { HttpClientModule } from '@angular/common/http';
 import { discardPeriodicTasks, fakeAsync, tick } from '@angular/core/testing';
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { RenderTemplateOptions, fireEvent, render, screen } from '@testing-library/angular';
 import { createMock } from '@testing-library/angular/jest-utils';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
@@ -55,13 +55,25 @@ describe('establishment select', () => {
 	<span class="textfield-label">Establishment Multiple Select</span>
 </label>`;
 
+	const rendererTemplateOptions: RenderTemplateOptions<LuEstablishmentSelectInputComponent> = {
+		imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
+		componentProviders: [
+			{
+				provide: ALuEstablishmentService,
+				useValue: mockEstablishment,
+			},
+			{
+				provide: ALuLegalUnitService,
+				useValue: mockLegalUnit,
+			},
+		],
+	};
+
 	describe('Basic', () => {
 		it('should display dialog with a click on a lu select ', async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 
 			const luSelectElement = screen.getByTestId('lu-select');
 			await userEvent.click(luSelectElement);
@@ -74,19 +86,7 @@ describe('establishment select', () => {
 			discardPeriodicTasks();
 
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-				componentProviders: [
-					{
-						provide: ALuEstablishmentService,
-						useValue: mockEstablishment,
-					},
-					{
-						provide: ALuLegalUnitService,
-						useValue: mockLegalUnit,
-					},
-				],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 			const luSelectElement = await screen.findByTestId('lu-select');
 
 			expect(luSelectElement).toBeInTheDocument();
@@ -101,9 +101,7 @@ describe('establishment select', () => {
 		}));
 
 		it('should check a11y', async () => {
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 			const luSelectElement = screen.getByTestId('lu-select');
 
 			const results = await axe(luSelectElement);
@@ -114,9 +112,7 @@ describe('establishment select', () => {
 	describe('multiple', () => {
 		it('should display dialog with a click on a lu select ', async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 			const luSelectElement = screen.getByTestId('lu-select-multiple');
 			await userEvent.click(luSelectElement);
 			const dial = screen.getByRole('dialog');
@@ -125,19 +121,7 @@ describe('establishment select', () => {
 
 		it('should select all establishment', fakeAsync(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-				componentProviders: [
-					{
-						provide: ALuEstablishmentService,
-						useValue: mockEstablishment,
-					},
-					{
-						provide: ALuLegalUnitService,
-						useValue: mockLegalUnit,
-					},
-				],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 
 			const luSelectElement = await screen.findByTestId('lu-select-multiple');
 			expect(luSelectElement).toBeInTheDocument();
@@ -153,19 +137,7 @@ describe('establishment select', () => {
 
 		it('should deselect all establishment', fakeAsync(async () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-				componentProviders: [
-					{
-						provide: ALuEstablishmentService,
-						useValue: mockEstablishment,
-					},
-					{
-						provide: ALuLegalUnitService,
-						useValue: mockLegalUnit,
-					},
-				],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 			const luSelectElement = await screen.findByTestId('lu-select-multiple');
 			fireEvent.click(luSelectElement);
 			tick(300); // debouncetime du composant
@@ -181,9 +153,7 @@ describe('establishment select', () => {
 		}));
 
 		it('should check a11y', async () => {
-			await render(testingStoryTemplate, {
-				imports: [LuEstablishmentSelectInputComponent, HttpClientModule],
-			});
+			await render(testingStoryTemplate, rendererTemplateOptions);
 			const luSelectElement = screen.getByTestId('lu-select-multiple');
 			const results = await axe(luSelectElement);
 			expect(results).toHaveNoViolations(); // of course not

--- a/packages/ng/form-field/form-field.component.scss
+++ b/packages/ng/form-field/form-field.component.scss
@@ -1,1 +1,1 @@
-@use '@lucca-front/scss/src/components/textfield';
+@use '@lucca-front/scss/src/components/textField';


### PR DESCRIPTION
## Description

Use linux nodes on CI

-----

- Fixed case of `textField` (was `textfield`, UNIX systems are case sensitive)
- Fixed establishment select tests where some providers were missing (weird that we see it with this change 🤔)


This PR was initially merged via https://github.com/LuccaSA/lucca-front/pull/2335 but it was removed in https://github.com/LuccaSA/lucca-front/pull/2346 when we had an issue with merges from rc to master