### PR TITLE
enh(userSelect): issue #2422 allow to disable principal

### DIFF
--- a/packages/ng/user/select/input/user-select-input.component.html
+++ b/packages/ng/user/select/input/user-select-input.component.html
@@ -26,8 +26,9 @@
 		></lu-user-paged-searcher>
 	</header>
 	<lu-user-homonyms></lu-user-homonyms>
-	<lu-option
-		*luUserMeOption="
+	<ng-container *ngIf="!disablePrincipal">
+		<lu-option
+			*luUserMeOption="
 			let user;
 			fields: fields;
 			filters: filters;
@@ -36,13 +37,14 @@
 			operations: operations;
 			clue: clue
 		"
-		[value]="user"
-	>
-		<div>
-			<b>{{ intl.me }} {{ user | luUserDisplay: searchFormat }}</b>
-		</div>
-		<div class="lu-select-additionalInformation" *ngIf="user.additionalInformation">({{ user.additionalInformation }})</div>
-	</lu-option>
+			[value]="user"
+		>
+			<div>
+				<b>{{ intl.me }} {{ user | luUserDisplay: searchFormat }}</b>
+			</div>
+			<div class="lu-select-additionalInformation" *ngIf="user.additionalInformation">({{ user.additionalInformation }})</div>
+		</lu-option>
+	</ng-container>
 
 	<lu-option *luForOptions="let user" [value]="user">
 		<div>{{ user | luUserDisplay: searchFormat }}</div>

--- a/packages/ng/user/select/input/user-select-input.component.ts
+++ b/packages/ng/user/select/input/user-select-input.component.ts
@@ -7,7 +7,7 @@ import { LuInputClearerComponent, LuInputDisplayerDirective } from '@lucca-front
 import { LuForOptionsDirective, LuOptionComparer, LuOptionItemComponent, LuOptionPickerAdvancedComponent } from '@lucca-front/ng/option';
 import { ILuInputWithPicker } from '@lucca-front/ng/picker';
 import { ALuSelectInputComponent } from '@lucca-front/ng/select';
-import { LuDisplayFullname, LuUserDisplayPipe } from '../../display/index';
+import { LuDisplayFullname, LuUserDisplayPipe } from '../../display';
 import { LuUserHomonymsComponent } from '../homonyms';
 import { LuUserMeOptionDirective } from '../me';
 import { LuUserPagedSearcherComponent } from '../searcher';
@@ -61,6 +61,7 @@ export class LuUserSelectInputComponent<U extends import('../../user.model').ILu
 	@Input() appInstanceId: number | string;
 	@Input() operations: number[];
 	@Input() enableFormerEmployees = false;
+	@Input() disablePrincipal = false;
 
 	clue = '';
 

--- a/stories/documentation/users/select/user-select.stories.html
+++ b/stories/documentation/users/select/user-select.stories.html
@@ -10,7 +10,13 @@
 	</label> -->
 
 	<label class="textfield u-marginTopM">
-		<lu-user-select class="textfield-input" [ngModel]="model" appInstanceId="6" [operations]="[1]"> </lu-user-select>
+		<lu-user-select
+			class="textfield-input"
+			[ngModel]="model"
+			appInstanceId="6"
+			[operations]="[1]"
+			[disablePrincipal]="disablePrincipal"
+		></lu-user-select>
 		<span class="textfield-label">Utilisateurs filtrés par operations/appInstanceId</span>
 	</label>
 </div>

--- a/stories/documentation/users/select/user-select.stories.ts
+++ b/stories/documentation/users/select/user-select.stories.ts
@@ -2,7 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { Component, Input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { provideAnimations } from '@angular/platform-browser/animations';
-import { LuUserSelectModule } from '@lucca-front/ng/user';
+import { ILuUser, LuUserSelectModule } from '@lucca-front/ng/user';
 import { Meta, StoryFn, applicationConfig } from '@storybook/angular';
 
 @Component({
@@ -12,7 +12,8 @@ import { Meta, StoryFn, applicationConfig } from '@storybook/angular';
 	imports: [LuUserSelectModule, FormsModule],
 })
 class UserSelectStory {
-	@Input() public model;
+	model: ILuUser;
+	@Input() disablePrincipal = false;
 }
 
 export default {
@@ -59,7 +60,6 @@ export const basic = template.bind({});
 basic.args = {};
 
 basic.parameters = {
-	controls: { include: [] },
 	docs: {
 		source: {
 			language: 'ts',


### PR DESCRIPTION
## Description

Closes #2422 
Add a parameter `enablePrincipal` within `user-select` to control principal display : 
Boolean set to `true`
![image](https://github.com/LuccaSA/lucca-front/assets/18485358/e1604da5-e05d-493a-ac93-bbe66c9e24e1)
Boolean set to `false`
![image](https://github.com/LuccaSA/lucca-front/assets/18485358/2e3f4441-0520-4852-955b-cf38a6875940)

-----

Surround  `luUserMeOption` with `ng-container` conditionnaly displayed depending on `enabledPrincipal` parameter value. 
Default value is set to `true` to avoid regress on existing uses.

-----
