### PR TITLE
[FIX] - translation deselect

### DIFF
--- a/packages/ng/option/selector/all/select-all.translate.ts
+++ b/packages/ng/option/selector/all/select-all.translate.ts
@@ -17,7 +17,7 @@ export const luOptionSelectAllTranslations: ILuTranslation<ILuOptionSelectAllLab
 	},
 	fr: {
 		select: 'Tout sélectionner',
-		deselect: 'Tout Déselectionner',
+		deselect: 'Tout déselectionner',
 	},
 	de: {
 		select: 'Alle auswählen',


### PR DESCRIPTION
## Description

On remplace le D majuscule de la traduction  deselect pour un d minuscule.

-----


-----
