### PR TITLE
[Icons] Fix icon default size

### DIFF
--- a/packages/icons/src/icon/component.scss
+++ b/packages/icons/src/icon/component.scss
@@ -2,7 +2,7 @@
 
 @mixin component {
 	font-weight: 400;
-	font-size: var(--icon-size, 1.25rem);
+	font-size: var(--icon-size, 1.5rem);
 	direction: ltr;
 	display: inline-block;
 	font-family: config.$font-name;

--- a/packages/scss/src/components/actionIcon/component.scss
+++ b/packages/scss/src/components/actionIcon/component.scss
@@ -33,8 +33,4 @@
 			background-color: var(--palettes-200, var(--palettes-grey-200));
 		}
 	}
-
-	.lucca-icon {
-		font-size: var(--icon-size, 1.5rem);
-	}
 }

--- a/packages/scss/src/components/calloutAccordion/component.scss
+++ b/packages/scss/src/components/calloutAccordion/component.scss
@@ -33,12 +33,10 @@
 		}
 
 		.calloutAccordion-summary-icon {
-			--icon-size: 1.5rem;
 			color: var(--palettes-700, var(--palettes-grey-700));
 		}
 
 		.calloutAccordion-summary-chevron {
-				--icon-size: 1.5rem;
 				color: var(--palettes-grey-700);
 				margin-left: auto;
 		}

--- a/packages/scss/src/components/calloutDisclosure/component.scss
+++ b/packages/scss/src/components/calloutDisclosure/component.scss
@@ -41,7 +41,6 @@
 		}
 
 		.calloutDisclosure-summary-icon {
-			--icon-size: 1.5rem;
 			color: var(--palettes-700, var(--palettes-grey-700));
 		}
 
@@ -50,7 +49,6 @@
 		}
 
 		.calloutDisclosure-summary-chevron {
-			--icon-size: 1.5rem;
 			color: var(--palettes-grey-700);
 			margin-left: auto;
 			transition: transform var(--commons-animations-durations-standard) ease;

--- a/packages/scss/src/components/calloutPopover/component.scss
+++ b/packages/scss/src/components/calloutPopover/component.scss
@@ -24,7 +24,6 @@
 
 	@at-root ($atRoot) {
 		.calloutPopover-icon {
-			--icon-size: 1.5rem;
 			color: var(--palettes-700, var(--palettes-grey-700));
 		}
 


### PR DESCRIPTION
## Description

Increase icon default size from `1.25rem (20px)` to `1.5rem (24px)` to fit with Figma

-----

Defaut values were: 
Figma : `24px`
Default HTML icon : `20px` 
Default Angular icon : `24px`
Nested in buttons, callout, etc : `24px`

Are now `24px` everywere

It's still possible to override `--icon-size` to keep our current default value (1.25rem) on HTML component

-----
