### PR TITLE
Clean states for buttons

### DIFF
--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use 'states';
 
 @mixin component {
 	@include icon.M;
@@ -43,9 +44,26 @@
 		@include icon.M;
 	}
 
-	&:not(.mod-outlined) {
+	// .mod-outline is deprecated
+	&:not(.mod-outlined, .mod-outline) {
 		.numericBadge {
 			@include numericBadge.primary;
 		}
+	}
+
+	&:hover {
+		@include states.hover;
+	}
+
+	&:focus-visible {
+		@include states.focusVisible;
+	}
+
+	&:active {
+		@include states.active;
+	}
+
+	&:disabled {
+		@include states.disabled;
 	}
 }

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -1,7 +1,6 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use 'states';
+@use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 
 @mixin component {
 	@include icon.M;
@@ -52,18 +51,26 @@
 	}
 
 	&:hover {
-		@include states.hover;
+		--components-button-color: var(--palettes-text, var(--palettes-primary-text));
+		--components-button-backgroundColor: var(--palettes-600, var(--palettes-primary-600));
 	}
 
 	&:focus-visible {
-		@include states.focusVisible;
+		@include a11y.focusVisible;
 	}
 
 	&:active {
-		@include states.active;
+		--components-button-backgroundColor: var(--palettes-800, var(--palettes-primary-800));
 	}
 
 	&:disabled {
-		@include states.disabled;
+		--components-button-cursor: default;
+		--components-button-color: var(--palettes-grey-500);
+		--components-button-backgroundColor: var(--commons-disabled-background);
+		--components-button-pointerEvents: none;
+
+		.numericBadge {
+			@include numericBadge.disabled;
+		}
 	}
 }

--- a/packages/scss/src/components/button/index.scss
+++ b/packages/scss/src/components/button/index.scss
@@ -16,43 +16,27 @@
 		@include XS;
 	}
 
-	&:hover {
-		@include hover;
-	}
-
-	&:focus-visible {
-		@include focusVisible;
-	}
-
-	&:active {
-		@include active;
-	}
-
-	&:is(.mod-outline, .mod-outlined) {
+	// .mod-outline is deprecated
+	&.mod-outlined,
+	&.mod-outline {
 		@include outlined;
 
-		&:hover {
-			@include outlinedHover;
-		}
-
-		&:active {
-			@include outlinedActive;
-		}
-
-		&:focus-visible {
-			@include outlinedFocusVisible;
+		// .disabled is deprecated
+		&.is-disabled,
+		&.disabled {
+			@include outlinedDisabled;
 		}
 	}
 
-	&:is(.mod-text, .mod-link) {
+	// .mod-link deprecated
+	&.mod-text,
+	&.mod-link {
 		@include text;
 
-		&:is(:hover, :focus-visible) {
-			@include textHover;
-		}
-
-		&:active {
-			@include textActive;
+		// .disabled is deprecated
+		&.is-disabled,
+		&.disabled {
+			@include textDisabled;
 		}
 	}
 
@@ -67,14 +51,11 @@
 		&.mod-XS {
 			@include counterXS;
 		}
-
-		&:hover {
-			@include counterHover;
-		}
 	}
 
 	// .mod-icon is deprecated
-	&:is(.mod-icon, .mod-withIcon) {
+	&.mod-withIcon,
+	&.mod-icon {
 		@include withIcon;
 
 		&.mod-S {
@@ -98,50 +79,28 @@
 		}
 	}
 
+	// .mod-delete is deprecated
+	&.mod-deleted,
 	&.mod-delete {
-		&:hover {
-			@include deleteHover;
+		@include deleted;
+
+		// .mod-link is deprecated
+		&.mod-text,
+		&.mod-link {
+			@include deletedText;
 		}
 
-		&:active {
-			@include deleteActive;
-		}
-
-		&.mod-text {
-			&:is(:hover, :focus-visible) {
-				@include deleteHover;
-			}
-
-			&:active {
-				@include deleteActive;
-			}
-		}
-
-		&.mod-outlined {
-			&:hover {
-				@include deleteOutlinedHover;
-			}
-
-			&:focus-visible {
-				@include deleteOutlinedFocusVisible;
-			}
-
-			&:active {
-				@include deleteActive;
-			}
+		// .mod-outline is deprecated
+		&.mod-outlined,
+		&.mod-outline {
+			@include deletedOutlined;
 		}
 	}
 
+	// .mod-invert is deprecated
+	&.mod-inverted,
 	&.mod-invert {
-		@include invert;
-
-		&:is(:hover, :focus-visible) {
-			@include invertHover;
-		}
-
-		&:active {
-			@include invertActive;
-		}
+		@include inverted;
 	}
 
 	&.mod-more {
@@ -156,7 +115,9 @@
 		}
 	}
 
-	&:is(.is-loading, .loading) {
+	// .loading is deprecated
+	&.is-loading,
+	&.loading {
 		@include loading;
 
 		&.mod-S {
@@ -164,23 +125,21 @@
 		}
 	}
 
-	&:is(.is-error, .error) {
+	// .error is deprecated
+	&.is-error,
+	&.error {
 		@include error;
 	}
 
-	&:is(.is-success, .success) {
+	// .success is deprecated
+	&.is-success,
+	&.success {
 		@include success;
 	}
 
-	&:is(.is-disabled, .disabled, :disabled) {
+	// .disabled is deprecated
+	&.is-disabled,
+	&.disabled {
 		@include disabled;
-
-		&:is(.mod-outlined, .mod-outline) {
-			@include disabledOutlined;
-		}
-
-		&:is(.mod-text, .mod-link) {
-			@include disabledText;
-		}
 	}
 }

--- a/packages/scss/src/components/button/index.scss
+++ b/packages/scss/src/components/button/index.scss
@@ -79,21 +79,19 @@
 		}
 	}
 
-	// .mod-delete is deprecated
-	&.mod-deleted,
 	&.mod-delete {
-		@include deleted;
+		@include delete;
 
 		// .mod-link is deprecated
 		&.mod-text,
 		&.mod-link {
-			@include deletedText;
+			@include deleteText;
 		}
 
 		// .mod-outline is deprecated
 		&.mod-outlined,
 		&.mod-outline {
-			@include deletedOutlined;
+			@include deleteOutlined;
 		}
 	}
 

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -1,7 +1,7 @@
-@use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/icons/src/icon/exports' as icons;
+@use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
-@use 'states';
 
 @mixin S {
 	@include icons.S;
@@ -57,22 +57,34 @@
 	--components-button-padding: var(--spacings-XXS) var(--spacings-XS);
 }
 
+@mixin textDisabled {
+	--components-button-backgroundColor: transparent;
+	--components-button-color: var(--palettes-grey-500);
+}
+
 @mixin text {
 	--components-button-backgroundColor: transparent;
 	--components-button-color: var(--palettes-700, var(--palettes-grey-700));
 
 	&:hover,
 	&:focus-visible {
-		@include states.textHover;
+		--components-button-color: var(--palettes-700, var(--palettes-grey-700));
+		--components-button-backgroundColor: var(--palettes-100, var(--palettes-grey-100));
 	}
 
 	&:active {
-		@include states.textActive;
+		--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
 	}
 
 	&:disabled {
-		@include states.textDisabled;
+		@include textDisabled;
 	}
+}
+
+@mixin outlinedDisabled {
+	--components-button-backgroundColor: var(--colors-white-color);
+	--components-button-boxShadow: 0 0 0 1px var(--palettes-grey-400);
+	--components-button-color: var(--palettes-grey-500);
 }
 
 @mixin outlined {
@@ -87,19 +99,20 @@
 	}
 
 	&:hover {
-		@include states.outlinedHover;
+		--components-button-color: var(--palettes-700, var(--palettes-grey-700));
+		--components-button-backgroundColor: var(--palettes-100, var(--palettes-grey-100));
 	}
 
 	&:active {
-		@include states.outlinedActive;
+		--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
 	}
 
 	&:focus-visible {
-		@include states.outlinedFocusVisible;
+		@include a11y.focusVisible($offset: 3px);
 	}
 
 	&:disabled {
-		@include states.outlinedDisabled;
+		@include outlinedDisabled;
 	}
 }
 
@@ -108,11 +121,12 @@
 
 	&:hover,
 	&:focus-visible {
-		@include states.invertedHover;
+		--components-button-color: var(--colors-white-color);
+		--components-button-backgroundColor: var(--palettes-800, var(--palettes-grey-800));
 	}
 
 	&:active {
-		@include states.invertedActive;
+		--components-button-backgroundColor: var(--palettes-700, var(--palettes-grey-700));
 	}
 }
 
@@ -136,38 +150,46 @@
 	--components-button-minWidth: 1.5rem;
 }
 
-@mixin deleted {
+@mixin delete {
 	&:hover {
-		@include states.deletedHover;
+		--components-button-color: var(--palettes-error-700);
+		--components-button-backgroundColor: var(--palettes-error-100);
 	}
 
 	&:active {
-		@include states.deletedActive;
+		--components-button-color: var(--palettes-error-700);
+		--components-button-backgroundColor: var(--palettes-error-200);
 	}
 }
 
-@mixin deletedText {
+@mixin deleteText {
 	&:hover,
 	&:focus-visible {
-		@include states.deletedHover;
+		--components-button-color: var(--palettes-error-700);
+		--components-button-backgroundColor: var(--palettes-error-100);
 	}
 
 	&:active {
-		@include states.deletedActive;
+		--components-button-color: var(--palettes-error-700);
+		--components-button-backgroundColor: var(--palettes-error-200);
 	}
 }
 
-@mixin deletedOutlined {
+@mixin deleteOutlined {
 	&:hover {
-		@include states.deletedOutlinedHover;
+		--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-error-400), var(--commons-boxShadow-XS);
+		--components-button-color: var(--palettes-error-700);
+		--components-button-backgroundColor: var(--palettes-error-100);
 	}
 
 	&:focus-visible {
-		@include states.deletedOutlinedFocusVisible;
+		--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-error-400), var(--commons-boxShadow-XS);
+		--components-button-color: var(--palettes-error-700);
 	}
 
 	&:active {
-		@include states.deletedActive;
+		--components-button-color: var(--palettes-error-700);
+		--components-button-backgroundColor: var(--palettes-error-200);
 	}
 }
 
@@ -188,7 +210,9 @@
 	}
 
 	&:hover {
-		@include states.counterHover;
+		.button-counter {
+			--components-button-backgroundColor: var(--palettes-500, var(--palettes-primary-500));
+		}
 	}
 }
 

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/icons/src/icon/exports' as icons;
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
+@use 'states';
 
 @mixin S {
 	@include icons.S;
@@ -59,6 +60,19 @@
 @mixin text {
 	--components-button-backgroundColor: transparent;
 	--components-button-color: var(--palettes-700, var(--palettes-grey-700));
+
+	&:hover,
+	&:focus-visible {
+		@include states.textHover;
+	}
+
+	&:active {
+		@include states.textActive;
+	}
+
+	&:disabled {
+		@include states.textDisabled;
+	}
 }
 
 @mixin outlined {
@@ -71,10 +85,35 @@
 		color: var(--palettes-800, var(--palettes-grey-800));
 		background-color: var(--palettes-300, var(--palettes-grey-300));
 	}
+
+	&:hover {
+		@include states.outlinedHover;
+	}
+
+	&:active {
+		@include states.outlinedActive;
+	}
+
+	&:focus-visible {
+		@include states.outlinedFocusVisible;
+	}
+
+	&:disabled {
+		@include states.outlinedDisabled;
+	}
 }
 
-@mixin invert {
+@mixin inverted {
 	--components-button-color: var(--colors-white-color);
+
+	&:hover,
+	&:focus-visible {
+		@include states.invertedHover;
+	}
+
+	&:active {
+		@include states.invertedActive;
+	}
 }
 
 @mixin more {
@@ -97,6 +136,41 @@
 	--components-button-minWidth: 1.5rem;
 }
 
+@mixin deleted {
+	&:hover {
+		@include states.deletedHover;
+	}
+
+	&:active {
+		@include states.deletedActive;
+	}
+}
+
+@mixin deletedText {
+	&:hover,
+	&:focus-visible {
+		@include states.deletedHover;
+	}
+
+	&:active {
+		@include states.deletedActive;
+	}
+}
+
+@mixin deletedOutlined {
+	&:hover {
+		@include states.deletedOutlinedHover;
+	}
+
+	&:focus-visible {
+		@include states.deletedOutlinedFocusVisible;
+	}
+
+	&:active {
+		@include states.deletedActive;
+	}
+}
+
 // deprecated
 @mixin counter {
 	--components-button-padding: var(--spacings-XS) calc(var(--spacings-XS) + var(--spacings-XXS)) var(--spacings-XS) var(--spacings-S);
@@ -111,6 +185,10 @@
 		align-items: center;
 		justify-content: center;
 		transition: background-color var(--commons-animations-durations-fast) ease;
+	}
+
+	&:hover {
+		@include states.counterHover;
 	}
 }
 

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -18,22 +18,10 @@
 	}
 }
 
-@mixin outlinedDisabled {
-	--components-button-backgroundColor: var(--colors-white-color);
-	--components-button-boxShadow: 0 0 0 1px var(--palettes-grey-400);
-	--components-button-color: var(--palettes-grey-500);
-}
-
-@mixin textDisabled {
-	--components-button-backgroundColor: transparent;
-	--components-button-color: var(--palettes-grey-500);
-}
-
 @mixin loading {
-	--components-button-opacity: var(--commons-disabled-opacity);
-
 	@include loading.spinner(var(--components-button-font-size));
 
+	--components-button-opacity: var(--commons-disabled-opacity);
 	--components-button-pointerEvents: none;
 	--components-button-color: transparent;
 	--components-button-userSelect: none;
@@ -75,77 +63,5 @@
 
 	&::after {
 		@include icon.generate('sign_close');
-	}
-}
-
-@mixin hover {
-	--components-button-color: var(--palettes-text, var(--palettes-primary-text));
-	--components-button-backgroundColor: var(--palettes-600, var(--palettes-primary-600));
-}
-
-@mixin focusVisible {
-	@include a11y.focusVisible;
-}
-
-@mixin active {
-	--components-button-backgroundColor: var(--palettes-800, var(--palettes-primary-800));
-}
-
-@mixin textHover {
-	--components-button-color: var(--palettes-700, var(--palettes-grey-700));
-	--components-button-backgroundColor: var(--palettes-100, var(--palettes-grey-100));
-}
-
-@mixin textActive {
-	--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
-}
-
-@mixin deletedHover {
-	--components-button-color: var(--palettes-error-700);
-	--components-button-backgroundColor: var(--palettes-error-100);
-}
-
-@mixin deletedActive {
-	--components-button-color: var(--palettes-error-700);
-	--components-button-backgroundColor: var(--palettes-error-200);
-}
-
-@mixin deletedOutlinedHover {
-	--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-error-400), var(--commons-boxShadow-XS);
-	--components-button-color: var(--palettes-error-700);
-	--components-button-backgroundColor: var(--palettes-error-100);
-}
-
-@mixin deletedOutlinedFocusVisible {
-	--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-error-400), var(--commons-boxShadow-XS);
-	--components-button-color: var(--palettes-error-700);
-}
-
-@mixin outlinedHover {
-	--components-button-color: var(--palettes-700, var(--palettes-grey-700));
-	--components-button-backgroundColor: var(--palettes-100, var(--palettes-grey-100));
-}
-
-@mixin outlinedActive {
-	--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
-}
-
-@mixin outlinedFocusVisible {
-	@include a11y.focusVisible($offset: 3px);
-}
-
-@mixin invertedHover {
-	--components-button-color: var(--colors-white-color);
-	--components-button-backgroundColor: var(--palettes-800, var(--palettes-grey-800));
-}
-
-@mixin invertedActive {
-	--components-button-backgroundColor: var(--palettes-700, var(--palettes-grey-700));
-}
-
-// deprecated
-@mixin counterHover {
-	.button-counter {
-		--components-button-backgroundColor: var(--palettes-500, var(--palettes-primary-500));
 	}
 }

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -18,31 +18,29 @@
 	}
 }
 
-@mixin disabledOutlined {
+@mixin outlinedDisabled {
 	--components-button-backgroundColor: var(--colors-white-color);
 	--components-button-boxShadow: 0 0 0 1px var(--palettes-grey-400);
+	--components-button-color: var(--palettes-grey-500);
 }
 
-@mixin disabledText {
+@mixin textDisabled {
 	--components-button-backgroundColor: transparent;
+	--components-button-color: var(--palettes-grey-500);
 }
 
 @mixin loading {
 	--components-button-opacity: var(--commons-disabled-opacity);
 
-	&:not(.mod-more) {
-		@include loading.spinner(var(--components-button-font-size));
+	@include loading.spinner(var(--components-button-font-size));
 
-		--components-button-pointerEvents: none;
-		--components-button-color: transparent;
-		--components-button-userSelect: none;
-	}
+	--components-button-pointerEvents: none;
+	--components-button-color: transparent;
+	--components-button-userSelect: none;
 }
 
 @mixin loadingS {
-	&:not(.mod-more) {
-		@include loading.spinner(var(--sizes-S-fontSize));
-	}
+	@include loading.spinner(var(--sizes-S-fontSize));
 }
 
 @mixin state {
@@ -63,24 +61,20 @@
 @mixin success {
 	@include core.cssvars('palettes', config.$success);
 
-	&:not(.mod-more) {
-		@include state;
+	@include state;
 
-		&::after {
-			@include icon.generate('sign_confirm');
-		}
+	&::after {
+		@include icon.generate('sign_confirm');
 	}
 }
 
 @mixin error {
 	@include core.cssvars('palettes', config.$error);
 
-	&:not(.mod-more) {
-		@include state;
+	@include state;
 
-		&::after {
-			@include icon.generate('sign_close');
-		}
+	&::after {
+		@include icon.generate('sign_close');
 	}
 }
 
@@ -106,23 +100,23 @@
 	--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
 }
 
-@mixin deleteHover {
+@mixin deletedHover {
 	--components-button-color: var(--palettes-error-700);
 	--components-button-backgroundColor: var(--palettes-error-100);
 }
 
-@mixin deleteActive {
+@mixin deletedActive {
 	--components-button-color: var(--palettes-error-700);
 	--components-button-backgroundColor: var(--palettes-error-200);
 }
 
-@mixin deleteOutlinedHover {
+@mixin deletedOutlinedHover {
 	--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-error-400), var(--commons-boxShadow-XS);
 	--components-button-color: var(--palettes-error-700);
 	--components-button-backgroundColor: var(--palettes-error-100);
 }
 
-@mixin deleteOutlinedFocusVisible {
+@mixin deletedOutlinedFocusVisible {
 	--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-error-400), var(--commons-boxShadow-XS);
 	--components-button-color: var(--palettes-error-700);
 }
@@ -140,15 +134,16 @@
 	@include a11y.focusVisible($offset: 3px);
 }
 
-@mixin invertHover {
+@mixin invertedHover {
 	--components-button-color: var(--colors-white-color);
 	--components-button-backgroundColor: var(--palettes-800, var(--palettes-grey-800));
 }
 
-@mixin invertActive {
+@mixin invertedActive {
 	--components-button-backgroundColor: var(--palettes-700, var(--palettes-grey-700));
 }
 
+// deprecated
 @mixin counterHover {
 	.button-counter {
 		--components-button-backgroundColor: var(--palettes-500, var(--palettes-primary-500));

--- a/packages/scss/src/components/divider/index.scss
+++ b/packages/scss/src/components/divider/index.scss
@@ -20,18 +20,5 @@
 
 	.button {
 		@include button.outlined;
-
-		// Need to be refactored on button side to reduce import to one mixin
-		&:hover {
-			@include button.outlinedHover;
-		}
-
-		&:active {
-			@include button.outlinedActive;
-		}
-
-		&:focus-visible {
-			@include button.outlinedFocusVisible;
-		}
 	}
 }


### PR DESCRIPTION
## Description

The aim of this project is always to have an important component properly architected for the management of nested components (molecules).

We now distinguish between native states (pseudo-selectors) and forced states (classes).

This makes it easier to import a component without having to redefine its native behaviors each time.

Pseudo-selectors are now in the component or its modifiers. And non-native states remain called from the index (with the prefix `.is-`).

-----

-----
