### PR TITLE
[Gauge / Progress] Fix height & background color

### DIFF
--- a/packages/scss/src/components/gauge/component.scss
+++ b/packages/scss/src/components/gauge/component.scss
@@ -1,9 +1,9 @@
 @mixin component($atRoot: 'without: rule') {
-	border-radius: var(--commons-borderRadius-M);
+	border-radius: var(--commons-borderRadius-full);
 	height: var(--components-gauge-height);
 	overflow: hidden;
 	position: relative;
-	background-color: rgba(var(--colors-grey-900-rgb), 0.05);
+	background-color: var(--components-gauge-background);
 
 	@at-root ($atRoot) {
 		.gauge-bar {

--- a/packages/scss/src/components/gauge/vars.scss
+++ b/packages/scss/src/components/gauge/vars.scss
@@ -1,3 +1,4 @@
 @mixin vars {
-	--components-gauge-height: 0.625rem;
+	--components-gauge-height: 0.5rem;
+	--components-gauge-background: var(--palettes-grey-100);
 }

--- a/packages/scss/src/components/progress/component.scss
+++ b/packages/scss/src/components/progress/component.scss
@@ -13,7 +13,8 @@
 		}
 	}
 
-	background-color: var(--commons-background-base);
+	background-color: var(--components-progress-background);
+	border-radius: var(--commons-borderRadius-full);
 	height: var(--components-progress-height);
 	margin: var(--components-progress-margin-vertical) var(--components-progress-margin-horizontal);
 	position: relative;

--- a/packages/scss/src/components/progress/vars.scss
+++ b/packages/scss/src/components/progress/vars.scss
@@ -1,7 +1,8 @@
 @mixin vars {
 	--components-progress-margin-vertical: var(--spacings-S);
 	--components-progress-margin-horizontal: 0;
-	--components-progress-height: var(--spacings-XXS);
+	--components-progress-height: 0.25rem;
+	--components-progress-background: var(--palettes-grey-100);
 	--components-progress-bar-background: var(--palettes-primary-700);
 	--components-progress-bar-gradient: linear-gradient(to right, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0.5) 100%);
 	--components-progress-duration: 1.5s;


### PR DESCRIPTION
## Description
### Gauge
- Height : 10px > 8px
- Background color : Replace transparent black by grey 100 (Keep a variable open in case it's needed on darker backgrounds) 
### Progress
- Background color : Replace Base by grey 100  (Keep a variable open in case it's needed on darker backgrounds) 
- Add border radius

-----
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/d754f138-65cf-4dcb-b6dc-a6b5a02db07e)
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/8159659e-b963-4a10-91b9-3c3ec55bba95)


-----
