### PR TITLE
fix(simple-select): URI encoding done twice instead of just once

### DIFF
--- a/packages/ng/simple-select/api/api-v3.directive.ts
+++ b/packages/ng/simple-select/api/api-v3.directive.ts
@@ -43,14 +43,21 @@ export class LuSimpleSelectApiV3Directive<T extends ILuApiItem> extends ALuSimpl
 			...filters,
 			fields,
 			...(orderBy ? { orderBy } : {}),
-			...(clue ? { name: `like,${encodeURIComponent(clue)}` } : {}),
+			...(clue ? { name: `like,${clue}` } : {}),
 		})),
 	);
 
 	protected override getOptions(params: Record<string, string | number | boolean>, page: number): Observable<T[]> {
 		return this.url$.pipe(
 			take(1),
-			switchMap((url) => this.httpClient.get<ILuApiCollectionResponse<T>>(url, { params: { ...params, paging: `${page * this.pageSize},${this.pageSize}` } })),
+			switchMap((url) =>
+				this.httpClient.get<ILuApiCollectionResponse<T>>(url, {
+					params: {
+						...params,
+						paging: `${page * this.pageSize},${this.pageSize}`,
+					},
+				}),
+			),
 			map((res) => res.data.items),
 		);
 	}

--- a/packages/ng/simple-select/api/api-v4.directive.ts
+++ b/packages/ng/simple-select/api/api-v4.directive.ts
@@ -36,14 +36,22 @@ export class LuSimpleSelectApiV4Directive<T extends ILuApiItem> extends ALuSimpl
 		map(([filters, sort, clue]) => ({
 			...filters,
 			...(sort ? { sort } : {}),
-			...(clue ? { search: encodeURIComponent(clue) } : {}),
+			...(clue ? { search: clue } : {}),
 		})),
 	);
 
 	protected override getOptions(params: Record<string, string | number | boolean>, page: number): Observable<T[]> {
 		return this.url$.pipe(
 			take(1),
-			switchMap((url) => this.httpClient.get<T[] | { items: T[] }>(url, { params: { ...params, page: page + 1, limit: this.pageSize } })),
+			switchMap((url) =>
+				this.httpClient.get<T[] | { items: T[] }>(url, {
+					params: {
+						...params,
+						page: page + 1,
+						limit: this.pageSize,
+					},
+				}),
+			),
 			map((res) => (Array.isArray(res) ? res : res?.items) ?? []),
 		);
 	}


### PR DESCRIPTION
## Description

This PR fixes a double encoding issue with apiVX directives for select components that turned `Lucca ` into `Lucca%25%20` due to it encoding once by hand (resulting in `Lucca%20`) and then having Angular encode params once again when assigned to HttpParams (resulting in `%` being encoded as `%25`).

Removing the manual encoding resulved the issue.

-----

-----
