### PR TITLE
fix(icons): fix missing type export in built bundle

### DIFF
--- a/build.js
+++ b/build.js
@@ -62,7 +62,7 @@ runTask('Lucca Front compilation', async () => {
 			output: OUTPUT_ICONS,
 		});
 		copyFiles({
-			patterns: ['lucca-icon.d.ts', 'package.json', 'src/**'],
+			patterns: ['index.d.ts', 'package.json', 'src/**'],
 			context: ICONS,
 			output: OUTPUT_ICONS,
 		});

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/LuccaSA/lucca-front.git"
   },
   "scripts": {},
-  "main": "lucca-icon.d.ts",
+  "main": "index.d.ts",
   "keywords": [
     "lucca",
     "icons"


### PR DESCRIPTION
## Description

This is a hotfix for the missing type export in `@lucca-front/icons` that was causing multiple components failing

-----
-----
