### PR TITLE
chore(skip-links): use inject syntax

### DIFF
--- a/packages/ng/a11y/skip-links/skip-links.component.ts
+++ b/packages/ng/a11y/skip-links/skip-links.component.ts
@@ -1,5 +1,5 @@
 import { DOCUMENT } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
 import { LU_SKIP_LINKS_TRANSLATIONS } from './skip-links.translate';
 
@@ -11,13 +11,13 @@ import { LU_SKIP_LINKS_TRANSLATIONS } from './skip-links.translate';
 	standalone: true,
 })
 export class LuSkipLinksComponent {
-	protected intl = getIntl(LU_SKIP_LINKS_TRANSLATIONS);
+	#document = inject(DOCUMENT);
 
-	constructor(@Inject(DOCUMENT) protected document: Document) {}
+	protected intl = getIntl(LU_SKIP_LINKS_TRANSLATIONS);
 
 	anchor(hash: string, e: Event) {
 		e.preventDefault();
-		this.document.location.hash = '';
-		this.document.location.hash = hash;
+		this.#document.location.hash = '';
+		this.#document.location.hash = hash;
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,43 +2,32 @@
 {
 	"compileOnSave": false,
 	"compilerOptions": {
-    "baseUrl": "./",
-    "outDir": "./dist/out-tsc",
-    "forceConsistentCasingInFileNames": true,
-    "strict": false,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
-    "noImplicitReturns": true,
-    "noFallthroughCasesInSwitch": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
-    "rootDirs": [
-      "./"
-    ],
-    "paths": {
-      "@lucca-front/icons": [
-        "packages/icons/index.d.ts"
-      ],
-      "@lucca-front/ng/*": [
-        "packages/ng/*/public-api.ts"
-      ],
-      "@/stories/*": [
-        "stories/documentation/*"
-      ]
-    },
-    "declaration": false,
-    "downlevelIteration": true,
-    "experimentalDecorators": true,
-    "moduleResolution": "node",
-    "importHelpers": true,
-    "target": "ES2022",
-    "module": "ESNext",
-    "lib": [
-      "es2020",
-      "dom"
-    ],
-    "useDefineForClassFields": false
-  },
+		"baseUrl": "./",
+		"outDir": "./dist/out-tsc",
+		"forceConsistentCasingInFileNames": true,
+		"strict": false,
+		"noImplicitOverride": true,
+		"noPropertyAccessFromIndexSignature": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"esModuleInterop": true,
+		"sourceMap": true,
+		"rootDirs": ["./"],
+		"paths": {
+			"@lucca-front/icons": ["packages/icons/index.d.ts"],
+			"@lucca-front/ng/*": ["packages/ng/*/public-api.ts"],
+			"@/stories/*": ["stories/documentation/*"]
+		},
+		"declaration": false,
+		"downlevelIteration": true,
+		"experimentalDecorators": true,
+		"moduleResolution": "node",
+		"importHelpers": true,
+		"target": "ES2022",
+		"module": "ESNext",
+		"lib": ["ES2022", "dom"],
+		"useDefineForClassFields": false
+	},
 	"angularCompilerOptions": {
 		"enableI18nLegacyMessageIdFormat": false,
 		"strictInjectionParameters": true,


### PR DESCRIPTION
## Description

No need for constructors with `inject()`.

-----

We could do that on the whole codebase.