### PR TITLE
refactor(wrappers): size now defaults to inherit rather than M

### DIFF
--- a/packages/ng/button/button.component.ts
+++ b/packages/ng/button/button.component.ts
@@ -17,7 +17,7 @@ export class ButtonComponent implements OnChanges {
 	#ngClazz = inject(NgClazz);
 
 	@Input()
-	size: 'M' | 'S' | 'XS' = 'M';
+	size: 'M' | 'S' | 'XS';
 
 	@Input({
 		transform: booleanAttribute,

--- a/packages/ng/callout/callout.component.ts
+++ b/packages/ng/callout/callout.component.ts
@@ -30,7 +30,7 @@ export class CalloutComponent {
 	/**
 	 * Which size should the callout be? Defaults to medium
 	 */
-	size: 'M' | 'S' = 'M';
+	size: 'M' | 'S';
 
 	@Input()
 	/**

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -59,7 +59,7 @@ export class FormFieldComponent implements OnChanges, OnDestroy, AfterViewInit {
 	inlineMessageState: InlineMessageState;
 
 	@Input()
-	size: FormFieldSize = 'M';
+	size: FormFieldSize;
 
 	@Input()
 	layout: 'default' | 'checkbox' = 'default';

--- a/packages/ng/forms/checkboxfield/checkboxfield.component.ts
+++ b/packages/ng/forms/checkboxfield/checkboxfield.component.ts
@@ -31,7 +31,7 @@ export class CheckboxfieldComponent extends AbstractFieldComponent {
 	inlineMessageState: InlineMessageState;
 
 	@Input()
-	size: FormFieldSize = 'M';
+	size: FormFieldSize;
 
 	override get required(): boolean {
 		return this.ngControl.control.hasValidator(Validators.requiredTrue);

--- a/packages/ng/forms/switchfield/switchfield.component.ts
+++ b/packages/ng/forms/switchfield/switchfield.component.ts
@@ -30,7 +30,7 @@ export class SwitchfieldComponent extends AbstractFieldComponent {
 	inlineMessageState: InlineMessageState;
 
 	@Input()
-	size: FormFieldSize = 'M';
+	size: FormFieldSize;
 
 	override get required(): boolean {
 		return this.ngControl.control.hasValidator(Validators.requiredTrue);

--- a/packages/ng/forms/textfield/textfield.component.ts
+++ b/packages/ng/forms/textfield/textfield.component.ts
@@ -39,7 +39,7 @@ export class TextfieldComponent extends AbstractFieldComponent {
 	inlineMessageState: InlineMessageState;
 
 	@Input()
-	size: FormFieldSize = 'M';
+	size: FormFieldSize;
 
 	@Input({ transform: booleanAttribute })
 	hasClearer = false;

--- a/packages/ng/icon/icon.component.ts
+++ b/packages/ng/icon/icon.component.ts
@@ -18,7 +18,7 @@ export class IconComponent {
 	alt: string;
 
 	@Input()
-	size: 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL' = 'M';
+	size: 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL';
 
 	@Input()
 	color: 'primary' | 'secondary' | 'error' | 'warning' | 'success' | 'light' | 'placeholder' | 'inherit' = 'inherit';

--- a/packages/ng/inline-message/inline-message.component.ts
+++ b/packages/ng/inline-message/inline-message.component.ts
@@ -23,7 +23,7 @@ export class InlineMessageComponent implements OnChanges {
 	state: InlineMessageState;
 
 	@Input()
-	size: 'S' | 'M' = 'M';
+	size: 'S' | 'M';
 
 	ngOnChanges(): void {
 		this.#ngClass.ngClass = {

--- a/packages/ng/numeric-badge/numeric-badge.component.ts
+++ b/packages/ng/numeric-badge/numeric-badge.component.ts
@@ -22,7 +22,7 @@ export class NumericBadgeComponent implements OnChanges {
 	/**
 	 * The size of the badge
 	 */
-	size: 'XS' | 'S' | 'M' = 'M';
+	size: 'XS' | 'S' | 'M';
 
 	@Input()
 	/**


### PR DESCRIPTION
## Description

We noticed an issue with icons, buttons and some other components that, when nested in wrappers, weren't behaving as they should. The issue being that since `size` defaulted to `M`, if the parent was using `mod-S` for its own size, the child component would not automatically be switched to `S` size as it already had a `mod-M` applied to it.

This created situations where icons are too large in a small component, for instance.

I fixed it by setting the default value for size to `undefined` (by just not defining it, not setting it explicitly) which won't apply any mod unless the size is explicitly passed as input value.

-----
-----
