### PR TITLE
Wrapped components fix default display 

### DIFF
--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.scss
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.scss
@@ -1,5 +1,5 @@
 @use '@lucca-front/scss/src/components/calloutDisclosure';
 
-:host {
+lu-callout-disclosure {
   display: block;
 }

--- a/packages/ng/callout/callout-popover/callout-popover.component.scss
+++ b/packages/ng/callout/callout-popover/callout-popover.component.scss
@@ -1,5 +1,5 @@
 @use '@lucca-front/scss/src/components/calloutPopover';
 
-:host {
+lu-callout-popover {
   display: inline-flex;
 }

--- a/packages/ng/callout/callout/callout.component.scss
+++ b/packages/ng/callout/callout/callout.component.scss
@@ -1,1 +1,5 @@
 @use '@lucca-front/scss/src/components/callout';
+
+lu-callout {
+  display: block;
+}

--- a/packages/ng/icon/icon.component.scss
+++ b/packages/ng/icon/icon.component.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/icons/src/main';
 
-:host {
+lu-icon {
   display: inline-flex;
 }
 


### PR DESCRIPTION
## Description

Default display of wrapped component in `:host` selector stopped to work when we switched components to `encapsulation: ViewEncapsulation.None`

-----