### PR TITLE
[Textfield] mod-search + size incompatibility 

### DIFF
--- a/packages/scss/src/components/textfields/mods.scss
+++ b/packages/scss/src/components/textfields/mods.scss
@@ -223,9 +223,9 @@
 	}
 
 	.textfield-input {
-		padding-right: var(--spacings-L);
+		padding-right: 2.5rem;
 
-		&[type='search']:is(:hover, :focus) {
+		&[type='search'] {
 			&::-webkit-search-cancel-button {
 				display: none;
 			}
@@ -257,6 +257,10 @@
 		font-size: var(--sizes-S-lineHeight);
 		bottom: 0.375rem;
 		right: 0.375rem;
+	}
+
+	.textfield-input {
+		padding-right: 2rem;
 	}
 
 	.textfield-actionClear { // deprecated
@@ -296,6 +300,10 @@
 		font-size: var(--sizes-XS-lineHeight);
 		bottom: var(--spacings-XXS);
 		right: var(--spacings-XXS);
+	}
+
+	.textfield-input {
+		padding-right: 1.5rem;
 	}
 
 	.textfield-actionClear { // deprecated


### PR DESCRIPTION
## Description

Fix `textfield mod-search` + `mod-S/XS` padding issue

-----

![image](https://github.com/LuccaSA/lucca-front/assets/25581936/0e040a2d-7159-4f4f-bc4b-2cdbfdd9334a)

- CSSvar was removed as this case didn't refer to a standard spacing but an arbitrary value depending on icon width
- Removing cancel button only on `hover`/`active` stated for` type="search"` leaded to extra right margin (or gap?) on defaut state. 

-----
