### PR TITLE
Fix checkbox border

### DIFF
--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -17,36 +17,42 @@
 			vertical-align: top;
 
 			&::before {
-				@include icon.generate('sign_confirm');
-
+				content: '';
 				background-color: var(--colors-white-color);
 				width: var(--components-checkbox-input-size);
 				height: var(--components-checkbox-input-size);
 				border-radius: 6px;
 				transition-duration: var(--commons-animations-durations-fast);
-				transition-property: box-shadow, color, background-color;
-				box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-700);
-				line-height: var(--components-checkbox-input-size);
-				font-size: var(--components-checkbox-input-size);
+				transition-property: border-color, color, background-color;
 				flex-grow: 0;
 				flex-shrink: 0;
 				flex-basis: auto;
-				color: transparent;
 				display: block;
-				text-align: center;
+
 				margin-top: 2px;
-				transform: translate3d(0, 0, 0); // Fix box-shadow artifacts
+				border: var(--components-checkbox-input-border-width) solid var(--palettes-grey-700);
+			}
+
+			&::after {
+				@include icon.generate('sign_confirm');
+
+				line-height: var(--components-checkbox-input-size);
+				font-size: var(--components-checkbox-input-size);
+				color: transparent;
+				text-align: center;
+				position: absolute;
+				margin-top: 2px;
 			}
 
 			&:hover {
 				&::before {
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-600);
+					border-color: var(--palettes-grey-600);
 				}
 			}
 
 			&:active {
 				&::before {
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-800);
+					border-color: var(--palettes-grey-800);
 				}
 			}
 		}
@@ -62,9 +68,12 @@
 
 			&:checked ~ .checkbox-label {
 				&::before {
-					color: var(--colors-white-color);
 					background-color: var(--palettes-700, var(--palettes-primary-700));
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-700, var(--palettes-primary-700));
+					border-color: var(--palettes-700, var(--palettes-primary-700));
+				}
+
+				&::after {
+					color: var(--colors-white-color);
 				}
 			}
 
@@ -72,14 +81,14 @@
 				&:hover {
 					&::before {
 						background-color: var(--palettes-600, var(--palettes-primary-600));
-						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-600, var(--palettes-primary-600));
+						border-color: var(--palettes-600, var(--palettes-primary-600));
 					}
 				}
 
 				&:active {
 					&::before {
 						background-color: var(--palettes-800, var(--palettes-primary-800));
-						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-800, var(--palettes-primary-800));
+						border-color: var(--palettes-800, var(--palettes-primary-800));
 					}
 				}
 			}

--- a/packages/scss/src/components/checkbox/states.scss
+++ b/packages/scss/src/components/checkbox/states.scss
@@ -7,7 +7,7 @@
 		cursor: default;
 
 		&::before {
-			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-500);
+			border-color: var(--palettes-grey-500);
 		}
 
 		.checkbox-label-helper {
@@ -17,9 +17,12 @@
 
 	&:checked ~ .checkbox-label {
 		&::before {
-			color: var(--palettes-grey-500);
 			background-color: var(--palettes-grey-100);
-			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-100);
+			border-color: var(--palettes-grey-100);
+		}
+
+		&::after {
+			color: var(--palettes-grey-500);
 		}
 	}
 }
@@ -27,7 +30,7 @@
 @mixin incomplete {
 	~ .checkbox-mixed ~ .checkbox-label,
 	~ .checkbox-label {
-		&::before {
+		&::after {
 			@include icon.generate('maths_minus');
 		}
 	}


### PR DESCRIPTION
## Description

We switch from a shadow to a real border to avoid calculation errors in Windows.
As the icon has insufficient space, it is moved to a `::after`.

-----



-----
