### PR TITLE
[Table] States colors & checkbox alignement fixes

### DIFF
--- a/packages/scss/src/components/checkbox/mods.scss
+++ b/packages/scss/src/components/checkbox/mods.scss
@@ -23,7 +23,7 @@
 }
 
 @mixin noLabel {
-	height: 1rem;
+	line-height: var(--components-checkbox-input-size);
 
 	.checkbox-label {
 		vertical-align: top;

--- a/packages/scss/src/components/table/index.scss
+++ b/packages/scss/src/components/table/index.scss
@@ -14,6 +14,14 @@
 
 	&.mod-clickable {
 		@include clickable;
+
+		.table-head-row,
+		.table-body-row,
+		.table-foot-row {
+			&.mod-selectable {
+				@include clickableSelectable;
+			}
+		}
 	}
 
 	&.mod-card {

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -221,7 +221,7 @@
 		.table-head-row-cell,
 		.table-body-row-cell,
 		.table-foot-row-cell {
-			background: var(--palettes-primary-50);
+			background-color: var(--palettes-primary-50);
 		}
 	}
 }

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -216,6 +216,27 @@
 			width: var(--spacings-S);
 		}
 	}
+
+	&:has(input[type='checkbox']:checked) {
+		.table-head-row-cell,
+		.table-body-row-cell,
+		.table-foot-row-cell {
+			background: var(--palettes-primary-50);
+		}
+	}
+}
+
+
+@mixin clickableSelectable {
+	&:hover {
+		&:has(input[type='checkbox']:checked) {
+			.table-head-row-cell,
+			.table-body-row-cell,
+			.table-foot-row-cell {
+				background-color: var(--palettes-primary-100);
+			}
+		}
+	}
 }
 
 @mixin twoLines($atRoot: 'without: rule') {

--- a/packages/scss/src/components/table/vars.scss
+++ b/packages/scss/src/components/table/vars.scss
@@ -3,6 +3,6 @@
 	--components-table-font-size: var(--sizes-M-fontSize);
 	--components-table-line-height: var(--sizes-M-lineHeight);
 	--components-table-zebra-background: #f5f5f5;
-	--components-table-hover-background: var(--palettes-grey-50);
+	--components-table-hover-background: var(--palettes-grey-25);
 	--components-table-card-padding: var(--spacings-M);
 }

--- a/stories/documentation/listings/table/table-selectable.stories.ts
+++ b/stories/documentation/listings/table/table-selectable.stories.ts
@@ -13,10 +13,11 @@ function getTemplate(args: TableSelectableStory): string {
 	  <thead class="table-head">
 	    <tr class="table-head-row mod-selectable">
 	      <th class="table-head-row-cell">
-				<span class="checkboxField">
-					<input type="checkbox" class="checkboxField-input" id="CB1" aria-describedby="CB1message" aria-required="true" />
-					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
-				</span>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CBall" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
+					<label class="u-mask" for="CBall">Label</label>
 				</th>
 	      <th class="table-head-row-cell">Label</th>
 	      <th class="table-head-row-cell">Label</th>
@@ -26,10 +27,11 @@ function getTemplate(args: TableSelectableStory): string {
 	  <tbody class="table-body">
 	    <tr class="table-body-row mod-selectable">
 	      <td class="table-body-row-cell">
-				<span class="checkboxField">
-					<input type="checkbox" class="checkboxField-input" id="CB2" aria-describedby="CB2message" aria-required="true" />
-					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
-				</span>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CB1" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
+					<label class="u-mask" for="CB1">Label</label>
 				</td>
 	      <td class="table-body-row-cell">Contenu</td>
 	      <td class="table-body-row-cell">Contenu</td>
@@ -37,10 +39,11 @@ function getTemplate(args: TableSelectableStory): string {
 	    </tr>
 	    <tr class="table-body-row mod-selectable">
 	      <td class="table-body-row-cell">
-				<span class="checkboxField">
-					<input type="checkbox" class="checkboxField-input" id="CB3" aria-describedby="CB3message" aria-required="true" />
-					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
-				</span>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CB2" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
+					<label class="u-mask" for="CB2">Label</label>
 				</td>
 	      <td class="table-body-row-cell">Contenu</td>
 	      <td class="table-body-row-cell">Contenu</td>

--- a/stories/documentation/listings/table/table-selectable.stories.ts
+++ b/stories/documentation/listings/table/table-selectable.stories.ts
@@ -13,10 +13,10 @@ function getTemplate(args: TableSelectableStory): string {
 	  <thead class="table-head">
 	    <tr class="table-head-row mod-selectable">
 	      <th class="table-head-row-cell">
-					<label class="checkbox">
-						<input class="checkbox-input" type="checkbox" />
-						<span class="checkbox-label"></span>
-					</label>
+				<span class="checkboxField">
+					<input type="checkbox" class="checkboxField-input" id="CB1" aria-describedby="CB1message" aria-required="true" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+				</span>
 				</th>
 	      <th class="table-head-row-cell">Label</th>
 	      <th class="table-head-row-cell">Label</th>
@@ -26,10 +26,10 @@ function getTemplate(args: TableSelectableStory): string {
 	  <tbody class="table-body">
 	    <tr class="table-body-row mod-selectable">
 	      <td class="table-body-row-cell">
-					<label class="checkbox">
-						<input class="checkbox-input" type="checkbox" />
-						<span class="checkbox-label"></span>
-					</label>
+				<span class="checkboxField">
+					<input type="checkbox" class="checkboxField-input" id="CB2" aria-describedby="CB2message" aria-required="true" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+				</span>
 				</td>
 	      <td class="table-body-row-cell">Contenu</td>
 	      <td class="table-body-row-cell">Contenu</td>
@@ -37,10 +37,10 @@ function getTemplate(args: TableSelectableStory): string {
 	    </tr>
 	    <tr class="table-body-row mod-selectable">
 	      <td class="table-body-row-cell">
-					<label class="checkbox">
-						<input class="checkbox-input" type="checkbox" />
-						<span class="checkbox-label"></span>
-					</label>
+				<span class="checkboxField">
+					<input type="checkbox" class="checkboxField-input" id="CB3" aria-describedby="CB3message" aria-required="true" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+				</span>
 				</td>
 	      <td class="table-body-row-cell">Contenu</td>
 	      <td class="table-body-row-cell">Contenu</td>

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -76,14 +76,14 @@
 <!-- Checkbox -->
 <section class="contentSection">
 	<h1>Selectable</h1>
-	<table class="table">
+	<table class="table mod-clickable">
 		<thead class="table-head">
 			<tr class="table-head-row mod-selectable">
 				<th class="table-head-row-cell">
-					<div class="checkbox mod-noLabel">
-						<input class="checkbox-input" type="checkbox" id="rowAll" />
-						<label class="checkbox-label" for="rowAll"></label>
-					</div>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CBALL" aria-describedby="CBALLmessage" aria-required="true" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
 				</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
@@ -93,10 +93,10 @@
 		<tbody class="table-body">
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
-					<div class="checkbox mod-noLabel">
-						<input class="checkbox-input" type="checkbox" id="row0" checked />
-						<label class="checkbox-label" for="row0"></label>
-					</div>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CB1" aria-describedby="CB1message" aria-required="true" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
@@ -104,10 +104,10 @@
 			</tr>
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
-					<div class="checkbox mod-noLabel">
-						<input class="checkbox-input" type="checkbox" id="row1" checked />
-						<label class="checkbox-label" for="row1"></label>
-					</div>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CB2" aria-describedby="CB2message" aria-required="true" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
@@ -115,10 +115,10 @@
 			</tr>
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
-					<div class="checkbox mod-noLabel">
-						<input class="checkbox-input" type="checkbox" id="row2" />
-						<label class="checkbox-label" for="row2"></label>
-					</div>
+					<span class="checkboxField">
+						<input type="checkbox" class="checkboxField-input" id="CB3" aria-describedby="CB3message" aria-required="true" />
+						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+					</span>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -76,7 +76,7 @@
 <!-- Checkbox -->
 <section class="contentSection">
 	<h1>Selectable</h1>
-	<table class="table mod-clickable">
+	<table class="table">
 		<thead class="table-head">
 			<tr class="table-head-row mod-selectable">
 				<th class="table-head-row-cell">
@@ -119,10 +119,10 @@
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
 					<span class="checkboxField">
-						<input type="checkbox" class="checkboxField-input" id="CB2" />
+						<input type="checkbox" class="checkboxField-input" id="CB3" />
 						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 					</span>
-					<label class="u-mask" for="CB2">Label</label>
+					<label class="u-mask" for="CB3">Label</label>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -81,9 +81,10 @@
 			<tr class="table-head-row mod-selectable">
 				<th class="table-head-row-cell">
 					<span class="checkboxField">
-						<input type="checkbox" class="checkboxField-input" id="CBALL" aria-describedby="CBALLmessage" aria-required="true" />
+						<input type="checkbox" class="checkboxField-input" id="CBall" />
 						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 					</span>
+					<label class="u-mask" for="CBall">Label</label>
 				</th>
 				<th class="table-head-row-cell">Head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
@@ -94,9 +95,10 @@
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
 					<span class="checkboxField">
-						<input type="checkbox" class="checkboxField-input" id="CB1" aria-describedby="CB1message" aria-required="true" />
+						<input type="checkbox" class="checkboxField-input" id="CB1" />
 						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 					</span>
+					<label class="u-mask" for="CB1">Label</label>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
@@ -105,9 +107,10 @@
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
 					<span class="checkboxField">
-						<input type="checkbox" class="checkboxField-input" id="CB2" aria-describedby="CB2message" aria-required="true" />
+						<input type="checkbox" class="checkboxField-input" id="CB2" />
 						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 					</span>
+					<label class="u-mask" for="CB2">Label</label>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>
@@ -116,9 +119,10 @@
 			<tr class="table-body-row mod-selectable">
 				<td class="table-body-row-cell">
 					<span class="checkboxField">
-						<input type="checkbox" class="checkboxField-input" id="CB3" aria-describedby="CB3message" aria-required="true" />
+						<input type="checkbox" class="checkboxField-input" id="CB2" />
 						<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 					</span>
+					<label class="u-mask" for="CB2">Label</label>
 				</td>
 				<td class="table-body-row-cell">Body cell</td>
 				<td class="table-body-row-cell">Body cell</td>


### PR DESCRIPTION
## Description

- Hover : grey 25 > grey 50
- Selected line : product 50
- Selected line hovered in a clickable table : product 100
- Fix checkbox alignement
- Replace old checkbox by the new one

-----
![Capture d’écran 2024-01-29 à 14 49 40](https://github.com/LuccaSA/lucca-front/assets/25581936/f458a637-d617-4563-966d-3f94af829f12)

https://github.com/LuccaSA/lucca-front/assets/25581936/95ac6353-d90f-4d64-8ff1-9f0f814b046c

https://github.com/LuccaSA/lucca-front/assets/25581936/f899966d-1693-41eb-a723-6e0a24128bbd

-----
