### PR TITLE
[luIcon] Fix component root size

### DIFF
--- a/packages/ng/icon/icon.component.scss
+++ b/packages/ng/icon/icon.component.scss
@@ -1,5 +1,9 @@
 @use '@lucca-front/icons/src/main';
 
+:host {
+  display: inline-flex;
+}
+
 .icon-color-success {
   color: var(--palettes-success-700);
 }


### PR DESCRIPTION
## Description

Fix luIcon root size

-----

before
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/94373ebc-8eac-4880-9218-f8d07137ea36)

after
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/79270082-2818-4d9d-a0a0-ff096252085a)

-----
