### PR TITLE
fix(commons): deprecated / as a division operator

### DIFF
--- a/packages/scss/src/commons/utils/media.scss
+++ b/packages/scss/src/commons/utils/media.scss
@@ -5,7 +5,7 @@
 @use '@lucca-front/scss/src/commons/config';
 
 @function pxToEm($value) {
-	@return calc($value / 16px) * 1em;
+	@return math.div($value, 16px) * 1em;
 }
 
 // les requêtes simples et multiples

--- a/packages/scss/src/commons/utils/media.scss
+++ b/packages/scss/src/commons/utils/media.scss
@@ -5,7 +5,7 @@
 @use '@lucca-front/scss/src/commons/config';
 
 @function pxToEm($value) {
-	@return $value / 16px * 1em;
+	@return calc($value / 16px) * 1em;
 }
 
 // les requêtes simples et multiples


### PR DESCRIPTION
## Description

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($value, 16px) or calc($value / 16px)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
8 │     @return $value / 16px * 1em;
  │             ^^^^^^^^^^^^^
  ╵
```

-----
