### PR TITLE
Fix NG wrap specificity 

### DIFF
--- a/packages/ng/styles/definitions/select/_select-input.scss
+++ b/packages/ng/styles/definitions/select/_select-input.scss
@@ -147,7 +147,7 @@
 			}
 
 			.numericBadge {
-				@include numericBadge.s;
+				@include numericBadge.S;
 			}
 		}
 	}

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/icons/src/icon/exports' as icon;
+
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin component {
@@ -24,11 +26,11 @@
 	background-color: var(--palettes-700, var(--palettes-primary-700));
 	color: var(--palettes-text, var(--palettes-primary-text));
 	cursor: pointer;
+	@include icon.M;
 
-	.button-icon,
-	.lucca-icon {
-		// .lucca-icon legacy
-		font-size: var(--icon-size, 1.5rem);
+	.button-icon {
+		// deprecated
+		@include icon.M;
 	}
 
 	&:last-of-type {

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -1,5 +1,5 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
-
+@use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin component {
@@ -28,11 +28,6 @@
 	cursor: pointer;
 	@include icon.M;
 
-	.button-icon {
-		// deprecated
-		@include icon.M;
-	}
-
 	&:last-of-type {
 		margin-right: 0;
 	}
@@ -49,6 +44,17 @@
 
 		&:active {
 			background-color: var(--palettes-800, var(--palettes-primary-800));
+		}
+	}
+
+	.button-icon {
+		// deprecated
+		@include icon.M;
+	}
+
+	&:not(.mod-outlined) {
+		.numericBadge {
+			@include numericBadge.primary;
 		}
 	}
 }

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/icons/src/icon/exports' as icons;
+@use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin S {
@@ -7,7 +8,11 @@
 	--components-button-line-height: var(--sizes-S-lineHeight);
 	--components-button-padding: 0.375rem 0.75rem;
 	--components-button-gap: .375rem;
-	@include icons.S
+	@include icons.S;
+
+	.numericBadge {
+		@include numericBadge.S;
+	}
 }
 
 @mixin XS {
@@ -15,7 +20,11 @@
 	--components-button-line-height: var(--sizes-XS-lineHeight);
 	--components-button-padding: var(--spacings-XXS) var(--spacings-XS);
 	--components-button-gap: var(--spacings-XXS);
-	@include icons.XS
+	@include icons.XS;
+
+	.numericBadge {
+		@include numericBadge.XS;
+	}
 }
 
 @mixin text {

--- a/packages/scss/src/components/clear/component.scss
+++ b/packages/scss/src/components/clear/component.scss
@@ -1,9 +1,11 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/reset';
+@use '@lucca-front/icons/src/icon/exports' as icon;
 
 @mixin component {
   @include reset.button;
-  
+  @include icon.XS;
+
   align-items: center;
   background-color: var(--palettes-grey-700);
   border-radius: 50% !important;
@@ -14,9 +16,6 @@
   text-decoration: none;
   width: var(--components-clear-size);
 
-  .lucca-icon {
-    font-size: var(--components-clear-icon-size);
-  }
 
   &:hover {
     background-color: var(--palettes-grey-600);

--- a/packages/scss/src/components/clear/mods.scss
+++ b/packages/scss/src/components/clear/mods.scss
@@ -13,5 +13,5 @@
 
 @mixin S {
   --components-clear-size: .75rem;
-  --components-clear-icon-size: .75rem;
+  --icon-size: .75rem;
 }

--- a/packages/scss/src/components/clear/vars.scss
+++ b/packages/scss/src/components/clear/vars.scss
@@ -1,4 +1,3 @@
 @mixin vars {
   --components-clear-size: 1rem;
-  --components-clear-icon-size: var(--sizes-XS-lineHeight);
 }

--- a/packages/scss/src/components/numericBadge/index.scss
+++ b/packages/scss/src/components/numericBadge/index.scss
@@ -5,10 +5,10 @@
 	@include component;
 
 	&.mod-S {
-		@include s;
+		@include S;
 	}
 
 	&.mod-XS {
-		@include xs;
+		@include XS;
 	}
 }

--- a/packages/scss/src/components/numericBadge/mods.scss
+++ b/packages/scss/src/components/numericBadge/mods.scss
@@ -1,11 +1,11 @@
-@mixin s {
+@mixin S {
   --components-numericBadge-size: 1.25rem;
   --components-numericBadge-borderRadius: 6px;
   --components-numericBadge-fontSize: var(--sizes-XS-fontSize);
   --components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
 }
 
-@mixin xs {
+@mixin XS {
   --components-numericBadge-size: 1rem;
   --components-numericBadge-borderRadius: var(--commons-borderRadius-M);
   --components-numericBadge-fontSize: var(--sizes-XS-fontSize);

--- a/packages/scss/src/components/textfields/mods.scss
+++ b/packages/scss/src/components/textfields/mods.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/components/clear/exports' as clear;
 
 @mixin password {
 	.textfield-suffix {
@@ -281,8 +282,7 @@
 	}
 
 	.textfield-clear {
-		--components-clear-size: 0.75rem;
-		--components-clear-icon-size: 0.75rem;
+		@include clear.S;
 
 		right: 2.125rem;
 		bottom: 0.625rem;
@@ -324,8 +324,7 @@
 	}
 
 	.textfield-clear {
-		--components-clear-size: 0.75rem;
-		--components-clear-icon-size: 0.75rem;
+		@include clear.S;
 
 		right: 1.75rem;
 		bottom: 0.375rem;

--- a/stories/documentation/actions/button/angular/button-counter.stories.ts
+++ b/stories/documentation/actions/button/angular/button-counter.stories.ts
@@ -12,7 +12,7 @@ export default {
 	],
 	render: ({ size, block, palette, state, luButton }) => {
 		return {
-			template: `<button luButton${luButton !== 'default' ? `="${luButton}"` : ''} 
+			template: `<button luButton${luButton !== 'default' ? `="${luButton}"` : ''}
 ${size !== 'M' ? `size=${size}` : ''}
 ${block ? 'block' : ''}
 ${palette !== 'none' ? `palette=${palette}` : ''}

--- a/stories/qa/button/button.stories.html
+++ b/stories/qa/button/button.stories.html
@@ -37,8 +37,8 @@
 <section class="contentSection">
 	<h2>Counter</h2>
 	<button type="button" class="button">Counting button<span class="numericBadge palette-primary">7</span></button>
-	<button type="button" class="button mod-S">Counting button<span class="numericBadge palette-primary mod-S">7</span></button>
-	<button type="button" class="button mod-XS">Counting button<span class="numericBadge palette-primary mod-XS">7</span></button>
+	<button type="button" class="button mod-S">Counting button<span class="numericBadge palette-primary">7</span></button>
+	<button type="button" class="button mod-XS">Counting button<span class="numericBadge palette-primary">7</span></button>
 </section>
 
 <!-- Icons -->

--- a/stories/qa/button/button.stories.html
+++ b/stories/qa/button/button.stories.html
@@ -36,9 +36,9 @@
 <!-- Counter -->
 <section class="contentSection">
 	<h2>Counter</h2>
-	<button type="button" class="button">Counting button<span class="numericBadge palette-primary">7</span></button>
-	<button type="button" class="button mod-S">Counting button<span class="numericBadge palette-primary">7</span></button>
-	<button type="button" class="button mod-XS">Counting button<span class="numericBadge palette-primary">7</span></button>
+	<button type="button" class="button">Counting button<span class="numericBadge">7</span></button>
+	<button type="button" class="button mod-S">Counting button<span class="numericBadge">7</span></button>
+	<button type="button" class="button mod-XS">Counting button<span class="numericBadge">7</span></button>
 </section>
 
 <!-- Icons -->


### PR DESCRIPTION
## Description

- [Button] Use icon size mixins
- [Button] Apply numericBadge sizes in size/palettes mixins
- [Clear] Use icon size mixins
- [Numeric badge] Harmonize size mixin names (`s`/`xs` > `S`/`XS`)

-----

Note: This PR is not specified as breaking as `numericBadge.s` / `numericBadge.xs` are not used yet outside of LF

-----