### PR TITLE
[i18n-input] Added component handling i18n translations for a single input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ storybook-static
 compodoc-static
 
 /.angular/cache
+/coverage/
 
 # IDE - Jetbrains
 .idea/*

--- a/packages/ng/i18n/i18n-input/i18n-input.component.html
+++ b/packages/ng/i18n/i18n-input/i18n-input.component.html
@@ -1,14 +1,43 @@
-<ng-content></ng-content>
-<lu-popover [trap-focus]="true" content-classes="i18n-lu-popover-content">
-	@if (translations && translations.length) {
-	<div class="i18n-panel-container">
-		<lu-i18n-panel [formControl]="formControl" class="i18n-panel-content"></lu-i18n-panel>
-		<div class="u-displayFlex u-gapXXS u-justifyContentFlexEnd u-paddingXS">
-			<button luButton type="button" (click)="closePopover(true)" [disabled]="!formControl.dirty || formControl.invalid">
-				{{submitLabel}}
-			</button>
-			<button luButton type="button" class="mod-text" (click)="closePopover()">{{cancelLabel}}</button>
-		</div>
-	</div>
-	}
-</lu-popover>
+@if (currentTranslation) {
+<ng-container [formGroup]="formGroup">
+	<label class="textfield mod-withSuffix" [class.mod-noLabel]="!label">
+		<input
+			class="textfield-input"
+			type="text"
+			[placeholder]="placeholder"
+			formControlName="currentTranslation"
+			cdkOverlayOrigin
+			#overlayOrigin="cdkOverlayOrigin"
+			[attr.aria-required]="currentTranslation.required"
+			(focus)="onTouched()"
+		/>
+		@if(label){
+		<span class="textfield-label">{{label}}</span>
+		}
+		<span class="textfield-suffix i18n-suffix" role="button" (click)="openPopover($event)" (keyup.enter)="openPopover($event)">
+			@if (currentTranslation.cultureIcon) {
+			<lu-icon
+				[icon]="currentTranslation.cultureIcon"
+				[alt]="currentTranslation.cultureName"
+				size="M"
+				[luTooltip]="currentTranslation.cultureName"
+				[luTooltipDisabled]="showPopover"
+			>
+			</lu-icon>
+			} @else { {{ currentTranslation.cultureName }} }
+		</span>
+	</label>
+
+	<ng-template
+		cdkConnectedOverlay
+		[cdkConnectedOverlayOpen]="showPopover"
+		[cdkConnectedOverlayOrigin]="overlayOrigin"
+		cdkConnectedOverlayPanelClass="lu-popover-panel"
+		[cdkConnectedOverlayWidth]="overlayOrigin.elementRef.nativeElement.offsetWidth"
+		[cdkConnectedOverlayPush]="true"
+		(overlayOutsideClick)="closePopover($event)"
+	>
+		<lu-i18n-panel formControlName="translations" class="lu-popover-content" cdkTrapFocus [cdkTrapFocusAutoCapture]="true"></lu-i18n-panel>
+	</ng-template>
+</ng-container>
+}

--- a/packages/ng/i18n/i18n-input/i18n-input.component.html
+++ b/packages/ng/i18n/i18n-input/i18n-input.component.html
@@ -1,0 +1,14 @@
+<ng-content></ng-content>
+<lu-popover [trap-focus]="true" content-classes="i18n-lu-popover-content">
+	@if (translations && translations.length) {
+	<div class="i18n-panel-container">
+		<lu-i18n-panel [formControl]="formControl" class="i18n-panel-content"></lu-i18n-panel>
+		<div class="u-displayFlex u-gapXXS u-justifyContentFlexEnd u-paddingXS">
+			<button luButton type="button" (click)="closePopover(true)" [disabled]="!formControl.dirty || formControl.invalid">
+				{{submitLabel}}
+			</button>
+			<button luButton type="button" class="mod-text" (click)="closePopover()">{{cancelLabel}}</button>
+		</div>
+	</div>
+	}
+</lu-popover>

--- a/packages/ng/i18n/i18n-input/i18n-input.component.scss
+++ b/packages/ng/i18n/i18n-input/i18n-input.component.scss
@@ -1,0 +1,13 @@
+.i18n-lu-popover-content {
+	padding: 0;
+
+	.i18n-panel-container {
+		display: grid;
+		max-height: 25rem;
+		grid-template-rows: minmax(auto, 1fr) auto;
+
+		.i18n-panel-content {
+			overflow: auto;
+		}
+	}
+}

--- a/packages/ng/i18n/i18n-input/i18n-input.component.scss
+++ b/packages/ng/i18n/i18n-input/i18n-input.component.scss
@@ -1,13 +1,4 @@
-.i18n-lu-popover-content {
-	padding: 0;
-
-	.i18n-panel-container {
-		display: grid;
-		max-height: 25rem;
-		grid-template-rows: minmax(auto, 1fr) auto;
-
-		.i18n-panel-content {
-			overflow: auto;
-		}
-	}
+.i18n-suffix {
+	pointer-events: unset;
+	cursor: pointer;
 }

--- a/packages/ng/i18n/i18n-input/i18n-input.component.spec.ts
+++ b/packages/ng/i18n/i18n-input/i18n-input.component.spec.ts
@@ -1,0 +1,193 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { LuI18nPanelComponent } from './i18n-panel/i18n-panel.component';
+import { LuI18nInputComponent } from './i18n-input.component';
+import { I18nTranslation } from './i18n-panel/i18n-translation.model';
+import { Component, ViewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { LuPopoverModule } from '@lucca-front/ng/popover';
+import spyOn = jest.spyOn;
+
+@Component({
+	selector: 'lu-test',
+	template: ` <button luI18nInput id="test" cancelLabel="Cancel" submitLabel="Submit" [(ngModel)]="translations"></button>`,
+	standalone: true,
+	imports: [FormsModule, LuI18nInputComponent],
+})
+export class TestComponent {
+	@ViewChild(LuI18nInputComponent)
+	inputComponent: LuI18nInputComponent;
+
+	translations = [];
+}
+
+describe('LuI18nInputComponent', () => {
+	let component: LuI18nInputComponent;
+	let testComponent: TestComponent;
+	let fixture: ComponentFixture<TestComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [LuI18nPanelComponent, LuI18nInputComponent, LuPopoverModule, NoopAnimationsModule, TestComponent],
+		}).compileComponents();
+	});
+
+	beforeEach(async () => {
+		fixture = TestBed.createComponent(TestComponent);
+		testComponent = fixture.componentInstance;
+		fixture.detectChanges();
+		await fixture.whenStable();
+		component = testComponent.inputComponent;
+	});
+
+	describe(`#init`, () => {
+		it(`should create component`, () => {
+			expect(component).toBeDefined();
+		});
+
+		it(`should init target`, () => {
+			expect(component.target).toBeDefined();
+			expect(component.target.overlap).toEqual(true);
+			expect(component.target.position).toEqual('below');
+			expect(component.target.alignment).toEqual('left');
+			expect(component.target.elementRef).toBeDefined();
+		});
+
+		it(`should init click event listener to open popover`, () => {
+			const spy = spyOn(component, 'openPopover');
+
+			const element = document.getElementById('test');
+			element.click();
+			expect(spy).toHaveBeenCalled();
+		});
+
+		it(`should init listener if no parent formcontrol`, () => {
+			const fixture = TestBed.createComponent(LuI18nInputComponent);
+			expect(() => fixture.componentInstance.closePopover(true)).not.toThrow();
+			expect(() => fixture.componentInstance.closePopover()).not.toThrow();
+		});
+	});
+
+	describe(`#writeValue`, () => {
+		let inputValues: I18nTranslation[];
+
+		beforeEach(() => {
+			inputValues = [
+				{
+					value: 'value1',
+					cultureName: 'cultureName1',
+					required: true,
+					cultureCode: 'cultureCode1',
+					cultureIcon: 'filter',
+				},
+				{
+					value: 'value2',
+					cultureName: 'cultureName2',
+					required: true,
+					cultureCode: 'cultureCode2',
+					cultureIcon: 'filter',
+				},
+			];
+			component.writeValue(inputValues);
+		});
+
+		it(`should copy translations into component`, () => {
+			expect(component.translations).toEqual(inputValues);
+		});
+
+		it(`should assign form control values`, () => {
+			expect(component.formControl.value).toEqual(inputValues);
+		});
+	});
+
+	describe(`#submit`, () => {
+		let formValue: I18nTranslation[];
+		beforeEach(() => {
+			formValue = [
+				{
+					value: 'value',
+					cultureName: 'cultureName',
+					required: true,
+					cultureCode: 'cultureCode',
+					cultureIcon: 'filter',
+				},
+			];
+			component.formControl.setValue(formValue);
+		});
+
+		it(`should assign panel values`, () => {
+			component.closePopover(true);
+			expect(component.translations).toEqual(formValue);
+		});
+
+		it(`should call change listener`, () => {
+			const mockChange = jest.fn();
+			component.registerOnChange(mockChange);
+			component.closePopover(true);
+			expect(mockChange).toHaveBeenCalledWith(formValue);
+		});
+
+		it(`should mark form as pristine`, () => {
+			component.closePopover(true);
+			expect(component.formControl.dirty).toBe(false);
+		});
+	});
+
+	describe(`#dismiss`, () => {
+		let formValue: I18nTranslation[];
+		beforeEach(() => {
+			component.translations = [
+				{
+					value: '',
+					cultureName: 'cultureName',
+					required: true,
+					cultureCode: 'cultureCode',
+					cultureIcon: 'filter',
+				},
+			];
+
+			formValue = [
+				{
+					...component.translations[0],
+					value: '',
+				},
+			];
+			component.formControl.setValue(formValue);
+		});
+
+		it(`should reset panel values`, () => {
+			component.closePopover();
+			expect(component.formControl.value).toEqual(component.translations);
+		});
+
+		it(`should call touch listener`, () => {
+			const mockTouched = jest.fn();
+			component.registerOnTouched(mockTouched);
+			component.closePopover();
+			expect(mockTouched).toHaveBeenCalled();
+		});
+
+		it(`should mark form as pristine`, () => {
+			component.closePopover();
+			expect(component.formControl.dirty).toBe(false);
+		});
+	});
+
+	describe(`#_emitOpen`, () => {
+		it(`should emit open event`, () => {
+			const spy = spyOn(component.onOpen, 'emit');
+			component.openPopover();
+			expect(spy).toHaveBeenCalled();
+		});
+	});
+
+	describe(`#_emitClose`, () => {
+		it(`should emit close event`, waitForAsync(() => {
+			const spy = spyOn(component.onClose, 'emit');
+			// can't seem to be able to check close emission when calling closePopover(). Timing issue?
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-call,@typescript-eslint/no-unsafe-member-access,@typescript-eslint/no-explicit-any
+			(component as any)._emitClose();
+			expect(spy).toHaveBeenCalled();
+		}));
+	});
+});

--- a/packages/ng/i18n/i18n-input/i18n-input.component.ts
+++ b/packages/ng/i18n/i18n-input/i18n-input.component.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, ElementRef, EventEmitter, forwardRef, HostListener, Input, Output, ViewChild, ViewContainerRef, ViewEncapsulation } from '@angular/core';
+import { ControlValueAccessor, FormControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, ReactiveFormsModule, ValidationErrors, Validator } from '@angular/forms';
+import { ALuPopoverTrigger, LuPopoverPanelComponent, LuPopoverTarget } from '@lucca-front/ng/popover';
+import { Overlay } from '@angular/cdk/overlay';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { LuI18nPanelComponent } from './i18n-panel/i18n-panel.component';
+import { I18nTranslation } from './i18n-panel/i18n-translation.model';
+import { CommonModule } from '@angular/common';
+
+@Component({
+	// eslint-disable-next-line @angular-eslint/component-selector
+	selector: '[luI18nInput]',
+	templateUrl: './i18n-input.component.html',
+	styleUrls: ['i18n-input.component.scss'],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	standalone: true,
+	encapsulation: ViewEncapsulation.None,
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => LuI18nInputComponent),
+			multi: true,
+		},
+		{
+			provide: NG_VALIDATORS,
+			useExisting: forwardRef(() => LuI18nInputComponent),
+			multi: true,
+		},
+	],
+	imports: [CommonModule, LuPopoverPanelComponent, LuI18nPanelComponent, ButtonComponent, ReactiveFormsModule],
+})
+export class LuI18nInputComponent extends ALuPopoverTrigger<LuPopoverPanelComponent> implements ControlValueAccessor, Validator {
+	@Output()
+	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
+	onOpen: EventEmitter<void> = new EventEmitter<void>();
+
+	@Output()
+	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
+	onClose: EventEmitter<void> = new EventEmitter<void>();
+
+	@HostListener('click')
+	public override openPopover(): void {
+		super.openPopover();
+	}
+
+	@ViewChild(LuPopoverPanelComponent)
+	public override set panel(panel: LuPopoverPanelComponent) {
+		super.panel = panel;
+	}
+
+	@Input({ required: true })
+	public submitLabel: string;
+
+	@Input({ required: true })
+	public cancelLabel: string;
+
+	public override get panel() {
+		return super.panel;
+	}
+
+	public formControl = new FormControl<I18nTranslation[]>([]);
+	public translations?: I18nTranslation[] = [];
+	#onChange: (translations: I18nTranslation[]) => void = () => {};
+	#onTouched: () => void = () => {};
+
+	constructor(overlay: Overlay, elementRef: ElementRef<HTMLElement>, viewContainerRef: ViewContainerRef) {
+		super(overlay, elementRef, viewContainerRef);
+		this.target = new LuPopoverTarget();
+		this.target.elementRef = elementRef;
+		this.target.overlap = true;
+		this.target.position = 'below';
+		this.target.alignment = 'left';
+	}
+
+	public override closePopover(submit = false) {
+		if (!submit) {
+			this.formControl.reset(this.translations, { emitEvent: false });
+			this.#onTouched();
+		} else {
+			this.translations = [...this.formControl.value];
+			this.formControl.markAsPristine();
+			this.#onChange(this.translations);
+		}
+		super.closePopover();
+	}
+
+	protected _emitOpen(): void {
+		this.onOpen.emit();
+	}
+
+	protected _emitClose(): void {
+		this.onClose.emit();
+	}
+
+	writeValue(translations?: I18nTranslation[]) {
+		this.translations = translations ? translations.map((t) => ({ ...t })) : [];
+		this.formControl.setValue(this.translations, { emitEvent: false });
+	}
+
+	registerOnChange(onChange: (translations: I18nTranslation[]) => void) {
+		this.#onChange = onChange;
+	}
+
+	registerOnTouched(onTouched: () => void) {
+		this.#onTouched = onTouched;
+	}
+
+	validate(): ValidationErrors | null {
+		return this.formControl.errors;
+	}
+}

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.html
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.html
@@ -1,0 +1,28 @@
+<form class="u-displayFlex u-flexDirectionColumn u-gapXS u-paddingXS">
+	@for (translation of translations; track translation.cultureCode){
+	<label class="textfield mod-longer mod-noLabel mod-withSuffix">
+		<input
+			class="textfield-input"
+			[(ngModel)]="translation.value"
+			(ngModelChange)="onChange(translations)"
+			(blur)="onTouched()"
+			[disabled]="isDisabled"
+			[required]="translation.required"
+			[name]="translation.cultureCode"
+		/>
+		<label class="textfield-label u-mask">{{ translation.cultureName }}</label>
+		@if (translation.cultureIcon){
+		<lu-icon
+			[icon]="translation.cultureIcon"
+			class="textfield-suffix i18n-suffix-icon"
+			[alt]="translation.cultureName"
+			size="M"
+			[luTooltip]="translation.cultureName"
+		>
+		</lu-icon>
+		} @else {
+		<span class="textfield-suffix">{{ translation.cultureName }}</span>
+		}
+	</label>
+	}
+</form>

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.html
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.html
@@ -1,4 +1,4 @@
-<form class="u-displayFlex u-flexDirectionColumn u-gapXS u-paddingXS">
+<form class="u-displayFlex u-flexDirectionColumn u-gapXS">
 	@for (translation of translations; track translation.cultureCode){
 	<label class="textfield mod-longer mod-noLabel mod-withSuffix">
 		<input

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.scss
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.scss
@@ -1,0 +1,3 @@
+.i18n-suffix-icon {
+	pointer-events: unset;
+}

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.spec.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.spec.ts
@@ -1,0 +1,168 @@
+import { LuI18nPanelComponent } from './i18n-panel.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { I18nTranslation } from './i18n-translation.model';
+import { Component, ViewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+	selector: 'lu-test',
+	template: ` <lu-i18n-panel [(ngModel)]="translations"></lu-i18n-panel>`,
+	standalone: true,
+	imports: [FormsModule, LuI18nPanelComponent],
+})
+export class TestComponent {
+	@ViewChild(LuI18nPanelComponent)
+	panel: LuI18nPanelComponent;
+
+	translations = [];
+}
+
+describe('LuI18nPanelComponent', () => {
+	let component: LuI18nPanelComponent;
+	let testComponent: TestComponent;
+	let fixture: ComponentFixture<TestComponent>;
+
+	beforeEach(async () => {
+		await TestBed.configureTestingModule({
+			imports: [TestComponent, NoopAnimationsModule, OverlayModule],
+		}).compileComponents();
+	});
+
+	beforeEach(async () => {
+		fixture = TestBed.createComponent(TestComponent);
+		testComponent = fixture.componentInstance;
+		fixture.detectChanges();
+		await fixture.whenStable();
+		component = testComponent.panel;
+	});
+
+	describe(`#init`, () => {
+		it(`should create component`, () => {
+			expect(component).toBeDefined();
+		});
+
+		it(`should be enabled by default`, () => {
+			expect(component.isDisabled).toBe(false);
+		});
+
+		it(`should init listener if no parent formcontrol`, () => {
+			const fixture = TestBed.createComponent(LuI18nPanelComponent);
+			expect(() => fixture.componentInstance.onChange([])).not.toThrow();
+			expect(() => fixture.componentInstance.onTouched()).not.toThrow();
+		});
+	});
+
+	describe(`#writeValue`, () => {
+		it(`should copy and assign given translations to the component`, () => {
+			const inputValue: I18nTranslation[] = [
+				{
+					value: 'value1',
+					cultureCode: 'cultureCode1',
+					cultureIcon: 'filter',
+					required: true,
+					cultureName: 'cultureName1',
+				},
+				{
+					value: 'value2',
+					cultureCode: 'cultureCode2',
+					cultureIcon: 'error',
+					required: true,
+					cultureName: 'cultureName2',
+				},
+			];
+
+			component.writeValue(inputValue);
+			expect(component.translations).toEqual(inputValue);
+		});
+
+		it(`should assign empty array if no translations are given`, () => {
+			component.writeValue(undefined);
+			expect(component.translations).toEqual([]);
+		});
+	});
+
+	describe(`#registerOnChange`, () => {
+		it('should assign change listener', () => {
+			const listener = () => {};
+
+			component.registerOnChange(listener);
+			expect(component.onChange).toEqual(listener);
+		});
+	});
+
+	describe(`#registerOnTouched`, () => {
+		it('should assign change listener', () => {
+			const listener = () => {};
+
+			component.registerOnTouched(listener);
+			expect(component.onTouched).toEqual(listener);
+		});
+	});
+
+	describe(`#setDisabledState`, () => {
+		it('should set the component disabled state', () => {
+			component.setDisabledState(true);
+			expect(component.isDisabled).toEqual(true);
+		});
+	});
+
+	describe(`#validate`, () => {
+		it('should return null if all required fields are filled', () => {
+			component.translations = [
+				{
+					value: '',
+					cultureCode: 'cultureCode1',
+					cultureIcon: 'filter',
+					required: false,
+					cultureName: 'cultureName1',
+				},
+				{
+					value: 'value2',
+					cultureCode: 'cultureCode2',
+					cultureIcon: 'error',
+					required: true,
+					cultureName: 'cultureName2',
+				},
+				{
+					value: '',
+					cultureCode: 'cultureCode2',
+					cultureIcon: 'error',
+					required: false,
+					cultureName: 'cultureName2',
+				},
+			];
+			expect(component.validate()).toEqual(null);
+		});
+
+		it('should return an error if any required field is not filled', () => {
+			component.translations = [
+				{
+					value: '',
+					cultureCode: 'cultureCode1',
+					cultureIcon: 'filter',
+					required: false,
+					cultureName: 'cultureName1',
+				},
+				{
+					value: 'value2',
+					cultureCode: 'cultureCode2',
+					cultureIcon: 'error',
+					required: true,
+					cultureName: 'cultureName2',
+				},
+				{
+					value: '',
+					cultureCode: 'cultureCode2',
+					cultureIcon: 'error',
+					required: true,
+					cultureName: 'cultureName2',
+				},
+			];
+			expect(component.validate()).toEqual({
+				required: true,
+			});
+		});
+	});
+});

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.spec.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.spec.ts
@@ -109,6 +109,11 @@ describe('LuI18nPanelComponent', () => {
 	});
 
 	describe(`#validate`, () => {
+		it('should return null if no translation is provided', () => {
+			component.translations = undefined;
+			expect(component.validate()).toEqual(null);
+		});
+
 		it('should return null if all required fields are filled', () => {
 			component.translations = [
 				{

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.ts
@@ -1,0 +1,61 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, forwardRef, inject } from '@angular/core';
+import { ControlValueAccessor, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
+import { I18nTranslation } from './i18n-translation.model';
+import { IconComponent } from '@lucca-front/ng/icon';
+import { CommonModule } from '@angular/common';
+import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
+
+@Component({
+	selector: 'lu-i18n-panel',
+	templateUrl: './i18n-panel.component.html',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	styleUrls: ['i18n-panel.component.scss'],
+	standalone: true,
+	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			useExisting: forwardRef(() => LuI18nPanelComponent),
+			multi: true,
+		},
+		{
+			provide: NG_VALIDATORS,
+			useExisting: forwardRef(() => LuI18nPanelComponent),
+			multi: true,
+		},
+	],
+	imports: [IconComponent, CommonModule, FormsModule, LuTooltipTriggerDirective],
+})
+export class LuI18nPanelComponent implements ControlValueAccessor, Validator {
+	public translations: I18nTranslation[] = [];
+	public isDisabled = false;
+
+	public onChange: (value: I18nTranslation[]) => void = () => {};
+	public onTouched: () => void = () => {};
+
+	private readonly changeDetectorRef = inject(ChangeDetectorRef);
+
+	writeValue(translations?: I18nTranslation[]): void {
+		this.translations = translations ? translations.map((t) => ({ ...t })) : [];
+		this.changeDetectorRef.markForCheck();
+	}
+
+	registerOnChange(onChange: (value: I18nTranslation[]) => void): void {
+		this.onChange = onChange;
+	}
+
+	registerOnTouched(onTouched: () => void): void {
+		this.onTouched = onTouched;
+	}
+
+	setDisabledState(isDisabled: boolean) {
+		this.isDisabled = isDisabled;
+	}
+
+	validate(): ValidationErrors | null {
+		return this.translations.some((t) => t.required && !t.value)
+			? {
+					required: true,
+			  }
+			: null;
+	}
+}

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-panel.component.ts
@@ -3,7 +3,8 @@ import { ControlValueAccessor, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, Va
 import { I18nTranslation } from './i18n-translation.model';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { CommonModule } from '@angular/common';
-import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
+import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+import { translationsValidator } from './i18n-translation.validator';
 
 @Component({
 	selector: 'lu-i18n-panel',
@@ -23,7 +24,7 @@ import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 			multi: true,
 		},
 	],
-	imports: [IconComponent, CommonModule, FormsModule, LuTooltipTriggerDirective],
+	imports: [IconComponent, CommonModule, FormsModule, LuTooltipModule],
 })
 export class LuI18nPanelComponent implements ControlValueAccessor, Validator {
 	public translations: I18nTranslation[] = [];
@@ -52,10 +53,6 @@ export class LuI18nPanelComponent implements ControlValueAccessor, Validator {
 	}
 
 	validate(): ValidationErrors | null {
-		return this.translations.some((t) => t.required && !t.value)
-			? {
-					required: true,
-			  }
-			: null;
+		return translationsValidator(this.translations);
 	}
 }

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-translation.model.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-translation.model.ts
@@ -5,5 +5,6 @@ export interface I18nTranslation {
 	cultureIcon?: LuccaIcon;
 	cultureName: string;
 	value: string;
-	required: boolean;
+	required?: boolean;
+	current?: boolean;
 }

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-translation.model.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-translation.model.ts
@@ -1,0 +1,9 @@
+import { LuccaIcon } from '@lucca-front/icons';
+
+export interface I18nTranslation {
+	cultureCode: string;
+	cultureIcon?: LuccaIcon;
+	cultureName: string;
+	value: string;
+	required: boolean;
+}

--- a/packages/ng/i18n/i18n-input/i18n-panel/i18n-translation.validator.ts
+++ b/packages/ng/i18n/i18n-input/i18n-panel/i18n-translation.validator.ts
@@ -1,0 +1,10 @@
+import { I18nTranslation } from './i18n-translation.model';
+import { ValidationErrors } from '@angular/forms';
+
+export const translationsValidator = (translations?: I18nTranslation[]): ValidationErrors | null => {
+	return translations?.some((t) => t.required && !t.value)
+		? {
+				required: true,
+		  }
+		: null;
+};

--- a/packages/ng/i18n/ng-package.json
+++ b/packages/ng/i18n/ng-package.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "public-api.ts"
+	}
+}

--- a/packages/ng/i18n/public-api.ts
+++ b/packages/ng/i18n/public-api.ts
@@ -1,0 +1,3 @@
+export * from './i18n-input/i18n-panel/i18n-panel.component';
+export * from './i18n-input/i18n-panel/i18n-translation.model';
+export * from './i18n-input/i18n-input.component';

--- a/stories/documentation/forms/i18n-input/i18n-input.stories.ts
+++ b/stories/documentation/forms/i18n-input/i18n-input.stories.ts
@@ -1,0 +1,113 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { applicationConfig, Meta, StoryFn } from '@storybook/angular';
+import { I18nTranslation, LuI18nInputComponent } from '@lucca-front/ng/i18n';
+
+@Component({
+	selector: 'i18n-input-stories',
+	standalone: true,
+	imports: [LuI18nInputComponent, FormsModule],
+	template: `
+		<div class="u-displayFlex">
+			<button type="button" class="button" luI18nInput submitLabel="Submit" cancelLabel="Cancel" [(ngModel)]="translations">{{ translations[0].value }}</button>
+		</div>
+	`,
+})
+class I18nInputStory {
+	translations: I18nTranslation[] = [
+		{
+			cultureCode: 'invariant',
+			cultureName: 'Default value',
+			value: 'Tomato',
+			required: true,
+			cultureIcon: 'mapGlobe',
+		},
+		{
+			cultureCode: 'fr-fr',
+			cultureName: 'fr-FR',
+			value: 'Tomate',
+			required: false,
+		},
+		{
+			cultureCode: 'en-us',
+			cultureName: 'en-US',
+			value: 'Tomato',
+			required: false,
+		},
+		{
+			cultureCode: 'es-es',
+			cultureName: 'es-ES',
+			value: '',
+			required: false,
+		},
+	];
+}
+
+export default {
+	title: 'Documentation/Forms/I18n-Input',
+	component: I18nInputStory,
+	argTypes: {},
+	decorators: [applicationConfig({ providers: [provideAnimations()] })],
+} as Meta;
+
+const template: StoryFn<I18nInputStory> = (args: I18nInputStory) => ({
+	props: args,
+});
+
+const code = `
+import { FormsModule } from '@angular/forms';
+import { LuI18nInputComponent } from '@lucca-front/ng/i18n';
+@Component({
+ selector: 'i18n-input-stories',
+ standalone: true,
+ imports: [LuI18nInputComponent, LuInputDisplayerDirective, FormsModule],
+ template: \`
+  <div class="u-displayFlex">
+   <button type="button" class="button" luI18nInput submitLabel="Submit" cancelLabel="Cancel" [(ngModel)]="translations">{{ translations[0].value }}</button>
+  </div>
+ \`,
+})
+class I18nInputStory {
+ translations: I18nTranslation[] = [
+  {
+   cultureCode: 'invariant',
+   cultureName: 'Default value',
+   value: 'Tomato',
+   required: true,
+   cultureIcon: 'mapGlobe',
+  },
+  {
+   cultureCode: 'fr-fr',
+   cultureName: 'fr-FR',
+   value: 'Tomate',
+   required: false,
+  },
+  {
+   cultureCode: 'en-us',
+   cultureName: 'en-US',
+   value: 'Tomato',
+   required: false,
+  },
+  {
+   cultureCode: 'es-es',
+   cultureName: 'es-ES',
+   value: '',
+   required: false,
+  },
+ ];
+}`;
+
+export const Basic = template.bind({});
+Basic.args = {};
+Basic.parameters = {
+	// Disable controls as they are not modifiable because of ComponentWrapper
+	controls: { include: [] },
+	docs: {
+		source: {
+			language: 'ts',
+			type: 'code',
+			code,
+		},
+	},
+};

--- a/stories/documentation/forms/i18n-input/i18n-input.stories.ts
+++ b/stories/documentation/forms/i18n-input/i18n-input.stories.ts
@@ -3,15 +3,19 @@ import { FormsModule } from '@angular/forms';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { applicationConfig, Meta, StoryFn } from '@storybook/angular';
 import { I18nTranslation, LuI18nInputComponent } from '@lucca-front/ng/i18n';
+import { JsonPipe } from '@angular/common';
+import { TextfieldComponent } from '../../../../packages/ng/forms/textfield/textfield.component';
 
 @Component({
 	selector: 'i18n-input-stories',
 	standalone: true,
-	imports: [LuI18nInputComponent, FormsModule],
+	imports: [LuI18nInputComponent, FormsModule, JsonPipe, TextfieldComponent],
 	template: `
-		<div class="u-displayFlex">
-			<button type="button" class="button" luI18nInput submitLabel="Submit" cancelLabel="Cancel" [(ngModel)]="translations">{{ translations[0].value }}</button>
-		</div>
+		<form class="u-displayFlex u-flexDirectionColumn" #form="ngForm">
+			<lu-i18n-textfield [(ngModel)]="translations" label="Label" placeholder="Placeholder" name="i18n"> </lu-i18n-textfield>
+			<p>Valid : {{ form.valid }}</p>
+			<p>Value : {{ translations | json }}</p>
+		</form>
 	`,
 })
 class I18nInputStory {
@@ -22,24 +26,24 @@ class I18nInputStory {
 			value: 'Tomato',
 			required: true,
 			cultureIcon: 'mapGlobe',
+			current: true,
 		},
 		{
 			cultureCode: 'fr-fr',
 			cultureName: 'fr-FR',
+			required: true,
 			value: 'Tomate',
-			required: false,
 		},
 		{
 			cultureCode: 'en-us',
 			cultureName: 'en-US',
 			value: 'Tomato',
-			required: false,
 		},
 		{
 			cultureCode: 'es-es',
 			cultureName: 'es-ES',
+			required: true,
 			value: '',
-			required: false,
 		},
 	];
 }
@@ -61,41 +65,41 @@ import { LuI18nInputComponent } from '@lucca-front/ng/i18n';
 @Component({
  selector: 'i18n-input-stories',
  standalone: true,
- imports: [LuI18nInputComponent, LuInputDisplayerDirective, FormsModule],
+ imports: [LuI18nInputDirective, LuInputDisplayerDirective, FormsModule],
  template: \`
-  <div class="u-displayFlex">
-   <button type="button" class="button" luI18nInput submitLabel="Submit" cancelLabel="Cancel" [(ngModel)]="translations">{{ translations[0].value }}</button>
-  </div>
+		<div class="u-displayFlex u-flexDirectionColumn">
+			<lu-i18n-textfield [(ngModel)]="translations" label="Label" placeholder="Placeholder" name="i18n"> </lu-i18n-textfield>
+			{{ translations | json }}
+		</div>
  \`,
 })
 class I18nInputStory {
- translations: I18nTranslation[] = [
-  {
-   cultureCode: 'invariant',
-   cultureName: 'Default value',
-   value: 'Tomato',
-   required: true,
-   cultureIcon: 'mapGlobe',
-  },
-  {
-   cultureCode: 'fr-fr',
-   cultureName: 'fr-FR',
-   value: 'Tomate',
-   required: false,
-  },
-  {
-   cultureCode: 'en-us',
-   cultureName: 'en-US',
-   value: 'Tomato',
-   required: false,
-  },
-  {
-   cultureCode: 'es-es',
-   cultureName: 'es-ES',
-   value: '',
-   required: false,
-  },
- ];
+  translations: I18nTranslation[] = [
+    {
+      cultureCode: 'invariant',
+      cultureName: 'Default value',
+      value: 'Tomato',
+      required: true,
+      cultureIcon: 'mapGlobe',
+      current: true,
+    },
+    {
+      cultureCode: 'fr-fr',
+      cultureName: 'fr-FR',
+      value: 'Tomate',
+    },
+    {
+      cultureCode: 'en-us',
+      cultureName: 'en-US',
+      value: 'Tomato',
+    },
+    {
+      cultureCode: 'es-es',
+      cultureName: 'es-ES',
+      required: true,
+      value: '',
+    },
+  ];
 }`;
 
 export const Basic = template.bind({});


### PR DESCRIPTION
## Description

* Added I18n panel component & model listing i18n translation
* Added first iteration of parent input component, displaying aforementionned panel on target element click. Usable in a form.
⚠️ This is not the final iteration for this component since it does not match LF needs for now

-----
V1:
The input in itself is a attribute component which prevents using it with other attribute component like `luButton`. It also implements `ControlValueAccessor` which will cause conflicts if used with other  `ControlValueAccessor` component or directives.
![image](https://github.com/LuccaSA/lucca-front/assets/144034885/eb6717e7-d8a4-451e-8f48-a1281b089aa6)

V2:
The input is a text form control. Panel has been simplified to be submit when clicking outside of it.
![chrome_qr746Y5S2t](https://github.com/LuccaSA/lucca-front/assets/144034885/d084a4e4-60a0-4dc2-a71c-fb9ee475c81d)

-----
