### PR TITLE
fix(callout): issue #2464 icon not displayed when iconless

### DIFF
--- a/packages/ng/callout/callout-popover/callout-popover.component.html
+++ b/packages/ng/callout/callout-popover/callout-popover.component.html
@@ -7,7 +7,7 @@
 	(mouseleave)="hideContent($event)"
 	(blur)="hideContent(null)"
 >
-	<lu-icon class="calloutPopover-icon" [icon]="icon"></lu-icon>
+	<lu-icon class="calloutPopover-icon" *ngIf="icon" [icon]="icon"></lu-icon>
 	{{buttonLabel}}
 </button>
 <ng-template #overlayContentRef>
@@ -18,7 +18,7 @@
 		(mouseleave)="hideContent($event)"
 	>
 		<div class="calloutPopover-overlay-head">
-			<lu-icon class="calloutPopover-overlay-head-icon palette-{{palette}}" [icon]="icon"></lu-icon>
+			<lu-icon class="calloutPopover-overlay-head-icon palette-{{palette}}" *ngIf="icon" [icon]="icon"></lu-icon>
 			<strong class="calloutPopover-overlay-head-title">
 				<ng-container *luPortal="heading"></ng-container>
 			</strong>


### PR DESCRIPTION
## Description

Closes #2464 : a callout popover now correctly doesn't include `lucca-icon` tag when no icon is provided

-----

Add `*ngIf` directives to display `lucca-icon` tags only when icon is provided

-----
