### PR TITLE
fix(ngClazz): change detection not applied properly on ngClass value change

### DIFF
--- a/packages/ng/core/tools/ng-clazz.directive.ts
+++ b/packages/ng/core/tools/ng-clazz.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, IterableDiffers, KeyValueDiffers, Renderer2 } from '@angular/core';
+import { ChangeDetectorRef, Directive, ElementRef, inject, IterableDiffers, KeyValueDiffers, Renderer2 } from '@angular/core';
 import { NgClass } from '@angular/common';
 
 // This directive exists to temporarily resolve a conflict in how directives work, see https://github.com/angular/angular/issues/52072
@@ -9,6 +9,13 @@ import { NgClass } from '@angular/common';
 })
 // eslint-disable-next-line @angular-eslint/directive-class-suffix
 export class NgClazz extends NgClass {
+	#cdr = inject(ChangeDetectorRef);
+
+	override set ngClass(value: NgClass['ngClass']) {
+		super.ngClass = value;
+		setTimeout(() => this.#cdr.markForCheck());
+	}
+
 	constructor() {
 		super(inject(IterableDiffers), inject(KeyValueDiffers), inject(ElementRef), inject(Renderer2));
 	}

--- a/packages/ng/icon/icon.component.ts
+++ b/packages/ng/icon/icon.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { LuccaIcon } from '@lucca-front/icons';
 
@@ -9,6 +9,7 @@ import { LuccaIcon } from '@lucca-front/icons';
 	templateUrl: './icon.component.html',
 	styleUrls: ['./icon.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	encapsulation: ViewEncapsulation.None,
 })
 export class IconComponent {
 	@Input({ required: true })

--- a/packages/ng/inline-message/inline-message.component.ts
+++ b/packages/ng/inline-message/inline-message.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, Input, OnChanges } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { NgIf } from '@angular/common';
 import { InlineMessageState } from './inline-message-state';
 import { NgClazz } from '@lucca-front/ng/core';
@@ -12,6 +12,10 @@ import { IconComponent } from '@lucca-front/ng/icon';
 	templateUrl: './inline-message.component.html',
 	styleUrls: ['./inline-message.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
+	encapsulation: ViewEncapsulation.None,
+	host: {
+		class: 'inlineMessage',
+	},
 })
 export class InlineMessageComponent implements OnChanges {
 	#ngClass = inject(NgClazz);
@@ -29,7 +33,6 @@ export class InlineMessageComponent implements OnChanges {
 		this.#ngClass.ngClass = {
 			[`mod-${this.size}`]: true,
 			[`is-${this.state}`]: true,
-			inlineMessage: true,
 		};
 	}
 }


### PR DESCRIPTION
## Description

Add `markForCheck` call to `NgClazz` so we can make sure class changes are going to be applied properly. This fixes an issue found in various BUs.

-----

This PR also includes changes to `lu-inline-message` because we were troubleshooting with it and I took this opportunity to fix some class management in it.

-----
