### PR TITLE
fix(commons): delete wrong parentheses usage in condition

### DIFF
--- a/packages/scss/src/commons/utils/reset.scss
+++ b/packages/scss/src/commons/utils/reset.scss
@@ -1,7 +1,7 @@
 @mixin list($suffix: '', $list: 'ul') {
 	margin: 0 #{$suffix};
 
-	@if $list == 'ul' or 'ol' {
+	@if $list == 'ul' or $list == 'ol' {
 		padding: 0 #{$suffix};
 		list-style-type: none #{$suffix};
 	}

--- a/packages/scss/src/commons/utils/reset.scss
+++ b/packages/scss/src/commons/utils/reset.scss
@@ -1,7 +1,7 @@
 @mixin list($suffix: '', $list: 'ul') {
 	margin: 0 #{$suffix};
 
-	@if $list == ('ul' or 'ol') {
+	@if $list == 'ul' or 'ol' {
 		padding: 0 #{$suffix};
 		list-style-type: none #{$suffix};
 	}


### PR DESCRIPTION
## Description

Actuellement on ne peut pas faire de reset en précisant `ol` comme paramètre dans l'appel de la mixin.
```
ol {
  @include reset.list($list: 'ol');
}
```

C'est parce que dans la mixin il ne faut pas les parenthèses dans la condition.
La solution de repli c'est de ne rien préciser en paramètre car c'est les mêmes styles que le `ul` qui est le choix par défaut.
```
ol {
  @include reset.list;
}
```

-----
