### PR TITLE
[Callout Popover] Fix XS icon size & radius

### DIFF
--- a/packages/scss/src/components/calloutPopover/mods.scss
+++ b/packages/scss/src/components/calloutPopover/mods.scss
@@ -17,9 +17,10 @@
   line-height: var(--sizes-XS-lineHeight);
   padding: 0.125rem var(--spacings-XXS);
   gap: var(--spacings-XXS);
+  border-radius: var(--commons-borderRadius-M);
 
   .calloutPopover-icon {
-    @include icon.XXS;
+    @include icon.XS;
   }
 }
 


### PR DESCRIPTION
## Description

Fix icon size and border radius for XS size

-----

![image](https://github.com/LuccaSA/lucca-front/assets/25581936/bb428c64-d735-4e61-b387-a10361f90da2)

-----
