### PR TITLE
docs(stories): stories and code display improvements

### DIFF
--- a/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
+++ b/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
@@ -62,5 +62,7 @@ export const Template: StoryObj<CalloutPopoverComponent> = {
 		heading: 'List title',
 		icon: 'signInfo',
 		palette: 'none',
+		closeDelay: 500,
+		openDelay: 50,
 	},
 };

--- a/stories/documentation/forms/fields/checkbox/angular/checkboxfield.stories.ts
+++ b/stories/documentation/forms/fields/checkbox/angular/checkboxfield.stories.ts
@@ -1,8 +1,8 @@
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { cleanupTemplate } from 'stories/helpers/stories';
+import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 
 export default {
@@ -29,19 +29,25 @@ export default {
 } as Meta;
 
 export const Basic: StoryObj<CheckboxInputComponent & FormFieldComponent> = {
-	render: ({ label, required, hiddenLabel, inlineMessage, size, inlineMessageState, tooltip }) => {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
 		return {
 			props: {
 				example: false,
 			},
-			template: cleanupTemplate(`<lu-form-field label="${label}"
-	${hiddenLabel ? 'hiddenLabel' : ''}
-	tooltip="${tooltip}"
-	inlineMessage="${inlineMessage}"
-	inlineMessageState="${inlineMessageState}"
-	size="${size}">
+			template: cleanupTemplate(`<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
 	<lu-checkbox-input
-	required="${required}"
+		${generateInputs(inputArgs, argTypes)}
 	[(ngModel)]="example"/>
 </lu-form-field>
 

--- a/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
+++ b/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
@@ -6,6 +6,7 @@ import { allLegumes, FilterLegumesPipe } from '@/stories/forms/select/select.uti
 import { HiddenArgType } from '../../../../../helpers/common-arg-types';
 import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { generateInputs } from '../../../../../helpers/stories';
 
 export default {
 	title: 'Documentation/Forms/Fields/Multi Select/Angular',
@@ -42,25 +43,26 @@ export default {
 } as Meta;
 
 export const Basic: StoryObj<LuMultiSelectInputComponent<unknown> & FormFieldComponent> = {
-	render: ({ label, required, hiddenLabel, inlineMessage, size, placeholder, inlineMessageState, disabled, tooltip, clearable }) => {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
 		return {
 			props: { legumes: allLegumes, example: [] },
 			template: `
-<lu-form-field
-	label="${label}"
-	${hiddenLabel ? 'hiddenLabel' : ''}
-	inlineMessage="${inlineMessage}"
-	inlineMessageState="${inlineMessageState}"
-	size="${size}"
-	tooltip="${tooltip}"
->
+<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
 	<lu-multi-select
-		${disabled ? 'disabled' : ''}
-		${clearable ? 'clearable' : ''}
+		${generateInputs(inputArgs, argTypes)}
 		[options]="legumes | filterLegumes:clue"
 		(clueChange)="clue = $event"
-		placeholder="${placeholder}"
-		required="${required}"
 		[(ngModel)]="example">
 	</lu-multi-select>
 </lu-form-field>

--- a/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
+++ b/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
@@ -6,6 +6,7 @@ import { allLegumes, FilterLegumesPipe } from '@/stories/forms/select/select.uti
 import { HiddenArgType } from '../../../../../helpers/common-arg-types';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { generateInputs } from '../../../../../helpers/stories';
 
 export default {
 	title: 'Documentation/Forms/Fields/Simple Select/Angular',
@@ -42,26 +43,25 @@ export default {
 } as Meta;
 
 export const Basic: StoryObj<LuSimpleSelectInputComponent<unknown> & FormFieldComponent> = {
-	render: ({ label, required, clearable, loading, hiddenLabel, inlineMessage, size, placeholder, inlineMessageState, disabled, tooltip }) => {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
 		return {
 			props: { legumes: allLegumes },
-			template: `
-<lu-form-field
-	label="${label}"
-	${hiddenLabel ? 'hiddenLabel' : ''}
-	inlineMessage="${inlineMessage}"
-	inlineMessageState="${inlineMessageState}"
-	size="${size}"
-	tooltip="${tooltip}"
->
+			template: `<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
 	<lu-simple-select
-		${loading ? 'loading' : ''}
-		${disabled ? 'disabled' : ''}
-		${clearable ? 'clearable' : ''}
+		${generateInputs(inputArgs, argTypes)}
 		[options]="legumes | filterLegumes:clue"
 		(clueChange)="clue = $event"
-		placeholder="${placeholder}"
-		required="${required}"
 		[(ngModel)]="example">
 	</lu-simple-select>
 </lu-form-field>

--- a/stories/documentation/forms/fields/switch/angular/switchfield.stories.ts
+++ b/stories/documentation/forms/fields/switch/angular/switchfield.stories.ts
@@ -2,7 +2,7 @@ import { CheckboxInputComponent, SwitchInputComponent } from '@lucca-front/ng/fo
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { cleanupTemplate } from 'stories/helpers/stories';
+import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 
 export default {
@@ -29,20 +29,25 @@ export default {
 } as Meta;
 
 export const Basic: StoryObj<SwitchInputComponent & FormFieldComponent> = {
-	render: ({ label, required, hiddenLabel, inlineMessage, size, inlineMessageState, tooltip }) => {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
 		return {
 			props: {
 				example: false,
 			},
-			template: cleanupTemplate(`<lu-form-field label="${label}"
-	${hiddenLabel ? 'hiddenLabel' : ''}
-	tooltip="${tooltip}"
-	inlineMessage="${inlineMessage}"
-	inlineMessageState="${inlineMessageState}"
-	size="${size}">
+			template: cleanupTemplate(`<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
 
-	<lu-switch-input
-	required="${required}"
+	<lu-switch-input ${generateInputs(inputArgs, argTypes)}
 	[(ngModel)]="example"/>
 
 </lu-form-field>

--- a/stories/documentation/forms/fields/text/angular/textfield.stories.ts
+++ b/stories/documentation/forms/fields/text/angular/textfield.stories.ts
@@ -2,7 +2,7 @@ import { TextInputComponent } from '@lucca-front/ng/forms';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { cleanupTemplate } from 'stories/helpers/stories';
+import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 
 export default {
@@ -38,30 +38,121 @@ export default {
 } as Meta;
 
 export const Basic: StoryObj<TextInputComponent & { disabled: boolean } & FormFieldComponent> = {
-	render: ({ label, required, hiddenLabel, inlineMessage, size, placeholder, prefix, suffix, inlineMessageState, hasClearer, disabled, tooltip, hasSearchIcon, searchIcon, type }) => {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
 		return {
-			props: {
-				prefix,
-				suffix,
-			},
-			template: cleanupTemplate(`
-<lu-form-field label="${label}"
-	${hiddenLabel ? 'hiddenLabel' : ''}
-	tooltip="${tooltip}"
-	inlineMessage="${inlineMessage}"
-	inlineMessageState="${inlineMessageState}"
-	size="${size}">
+			template: cleanupTemplate(`<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
 
 	<lu-text-input
-		required="${required}"
-		${hasClearer ? 'hasClearer' : ''}
-		${hasSearchIcon ? 'hasSearchIcon' : ''}
-		${disabled ? 'disabled' : ''}
+	${generateInputs(inputArgs, argTypes)}
+		[(ngModel)]="example">
+	</lu-text-input>
+
+</lu-form-field>
+
+{{example}}`),
+			moduleMetadata: {
+				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+			},
+		};
+	},
+	args: {
+		label: 'Label',
+		required: true,
+		hiddenLabel: false,
+		hasClearer: true,
+		hasSearchIcon: false,
+		searchIcon: 'search',
+		disabled: false,
+		inlineMessage: 'Helper Text',
+		inlineMessageState: 'default',
+		size: 'M',
+		type: 'text',
+		placeholder: 'Placeholder',
+		tooltip: "Je suis un message d'aide",
+	},
+};
+
+export const PasswordVisiblity: StoryObj<TextInputComponent & { disabled: boolean } & FormFieldComponent> = {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
+		return {
+			template: cleanupTemplate(`
+<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
+
+	<lu-text-input ${generateInputs(inputArgs, argTypes)}
+		type="password"
+		[(ngModel)]="example">
+	</lu-text-input>
+
+</lu-form-field>
+
+{{example}}`),
+			moduleMetadata: {
+				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+			},
+		};
+	},
+	args: {
+		label: 'Label',
+		required: true,
+		hiddenLabel: false,
+		hasClearer: true,
+		hasSearchIcon: false,
+		searchIcon: 'search',
+		disabled: false,
+		inlineMessage: 'Helper Text',
+		inlineMessageState: 'default',
+		size: 'M',
+		placeholder: 'Placeholder',
+		tooltip: "Je suis un message d'aide",
+	},
+};
+
+export const WithPrefixAndSuffix: StoryObj<TextInputComponent & { disabled: boolean } & FormFieldComponent> = {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, prefix, suffix, ...inputArgs } = args;
+		return {
+			props: {
+				prefix: args.prefix,
+				suffix: args.suffix,
+			},
+			template: cleanupTemplate(`<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
+
+	<lu-text-input
+		${generateInputs(inputArgs, argTypes)}
 		[prefix]="prefix"
 		[suffix]="suffix"
-		searchIcon="${searchIcon}"
-		placeholder="${placeholder}"
-		type="${type}"
 		[(ngModel)]="example">
 	</lu-text-input>
 

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -19,6 +19,14 @@ const hiddenArgTypes = {
 	options: HiddenArgType,
 	overlayConfig: HiddenArgType,
 	valueTpl: HiddenArgType,
+	previousPage: HiddenArgType,
+	nextPage: HiddenArgType,
+	clueChange: HiddenArgType,
+	legumes: HiddenArgType,
+	legumeColor: HiddenArgType,
+	selectedLegumes: HiddenArgType,
+	page: HiddenArgType,
+	colorNameByColor: HiddenArgType,
 };
 
 export const Basic = generateStory({

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -17,6 +17,13 @@ const hiddenArgTypes = {
 	optionTpl: HiddenArgType,
 	overlayConfig: HiddenArgType,
 	valueTpl: HiddenArgType,
+	previousPage: HiddenArgType,
+	nextPage: HiddenArgType,
+	clueChange: HiddenArgType,
+	legumes: HiddenArgType,
+	legumeColor: HiddenArgType,
+	page: HiddenArgType,
+	colorNameByColor: HiddenArgType,
 };
 export const Basic = generateStory({
 	name: 'Basic',

--- a/stories/documentation/users/select/user-select.stories.ts
+++ b/stories/documentation/users/select/user-select.stories.ts
@@ -57,7 +57,9 @@ class UserSelectStoriesModule {}
 `;
 
 export const basic = template.bind({});
-basic.args = {};
+basic.args = {
+	disablePrincipal: false,
+};
 
 basic.parameters = {
 	docs: {


### PR DESCRIPTION
## Description

Various stories imrovements:

- Simple select Input doc cleanup
- Multi select input doc cleanup
- Textfield now has 3 stories: basic, with prefix/suffix, password visibility
- callout popover now has base values for `closeDelay` and `openDelay`
- luUserSelect now has a base value for `disablePrincipal`
- Better code formatting for ZeroHeight renderer using `generateInputs`

-----

-----
