### PR TITLE
enh(button): dynamically add mod-onlyIcon & withIcon classes

### DIFF
--- a/packages/ng/button/button.component.ts
+++ b/packages/ng/button/button.component.ts
@@ -69,7 +69,7 @@ export class ButtonComponent implements OnChanges {
 			[`palette-${this.palette}`]: true,
 			[`is-${this.state}`]: true,
 			['mod-onlyIcon']: this.iconOnly,
-			['withIcon']: this.#iconComponentRef !== undefined,
+			['mod-withIcon']: this.#iconComponentRef !== undefined,
 		};
 
 		if (this.luButton !== '') {

--- a/packages/ng/button/button.component.ts
+++ b/packages/ng/button/button.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, Input, OnChanges } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ElementRef, inject, Input, OnChanges } from '@angular/core';
 import { NgClazz, Palette } from '@lucca-front/ng/core';
+import { IconComponent } from '@lucca-front/ng/icon';
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector
@@ -15,6 +16,7 @@ import { NgClazz, Palette } from '@lucca-front/ng/core';
 })
 export class ButtonComponent implements OnChanges {
 	#ngClazz = inject(NgClazz);
+	#elementRef = inject(ElementRef);
 
 	@Input()
 	size: 'M' | 'S' | 'XS';
@@ -37,13 +39,39 @@ export class ButtonComponent implements OnChanges {
 	 */
 	luButton: '' | 'outlined' | 'text' | 'text-invert' = '';
 
+	#iconComponentRef?: ElementRef;
+
+	@ContentChild(IconComponent, { read: ElementRef })
+	set iconComponentRef(ref: ElementRef) {
+		this.#iconComponentRef = ref;
+		this.updateClasses();
+	}
+
+	private get iconOnly(): boolean {
+		const listOfNode = Array.from((this.#elementRef?.nativeElement as HTMLButtonElement)?.childNodes || []);
+		const noText = listOfNode.every((node) => node.nodeName !== '#text');
+		// ignore icon and comment
+		const noSpan =
+			listOfNode.filter((node) => {
+				return !(node.nodeName === '#comment' || (node as HTMLElement)?.tagName?.toLowerCase() === 'lu-icon');
+			}).length == 0;
+		return !!this.#iconComponentRef && noSpan && noText;
+	}
+
 	ngOnChanges(): void {
+		this.updateClasses();
+	}
+
+	updateClasses(): void {
 		const ngClassConfig = {
 			[`mod-${this.size}`]: true,
 			[`mod-block`]: this.block,
 			[`palette-${this.palette}`]: true,
 			[`is-${this.state}`]: true,
+			['mod-onlyIcon']: this.iconOnly,
+			['withIcon']: this.#iconComponentRef !== undefined,
 		};
+
 		if (this.luButton !== '') {
 			if (this.luButton === 'text-invert') {
 				ngClassConfig['mod-text'] = true;

--- a/packages/ng/button/button.component.ts
+++ b/packages/ng/button/button.component.ts
@@ -16,7 +16,7 @@ import { IconComponent } from '@lucca-front/ng/icon';
 })
 export class ButtonComponent implements OnChanges {
 	#ngClazz = inject(NgClazz);
-	#elementRef = inject(ElementRef);
+	#elementRef = inject<ElementRef<HTMLButtonElement>>(ElementRef);
 
 	@Input()
 	size: 'M' | 'S' | 'XS';
@@ -39,21 +39,21 @@ export class ButtonComponent implements OnChanges {
 	 */
 	luButton: '' | 'outlined' | 'text' | 'text-invert' = '';
 
-	#iconComponentRef?: ElementRef;
+	#iconComponentRef?: ElementRef<HTMLElement>;
 
-	@ContentChild(IconComponent, { read: ElementRef })
-	set iconComponentRef(ref: ElementRef) {
+	@ContentChild(IconComponent, { read: ElementRef<HTMLElement> })
+	set iconComponentRef(ref: ElementRef<HTMLElement>) {
 		this.#iconComponentRef = ref;
 		this.updateClasses();
 	}
 
 	private get iconOnly(): boolean {
-		const listOfNode = Array.from((this.#elementRef?.nativeElement as HTMLButtonElement)?.childNodes || []);
-		const noText = listOfNode.every((node) => node.nodeName !== '#text');
+		const childNodes = Array.from(this.#elementRef?.nativeElement?.childNodes || []);
+		const noText = childNodes.every(({ nodeName }) => nodeName !== '#text');
 		// ignore icon and comment
 		const noSpan =
-			listOfNode.filter((node) => {
-				return !(node.nodeName === '#comment' || (node as HTMLElement)?.tagName?.toLowerCase() === 'lu-icon');
+			childNodes.filter(({ nodeName }) => {
+				return !(nodeName === '#comment' || nodeName.toLowerCase() === 'lu-icon');
 			}).length == 0;
 		return !!this.#iconComponentRef && noSpan && noText;
 	}

--- a/stories/documentation/actions/button/angular/button-icon.stories.ts
+++ b/stories/documentation/actions/button/angular/button-icon.stories.ts
@@ -11,14 +11,14 @@ export default {
 			imports: [IconComponent],
 		}),
 	],
-	render: ({ luButton, ...inputs }, { argTypes }) => {
+	render: ({ luButton, label, ...inputs }, { argTypes }) => {
 		return {
-			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''} ${generateInputs(inputs, argTypes)}><lu-icon icon="signInfo"></lu-icon></button>`,
+			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''} ${generateInputs(inputs, argTypes)}><lu-icon icon="signInfo"></lu-icon>${label}</button>`,
 		};
 	},
 } as Meta;
 
-export const Basic: StoryObj<ButtonComponent> = {
+export const Basic: StoryObj<ButtonComponent & {label: string}> = {
 	argTypes: {
 		luButton: {
 			options: ['', 'outlined', 'text', 'text-invert'],
@@ -33,5 +33,6 @@ export const Basic: StoryObj<ButtonComponent> = {
 		palette: 'none',
 		state: 'default',
 		luButton: '',
+		label: '',
 	},
 };

--- a/stories/documentation/actions/button/angular/button-icon.stories.ts
+++ b/stories/documentation/actions/button/angular/button-icon.stories.ts
@@ -3,6 +3,7 @@ import { ButtonComponent } from '@lucca-front/ng/button';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { generateInputs } from 'stories/helpers/stories';
 
+
 export default {
 	title: 'Documentation/Actions/Button/Angular/Icon',
 	component: ButtonComponent,

--- a/stories/documentation/actions/button/angular/button-icon.stories.ts
+++ b/stories/documentation/actions/button/angular/button-icon.stories.ts
@@ -13,7 +13,7 @@ export default {
 	],
 	render: ({ luButton, ...inputs }, { argTypes }) => {
 		return {
-			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''} ${generateInputs(inputs, argTypes)}><lu-icon icon="signInfo"></lu-icon> Click me !</button>`,
+			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''} ${generateInputs(inputs, argTypes)}><lu-icon icon="signInfo"></lu-icon></button>`,
 		};
 	},
 } as Meta;


### PR DESCRIPTION
## Description

Closes #2499 : `mod-onlyIcon` when child `IconComponent` exists. `withIcon` class when the button is empty (text / span)

-----
