### PR TITLE
fix inline message icon size + remove style encapsulation

### DIFF
--- a/packages/ng/inline-message/inline-message.component.ts
+++ b/packages/ng/inline-message/inline-message.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { InlineMessageState } from './inline-message-state';
 import { NgClazz } from '@lucca-front/ng/core';
@@ -12,6 +12,7 @@ import { IconComponent } from '@lucca-front/ng/icon';
 	templateUrl: './inline-message.component.html',
 	styleUrls: ['./inline-message.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	encapsulation: ViewEncapsulation.None,
 })
 export class InlineMessageComponent implements OnChanges {
 	#ngClass = inject(NgClazz);

--- a/packages/scss/src/components/inlineMessage/component.scss
+++ b/packages/scss/src/components/inlineMessage/component.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/icons/src/icon/exports' as icon;
+
 @mixin component {
   display: flex;
   gap: var(--components-inlineMessage-gap);
@@ -6,7 +8,7 @@
   color: var(--components-inlineMessage-color);
 
   .lucca-icon {
-    font-size: var(--components-inlineMessage-icon-fontSize);
+    @include icon.XS;
     color: var(--components-inlineMessage-icon-color);
     margin-top: 2px;
   }

--- a/packages/scss/src/components/inlineMessage/mods.scss
+++ b/packages/scss/src/components/inlineMessage/mods.scss
@@ -5,6 +5,6 @@
 	--components-inlineMessage-lineHeight: var(--sizes-XS-lineHeight);
 
 	.lucca-icon {
-		font-size: 0.75rem;
+    @include icon.XXS;
 	}
 }

--- a/packages/scss/src/components/inlineMessage/mods.scss
+++ b/packages/scss/src/components/inlineMessage/mods.scss
@@ -1,5 +1,10 @@
+@use '@lucca-front/icons/src/icon/exports' as icon;
+
 @mixin S {
 	--components-inlineMessage-fontSize: var(--sizes-XS-fontSize);
 	--components-inlineMessage-lineHeight: var(--sizes-XS-lineHeight);
-	--components-inlineMessage-icon-fontSize: .75rem;
+
+	.lucca-icon {
+		font-size: 0.75rem;
+	}
 }

--- a/packages/scss/src/components/inlineMessage/vars.scss
+++ b/packages/scss/src/components/inlineMessage/vars.scss
@@ -1,7 +1,6 @@
 @mixin vars {
   --components-inlineMessage-fontSize: var(--sizes-S-fontSize);
   --components-inlineMessage-lineHeight: var(--sizes-S-lineHeight);
-  --components-inlineMessage-icon-fontSize: var(--sizes-XS-lineHeight);
   --components-inlineMessage-color: var(--palettes-grey-700);
   --components-inlineMessage-icon-color: var(--palettes-grey-600);
 }


### PR DESCRIPTION
## Description

- Fix icon size
- Remove style encapsulation in Angular component as discussed to avoid nested components imports issues 

-----

![image](https://github.com/LuccaSA/lucca-front/assets/25581936/f9772100-260d-4cce-ba80-8de482662bf0)

-----