### PR TITLE
New architecture for palettes

### DIFF
--- a/packages/ng/a11y/skip-links/skip-links.component.html
+++ b/packages/ng/a11y/skip-links/skip-links.component.html
@@ -1,10 +1,12 @@
 <nav role="navigation" id="top" class="skipLinks" [attr.aria-label]="intl.Goto">
 	<a
-		class="skipLinks-action palette-grey mod-XS"
+		class="skipLinks-action palette-neutral mod-XS"
 		href="#lucca-banner-solutions-container"
 		(click)="anchor('#lucca-banner-solutions-container', $event)"
 		>{{ intl.Goto_Nav_Banner }}</a
 	>
-	<a class="skipLinks-action palette-grey mod-XS" href="#navSide" (click)="anchor('#navSide', $event)">{{ intl.Goto_Nav_Navside }}</a>
-	<a class="skipLinks-action palette-grey mod-XS" href="#main-content" (click)="anchor('#main-content', $event)">{{ intl.Goto_Content }}</a>
+	<a class="skipLinks-action palette-neutral mod-XS" href="#navSide" (click)="anchor('#navSide', $event)">{{ intl.Goto_Nav_Navside }}</a>
+	<a class="skipLinks-action palette-neutral mod-XS" href="#main-content" (click)="anchor('#main-content', $event)"
+		>{{ intl.Goto_Content }}</a
+	>
 </nav>

--- a/packages/ng/a11y/skip-links/skip-links.component.scss
+++ b/packages/ng/a11y/skip-links/skip-links.component.scss
@@ -32,7 +32,7 @@
 
 	&:focus-visible {
 		outline-offset: 2px;
-		outline: 2px solid var(--palettes-primary-700);
+		outline: 2px solid var(--palettes-product-700);
 	}
 
 	&:not(:focus, :focus-visible) {

--- a/packages/ng/a11y/skip-links/skip-links.component.scss
+++ b/packages/ng/a11y/skip-links/skip-links.component.scss
@@ -21,7 +21,7 @@
 	line-height: var(--sizes-XS-lineHeight);
 	padding: var(--spacings-XXS) var(--spacings-XS);
 	transition: all var(--commons-animations-durations-fast);
-	background-color: var(--palettes-grey-600);
+	background-color: var(--palettes-neutral-600);
 	display: inline-block;
 	position: relative;
 	text-decoration: none;

--- a/packages/ng/core-select/option/option.component.scss
+++ b/packages/ng/core-select/option/option.component.scss
@@ -2,12 +2,12 @@
 @include optionItemStyle;
 
 .is-disabled {
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	user-select: none;
 	cursor: default;
 
 	&.is-selected {
-		background-color: var(--palettes-grey-100);
+		background-color: var(--palettes-neutral-100);
 	}
 
 	&:hover {

--- a/packages/ng/core/type/style.ts
+++ b/packages/ng/core/type/style.ts
@@ -1,4 +1,4 @@
 /**
  * Available CSS palettes
  */
-export type Palette = 'success' | 'warning' | 'error' | 'primary' | 'grey' | 'none';
+export type Palette = 'success' | 'warning' | 'error' | 'product' | 'neutral' | 'none';

--- a/packages/ng/core/type/style.ts
+++ b/packages/ng/core/type/style.ts
@@ -1,4 +1,6 @@
 /**
  * Available CSS palettes
  */
-export type Palette = 'success' | 'warning' | 'error' | 'product' | 'neutral' | 'none';
+// primary is deprecated
+// grey is deprecated
+export type Palette = 'success' | 'warning' | 'error' | 'product' | 'neutral' | 'none' | 'primary' | 'grey';

--- a/packages/ng/date/calendar/calendar-input.component.scss
+++ b/packages/ng/date/calendar/calendar-input.component.scss
@@ -44,7 +44,7 @@
 		text-align: center;
 		height: var(--components-calendar-day-size);
 		font-size: var(--sizes-S-fontSize);
-		color: var(--palettes-primary-700);
+		color: var(--palettes-product-700);
 
 		.calendar-labels-item {
 			width: var(--components-calendar-day-size);
@@ -89,7 +89,7 @@
 	}
 
 	&.is-today {
-		color: var(--palettes-primary-700);
+		color: var(--palettes-product-700);
 		font-weight: 600;
 
 		&:after {
@@ -99,7 +99,7 @@
 			left: var(--spacings-XS);
 			right: var(--spacings-XS);
 			height: 2px;
-			background: var(--palettes-primary-700);
+			background: var(--palettes-product-700);
 			z-index: 1;
 		}
 	}
@@ -123,8 +123,8 @@
 
 	&.is-active {
 		.calendar-grid-item-content {
-			background: var(--palettes-primary-700);
-			color: var(--palettes-primary-text);
+			background: var(--palettes-product-700);
+			color: var(--palettes-product-text);
 		}
 
 		&.is-today {
@@ -135,7 +135,8 @@
 		}
 	}
 
-	&.is-disabled, &[disabled] {
+	&.is-disabled,
+	&[disabled] {
 		color: var(--palettes-grey-500);
 		pointer-events: none;
 

--- a/packages/ng/date/calendar/calendar-input.component.scss
+++ b/packages/ng/date/calendar/calendar-input.component.scss
@@ -21,7 +21,7 @@
 
 .calendar-header-date {
 	font-weight: 600;
-	color: var(--palettes-grey-900);
+	color: var(--palettes-neutral-900);
 	font-size: var(--sizes-L-fontSize);
 	line-height: var(--sizes-L-lineHeight);
 	padding: 0;
@@ -81,11 +81,11 @@
 	position: relative;
 	padding: 0;
 	outline: none;
-	color: var(--palettes-grey-800);
+	color: var(--palettes-neutral-800);
 
 	&.is-previousMonth,
 	&.is-nextMonth {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 	}
 
 	&.is-today {
@@ -106,13 +106,13 @@
 
 	&:hover {
 		.calendar-grid-item-content {
-			background: var(--palettes-grey-50);
+			background: var(--palettes-neutral-50);
 		}
 	}
 
 	&:active {
 		.calendar-grid-item-content {
-			background: var(--palettes-grey-100);
+			background: var(--palettes-neutral-100);
 		}
 	}
 
@@ -137,7 +137,7 @@
 
 	&.is-disabled,
 	&[disabled] {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 		pointer-events: none;
 
 		&:hover .calendar-grid-item-content {

--- a/packages/ng/establishment/select/input/establishment-select-input.component.scss
+++ b/packages/ng/establishment/select/input/establishment-select-input.component.scss
@@ -20,7 +20,7 @@
 	width: 100%;
 	justify-content: flex-start;
 	font-weight: 600;
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 	text-decoration: underline;
 
 	&.mod-readonly {
@@ -38,7 +38,7 @@
 			background-color: transparent;
 
 			~ .lu-picker-content-option lu-option {
-				background-color: var(--palettes-grey-50);
+				background-color: var(--palettes-neutral-50);
 				border-radius: var(--commons-borderRadius-M);
 			}
 		}

--- a/packages/ng/icon/icon.component.scss
+++ b/packages/ng/icon/icon.component.scss
@@ -9,7 +9,7 @@ lu-icon {
 }
 
 .icon-color-secondary {
-	color: var(--palettes-secondary-700);
+	color: var(--palettes-product-700);
 }
 
 .icon-color-error {

--- a/packages/ng/icon/icon.component.scss
+++ b/packages/ng/icon/icon.component.scss
@@ -1,33 +1,33 @@
 @use '@lucca-front/icons/src/main';
 
 lu-icon {
-  display: inline-flex;
+	display: inline-flex;
 }
 
 .icon-color-primary {
-  color: var(--palettes-primary-700);
+	color: var(--palettes-product-700);
 }
 
 .icon-color-secondary {
-  color: var(--palettes-secondary-700);
+	color: var(--palettes-secondary-700);
 }
 
 .icon-color-error {
-  color: var(--palettes-error-700);
+	color: var(--palettes-error-700);
 }
 
 .icon-color-warning {
-  color: var(--palettes-warning-700);
+	color: var(--palettes-warning-700);
 }
 
 .icon-color-success {
-  color: var(--palettes-success-700);
+	color: var(--palettes-success-700);
 }
 
 .icon-color-light {
-  color: var(--palettes-grey-600);
+	color: var(--palettes-grey-600);
 }
 
 .icon-color-placeholder {
-  color: var(--palettes-grey-400);
+	color: var(--palettes-grey-400);
 }

--- a/packages/ng/icon/icon.component.scss
+++ b/packages/ng/icon/icon.component.scss
@@ -4,11 +4,11 @@ lu-icon {
 	display: inline-flex;
 }
 
-.icon-color-primary {
-	color: var(--palettes-product-700);
-}
-
-.icon-color-secondary {
+// .icon-color-primary is deprecated
+// .icon-color-secondary is deprecated
+.icon-color-primary,
+.icon-color-secondary,
+.icon-color-product {
 	color: var(--palettes-product-700);
 }
 

--- a/packages/ng/icon/icon.component.scss
+++ b/packages/ng/icon/icon.component.scss
@@ -25,9 +25,9 @@ lu-icon {
 }
 
 .icon-color-light {
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 }
 
 .icon-color-placeholder {
-	color: var(--palettes-grey-400);
+	color: var(--palettes-neutral-400);
 }

--- a/packages/ng/icon/icon.component.ts
+++ b/packages/ng/icon/icon.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { NgIf } from '@angular/common';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
 
 @Component({
@@ -22,5 +22,5 @@ export class IconComponent {
 	size: 'XXS' | 'XS' | 'S' | 'M' | 'L' | 'XL' | 'XXL';
 
 	@Input()
-	color: 'primary' | 'secondary' | 'error' | 'warning' | 'success' | 'light' | 'placeholder' | 'inherit' = 'inherit';
+	color: 'primary' | 'secondary' | 'product' | 'error' | 'warning' | 'success' | 'light' | 'placeholder' | 'inherit' = 'inherit';
 }

--- a/packages/ng/material/style/components/_datepicker.scss
+++ b/packages/ng/material/style/components/_datepicker.scss
@@ -93,8 +93,8 @@
 
 		&:hover,
 		&.mat-calendar-body-selected {
-			background-color: var(--palette-primary-700);
-			color: var(--palette-primary-text);
+			background-color: var(--palettes-primary-700);
+			color: var(--palettes-primary-text);
 		}
 	}
 

--- a/packages/ng/material/style/components/_datepicker.scss
+++ b/packages/ng/material/style/components/_datepicker.scss
@@ -85,7 +85,7 @@
 		box-shadow: form.fakeBorderOverlay(var(--commons-divider-color));
 		border: none;
 		border-radius: 0;
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		height: 100%;
 		left: 0;
 		top: 0;
@@ -108,7 +108,7 @@
 md-month-view,
 mat-month-view {
 	.mat-calendar-table-header th {
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		font-size: 0.9em;
 		padding-bottom: 0.4em;
 	}

--- a/packages/ng/material/style/components/_datepicker.scss
+++ b/packages/ng/material/style/components/_datepicker.scss
@@ -93,8 +93,8 @@
 
 		&:hover,
 		&.mat-calendar-body-selected {
-			background-color: var(--palettes-primary-700);
-			color: var(--palettes-primary-text);
+			background-color: var(--palettes-product-700);
+			color: var(--palettes-product-text);
 		}
 	}
 

--- a/packages/ng/modal/modal-panel.component.html
+++ b/packages/ng/modal/modal-panel.component.html
@@ -27,7 +27,7 @@
 				(click)="submit()"
 			>
 				{{ submitLabel$ | async }}
-				<label class="numericBadge palette-primary" *ngIf="hasSubmitCounter$ | async">{{ submitCounter$ | async }}</label>
+				<label class="numericBadge palette-product" *ngIf="hasSubmitCounter$ | async">{{ submitCounter$ | async }}</label>
 			</button>
 			<button type="button" class="button mod-text" (click)="dismiss()">{{ cancelLabel$ | async }}</button>
 		</div>

--- a/packages/ng/modal/modal-panel.component.ts
+++ b/packages/ng/modal/modal-panel.component.ts
@@ -3,7 +3,7 @@ import { AsyncPipe, NgClass, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Directive, DoCheck, ElementRef, HostBinding, Injector, OnDestroy, Renderer2, Type, ViewChild, ViewContainerRef } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { isObservable, Observable, of, ReplaySubject, Subject, Subscription, timer } from 'rxjs';
+import { Observable, ReplaySubject, Subject, Subscription, isObservable, of, timer } from 'rxjs';
 import { delay, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { LuModalClasses } from './modal-config.model';
 import { ALuModalRef } from './modal-ref.model';
@@ -33,7 +33,7 @@ export abstract class ALuModalPanelComponent<T extends ILuModalContent> implemen
 		return !this._componentInstance.submitAction;
 	}
 	get submitPalette() {
-		return this._componentInstance.submitPalette || 'primary';
+		return this._componentInstance.submitPalette || 'product';
 	}
 
 	submitClass$ = new Subject();

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -45,7 +45,7 @@
 		</div>
 	</div>
 	<!--<div class="lu-picker-content-add">
-		<button class="button mod-text mod-icon palette-primary" type="button">
+		<button class="button mod-text mod-icon palette-product" type="button">
 			<span aria-hidden="true" class="lucca-icon icon-mathsPlus"></span>Add a new supplier
 		</button>
 	</div>-->

--- a/packages/ng/multi-select/panel/panel.component.scss
+++ b/packages/ng/multi-select/panel/panel.component.scss
@@ -4,6 +4,6 @@
 	line-height: var(--sizes-S-lineHeight);
 	width: 100%;
 	text-align: left;
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 	margin: 0;
 }

--- a/packages/ng/option/item/option-item.component.scss
+++ b/packages/ng/option/item/option-item.component.scss
@@ -2,12 +2,12 @@
 @include optionItemStyle;
 
 .is-disabled {
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	user-select: none;
 	cursor: default;
 
 	&.is-selected {
-		background-color: var(--palettes-grey-100);
+		background-color: var(--palettes-neutral-100);
 	}
 
 	&:hover {

--- a/packages/ng/option/item/tree-option-item.component.scss
+++ b/packages/ng/option/item/tree-option-item.component.scss
@@ -3,16 +3,16 @@
 
 :host {
 	--components-options-tree-multiple-padding: 2.25rem;
-	--components-options-tree-padding-child: .75rem;
+	--components-options-tree-padding-child: 0.75rem;
 }
 
 .is-disabled {
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	user-select: none;
 	cursor: default;
 
 	&.is-selected {
-		background-color: var(--palettes-grey-100);
+		background-color: var(--palettes-neutral-100);
 	}
 
 	&:hover {
@@ -27,7 +27,7 @@
 
 	&:hover {
 		.optionItem-value {
-			background: var(--palettes-grey-50);
+			background: var(--palettes-neutral-50);
 		}
 
 		.optionItem-icons {

--- a/packages/ng/qualification/select/input/qualification-select-input.component.scss
+++ b/packages/ng/qualification/select/input/qualification-select-input.component.scss
@@ -1,4 +1,4 @@
-@import "_definitions";
+@import '_definitions';
 @include selectInputStyle;
 
 .optionItem-groupKey {
@@ -7,7 +7,7 @@
 	line-height: var(--sizes-S-lineHeight);
 	width: 100%;
 	text-align: left;
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 	margin: 0;
 
 	&:first-of-type {

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -44,7 +44,7 @@
 		</div>
 	</div>
 	<!--<div class="lu-picker-content-add">
-		<button class="button mod-text mod-icon palette-primary" type="button">
+		<button class="button mod-text mod-icon palette-product" type="button">
 			<span aria-hidden="true" class="lucca-icon icon-mathsPlus"></span>Add a new supplier
 		</button>
 	</div>-->

--- a/packages/ng/styles/components/_dropdown.scss
+++ b/packages/ng/styles/components/_dropdown.scss
@@ -49,17 +49,17 @@
 	}
 
 	&:hover {
-		background-color: var(--palettes-grey-50);
+		background-color: var(--palettes-neutral-50);
 		color: currentColor;
 	}
 
 	&:focus-visible {
 		@include a11y.focusVisible();
-		background-color: var(--palettes-grey-50);
+		background-color: var(--palettes-neutral-50);
 	}
 
 	&.is-disabled {
-		color: var(--palettes-grey-400);
+		color: var(--palettes-neutral-400);
 		pointer-events: none;
 
 		&:hover {

--- a/packages/ng/styles/components/_picker.scss
+++ b/packages/ng/styles/components/_picker.scss
@@ -25,7 +25,7 @@
 }
 
 .lu-picker-content-option-emptyState {
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 	text-align: center;
 }
 
@@ -34,7 +34,7 @@
 	line-height: var(--sizes-S-lineHeight);
 	font-weight: 600;
 	padding: var(--components-options-item-padding-vertical) var(--components-options-item-padding-horizontal);
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 	position: sticky;
 	top: 0;
 	background-color: var(--colors-white-color);
@@ -54,10 +54,11 @@
 .lu-picker-content-loading {
 	padding: var(--spacings-XXS);
 	display: flex;
-	color: var(--palettes-grey-600)
+	color: var(--palettes-neutral-600);
 }
 
-.lu-picker-loading { // deprecated
+.lu-picker-loading {
+	// deprecated
 	position: absolute;
 	left: 50%;
 	top: 50%;

--- a/packages/ng/styles/components/_popup.scss
+++ b/packages/ng/styles/components/_popup.scss
@@ -132,7 +132,7 @@
 			}
 		}
 		.lu-modal-content-title {
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			font-size: var(--sizes-XL-fontSize);
 			margin-top: 2.5rem;
 		}

--- a/packages/ng/styles/components/cdk/_dragDrop.scss
+++ b/packages/ng/styles/components/cdk/_dragDrop.scss
@@ -44,8 +44,8 @@
 .cdk-drag-preview {
 	z-index: 9999 !important;
 	box-sizing: border-box;
-	box-shadow: form.fakeBorderOverlay(var(--palettes-secondary-200));
-	background-color: var(--palettes-secondary-50);
+	box-shadow: form.fakeBorderOverlay(var(--palettes-product-200));
+	background-color: var(--palettes-product-50);
 	border-radius: var(--commons-borderRadius-M);
 	cursor: grabbing;
 }

--- a/packages/ng/styles/components/cdk/_dragDrop.scss
+++ b/packages/ng/styles/components/cdk/_dragDrop.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 
 .cdk-drag-placeholder {
-	box-shadow: form.fakeBorderOverlay(var(--palettes-grey-200));
-	background-color: var(--palettes-grey-100);
+	box-shadow: form.fakeBorderOverlay(var(--palettes-neutral-200));
+	background-color: var(--palettes-neutral-100);
 	* {
 		opacity: 0;
 	}

--- a/packages/ng/styles/components/cdk/_overlay.scss
+++ b/packages/ng/styles/components/cdk/_overlay.scss
@@ -46,7 +46,7 @@
 	}
 
 	&.cdk-overlay-dark-backdrop {
-		background-color: rgba(var(--colors-grey-900-rgb), 0.6);
+		background-color: rgba(var(--colors-neutral-900-rgb), 0.6);
 	}
 	&.cdk-overlay-transparent-backdrop {
 		background: 0 0;

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -9,7 +9,7 @@
 
 	--components-options-checkbox-left: 0.5rem;
 	--components-options-checkbox-size: 1.25rem;
-	--components-options-checkbox-color: var(--palettes-primary-700);
+	--components-options-checkbox-color: var(--palettes-product-700);
 	--components-options-checkbox-border-radius: 6px;
 	--components-options-checkbox-border-color: var(--palettes-grey-700);
 	--components-options-establishment-multiple-padding: 2rem;
@@ -33,7 +33,7 @@
 		cursor: pointer;
 
 		&.is-selected {
-			background-color: var(--palettes-primary-50);
+			background-color: var(--palettes-product-50);
 
 			&:before {
 				content: '';
@@ -42,24 +42,24 @@
 				bottom: 0;
 				left: calc(var(--spacings-XXS) * -1);
 				width: 2px;
-				background-color: var(--palettes-primary-700);
+				background-color: var(--palettes-product-700);
 				border-top-right-radius: var(--commons-borderRadius-M);
 				border-bottom-right-radius: var(--commons-borderRadius-M);
 			}
 
 			&:hover {
-				background-color: var(--palettes-primary-100);
+				background-color: var(--palettes-product-100);
 			}
 
 			&:active {
-				background-color: var(--palettes-primary-200);
+				background-color: var(--palettes-product-200);
 			}
 
 			&.is-highlighted {
-				background-color: var(--palettes-primary-100);
+				background-color: var(--palettes-product-100);
 
 				&:hover {
-					background-color: var(--palettes-primary-200);
+					background-color: var(--palettes-product-200);
 				}
 			}
 		}

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -5,13 +5,13 @@
 	--components-options-item-padding-vertical: var(--spacings-XXS);
 	--components-options-item-padding-horizontal: var(--spacings-XS);
 	--components-options-item-multiple-padding: 2.25rem;
-	--components-options-item-icon-color: var(--palettes-grey-800);
+	--components-options-item-icon-color: var(--palettes-neutral-800);
 
 	--components-options-checkbox-left: 0.5rem;
 	--components-options-checkbox-size: 1.25rem;
 	--components-options-checkbox-color: var(--palettes-product-700);
 	--components-options-checkbox-border-radius: 6px;
-	--components-options-checkbox-border-color: var(--palettes-grey-700);
+	--components-options-checkbox-border-color: var(--palettes-neutral-700);
 	--components-options-establishment-multiple-padding: 2rem;
 }
 
@@ -65,24 +65,24 @@
 		}
 
 		&:hover {
-			background-color: var(--palettes-grey-50);
+			background-color: var(--palettes-neutral-50);
 		}
 
 		&.is-highlighted,
 		&.is-focus {
-			background-color: var(--palettes-grey-50);
+			background-color: var(--palettes-neutral-50);
 
 			&:hover {
-				background-color: var(--palettes-grey-50);
+				background-color: var(--palettes-neutral-50);
 			}
 
 			&:active {
-				background-color: var(--palettes-grey-100);
+				background-color: var(--palettes-neutral-100);
 			}
 		}
 
 		&:active {
-			background-color: var(--palettes-grey-100);
+			background-color: var(--palettes-neutral-100);
 		}
 	}
 
@@ -151,7 +151,7 @@
 			}
 
 			&.is-disabled {
-				--components-options-checkbox-border-color: var(--palettes-grey-500);
+				--components-options-checkbox-border-color: var(--palettes-neutral-500);
 			}
 
 			&:not(.is-disabled):hover {

--- a/packages/ng/styles/definitions/option/_option-placeholder.scss
+++ b/packages/ng/styles/definitions/option/_option-placeholder.scss
@@ -3,6 +3,6 @@
 		display: block;
 		padding: var(--components-options-item-padding-vertical) var(--components-options-item-padding-horizontal);
 		font-style: italic;
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 	}
 }

--- a/packages/ng/styles/definitions/option/_option-searcher.scss
+++ b/packages/ng/styles/definitions/option/_option-searcher.scss
@@ -10,7 +10,7 @@
 	.checkbox.mod-formerEmployee {
 		padding: var(--spacings-XXS) var(--components-options-item-padding-horizontal);
 		border-bottom: var(--commons-divider-width) solid var(--commons-divider-color);
-		background-color: var(--palettes-grey-50);
+		background-color: var(--palettes-neutral-50);
 		font-style: italic;
 	}
 }

--- a/packages/ng/styles/definitions/option/_option-selector.scss
+++ b/packages/ng/styles/definitions/option/_option-selector.scss
@@ -1,11 +1,11 @@
 @mixin optionSelectorStyle {
 	.selectAll-button {
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		font-size: var(--sizes-S-fontSize);
 		outline: none;
 
 		&:hover {
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 		}
 	}
 }

--- a/packages/ng/styles/definitions/select/_select-input.scss
+++ b/packages/ng/styles/definitions/select/_select-input.scss
@@ -6,10 +6,10 @@
 	:host {
 		--components-select-input-padding-horizontal: var(--spacings-XS);
 		--components-select-input-padding-vertical: var(--spacings-XS);
-		--components-select-framed-color: var(--palettes-grey-500);
-		--components-select-framed-color50: var(--palettes-grey-50);
-		--components-select-framed-see-through: var(--palettes-grey-50);
-		--components-select-framed-text: var(--palettes-grey-800);
+		--components-select-framed-color: var(--palettes-neutral-500);
+		--components-select-framed-color50: var(--palettes-neutral-50);
+		--components-select-framed-see-through: var(--palettes-neutral-50);
+		--components-select-framed-text: var(--palettes-neutral-800);
 		--components-select-framed-placeholder: #cccccc;
 		--components-select-framed-side-padding: var(--spacings-S);
 		--components-select-framed-top-padding: var(--spacings-L);
@@ -24,7 +24,7 @@
 		&::after {
 			@include icon.generate('arrow_chevron_bottom');
 
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			bottom: var(--components-select-input-padding-vertical);
 			font-size: var(--sizes-M-lineHeight);
 			line-height: var(--sizes-M-lineHeight);
@@ -34,7 +34,8 @@
 			transition: transform var(--commons-animations-durations-standard) ease;
 		}
 
-		&[disabled], &.is-disabled {
+		&[disabled],
+		&.is-disabled {
 			cursor: not-allowed;
 			pointer-events: all;
 		}
@@ -57,7 +58,7 @@
 	}
 
 	.lu-select-placeholder {
-		color: var(--palettes-grey-400);
+		color: var(--palettes-neutral-400);
 		line-height: var(--sizes-M-lineHeight);
 		min-height: calc(var(--components-select-framed-bottom-padding) + var(--sizes-M-lineHeight));
 		padding: var(--components-select-input-padding-vertical) 3.5rem var(--components-select-input-padding-vertical)
@@ -81,7 +82,6 @@
 	}
 
 	::ng-deep .lu-select-value {
-
 		.label {
 			padding: var(--spacings-XXS) var(--spacings-XS);
 			margin-left: 0;
@@ -159,7 +159,7 @@
 			padding: var(--components-select-framed-top-padding) 0 0;
 
 			&::after {
-				color: var(--palettes-grey-500);
+				color: var(--palettes-neutral-500);
 				bottom: var(--components-select-framed-bottom-padding);
 				right: var(--spacings-XS);
 			}
@@ -170,7 +170,7 @@
 			}
 
 			.lu-select-placeholder {
-				color: var(--palettes-grey-400);
+				color: var(--palettes-neutral-400);
 				padding: 0 calc(var(--components-select-framed-side-padding) * 3) var(--components-select-framed-bottom-padding)
 					var(--components-select-framed-side-padding);
 			}
@@ -189,14 +189,14 @@
 			padding: 0;
 			height: auto;
 			padding-top: var(--spacings-S);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 		}
 	}
 
 	// Material
 	:host-context(.textfield.mod-material) {
 		&::after {
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 			bottom: 0.6rem;
 			right: 0;
 		}
@@ -252,11 +252,11 @@
 	:host-context(.textfield.mod-outlined) {
 		&.textfield-input {
 			&::after {
-				color: var(--palettes-grey-600);
+				color: var(--palettes-neutral-600);
 			}
 
 			.lu-select-placeholder {
-				color: var(--palettes-grey-400);
+				color: var(--palettes-neutral-400);
 			}
 		}
 		// Error

--- a/packages/ng/styles/definitions/tooltip/_tooltip.scss
+++ b/packages/ng/styles/definitions/tooltip/_tooltip.scss
@@ -1,6 +1,6 @@
 @mixin tooltipStyle {
 	.lu-tooltip-panel {
-		--components-tooltip-background-color: var(--palettes-grey-900);
+		--components-tooltip-background-color: var(--palettes-neutral-900);
 		--components-tooltip-color: var(--colors-white-color);
 		--components-tooltip-max-width: 15rem;
 

--- a/packages/ng/styles/definitions/user/user-picture.scss
+++ b/packages/ng/styles/definitions/user/user-picture.scss
@@ -31,7 +31,7 @@
 		align-items: center;
 		aspect-ratio: 1;
 		border-radius: var(--commons-borderRadius-full);
-		background-color: var(--palettes-grey-50);
+		background-color: var(--palettes-neutral-50);
 		background-position: center;
 		background-size: cover;
 		background-repeat: no-repeat;
@@ -85,11 +85,11 @@
 
 	&.mod-placeholder {
 		.picture {
-			background: var(--palettes-grey-200) !important;
+			background: var(--palettes-neutral-200) !important;
 
 			&::before {
 				@include icon.generate('people_person');
-				color: var(--palettes-grey-600);
+				color: var(--palettes-neutral-600);
 				font-weight: 400;
 				font-size: var(--components-user-picture-placeholder, var(--components-userPicture-M-placeholder));
 			}

--- a/packages/ng/styles/definitions/user/user-tile.scss
+++ b/packages/ng/styles/definitions/user/user-tile.scss
@@ -12,9 +12,9 @@
 	}
 
 	.user-tile-label {
-    font-size: var(--sizes-S-fontSize);
+		font-size: var(--sizes-S-fontSize);
 		line-height: var(--sizes-XS-lineHeight);
-    color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 	}
 
 	.user-tile-footnote {
@@ -50,33 +50,33 @@
 		}
 	}
 
-  &.mod-XXS {
+	&.mod-XXS {
 		--components-user-picture-image-size: var(--components-userPicture-XXS-image);
 		--components-user-picture-font-size: var(--components-userPicture-XXS-fontSize);
-  }
+	}
 
-  &.mod-XS {
+	&.mod-XS {
 		--components-user-picture-image-size: var(--components-userPicture-XS-image);
 		--components-user-picture-font-size: var(--components-userPicture-XS-fontSize);
-  }
+	}
 
-  &.mod-S {
+	&.mod-S {
 		--components-user-picture-image-size: var(--components-userPicture-S-image);
 		--components-user-picture-font-size: var(--components-userPicture-S-fontSize);
-  }
+	}
 
-  &.mod-L {
+	&.mod-L {
 		--components-user-picture-image-size: var(--components-userPicture-L-image);
 		--components-user-picture-font-size: var(--components-userPicture-L-fontSize);
-  }
+	}
 
-  &.mod-XL {
+	&.mod-XL {
 		--components-user-picture-image-size: var(--components-userPicture-XL-image);
 		--components-user-picture-font-size: var(--components-userPicture-XL-fontSize);
-  }
+	}
 
-  &.mod-XXL {
+	&.mod-XXL {
 		--components-user-picture-image-size: var(--components-userPicture-XXL-image);
 		--components-user-picture-font-size: var(--components-userPicture-XXL-fontSize);
-  }
+	}
 }

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -94,7 +94,7 @@
 			font-weight: 600;
 		}
 
-		@each $palette in list.join(config.$palettes, config.$states) {
+		@each $palette in list.join(config.$palettesForClasses, config.$palettesStates) {
 			$paletteExists: map.get(config.$palettesInterpolation, $palette);
 
 			@if $paletteExists {

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -54,7 +54,7 @@
 
 		body {
 			background-color: var(--commons-background-base);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			font-family: var(--commons-font-family);
 			font-size: var(--sizes-M-fontSize);
 			line-height: var(--sizes-M-lineHeight);

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -94,12 +94,12 @@
 			font-weight: 600;
 		}
 
-		@each $palette in list.join(config.$palettesForClasses, config.$palettesStates) {
+		@each $palette in config.$palettesAll {
 			$paletteExists: map.get(config.$palettesInterpolation, $palette);
 
 			@if $paletteExists {
 				.palette-#{$palette} {
-					@each $shade in config.$shades {
+					@each $shade in config.$palettesShades {
 						@if map.get($paletteExists, $shade) {
 							--palettes-#{$shade}: var(--palettes-#{$palette}-#{$shade});
 						}

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,14 +1,16 @@
 @use 'sass:list';
 
+$product: 'brand' !default;
 $shades: text, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
-$states: 'error', 'warning', 'success';
-$palettesDeprecated: 'lucca', 'primary', 'secondary', 'grey' !default;
-$palettes: 'brand', 'product', 'neutral', 'navigation' !default;
-$decoratives: 'kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin',
+$palettesStates: 'error', 'warning', 'success';
+$palettesDefault: 'brand', 'neutral', 'navigation', 'product';
+$palettesOtherProduct: () !default;
+$palettesDeprecated: ('lucca', 'grey', 'primary', 'secondary') !default;
+$palettesDecorative: 'kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin',
 	'pineapple' !default;
 
-$palettes: list.join($palettes, $palettesDeprecated);
-$allPalettes: list.join(list.join($palettes, $states), $decoratives);
+$palettesForClasses: list.join(list.join($palettesDefault, $palettesOtherProduct), $palettesDeprecated);
+$palettesForCssVars: list.join(list.join($palettesDefault, $palettesStates), $palettesDecorative);
 
 $brand: (
 	text: #ffffff,
@@ -79,8 +81,6 @@ $poplee: (
 	800: #005685,
 	900: #003c5c,
 ) !default;
-
-$product: $brand !default;
 
 $neutral: (
 	text: #ffffff,
@@ -311,9 +311,23 @@ $colors: (
 	'black': #121212,
 );
 
+// grey-900 is deprecated
 $colorsRgb: (
 	'white': '255, 255, 255',
+	'grey-900': '19, 29, 53',
 	'neutral-900': '19, 29, 53',
+);
+
+// switch case
+$prod: map-get(
+	(
+		'brand': $brand,
+		'cleemy': $cleemy,
+		'timmi': $timmi,
+		'poplee': $poplee,
+		'pagga': $pagga,
+	),
+	$product
 );
 
 // https://sass-lang.com/documentation/variables/#advanced-variable-functions
@@ -322,9 +336,9 @@ $palettesInterpolation: (
 	'brand': $brand,
 	'grey': $neutral,
 	'neutral': $neutral,
-	'primary': $product,
-	'secondary': $product,
-	'product': $product,
+	'primary': $prod,
+	'secondary': $prod,
+	'product': $prod,
 	'navigation': $navigation,
 	'success': $success,
 	'error': $error,

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,16 +1,22 @@
 @use 'sass:list';
 
 $product: 'brand' !default;
-$shades: text, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
-$palettesStates: 'error', 'warning', 'success';
-$palettesDefault: 'brand', 'neutral', 'navigation', 'product';
+$palettesShades: text, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
+$palettesStates: 'critical', 'error', 'warning', 'success';
+$palettesDefault: 'brand', 'neutral', 'navigation';
+$palettesProduct: 'product';
 $palettesOtherProduct: () !default;
-$palettesDeprecated: ('lucca', 'grey', 'primary', 'secondary') !default;
 $palettesDecorative: 'kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin',
 	'pineapple' !default;
+$palettesDeprecated: ('lucca', 'grey', 'primary', 'secondary') !default;
 
-$palettesForClasses: list.join(list.join($palettesDefault, $palettesOtherProduct), $palettesDeprecated);
-$palettesForCssVars: list.join(list.join($palettesDefault, $palettesStates), $palettesDecorative);
+$palettesAll: list.join(
+	list.join(
+		list.join(list.join(list.join($palettesStates, $palettesDefault), $palettesProduct), $palettesOtherProduct),
+		$palettesDecorative
+	),
+	$palettesDeprecated
+);
 
 $brand: (
 	text: #ffffff,
@@ -134,7 +140,7 @@ $warning: (
 	900: #802a00,
 );
 
-$error: (
+$critical: (
 	text: #ffffff,
 	50: #ffebec,
 	100: #ffd6d8,
@@ -341,7 +347,8 @@ $palettesInterpolation: (
 	'product': $prod,
 	'navigation': $navigation,
 	'success': $success,
-	'error': $error,
+	'error': $critical,
+	'critical': $critical,
 	'warning': $warning,
 	'kiwi': $kiwi,
 	'lime': $lime,

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -2,14 +2,13 @@
 
 $shades: text, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
 $states: 'error', 'warning', 'success';
-$palettes: 'lucca', 'primary', 'secondary', 'grey', 'navigation';
-$newPalettes: 'brand', 'product', 'neutral' !default;
+$palettesDeprecated: 'lucca', 'primary', 'secondary', 'grey' !default;
+$palettes: 'brand', 'product', 'neutral', 'navigation' !default;
 $decoratives: 'kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin',
 	'pineapple' !default;
 
-$palettes: list.join($palettes, $newPalettes);
-$allPalettes: list.join($palettes, $states);
-$allPalettes: list.join($allPalettes, $decoratives);
+$palettes: list.join($palettes, $palettesDeprecated);
+$allPalettes: list.join(list.join($palettes, $states), $decoratives);
 
 $brand: (
 	text: #ffffff,
@@ -25,19 +24,63 @@ $brand: (
 	900: #611405,
 );
 
-$product: (
+$cleemy: (
 	text: #ffffff,
-	50: #fff1eb,
-	100: #ffe0d1,
-	200: #ffccb3,
-	300: #ffbe9e,
-	400: #ffaa80,
-	500: #ff9361,
-	600: #ff7b3d,
-	700: #e06029,
-	800: #b43409,
-	900: #611405,
+	50: #ecf9f7,
+	100: #ceeee9,
+	200: #a4e0da,
+	300: #7acdc6,
+	400: #54bbb2,
+	500: #00ada5,
+	600: #009491,
+	700: #00807d,
+	800: #00545c,
+	900: #00333d,
 ) !default;
+
+$pagga: (
+	text: #ffffff,
+	50: #fbeffa,
+	100: #f5dbf4,
+	200: #ebc1e9,
+	300: #e1a8df,
+	400: #da8bd6,
+	500: #d16bcc,
+	600: #c94cc5,
+	700: #b413ac,
+	800: #86147e,
+	900: #61005c,
+) !default;
+
+$timmi: (
+	text: #ffffff,
+	50: #f0f1fe,
+	100: #e0e1ff,
+	200: #cac9fd,
+	300: #b9b2fa,
+	400: #a69df0,
+	500: #9989ec,
+	600: #866ce4,
+	700: #6f52d1,
+	800: #5027a5,
+	900: #24075a,
+) !default;
+
+$poplee: (
+	text: #ffffff,
+	50: #e6f6fe,
+	100: #cbeafb,
+	200: #b1def6,
+	300: #98d2f1,
+	400: #7bc3ea,
+	500: #62b7e4,
+	600: #3a9ed4,
+	700: #0f7db8,
+	800: #005685,
+	900: #003c5c,
+) !default;
+
+$product: $brand !default;
 
 $neutral: (
 	text: #ffffff,
@@ -270,7 +313,7 @@ $colors: (
 
 $colorsRgb: (
 	'white': '255, 255, 255',
-	'grey-900': '19, 29, 53',
+	'neutral-900': '19, 29, 53',
 );
 
 // https://sass-lang.com/documentation/variables/#advanced-variable-functions
@@ -298,6 +341,10 @@ $palettesInterpolation: (
 	'watermelon': $watermelon,
 	'pumpkin': $pumpkin,
 	'pineapple': $pineapple,
+	'pagga': $pagga,
+	'poplee': $poplee,
+	'timmi': $timmi,
+	'cleemy': $cleemy,
 );
 
 $breakpoints: (
@@ -369,40 +416,40 @@ $borderRadius: (
 
 $elevations: (
 	// deprecated
-	'1': '0 1px 2px rgba(var(--colors-grey-900-rgb), 0.06), 0px 2px 8px rgba(var(--colors-grey-900-rgb), 0.04)',
+	'1': '0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.06), 0px 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04)',
 	'2':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 1px 2px rgba(var(--colors-grey-900-rgb), 0.02), 0 2px 6px rgba(var(--colors-grey-900-rgb), 0.05)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.02), 0 2px 6px rgba(var(--colors-neutral-900-rgb), 0.05)',
 	'3':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 2px 4px rgba(var(--colors-grey-900-rgb), 0.02), 0 4px 10px rgba(var(--colors-grey-900-rgb), 0.06)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 2px 4px rgba(var(--colors-neutral-900-rgb), 0.02), 0 4px 10px rgba(var(--colors-neutral-900-rgb), 0.06)',
 	'4':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 3px 6px rgba(var(--colors-grey-900-rgb), 0.04), 0 4px 16px rgba(var(--colors-grey-900-rgb), 0.08)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 3px 6px rgba(var(--colors-neutral-900-rgb), 0.04), 0 4px 16px rgba(var(--colors-neutral-900-rgb), 0.08)',
 	'5':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 4px 8px rgba(var(--colors-grey-900-rgb), 0.06), 0 12px 32px rgba(var(--colors-grey-900-rgb), 0.08)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 4px 8px rgba(var(--colors-neutral-900-rgb), 0.06), 0 12px 32px rgba(var(--colors-neutral-900-rgb), 0.08)',
 	'6':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), -2px 2px 8px rgba(var(--colors-grey-900-rgb), 0.04), -12px 6px 24px rgba(var(--colors-grey-900-rgb), 0.06)'
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), -2px 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04), -12px 6px 24px rgba(var(--colors-neutral-900-rgb), 0.06)'
 );
 
 $boxShadows: (
-	'XXS': '0 2px 8px rgba(var(--colors-grey-900-rgb), .2), 0 1px 2px rgba(var(--colors-grey-900-rgb), 0.15)',
+	'XXS': '0 2px 8px rgba(var(--colors-neutral-900-rgb), .2), 0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.15)',
 	// deprecated
-	'XS': '0 1px 2px rgba(var(--colors-grey-900-rgb), 0.06), 0 2px 8px rgba(var(--colors-grey-900-rgb), 0.04)',
+	'XS': '0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.06), 0 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04)',
 	'S':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 1px 2px rgba(var(--colors-grey-900-rgb), 0.02), 0 2px 6px rgba(var(--colors-grey-900-rgb), 0.06)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.02), 0 2px 6px rgba(var(--colors-neutral-900-rgb), 0.06)',
 	'M':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 2px 4px rgba(var(--colors-grey-900-rgb), 0.02), 0 4px 10px rgba(var(--colors-grey-900-rgb), 0.06)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 2px 4px rgba(var(--colors-neutral-900-rgb), 0.02), 0 4px 10px rgba(var(--colors-neutral-900-rgb), 0.06)',
 	'L':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 3px 6px rgba(var(--colors-grey-900-rgb), 0.04), 0 4px 16px rgba(var(--colors-grey-900-rgb), 0.08)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 3px 6px rgba(var(--colors-neutral-900-rgb), 0.04), 0 4px 16px rgba(var(--colors-neutral-900-rgb), 0.08)',
 	'XL':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), 0 4px 8px rgba(var(--colors-grey-900-rgb), 0.06), 0 12px 32px rgba(var(--colors-grey-900-rgb), 0.08)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 4px 8px rgba(var(--colors-neutral-900-rgb), 0.06), 0 12px 32px rgba(var(--colors-neutral-900-rgb), 0.08)',
 	'XXL':
-		'0 0 0 1px rgba(var(--colors-grey-900-rgb), 0.03), -2px 2px 8px rgba(var(--colors-grey-900-rgb), 0.04), -12px 6px 24px rgba(var(--colors-grey-900-rgb), 0.06)',
+		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), -2px 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04), -12px 6px 24px rgba(var(--colors-neutral-900-rgb), 0.06)',
 );
 
 $disabled: (
 	'opacity': 0.4,
-	'background': 'var(--palettes-grey-100)',
-	'color': 'var(--palettes-grey-600)',
-	'placeholder': 'var(--palettes-grey-400)',
+	'background': 'var(--palettes-neutral-100)',
+	'color': 'var(--palettes-neutral-600)',
+	'placeholder': 'var(--palettes-neutral-400)',
 );
 
 $animations: (
@@ -418,12 +465,12 @@ $durations: (
 );
 
 $loading: (
-	'frontground': var(--palettes-primary-500),
+	'frontground': var(--palettes-product-500),
 	'speed': 600ms,
 );
 
 $textLink: (
-	color: var(--palettes-primary-700),
-	hover: var(--palettes-primary-600),
-	disabled: var(--palettes-grey-500),
+	color: var(--palettes-product-700),
+	hover: var(--palettes-product-600),
+	disabled: var(--palettes-neutral-500),
 );

--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -89,7 +89,7 @@ $overflow: 'hidden', 'auto', 'visible', 'scroll';
 }
 
 @mixin palettes($suffix: '!important') {
-	@each $palette in list.join(config.$palettesForClasses, config.$palettesStates) {
+	@each $palette in config.$palettesAll {
 		.u-text#{transform.capitalize($palette)} {
 			color: var(--palettes-#{$palette}-700) #{$suffix};
 		}

--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -89,7 +89,7 @@ $overflow: 'hidden', 'auto', 'visible', 'scroll';
 }
 
 @mixin palettes($suffix: '!important') {
-	@each $palette in list.join(config.$palettes, config.$states) {
+	@each $palette in list.join(config.$palettesForClasses, config.$palettesStates) {
 		.u-text#{transform.capitalize($palette)} {
 			color: var(--palettes-#{$palette}-700) #{$suffix};
 		}

--- a/packages/scss/src/commons/utils/a11y.scss
+++ b/packages/scss/src/commons/utils/a11y.scss
@@ -11,11 +11,11 @@
 	contain: paint #{$suffix};
 }
 
-@mixin focusVisible($offset: 2px, $borderRadius: false, $color: var(--palettes-primary-700)) {
+@mixin focusVisible($offset: 2px, $borderRadius: false, $color: var(--palettes-product-700)) {
 	outline: 2px solid $color;
 	outline-offset: $offset;
 
 	@if $borderRadius != false {
-	  border-radius: $borderRadius;
+		border-radius: $borderRadius;
 	}
 }

--- a/packages/scss/src/commons/utils/loading.scss
+++ b/packages/scss/src/commons/utils/loading.scss
@@ -24,7 +24,7 @@
 	}
 }
 
-@mixin gradient($backgroundColor: transparent, $color: rgba(var(--colors-grey-900-rgb), 0.1)) {
+@mixin gradient($backgroundColor: transparent, $color: rgba(var(--colors-neutral-900-rgb), 0.1)) {
 	@keyframes loadingGradient {
 		0% {
 			background-position: 100% 0%;

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -28,13 +28,13 @@
 	@include core.cssvars('colors', config.$colors, '-color');
 	@include core.cssvars('colors', config.$colorsRgb, '-rgb');
 
-	--commons-background-base: var(--palettes-grey-25);
+	--commons-background-base: var(--palettes-neutral-25);
 	--commons-banner-height: 50px;
 	--commons-font-family: 'Source Sans Pro', Tahoma, sans-serif;
 	--commons-divider-width: 1px;
-	--commons-divider-color: var(--palettes-grey-200); // deprecated
+	--commons-divider-color: var(--palettes-neutral-200); // deprecated
 	--commons-divider-style: solid;
 	--commons-divider-border: var(--commons-divider-width) var(--commons-divider-style) var(--commons-divider-color);
-	--commons-border-100: var(--palettes-grey-100);
-	--commons-border-200: var(--palettes-grey-200);
+	--commons-border-100: var(--palettes-neutral-100);
+	--commons-border-200: var(--palettes-neutral-200);
 }

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use 'sass:list';
 
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/core';
@@ -11,7 +12,7 @@
 	@include core.cssvars('commons-loading', config.$loading);
 	@include core.cssvars('commons-text-link', config.$textLink);
 
-	@each $palette in config.$palettesForCssVars {
+	@each $palette in config.$palettesAll {
 		@include core.cssvars('palettes-#{$palette}', map.get(config.$palettesInterpolation, $palette));
 	}
 

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -11,7 +11,7 @@
 	@include core.cssvars('commons-loading', config.$loading);
 	@include core.cssvars('commons-text-link', config.$textLink);
 
-	@each $palette in config.$allPalettes {
+	@each $palette in config.$palettesForCssVars {
 		@include core.cssvars('palettes-#{$palette}', map.get(config.$palettesInterpolation, $palette));
 	}
 

--- a/packages/scss/src/components/actionIcon/component.scss
+++ b/packages/scss/src/components/actionIcon/component.scss
@@ -4,7 +4,7 @@
 	background-color: transparent;
 	border: 0;
 	border-radius: var(--commons-borderRadius-M);
-	color: var(--palettes-700, var(--palettes-grey-700));
+	color: var(--palettes-700, var(--palettes-neutral-700));
 	height: 2.5rem;
 	width: 2.5rem;
 	transition: background-color var(--commons-animations-durations-fast) ease, color var(--commons-animations-durations-fast) ease;
@@ -21,16 +21,16 @@
 
 	&:not([disabled], .is-disabled) {
 		&:hover {
-			background-color: var(--palettes-100, var(--palettes-grey-100));
+			background-color: var(--palettes-100, var(--palettes-neutral-100));
 		}
 
 		&:focus-visible {
 			@include a11y.focusVisible;
-			background-color: var(--palettes-100, var(--palettes-grey-100));
+			background-color: var(--palettes-100, var(--palettes-neutral-100));
 		}
 
 		&:active {
-			background-color: var(--palettes-200, var(--palettes-grey-200));
+			background-color: var(--palettes-200, var(--palettes-neutral-200));
 		}
 	}
 }

--- a/packages/scss/src/components/actionIcon/mods.scss
+++ b/packages/scss/src/components/actionIcon/mods.scss
@@ -18,7 +18,7 @@
 }
 
 @mixin outlined {
-	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-400, var(--palettes-grey-400));
+	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-400, var(--palettes-neutral-400));
 	background-color: var(--colors-white-color);
 
 	&:focus-visible {

--- a/packages/scss/src/components/actionIcon/states.scss
+++ b/packages/scss/src/components/actionIcon/states.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/components/loading/exports' as loading;
 
 @mixin disabled {
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	pointer-events: none;
 	cursor: default;
 }
@@ -15,7 +15,6 @@
 
 	@include loading.vars;
 	@include loading.component;
-
 
 	&::before,
 	&::after {

--- a/packages/scss/src/components/avatar/component.scss
+++ b/packages/scss/src/components/avatar/component.scss
@@ -27,7 +27,7 @@
 
 			display: flex;
 			text-decoration: none;
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			transition: transform var(--commons-animations-durations-fast);
 			transform: scale(var(--components-avatarWrapper-scale));
 			color: currentColor;
@@ -48,7 +48,7 @@
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			width: var(--components-avatar-size);
 			height: var(--components-avatar-size);
 			font-size: var(--components-avatarWrapper-fontSize);

--- a/packages/scss/src/components/box/index.scss
+++ b/packages/scss/src/components/box/index.scss
@@ -4,8 +4,10 @@
 	@include vars;
 	@include component;
 
+	// .mod-grey is deprecated
+	&.mod-neutral,
 	&.mod-grey {
-		@include grey;
+		@include neutral;
 	}
 
 	&.mod-withArrow {

--- a/packages/scss/src/components/box/mods.scss
+++ b/packages/scss/src/components/box/mods.scss
@@ -1,5 +1,5 @@
 @mixin grey {
-	--components-box-background: var(--palettes-grey-25);
+	--components-box-background: var(--palettes-neutral-25);
 }
 
 @mixin toggle {
@@ -36,7 +36,7 @@
 	left: var(--components-box-arrow-left);
 
 	&.mod-grey {
-		--components-box-arrow-background: var(--palettes-grey-25);
+		--components-box-arrow-background: var(--palettes-neutral-25);
 	}
 }
 

--- a/packages/scss/src/components/box/mods.scss
+++ b/packages/scss/src/components/box/mods.scss
@@ -1,4 +1,4 @@
-@mixin grey {
+@mixin neutral {
 	--components-box-background: var(--palettes-neutral-25);
 }
 
@@ -35,6 +35,8 @@
 	bottom: var(--components-box-arrow-bottom);
 	left: var(--components-box-arrow-left);
 
+	// .mod-grey is deprecated
+	&.mod-neutral,
 	&.mod-grey {
 		--components-box-arrow-background: var(--palettes-neutral-25);
 	}

--- a/packages/scss/src/components/breadcrumbs/component.scss
+++ b/packages/scss/src/components/breadcrumbs/component.scss
@@ -20,7 +20,7 @@
 			&:not(:first-child) {
 				&::before {
 					@include icon.generate('arrow_chevron_right');
-					color: var(--palettes-grey-600);
+					color: var(--palettes-neutral-600);
 					font-size: var(--sizes-XS-lineHeight);
 					padding: 0 var(--spacings-XXS);
 				}
@@ -28,7 +28,7 @@
 		}
 
 		.breadcrumbs-list-item-action {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			transition-duration: var(--commons-animations-durations-fast);
 			transition-property: color;
 			text-decoration: none;
@@ -39,7 +39,7 @@
 			cursor: pointer;
 
 			&:hover {
-				color: var(--palettes-grey-600);
+				color: var(--palettes-neutral-600);
 				text-decoration: underline;
 			}
 

--- a/packages/scss/src/components/breadcrumbs/states.scss
+++ b/packages/scss/src/components/breadcrumbs/states.scss
@@ -11,6 +11,6 @@
 	&:hover,
 	&:focus-visible {
 		outline: none;
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 	}
 }

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -55,8 +55,8 @@
 	}
 
 	&:hover {
-		--components-button-color: var(--palettes-text, var(--palettes-primary-text));
-		--components-button-backgroundColor: var(--palettes-600, var(--palettes-primary-600));
+		--components-button-color: var(--palettes-text, var(--palettes-product-text));
+		--components-button-backgroundColor: var(--palettes-600, var(--palettes-product-600));
 	}
 
 	&:focus-visible {
@@ -64,7 +64,7 @@
 	}
 
 	&:active {
-		--components-button-backgroundColor: var(--palettes-800, var(--palettes-primary-800));
+		--components-button-backgroundColor: var(--palettes-800, var(--palettes-product-800));
 	}
 
 	&:disabled {

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -50,7 +50,7 @@
 	// .mod-outline is deprecated
 	&:not(.mod-outlined, .mod-outline) {
 		.numericBadge {
-			@include numericBadge.primary;
+			@include numericBadge.product;
 		}
 	}
 

--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -69,7 +69,7 @@
 
 	&:disabled {
 		--components-button-cursor: default;
-		--components-button-color: var(--palettes-grey-500);
+		--components-button-color: var(--palettes-neutral-500);
 		--components-button-backgroundColor: var(--commons-disabled-background);
 		--components-button-pointerEvents: none;
 

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -198,7 +198,7 @@
 	--components-button-padding: var(--spacings-XS) calc(var(--spacings-XS) + var(--spacings-XXS)) var(--spacings-XS) var(--spacings-S);
 
 	.button-counter {
-		background-color: var(--palettes-600, var(--palettes-primary-600));
+		background-color: var(--palettes-600, var(--palettes-product-600));
 		border-radius: 1rem;
 		display: flex;
 		font-size: var(--sizes-XS-fontSize);
@@ -211,7 +211,7 @@
 
 	&:hover {
 		.button-counter {
-			--components-button-backgroundColor: var(--palettes-500, var(--palettes-primary-500));
+			--components-button-backgroundColor: var(--palettes-500, var(--palettes-product-500));
 		}
 	}
 }

--- a/packages/scss/src/components/button/mods.scss
+++ b/packages/scss/src/components/button/mods.scss
@@ -59,21 +59,21 @@
 
 @mixin textDisabled {
 	--components-button-backgroundColor: transparent;
-	--components-button-color: var(--palettes-grey-500);
+	--components-button-color: var(--palettes-neutral-500);
 }
 
 @mixin text {
 	--components-button-backgroundColor: transparent;
-	--components-button-color: var(--palettes-700, var(--palettes-grey-700));
+	--components-button-color: var(--palettes-700, var(--palettes-neutral-700));
 
 	&:hover,
 	&:focus-visible {
-		--components-button-color: var(--palettes-700, var(--palettes-grey-700));
-		--components-button-backgroundColor: var(--palettes-100, var(--palettes-grey-100));
+		--components-button-color: var(--palettes-700, var(--palettes-neutral-700));
+		--components-button-backgroundColor: var(--palettes-100, var(--palettes-neutral-100));
 	}
 
 	&:active {
-		--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
+		--components-button-backgroundColor: var(--palettes-200, var(--palettes-neutral-200));
 	}
 
 	&:disabled {
@@ -83,28 +83,28 @@
 
 @mixin outlinedDisabled {
 	--components-button-backgroundColor: var(--colors-white-color);
-	--components-button-boxShadow: 0 0 0 1px var(--palettes-grey-400);
-	--components-button-color: var(--palettes-grey-500);
+	--components-button-boxShadow: 0 0 0 1px var(--palettes-neutral-400);
+	--components-button-color: var(--palettes-neutral-500);
 }
 
 @mixin outlined {
 	--components-button-backgroundColor: var(--colors-white-color);
-	--components-button-color: var(--palettes-700, var(--palettes-grey-700));
-	--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-400, var(--palettes-grey-400));
+	--components-button-color: var(--palettes-700, var(--palettes-neutral-700));
+	--components-button-boxShadow: 0 0 0 var(--commons-divider-width) var(--palettes-400, var(--palettes-neutral-400));
 
 	// deprecated
 	.button-counter {
-		color: var(--palettes-800, var(--palettes-grey-800));
-		background-color: var(--palettes-300, var(--palettes-grey-300));
+		color: var(--palettes-800, var(--palettes-neutral-800));
+		background-color: var(--palettes-300, var(--palettes-neutral-300));
 	}
 
 	&:hover {
-		--components-button-color: var(--palettes-700, var(--palettes-grey-700));
-		--components-button-backgroundColor: var(--palettes-100, var(--palettes-grey-100));
+		--components-button-color: var(--palettes-700, var(--palettes-neutral-700));
+		--components-button-backgroundColor: var(--palettes-100, var(--palettes-neutral-100));
 	}
 
 	&:active {
-		--components-button-backgroundColor: var(--palettes-200, var(--palettes-grey-200));
+		--components-button-backgroundColor: var(--palettes-200, var(--palettes-neutral-200));
 	}
 
 	&:focus-visible {
@@ -122,11 +122,11 @@
 	&:hover,
 	&:focus-visible {
 		--components-button-color: var(--colors-white-color);
-		--components-button-backgroundColor: var(--palettes-800, var(--palettes-grey-800));
+		--components-button-backgroundColor: var(--palettes-800, var(--palettes-neutral-800));
 	}
 
 	&:active {
-		--components-button-backgroundColor: var(--palettes-700, var(--palettes-grey-700));
+		--components-button-backgroundColor: var(--palettes-700, var(--palettes-neutral-700));
 	}
 }
 

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -9,7 +9,7 @@
 
 @mixin disabled {
 	--components-button-cursor: default;
-	--components-button-color: var(--palettes-grey-500);
+	--components-button-color: var(--palettes-neutral-500);
 	--components-button-backgroundColor: var(--commons-disabled-background);
 	--components-button-pointerEvents: none;
 

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -57,7 +57,7 @@
 }
 
 @mixin error {
-	@include core.cssvars('palettes', config.$error);
+	@include core.cssvars('palettes', config.$critical);
 
 	@include state;
 

--- a/packages/scss/src/components/button/vars.scss
+++ b/packages/scss/src/components/button/vars.scss
@@ -10,6 +10,6 @@
 	--components-button-minWidth: none;
 	--components-button-userSelect: auto;
 	--components-button-boxShadow: none;
-	--components-button-color: var(--palettes-text, var(--palettes-primary-text));
-	--components-button-backgroundColor: var(--palettes-700, var(--palettes-primary-700));
+	--components-button-color: var(--palettes-text, var(--palettes-product-text));
+	--components-button-backgroundColor: var(--palettes-700, var(--palettes-product-700));
 }

--- a/packages/scss/src/components/buttonGroup/mods.scss
+++ b/packages/scss/src/components/buttonGroup/mods.scss
@@ -1,11 +1,11 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin outlined {
-	background-color: var(--palettes-400, var(--palettes-grey-400));
-	box-shadow: 0 0 0 1px var(--palettes-400, var(--palettes-grey-400));
+	background-color: var(--palettes-400, var(--palettes-neutral-400));
+	box-shadow: 0 0 0 1px var(--palettes-400, var(--palettes-neutral-400));
 
 	&:is(.is-disabled, .disabled) {
-		box-shadow: 0 0 0 1px var(--palettes-grey-200);
+		box-shadow: 0 0 0 1px var(--palettes-neutral-200);
 	}
 
 	.button {
@@ -25,7 +25,7 @@
 			}
 
 			&:is([disabled], .is-disabled) {
-				box-shadow: 0 0 0 1px var(--palettes-grey-200);
+				box-shadow: 0 0 0 1px var(--palettes-neutral-200);
 			}
 		}
 	}

--- a/packages/scss/src/components/callout/component.scss
+++ b/packages/scss/src/components/callout/component.scss
@@ -5,9 +5,9 @@
 @mixin component($atRoot: 'without: rule') {
 	align-items: flex-start;
 	border-radius: var(--commons-borderRadius-L);
-	background-color: var(--palettes-50, var(--palettes-grey-50));
-	color: var(--palettes-grey-800);
-	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-300, var(--palettes-grey-300));
+	background-color: var(--palettes-50, var(--palettes-neutral-50));
+	color: var(--palettes-neutral-800);
+	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-300, var(--palettes-neutral-300));
 	gap: 0.75rem;
 	padding: var(--spacings-XS) 0.75rem;
 	position: relative;
@@ -18,8 +18,8 @@
 
 	a,
 	.link {
-		--commons-text-link-color: var(--palettes-grey-800);
-		--commons-text-link-hover: var(--palettes-grey-700);
+		--commons-text-link-color: var(--palettes-neutral-800);
+		--commons-text-link-hover: var(--palettes-neutral-700);
 	}
 
 	@at-root ($atRoot) {
@@ -36,7 +36,7 @@
 
 		.callout-icon {
 			display: inline-flex;
-			color: var(--palettes-700, var(--palettes-grey-700));
+			color: var(--palettes-700, var(--palettes-neutral-700));
 
 			.lucca-icon {
 				font-size: var(--sizes-M-lineHeight);

--- a/packages/scss/src/components/calloutAccordion/component.scss
+++ b/packages/scss/src/components/calloutAccordion/component.scss
@@ -4,16 +4,16 @@
 
 @mixin component($atRoot: 'without: rule') {
 	border-radius: var(--commons-borderRadius-L);
-	background-color: var(--palettes-50, var(--palettes-grey-50));
-	color: var(--palettes-grey-800);
-	border-color: var(--palettes-300, var(--palettes-grey-300));
+	background-color: var(--palettes-50, var(--palettes-neutral-50));
+	color: var(--palettes-neutral-800);
+	border-color: var(--palettes-300, var(--palettes-neutral-300));
 	border-style: solid;
 	border-width: var(--commons-divider-width);
 
 	a,
 	.link {
-		--commons-text-link-color: var(--palettes-grey-800);
-		--commons-text-link-hover: var(--palettes-grey-700);
+		--commons-text-link-color: var(--palettes-neutral-800);
+		--commons-text-link-hover: var(--palettes-neutral-700);
 	}
 
 	@at-root ($atRoot) {
@@ -33,18 +33,18 @@
 		}
 
 		.calloutAccordion-summary-icon {
-			color: var(--palettes-700, var(--palettes-grey-700));
+			color: var(--palettes-700, var(--palettes-neutral-700));
 		}
 
 		.calloutAccordion-summary-chevron {
-				color: var(--palettes-grey-700);
-				margin-left: auto;
+			color: var(--palettes-neutral-700);
+			margin-left: auto;
 		}
 
 		.calloutAccordion-details {
 			margin: 0 3rem;
 			padding: var(--spacings-XS) 0 var(--spacings-S);
-			border-top: 1px solid var(--palettes-200, var(--palettes-grey-200));
+			border-top: 1px solid var(--palettes-200, var(--palettes-neutral-200));
 		}
 	}
 }

--- a/packages/scss/src/components/calloutDisclosure/component.scss
+++ b/packages/scss/src/components/calloutDisclosure/component.scss
@@ -4,14 +4,14 @@
 
 @mixin component($atRoot: 'without: rule') {
 	border-radius: var(--commons-borderRadius-L);
-	background-color: var(--palettes-50, var(--palettes-grey-50));
-	color: var(--palettes-grey-800);
-	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-300, var(--palettes-grey-300));
+	background-color: var(--palettes-50, var(--palettes-neutral-50));
+	color: var(--palettes-neutral-800);
+	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-300, var(--palettes-neutral-300));
 
 	a,
 	.link {
-		--commons-text-link-color: var(--palettes-grey-800);
-		--commons-text-link-hover: var(--palettes-grey-700);
+		--commons-text-link-color: var(--palettes-neutral-800);
+		--commons-text-link-hover: var(--palettes-neutral-700);
 	}
 
 	@at-root ($atRoot) {
@@ -26,20 +26,20 @@
 			position: relative;
 
 			&:hover {
-				background-color: var(--palettes-100, var(--palettes-grey-100));
+				background-color: var(--palettes-100, var(--palettes-neutral-100));
 			}
 
 			&:focus-visible {
 				@include a11y.focusVisible($offset: 3px, $borderRadius: 6px);
 
 				~ .calloutDisclosure-details {
-					box-shadow: none
+					box-shadow: none;
 				}
 			}
 		}
 
 		.calloutDisclosure-summary-icon {
-			color: var(--palettes-700, var(--palettes-grey-700));
+			color: var(--palettes-700, var(--palettes-neutral-700));
 		}
 
 		.calloutDisclosure-summary-title {
@@ -47,7 +47,7 @@
 		}
 
 		.calloutDisclosure-summary-chevron {
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 			margin-left: auto;
 			transition: transform var(--commons-animations-durations-standard) ease;
 		}
@@ -55,7 +55,7 @@
 		.calloutDisclosure-details {
 			margin: 0 calc(var(--components-calloutDisclosure-paddingHorizontal) + 2.25rem);
 			padding: var(--spacings-XS) 0 var(--spacings-S);
-			box-shadow: 0 -1px 0 0 var(--palettes-200, var(--palettes-grey-200));
+			box-shadow: 0 -1px 0 0 var(--palettes-200, var(--palettes-neutral-200));
 		}
 	}
 }

--- a/packages/scss/src/components/calloutPopover/component.scss
+++ b/packages/scss/src/components/calloutPopover/component.scss
@@ -8,13 +8,13 @@
 	align-items: center;
 	padding: var(--spacings-XS);
 	border-radius: var(--commons-borderRadius-L);
-	background-color: var(--palettes-50, var(--palettes-grey-50));
+	background-color: var(--palettes-50, var(--palettes-neutral-50));
 	border: 0;
-	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-300, var(--palettes-grey-300));
+	box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-300, var(--palettes-neutral-300));
 	cursor: pointer;
 
 	&:hover {
-		background-color: var(--palettes-100, var(--palettes-grey-100));
+		background-color: var(--palettes-100, var(--palettes-neutral-100));
 	}
 
 	&:focus-visible {
@@ -23,17 +23,17 @@
 
 	@at-root ($atRoot) {
 		.calloutPopover-icon {
-			color: var(--palettes-700, var(--palettes-grey-700));
+			color: var(--palettes-700, var(--palettes-neutral-700));
 		}
 
 		.calloutPopover-overlay {
-		  width: var(--components-calloutPopover-width);
+			width: var(--components-calloutPopover-width);
 			max-width: 100vw;
 		}
 
 		.calloutPopover-overlay-head {
-		  display: flex;
-		  gap: var(--spacings-XS);
+			display: flex;
+			gap: var(--spacings-XS);
 		}
 
 		.calloutPopover-overlay-head-title {
@@ -45,13 +45,13 @@
 
 		.calloutPopover-overlay-head-icon {
 			@include icon.M;
-		  color: var(--palettes-700, var(--palettes-grey-700));
+			color: var(--palettes-700, var(--palettes-neutral-700));
 		}
 
 		.calloutPopover-overlay-content {
 			margin: var(--spacings-XS) 0.75rem var(--spacings-XS) var(--components-calloutPopover-content-margin);
 			padding-top: var(--spacings-XS);
-			border-top: var(--commons-divider-width) solid var(--palettes-grey-200);
+			border-top: var(--commons-divider-width) solid var(--palettes-neutral-200);
 		}
 	}
 }

--- a/packages/scss/src/components/card/index.scss
+++ b/packages/scss/src/components/card/index.scss
@@ -4,8 +4,10 @@
 	@include vars;
 	@include component;
 
+	// .mod-grey is deprecated
+	&.mod-neutral,
 	&.mod-grey {
-		@include grey;
+		@include neutral;
 	}
 
 	&.mod-clickable {

--- a/packages/scss/src/components/card/mods.scss
+++ b/packages/scss/src/components/card/mods.scss
@@ -1,6 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-@mixin grey {
+@mixin neutral {
 	--components-card-background: var(--palettes-neutral-50);
 }
 

--- a/packages/scss/src/components/card/mods.scss
+++ b/packages/scss/src/components/card/mods.scss
@@ -1,11 +1,11 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin grey {
-	--components-card-background: var(--palettes-grey-50);
+	--components-card-background: var(--palettes-neutral-50);
 }
 
 @mixin clickable {
-	color: var(--palettes-grey-800);
+	color: var(--palettes-neutral-800);
 	text-decoration: none;
 	cursor: pointer;
 

--- a/packages/scss/src/components/card/vars.scss
+++ b/packages/scss/src/components/card/vars.scss
@@ -1,9 +1,9 @@
 @mixin vars {
 	--components-card-background: var(--colors-white-color);
-	--components-card-content-padding: .75rem var(--spacings-S);
+	--components-card-content-padding: 0.75rem var(--spacings-S);
 	--components-card-footer-padding: var(--spacings-XS) var(--spacings-M);
 	--components-card-border-radius: var(--commons-borderRadius-L);
 	--components-card-border-color: var(--commons-divider-color);
-	--components-card-hover-border: var(--palettes-grey-400);
-	--components-card-hover-background: var(--palettes-grey-100);
+	--components-card-hover-border: var(--palettes-neutral-400);
+	--components-card-hover-background: var(--palettes-neutral-100);
 }

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -63,23 +63,23 @@
 			&:checked ~ .checkbox-label {
 				&::before {
 					color: var(--colors-white-color);
-					background-color: var(--palettes-700, var(--palettes-primary-700));
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-700, var(--palettes-primary-700));
+					background-color: var(--palettes-700, var(--palettes-product-700));
+					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-700, var(--palettes-product-700));
 				}
 			}
 
 			&:not(:disabled):checked ~ .checkbox-label {
 				&:hover {
 					&::before {
-						background-color: var(--palettes-600, var(--palettes-primary-600));
-						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-600, var(--palettes-primary-600));
+						background-color: var(--palettes-600, var(--palettes-product-600));
+						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-600, var(--palettes-product-600));
 					}
 				}
 
 				&:active {
 					&::before {
-						background-color: var(--palettes-800, var(--palettes-primary-800));
-						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-800, var(--palettes-primary-800));
+						background-color: var(--palettes-800, var(--palettes-product-800));
+						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-800, var(--palettes-product-800));
 					}
 				}
 			}

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -24,7 +24,7 @@
 				border-radius: 6px;
 				transition-duration: var(--commons-animations-durations-fast);
 				transition-property: box-shadow, color, background-color;
-				box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-700);
+				box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-700);
 				line-height: var(--components-checkbox-input-size);
 				font-size: var(--components-checkbox-input-size);
 				flex-grow: 0;
@@ -40,19 +40,19 @@
 
 			&:hover {
 				&::before {
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-600);
+					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-600);
 				}
 			}
 
 			&:active {
 				&::before {
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-800);
+					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-800);
 				}
 			}
 		}
 
 		.checkbox-label-helper {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
 		}

--- a/packages/scss/src/components/checkbox/states.scss
+++ b/packages/scss/src/components/checkbox/states.scss
@@ -3,23 +3,23 @@
 
 @mixin disabled {
 	~ .checkbox-label {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 		cursor: default;
 
 		&::before {
-			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-500);
+			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-500);
 		}
 
 		.checkbox-label-helper {
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 		}
 	}
 
 	&:checked ~ .checkbox-label {
 		&::before {
-			color: var(--palettes-grey-500);
-			background-color: var(--palettes-grey-100);
-			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-grey-100);
+			color: var(--palettes-neutral-500);
+			background-color: var(--palettes-neutral-100);
+			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-100);
 		}
 	}
 }

--- a/packages/scss/src/components/checkboxField/component.scss
+++ b/packages/scss/src/components/checkboxField/component.scss
@@ -8,7 +8,7 @@
 		.checkboxField-icon {
 			width: var(--component-checkboxField-size);
 			height: var(--component-checkboxField-size);
-			border: 2px solid var(--palettes-grey-700);
+			border: 2px solid var(--palettes-neutral-700);
 			border-radius: var(--component-checkboxField-borderRadius);
 			position: relative;
 			color: var(--colors-white-color);

--- a/packages/scss/src/components/checkboxField/states.scss
+++ b/packages/scss/src/components/checkboxField/states.scss
@@ -27,7 +27,7 @@
 
 @mixin hover {
 	~ .checkboxField-icon {
-		border-color: var(--palettes-grey-600);
+		border-color: var(--palettes-neutral-600);
 	}
 }
 
@@ -47,9 +47,9 @@
 
 @mixin checkedDisabled {
 	~ .checkboxField-icon {
-		background-color: var(--palettes-grey-100);
-		border-color: var(--palettes-grey-100);
-		color: var(--palettes-grey-500);
+		background-color: var(--palettes-neutral-100);
+		border-color: var(--palettes-neutral-100);
+		color: var(--palettes-neutral-500);
 	}
 }
 
@@ -69,7 +69,7 @@
 
 @mixin active {
 	~ .checkboxField-icon {
-		border-color: var(--palettes-grey-800);
+		border-color: var(--palettes-neutral-800);
 	}
 }
 
@@ -77,7 +77,7 @@
 	cursor: default;
 
 	~ .checkboxField-icon {
-		border-color: var(--palettes-grey-500);
+		border-color: var(--palettes-neutral-500);
 	}
 }
 

--- a/packages/scss/src/components/checkboxField/states.scss
+++ b/packages/scss/src/components/checkboxField/states.scss
@@ -15,8 +15,8 @@
 
 @mixin checked {
 	~ .checkboxField-icon {
-		background-color: var(--palettes-primary-700);
-		border-color: var(--palettes-primary-700);
+		background-color: var(--palettes-product-700);
+		border-color: var(--palettes-product-700);
 
 		.checkboxField-icon-check {
 			transform: scale(1);
@@ -33,15 +33,15 @@
 
 @mixin checkedHover {
 	~ .checkboxField-icon {
-		background-color: var(--palettes-primary-600);
-		border-color: var(--palettes-primary-600);
+		background-color: var(--palettes-product-600);
+		border-color: var(--palettes-product-600);
 	}
 }
 
 @mixin checkedActive {
 	~ .checkboxField-icon {
-		background-color: var(--palettes-primary-800);
-		border-color: var(--palettes-primary-800);
+		background-color: var(--palettes-product-800);
+		border-color: var(--palettes-product-800);
 	}
 }
 
@@ -55,8 +55,8 @@
 
 @mixin checkedHover {
 	~ .checkboxField-icon {
-		background-color: var(--palettes-primary-600);
-		border-color: var(--palettes-primary-600);
+		background-color: var(--palettes-product-600);
+		border-color: var(--palettes-product-600);
 	}
 }
 

--- a/packages/scss/src/components/chip/component.scss
+++ b/packages/scss/src/components/chip/component.scss
@@ -3,9 +3,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 
 @mixin component($atRoot: 'without: rule') {
-	background-color: var(--palettes-700, var(--palettes-grey-200));
+	background-color: var(--palettes-700, var(--palettes-neutral-200));
 	border-radius: var(--commons-borderRadius-M);
-	color: var(--palettes-text, var(--palettes-grey-800));
+	color: var(--palettes-text, var(--palettes-neutral-800));
 	display: inline-flex;
 	align-items: center;
 	gap: var(--spacings-XS);
@@ -36,7 +36,7 @@
 
 			&::before {
 				border-radius: var(--commons-borderRadius-full);
-				background-color: var(--components-chip-kill-disk-color, var(--palettes-grey-700));
+				background-color: var(--components-chip-kill-disk-color, var(--palettes-neutral-700));
 			}
 
 			&::after {
@@ -47,7 +47,7 @@
 			}
 
 			&:hover {
-				--components-chip-kill-disk-color: var(--palettes-grey-600);
+				--components-chip-kill-disk-color: var(--palettes-neutral-600);
 				--components-chip-kill-cross-color: var(--palettes-700, var(--colors-white-color));
 			}
 
@@ -58,7 +58,7 @@
 			}
 
 			&:active {
-				--components-chip-kill-disk-color: var(--palettes-50, var(--palettes-grey-800));
+				--components-chip-kill-disk-color: var(--palettes-50, var(--palettes-neutral-800));
 			}
 		}
 	}

--- a/packages/scss/src/components/chip/index.scss
+++ b/packages/scss/src/components/chip/index.scss
@@ -8,8 +8,10 @@
 		@include S;
 	}
 
+	// .palette-primary is deprecated
+	&.palette-product,
 	&.palette-primary {
-		@include primary;
+		@include product;
 	}
 
 	&.mod-unkillable {

--- a/packages/scss/src/components/chip/mods.scss
+++ b/packages/scss/src/components/chip/mods.scss
@@ -5,7 +5,7 @@
 	--components-chip-lineHeight: var(--sizes-XS-lineHeight);
 }
 
-@mixin primary {
+@mixin product {
 	.chip-kill {
 		--components-chip-kill-cross-color: var(--palettes-product-700);
 		--components-chip-kill-disk-color: var(--colors-white-color);

--- a/packages/scss/src/components/chip/mods.scss
+++ b/packages/scss/src/components/chip/mods.scss
@@ -35,6 +35,6 @@
 	text-decoration: none;
 
 	&:hover {
-		background-color: var(--palettes-600, var(--palettes-grey-100));
+		background-color: var(--palettes-600, var(--palettes-neutral-100));
 	}
 }

--- a/packages/scss/src/components/chip/mods.scss
+++ b/packages/scss/src/components/chip/mods.scss
@@ -7,15 +7,15 @@
 
 @mixin primary {
 	.chip-kill {
-		--components-chip-kill-cross-color: var(--palettes-primary-700);
+		--components-chip-kill-cross-color: var(--palettes-product-700);
 		--components-chip-kill-disk-color: var(--colors-white-color);
 
 		&:hover {
-			--components-chip-kill-disk-color: var(--palettes-primary-50);
+			--components-chip-kill-disk-color: var(--palettes-product-50);
 		}
 
 		&:active {
-			--components-chip-kill-disk-color: var(--palettes-primary-50);
+			--components-chip-kill-disk-color: var(--palettes-product-50);
 		}
 
 		&:focus-visible {

--- a/packages/scss/src/components/chip/states.scss
+++ b/packages/scss/src/components/chip/states.scss
@@ -1,8 +1,8 @@
 @mixin disabled {
-  background: var(--palettes-grey-100);
-  color: var(--palettes-grey-500);
+	background: var(--palettes-neutral-100);
+	color: var(--palettes-neutral-500);
 
-  .chip-kill {
-    display: none;
-  }
+	.chip-kill {
+		display: none;
+	}
 }

--- a/packages/scss/src/components/clear/component.scss
+++ b/packages/scss/src/components/clear/component.scss
@@ -34,8 +34,8 @@
 	}
 
 	&:hover {
-		--components-clear-cross-color: var(--palettes-grey-text);
-		--components-clear-background: var(--palettes-grey-600);
+		--components-clear-cross-color: var(--palettes-neutral-text);
+		--components-clear-background: var(--palettes-neutral-600);
 	}
 
 	&:focus-visible {
@@ -43,7 +43,7 @@
 	}
 
 	&:active {
-		--components-clear-background: var(--palettes-grey-800);
+		--components-clear-background: var(--palettes-neutral-800);
 	}
 
 	//to prevent breaking change. lucca-icon is no longer needed.

--- a/packages/scss/src/components/clear/index.scss
+++ b/packages/scss/src/components/clear/index.scss
@@ -11,11 +11,12 @@
 	// .palette-primary is deprecated
 	&.palette-product:not([disabled]),
 	&.palette-primary:not([disabled]) {
-		@include primary;
+		@include product;
 	}
 
 	&[disabled] {
 		@include disabled;
+
 		cursor: default;
 	}
 }

--- a/packages/scss/src/components/clear/index.scss
+++ b/packages/scss/src/components/clear/index.scss
@@ -8,6 +8,8 @@
 		@include S;
 	}
 
+	// .palette-primary is deprecated
+	&.palette-product:not([disabled]),
 	&.palette-primary:not([disabled]) {
 		@include primary;
 	}

--- a/packages/scss/src/components/clear/mods.scss
+++ b/packages/scss/src/components/clear/mods.scss
@@ -1,4 +1,4 @@
-@mixin primary {
+@mixin product {
 	--components-clear-cross-color: var(--palettes-product-700);
 	--components-clear-background: var(--colors-white-color);
 

--- a/packages/scss/src/components/clear/mods.scss
+++ b/packages/scss/src/components/clear/mods.scss
@@ -1,13 +1,13 @@
 @mixin primary {
-	--components-clear-cross-color: var(--palettes-primary-700);
+	--components-clear-cross-color: var(--palettes-product-700);
 	--components-clear-background: var(--colors-white-color);
 
 	&:hover {
-		--components-clear-background: var(--palettes-primary-50);
+		--components-clear-background: var(--palettes-product-50);
 	}
 
 	&:active {
-		--components-clear-background: var(--palettes-primary-50);
+		--components-clear-background: var(--palettes-product-50);
 	}
 }
 

--- a/packages/scss/src/components/clear/states.scss
+++ b/packages/scss/src/components/clear/states.scss
@@ -1,4 +1,4 @@
 @mixin disabled {
-	--components-clear-cross-color: var(--palettes-grey-500);
-	--components-clear-background: var(--palettes-grey-300);
+	--components-clear-cross-color: var(--palettes-neutral-500);
+	--components-clear-background: var(--palettes-neutral-300);
 }

--- a/packages/scss/src/components/clear/vars.scss
+++ b/packages/scss/src/components/clear/vars.scss
@@ -1,6 +1,6 @@
 @mixin vars {
 	--components-clear-size: 1rem;
-	--components-clear-background: var(--palettes-grey-700);
+	--components-clear-background: var(--palettes-neutral-700);
 	--components-clear-cross-color: var(--colors-white-color);
 	--components-clear-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' fill='none'%3E%3Cpath d='M5.80473 4.86192C5.54438 4.60157 5.12227 4.60157 4.86192 4.86192C4.60157 5.12227 4.60157 5.54438 4.86192 5.80473L7.05718 7.99999L4.86192 10.1953C4.60157 10.4556 4.60157 10.8777 4.86192 11.1381C5.12227 11.3984 5.54438 11.3984 5.80473 11.1381L7.99999 8.9428L10.1953 11.1381C10.4556 11.3984 10.8777 11.3984 11.1381 11.1381C11.3984 10.8777 11.3984 10.4556 11.1381 10.1953L8.9428 7.99999L11.1381 5.80473C11.3984 5.54438 11.3984 5.12227 11.1381 4.86192C10.8777 4.60157 10.4556 4.60157 10.1953 4.86192L7.99999 7.05718L5.80473 4.86192Z' fill='currentColor'/%3E%3C/svg%3E");
 }

--- a/packages/scss/src/components/collapse/component.scss
+++ b/packages/scss/src/components/collapse/component.scss
@@ -16,7 +16,7 @@
 
 			&:focus-within,
 			&:hover {
-				color: var(--palettes-grey-900);
+				color: var(--palettes-neutral-900);
 			}
 
 			&::before {

--- a/packages/scss/src/components/divider/component.scss
+++ b/packages/scss/src/components/divider/component.scss
@@ -19,7 +19,7 @@
 		text-align: center;
 		font-size: var(--components-divider-fontSize);
 		line-height: var(--components-divider-lineHeight);
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 
 		&::before,
 		&::after {
@@ -32,7 +32,7 @@
 		}
 
 		.lucca-icon {
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 		}
 	}
 }

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -25,8 +25,8 @@
 		}
 
 		.emptyState-content-icon {
-			--components-emptyState-icon-background-color: var(--palettes-100, var(--palettes-primary-100));
-			--components-emptyState-icon-action-color: var(--palettes-600, var(--palettes-primary-600));
+			--components-emptyState-icon-background-color: var(--palettes-100, var(--palettes-product-100));
+			--components-emptyState-icon-action-color: var(--palettes-600, var(--palettes-product-600));
 		}
 
 		.emptyState-content-text {

--- a/packages/scss/src/components/emptyStateDeprecated/component.scss
+++ b/packages/scss/src/components/emptyStateDeprecated/component.scss
@@ -5,11 +5,11 @@
 
 	@at-root ($atRoot) {
 		.emptyState-title {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 		}
 
 		.emptyState-description {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			margin-bottom: var(--spacings-L);
 		}
 	}

--- a/packages/scss/src/components/field/component.scss
+++ b/packages/scss/src/components/field/component.scss
@@ -42,7 +42,7 @@
 			width: 100%;
 
 			&::placeholder {
-				color: var(--palettes-grey-200);
+				color: var(--palettes-neutral-200);
 			}
 		}
 
@@ -106,7 +106,7 @@
 		.textfield-messages-helper,
 		.radiosfield-messages-helper,
 		.checkboxesfield-messages-helper {
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 		}
 	}
 }

--- a/packages/scss/src/components/field/mods.scss
+++ b/packages/scss/src/components/field/mods.scss
@@ -120,7 +120,7 @@
 	.textfield-messages-helper,
 	.radiosfield-messages-helper,
 	.checkboxesfield-messages-helper {
-		background-color: var(--palettes-grey-600);
+		background-color: var(--palettes-neutral-600);
 		color: var(--colors-white-color);
 	}
 
@@ -142,7 +142,7 @@
 			background-color: var(--colors-white-color);
 
 			&::placeholder {
-				color: var(--palettes-grey-400);
+				color: var(--palettes-neutral-400);
 			}
 
 			&:focus,
@@ -219,7 +219,7 @@
 		}
 
 		&::placeholder {
-			color: var(--palettes-grey-400);
+			color: var(--palettes-neutral-400);
 		}
 
 		@if ($state == 'error') {
@@ -265,7 +265,7 @@
 
 @mixin framedSearch {
 	&::after {
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		padding: var(--components-field-framed-side-padding);
 		bottom: 0;
 		right: 0;

--- a/packages/scss/src/components/field/states.scss
+++ b/packages/scss/src/components/field/states.scss
@@ -4,13 +4,13 @@
 
 @mixin hover {
 	&::placeholder {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 	}
 }
 
 @mixin focus {
 	&::placeholder {
-		color: var(--palettes-grey-200);
+		color: var(--palettes-neutral-200);
 	}
 }
 
@@ -30,7 +30,7 @@
 }
 
 @mixin inputDisabled {
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	cursor: not-allowed;
 }
 

--- a/packages/scss/src/components/field/vars.scss
+++ b/packages/scss/src/components/field/vars.scss
@@ -1,9 +1,9 @@
 @mixin vars {
 	--components-field-font-size: var(--sizes-M-fontSize);
 	--components-field-horizontal-spacing: var(--spacings-M);
-	--components-field-input-color: var(--palettes-grey-800);
+	--components-field-input-color: var(--palettes-neutral-800);
 	--components-field-input-inline-margin: 0.15rem;
-	--components-field-label-color: var(--palettes-grey-800);
+	--components-field-label-color: var(--palettes-neutral-800);
 	--components-field-label-margin-bottom: var(--spacings-XXS);
 	--components-field-message-font-size: var(--sizes-XS-fontSize);
 	--components-field-message-margin-top: var(--spacings-XXS);
@@ -20,9 +20,9 @@
 	--components-field-compact-label-sizes-long: 9rem;
 	--components-field-compact-label-sizes-longer: 11rem;
 
-	--components-field-framed-color50: var(--palettes-grey-50);
+	--components-field-framed-color50: var(--palettes-neutral-50);
 	--components-field-framed-color: #9299b0;
-	--components-field-framed-border: var(--palettes-grey-200);
+	--components-field-framed-border: var(--palettes-neutral-200);
 	--components-field-framed-text: #4c5775;
 	--components-field-framed-side-padding: var(--spacings-S);
 	--components-field-framed-top-padding: var(--spacings-L);

--- a/packages/scss/src/components/fieldset/component.scss
+++ b/packages/scss/src/components/fieldset/component.scss
@@ -36,7 +36,7 @@
 		.fieldset-title-content-text-helper {
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 			font-weight: 400;
 			display: block;
 		}

--- a/packages/scss/src/components/file/component.scss
+++ b/packages/scss/src/components/file/component.scss
@@ -100,7 +100,7 @@
 			&:not(:disabled) {
 				~ .file-content {
 					&::before {
-						border: 1px dashed var(--palettes-primary-400);
+						border: 1px dashed var(--palettes-product-400);
 					}
 
 					.file-button {

--- a/packages/scss/src/components/file/component.scss
+++ b/packages/scss/src/components/file/component.scss
@@ -23,7 +23,7 @@
 		font-weight: 600;
 		display: block;
 		position: relative;
-		color: var(--palettes-grey-700);
+		color: var(--palettes-neutral-700);
 	}
 
 	.file-or {
@@ -32,11 +32,11 @@
 		margin-bottom: var(--spacings-XXS);
 		display: block;
 		position: relative;
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 
 		&:not(:empty) {
 			margin-bottom: var(--spacings-XS);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 		}
 	}
 
@@ -50,7 +50,7 @@
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
 			margin-bottom: var(--spacings-S);
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			display: block;
 		}
 	}
@@ -58,7 +58,7 @@
 	.file-formats {
 		font-size: var(--sizes-S-fontSize);
 		line-height: var(--sizes-S-lineHeight);
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		position: relative;
 		display: block;
 	}
@@ -88,7 +88,7 @@
 
 		~ .file-content {
 			&::before {
-				border: 1px dashed var(--palettes-grey-400);
+				border: 1px dashed var(--palettes-neutral-400);
 				border-radius: var(--commons-borderRadius-M);
 				position: absolute;
 				inset: 0;
@@ -104,7 +104,7 @@
 					}
 
 					.file-button {
-						background-color: var(--palettes-100, var(--palettes-grey-100));
+						background-color: var(--palettes-100, var(--palettes-neutral-100));
 					}
 				}
 			}

--- a/packages/scss/src/components/file/states.scss
+++ b/packages/scss/src/components/file/states.scss
@@ -9,7 +9,7 @@
 		.file-or,
 		.file-formats,
 		.file-button {
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 		}
 	}
 }
@@ -27,7 +27,7 @@
 	~ .file-content {
 		.file-title {
 			font-weight: 400;
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
 			font-style: italic;

--- a/packages/scss/src/components/file/states.scss
+++ b/packages/scss/src/components/file/states.scss
@@ -17,8 +17,8 @@
 @mixin droppable {
 	~ .file-content {
 		&::before {
-			background-color: var(--palettes-primary-50);
-			border: 1px dashed var(--palettes-primary-400);
+			background-color: var(--palettes-product-50);
+			border: 1px dashed var(--palettes-product-400);
 		}
 	}
 }
@@ -75,7 +75,7 @@
 	background-color: var(--commons-background-base);
 
 	.file-icon {
-		color: var(--palettes-primary-500);
+		color: var(--palettes-product-500);
 	}
 }
 

--- a/packages/scss/src/components/form/mods.scss
+++ b/packages/scss/src/components/form/mods.scss
@@ -157,7 +157,8 @@
 			bottom: 0;
 			right: 0;
 			z-index: 10;
-			padding: var(--components-field-framed-label-top-offset) var(--components-field-framed-side-padding) var(--components-field-framed-bottom-padding);
+			padding: var(--components-field-framed-label-top-offset) var(--components-field-framed-side-padding)
+				var(--components-field-framed-bottom-padding);
 		}
 	}
 }
@@ -190,7 +191,7 @@
 	margin-bottom: 0;
 	background-color: var(--colors-white-color);
 	padding: 0;
-	box-shadow: form.fakeBorderOverlay(var(--palettes-grey-200));
+	box-shadow: form.fakeBorderOverlay(var(--palettes-neutral-200));
 	transition: background-color var(--commons-animations-durations-standard);
 	margin-bottom: 0 !important;
 
@@ -210,12 +211,12 @@
 			position: relative;
 			z-index: 1;
 			background-color: var(--colors-white-color);
-			box-shadow: form.fakeBorderOverlay(var(--palettes-grey-600));
+			box-shadow: form.fakeBorderOverlay(var(--palettes-neutral-600));
 		}
 
 		&:focus {
 			z-index: 4;
-			box-shadow: form.fakeBorderOverlay(var(--palettes-grey-600)), 0 0 0 4px var(--palettes-grey-50);
+			box-shadow: form.fakeBorderOverlay(var(--palettes-neutral-600)), 0 0 0 4px var(--palettes-neutral-50);
 		}
 	}
 

--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -6,7 +6,7 @@
 	width: fit-content;
 
 	.lucca-icon {
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		font-size: var(--components-formLabel-help-fontSize);
 		line-height: var(--components-formLabel-help-lineHeight);
 		margin-left: 0.125rem;

--- a/packages/scss/src/components/formLabel/states.scss
+++ b/packages/scss/src/components/formLabel/states.scss
@@ -1,8 +1,8 @@
 @mixin error {
-  --components-formLabel-color: var(--palettes-error-700);
+	--components-formLabel-color: var(--palettes-error-700);
 }
 
 @mixin disabled {
-  --components-formLabel-color: var(--palettes-grey-500);
-  pointer-events: none;
+	--components-formLabel-color: var(--palettes-neutral-500);
+	pointer-events: none;
 }

--- a/packages/scss/src/components/formLabel/vars.scss
+++ b/packages/scss/src/components/formLabel/vars.scss
@@ -1,7 +1,7 @@
 @mixin vars {
-  --components-formLabel-fontSize: var(--sizes-M-fontSize);
-  --components-formLabel-lineHeight: var(--sizes-M-lineHeight);
-  --components-formLabel-color: var(--palettes-grey-800);
-  --components-formLabel-help-fontSize: var(--sizes-XS-lineHeight);
-  --components-formLabel-help-lineHeight: var(--sizes-M-lineHeight);
+	--components-formLabel-fontSize: var(--sizes-M-fontSize);
+	--components-formLabel-lineHeight: var(--sizes-M-lineHeight);
+	--components-formLabel-color: var(--palettes-neutral-800);
+	--components-formLabel-help-fontSize: var(--sizes-XS-lineHeight);
+	--components-formLabel-help-lineHeight: var(--sizes-M-lineHeight);
 }

--- a/packages/scss/src/components/gauge/component.scss
+++ b/packages/scss/src/components/gauge/component.scss
@@ -7,7 +7,7 @@
 
 	@at-root ($atRoot) {
 		.gauge-bar {
-			color: var(--palettes-700, var(--palettes-primary-700));
+			color: var(--palettes-700, var(--palettes-product-700));
 			border-bottom-width: var(--components-gauge-height);
 			transition-duration: var(--commons-animations-durations-standard);
 			transition-property: border-color, width, height;

--- a/packages/scss/src/components/gauge/vars.scss
+++ b/packages/scss/src/components/gauge/vars.scss
@@ -1,4 +1,4 @@
 @mixin vars {
 	--components-gauge-height: 0.5rem;
-	--components-gauge-background: var(--palettes-grey-100);
+	--components-gauge-background: var(--palettes-neutral-100);
 }

--- a/packages/scss/src/components/header/component.scss
+++ b/packages/scss/src/components/header/component.scss
@@ -64,7 +64,7 @@
 		}
 
 		.header-nav-title {
-			color: var(--palettes-primary-700);
+			color: var(--palettes-product-700);
 			line-height: var(--sizes-XS-lineHeight);
 			margin: 0;
 		}

--- a/packages/scss/src/components/header/component.scss
+++ b/packages/scss/src/components/header/component.scss
@@ -36,7 +36,7 @@
 			border-right-color: var(--commons-divider-color);
 			border-right-width: var(--commons-divider-width);
 			border-right-style: solid;
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 			height: var(--components-header-height);
 			width: var(--components-header-height);
 			line-height: var(--components-header-height);
@@ -50,7 +50,7 @@
 
 			&:hover {
 				background-color: var(--commons-background-base);
-				color: var(--palettes-grey-800);
+				color: var(--palettes-neutral-800);
 			}
 
 			&::before {
@@ -59,7 +59,7 @@
 		}
 
 		.header-nav-category {
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 			font-size: var(--sizes-S-fontSize);
 		}
 

--- a/packages/scss/src/components/inlineMessage/states.scss
+++ b/packages/scss/src/components/inlineMessage/states.scss
@@ -1,41 +1,41 @@
 @mixin success {
-  --components-inlineMessage-icon-color: var(--palettes-success-700);
-  --components-inlineMessage-gap: var(--spacings-XXS);
+	--components-inlineMessage-icon-color: var(--palettes-success-700);
+	--components-inlineMessage-gap: var(--spacings-XXS);
 
-  .lucca-icon {
-    &::before {
+	.lucca-icon {
+		&::before {
 			content: '\e9ed'; // Remove when content alternative will have a good support
-			content: '\e9ed' / '';
+			content: '\e9ed'/ '';
 		}
-  }
+	}
 }
 
 @mixin warning {
-  --components-inlineMessage-icon-color: var(--palettes-warning-700);
-  --components-inlineMessage-gap: var(--spacings-XXS);
+	--components-inlineMessage-icon-color: var(--palettes-warning-700);
+	--components-inlineMessage-gap: var(--spacings-XXS);
 
-  .lucca-icon {
-    &::before {
-      content: '\e992'; // Remove when content alternative will have a good support
-      content: '\e992' / '';
-    }
-  }
+	.lucca-icon {
+		&::before {
+			content: '\e992'; // Remove when content alternative will have a good support
+			content: '\e992'/ '';
+		}
+	}
 }
 
 @mixin error {
-  --components-inlineMessage-icon-color: var(--palettes-error-700);
-  --components-inlineMessage-color: var(--palettes-error-700);
-  --components-inlineMessage-gap: var(--spacings-XXS);
+	--components-inlineMessage-icon-color: var(--palettes-error-700);
+	--components-inlineMessage-color: var(--palettes-error-700);
+	--components-inlineMessage-gap: var(--spacings-XXS);
 
-  .lucca-icon {
-    &::before {
+	.lucca-icon {
+		&::before {
 			content: '\e92c'; // Remove when content alternative will have a good support
-			content: '\e92c' / '';
+			content: '\e92c'/ '';
 		}
-  }
+	}
 }
 
 @mixin disabled {
-  --components-inlineMessage-icon-color: var(--palettes-grey-500);
-  --components-inlineMessage-color: var(--palettes-grey-500);
+	--components-inlineMessage-icon-color: var(--palettes-neutral-500);
+	--components-inlineMessage-color: var(--palettes-neutral-500);
 }

--- a/packages/scss/src/components/inlineMessage/vars.scss
+++ b/packages/scss/src/components/inlineMessage/vars.scss
@@ -1,6 +1,6 @@
 @mixin vars {
-  --components-inlineMessage-fontSize: var(--sizes-S-fontSize);
-  --components-inlineMessage-lineHeight: var(--sizes-S-lineHeight);
-  --components-inlineMessage-color: var(--palettes-grey-700);
-  --components-inlineMessage-icon-color: var(--palettes-grey-600);
+	--components-inlineMessage-fontSize: var(--sizes-S-fontSize);
+	--components-inlineMessage-lineHeight: var(--sizes-S-lineHeight);
+	--components-inlineMessage-color: var(--palettes-neutral-700);
+	--components-inlineMessage-icon-color: var(--palettes-neutral-600);
 }

--- a/packages/scss/src/components/label/vars.scss
+++ b/packages/scss/src/components/label/vars.scss
@@ -1,12 +1,12 @@
 @mixin vars {
-	--components-label-default-palette-50: var(--palettes-primary-50);
-	--components-label-default-palette-100: var(--palettes-primary-100);
-	--components-label-default-palette-200: var(--palettes-primary-200);
-	--components-label-default-palette-300: var(--palettes-primary-300);
-	--components-label-default-palette-400: var(--palettes-primary-400);
-	--components-label-default-palette-500: var(--palettes-primary-500);
-	--components-label-default-palette-600: var(--palettes-primary-600);
-	--components-label-default-palette-700: var(--palettes-primary-700);
-	--components-label-default-palette-800: var(--palettes-primary-800);
-	--components-label-default-palette-900: var(--palettes-primary-900);
+	--components-label-default-palette-50: var(--palettes-product-50);
+	--components-label-default-palette-100: var(--palettes-product-100);
+	--components-label-default-palette-200: var(--palettes-product-200);
+	--components-label-default-palette-300: var(--palettes-product-300);
+	--components-label-default-palette-400: var(--palettes-product-400);
+	--components-label-default-palette-500: var(--palettes-product-500);
+	--components-label-default-palette-600: var(--palettes-product-600);
+	--components-label-default-palette-700: var(--palettes-product-700);
+	--components-label-default-palette-800: var(--palettes-product-800);
+	--components-label-default-palette-900: var(--palettes-product-900);
 }

--- a/packages/scss/src/components/list/component.scss
+++ b/packages/scss/src/components/list/component.scss
@@ -9,7 +9,7 @@
 		.list-item {
 			border-bottom-width: var(--commons-divider-width);
 			border-bottom-color: var(--commons-divider-color);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			border-bottom-style: solid;
 			align-items: center;
 			display: flex;
@@ -23,7 +23,7 @@
 
 		.list-item-content {
 			padding: var(--components-list-padding);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			text-decoration: none;
 			width: 100%;
 		}

--- a/packages/scss/src/components/list/mods.scss
+++ b/packages/scss/src/components/list/mods.scss
@@ -22,7 +22,7 @@
 	padding-left: var(--spacings-S);
 
 	.list-item-handler {
-		color: var(--palettes-grey-400);
+		color: var(--palettes-neutral-400);
 		font-size: 1.3rem;
 		left: 0;
 		width: 2.4rem;

--- a/packages/scss/src/components/list/vars.scss
+++ b/packages/scss/src/components/list/vars.scss
@@ -1,5 +1,5 @@
 @mixin vars {
 	--components-list-margin-bottom: var(--spacings-S);
 	--components-list-padding: var(--spacings-S) var(--spacings-M);
-	--components-list-hover-background: var(--palettes-primary-50);
+	--components-list-hover-background: var(--palettes-product-50);
 }

--- a/packages/scss/src/components/menu/component.scss
+++ b/packages/scss/src/components/menu/component.scss
@@ -21,7 +21,8 @@
 		}
 	}
 
-	.label { // deprecated
+	.label {
+		// deprecated
 		margin-right: 0;
 		background-color: var(--palettes-grey-100);
 		color: var(--palettes-grey-700);
@@ -55,7 +56,7 @@
 			z-index: 1;
 
 			&::after {
-				background-color: var(--palettes-700, var(--palettes-primary-700));
+				background-color: var(--palettes-700, var(--palettes-product-700));
 				border-radius: var(--commons-borderRadius-M) var(--commons-borderRadius-M) 0 0;
 				transition-duration: var(--commons-animations-durations-fast);
 				transition-property: transform;
@@ -76,9 +77,10 @@
 						color: var(--palettes-grey-900);
 					}
 
-					.label { // deprecated
-						background-color: var(--palettes-100, var(--palettes-primary-100));
-						color: var(--palettes-700, var(--palettes-primary-700));
+					.label {
+						// deprecated
+						background-color: var(--palettes-100, var(--palettes-product-100));
+						color: var(--palettes-700, var(--palettes-product-700));
 					}
 
 					&::after {

--- a/packages/scss/src/components/menu/component.scss
+++ b/packages/scss/src/components/menu/component.scss
@@ -24,8 +24,8 @@
 	.label {
 		// deprecated
 		margin-right: 0;
-		background-color: var(--palettes-grey-100);
-		color: var(--palettes-grey-700);
+		background-color: var(--palettes-neutral-100);
+		color: var(--palettes-neutral-700);
 	}
 
 	@at-root ($atRoot) {
@@ -43,7 +43,7 @@
 			@include reset.button;
 			padding: var(--components-menu-padding);
 			border-radius: var(--commons-borderRadius-M);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			display: inline-flex;
 			align-items: center;
 			text-align: center;
@@ -74,7 +74,7 @@
 			&:not(.is-disabled, [disabled]) {
 				&:hover {
 					&:not(.is-active, [aria-current='page']) {
-						color: var(--palettes-grey-900);
+						color: var(--palettes-neutral-900);
 					}
 
 					.label {

--- a/packages/scss/src/components/menu/states.scss
+++ b/packages/scss/src/components/menu/states.scss
@@ -21,7 +21,7 @@
 	}
 
 	.numericBadge {
-		@include numericBadge.primary;
+		@include numericBadge.product;
 	}
 }
 

--- a/packages/scss/src/components/menu/states.scss
+++ b/packages/scss/src/components/menu/states.scss
@@ -29,7 +29,7 @@
 	&,
 	.label {
 		// deprecated
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 		pointer-events: none;
 	}
 

--- a/packages/scss/src/components/menu/states.scss
+++ b/packages/scss/src/components/menu/states.scss
@@ -1,15 +1,16 @@
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 
 @mixin active {
-	color: var(--palettes-700, var(--palettes-primary-700));
+	color: var(--palettes-700, var(--palettes-product-700));
 
-	.label { // deprecated
-		background-color: var(--palettes-100, var(--palettes-primary-100));
-		color: var(--palettes-700, var(--palettes-primary-700));
+	.label {
+		// deprecated
+		background-color: var(--palettes-100, var(--palettes-product-100));
+		color: var(--palettes-700, var(--palettes-product-700));
 	}
 
 	&::after {
-		background-color: var(--palettes-700, var(--palettes-primary-700));
+		background-color: var(--palettes-700, var(--palettes-product-700));
 		transform: scale(1);
 	}
 
@@ -26,7 +27,8 @@
 
 @mixin disabled {
 	&,
-	.label { // deprecated
+	.label {
+		// deprecated
 		color: var(--palettes-grey-500);
 		pointer-events: none;
 	}

--- a/packages/scss/src/components/mobileHeader/component.scss
+++ b/packages/scss/src/components/mobileHeader/component.scss
@@ -4,7 +4,7 @@
 	gap: var(--spacings-XS);
 	background-color: var(--colors-white-color);
 	box-shadow: 0 1px 0 var(--commons-border-100);
-	padding: .375rem .75rem;
+	padding: 0.375rem 0.75rem;
 	min-height: 3.5rem;
 
 	@at-root ($atRoot) {
@@ -18,13 +18,13 @@
 			padding: 0;
 			font-size: var(--sizes-M-fontSize);
 			line-height: var(--sizes-M-lineHeight);
-			color: var(--palettes-grey-900);
+			color: var(--palettes-neutral-900);
 		}
 
 		.mobileHeader-title-sub {
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 		}
 	}
 }

--- a/packages/scss/src/components/mobileNavigation/component.scss
+++ b/packages/scss/src/components/mobileNavigation/component.scss
@@ -38,15 +38,15 @@
 				font-size: var(--sizes-M-lineHeight);
 			}
 
-			&[aria-current="page"] {
-				color: var(--palettes-primary-700);
+			&[aria-current='page'] {
+				color: var(--palettes-product-700);
 				font-weight: 600;
 			}
 		}
 
 		.mobileNavigation-list-item-link-counter {
-			--components-numericBadge-background: var(--palettes-primary-200);
-			--components-numericBadge-color: var(--palettes-primary-800);
+			--components-numericBadge-background: var(--palettes-product-200);
+			--components-numericBadge-color: var(--palettes-product-800);
 			box-shadow: 0 0 0 2px var(--colors-white-color);
 			position: absolute;
 			left: calc(50% + 5px);

--- a/packages/scss/src/components/mobileNavigation/component.scss
+++ b/packages/scss/src/components/mobileNavigation/component.scss
@@ -20,7 +20,7 @@
 		}
 
 		.mobileNavigation-list-item-link {
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 			display: flex;
 			flex-direction: column;
 			font-size: var(--sizes-XS-fontSize);

--- a/packages/scss/src/components/mobileNavigation/mods.scss
+++ b/packages/scss/src/components/mobileNavigation/mods.scss
@@ -1,5 +1,5 @@
 // @mixin outlined {
-// 	color: var(--palettes-600, var(--palettes-grey-600));
+// 	color: var(--palettes-600, var(--palettes-neutral-600));
 // 	background-color: var(--colors-white-color);
-// 	box-shadow: 0 0 0 1px var(--palettes-300, var(--palettes-grey-300));
+// 	box-shadow: 0 0 0 1px var(--palettes-300, var(--palettes-neutral-300));
 // }

--- a/packages/scss/src/components/multiSelect/component.scss
+++ b/packages/scss/src/components/multiSelect/component.scss
@@ -40,14 +40,14 @@
 			border: 0;
 			padding: 0;
 			outline: none;
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			font-size: var(--components-multiSelect-fontSize);
 			line-height: var(--components-multiSelect-lineHeight);
 			background-color: transparent;
 			cursor: pointer;
 
 			&::placeholder {
-				color: var(--palettes-grey-400);
+				color: var(--palettes-neutral-400);
 			}
 		}
 

--- a/packages/scss/src/components/multiSelect/states.scss
+++ b/packages/scss/src/components/multiSelect/states.scss
@@ -1,35 +1,35 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin focused {
-  @include a11y.focusVisible($offset: 3px);
+	@include a11y.focusVisible($offset: 3px);
 }
 
 @mixin invalid {
-  --components-multiSelect-border-color: var(--palettes-error-400);
-  --components-multiSelect-background: var(--palettes-error-50);
-  --components-multiSelect-placeholder: var(--palettes-error-400);
+	--components-multiSelect-border-color: var(--palettes-error-400);
+	--components-multiSelect-background: var(--palettes-error-50);
+	--components-multiSelect-placeholder: var(--palettes-error-400);
 }
 
 @mixin disabled {
-  --components-multiSelect-border-color: var(--palettes-grey-300);
-  --components-multiSelect-background: var(--palettes-grey-100);
-  --components-multiSelect-placeholder: var(--palettes-grey-400);
-  --components-multiSelect-arrow-color: var(--palettes-grey-500);
-  pointer-events: none;
+	--components-multiSelect-border-color: var(--palettes-neutral-300);
+	--components-multiSelect-background: var(--palettes-neutral-100);
+	--components-multiSelect-placeholder: var(--palettes-neutral-400);
+	--components-multiSelect-arrow-color: var(--palettes-neutral-500);
+	pointer-events: none;
 }
 
 @mixin displayerFilterFilled {
-  .multipleSelect-displayer-search {
-    opacity: 0;
-  }
+	.multipleSelect-displayer-search {
+		opacity: 0;
+	}
 }
 
 @mixin displayerFilterExpended {
-  .multipleSelect-displayer-filter {
-    display: none;
-  }
+	.multipleSelect-displayer-filter {
+		display: none;
+	}
 
-  .multipleSelect-displayer-search {
-    opacity: 1;
-  }
+	.multipleSelect-displayer-search {
+		opacity: 1;
+	}
 }

--- a/packages/scss/src/components/multiSelect/vars.scss
+++ b/packages/scss/src/components/multiSelect/vars.scss
@@ -1,10 +1,10 @@
 @mixin vars {
-  --components-multiSelect-fontSize: var(--sizes-M-fontSize);
-  --components-multiSelect-lineHeight: var(--sizes-M-lineHeight);
-  --components-multiSelect-padding: var(--spacings-XS);
-  --components-multiSelect-gap: var(--spacings-XS);
-  --components-multiSelect-background: var(--colors-white-color);
-  --components-multiSelect-border-color: var(--palettes-grey-300);
-  --components-multiSelect-placeholder: var(--palettes-grey-400);
-  --components-multiSelect-arrow-color: var(--palettes-grey-600);
+	--components-multiSelect-fontSize: var(--sizes-M-fontSize);
+	--components-multiSelect-lineHeight: var(--sizes-M-lineHeight);
+	--components-multiSelect-padding: var(--spacings-XS);
+	--components-multiSelect-gap: var(--spacings-XS);
+	--components-multiSelect-background: var(--colors-white-color);
+	--components-multiSelect-border-color: var(--palettes-neutral-300);
+	--components-multiSelect-placeholder: var(--palettes-neutral-400);
+	--components-multiSelect-arrow-color: var(--palettes-neutral-600);
 }

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -83,7 +83,7 @@
 			height: 100%;
 			align-items: center;
 			display: flex;
-			column-gap: .75rem;
+			column-gap: 0.75rem;
 			text-decoration: none;
 			user-select: none;
 			color: var(--components-navSide-fullwidth-palette-text);
@@ -108,11 +108,12 @@
 		.navSide-item-link {
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
-			padding: .75rem var(--spacings-S);
+			padding: 0.75rem var(--spacings-S);
 			font-weight: 600;
 		}
 
-		.navSide-item-alert { // deprecated
+		.navSide-item-alert {
+			// deprecated
 			font-size: var(--sizes-XS-fontSize);
 			font-weight: 600;
 			background-color: var(--components-navSide-fullwidth-palette-alert-color);
@@ -184,7 +185,8 @@
 				}
 			}
 
-			.navSide-item-alert { // deprecated
+			.navSide-item-alert {
+				// deprecated
 				background-color: var(--components-navSide-bottom-section-palette-alert-color);
 				color: var(--components-navSide-bottom-section-palette-alert-text);
 			}
@@ -202,7 +204,7 @@
 			}
 
 			&::before {
-				background-color: rgba(var(--colors-grey-900-rgb), 0.15);
+				background-color: rgba(var(--colors-neutral-900-rgb), 0.15);
 				border-radius: 1em;
 				height: 1em;
 				width: 1em;

--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -13,7 +13,7 @@
 	.navSide-item-link {
 		color: var(--components-navSide-compact-palette-text);
 		font-size: var(--components-navSide-compact-font-size);
-		padding: .75rem var(--spacings-XS);
+		padding: 0.75rem var(--spacings-XS);
 		flex-direction: column;
 		justify-content: center;
 		position: relative;
@@ -26,7 +26,8 @@
 		display: none;
 	}
 
-	.navSide-item-alert { // deprecated
+	.navSide-item-alert {
+		// deprecated
 		background-color: var(--components-navSide-compact-palette-alert-color);
 		color: var(--components-navSide-compact-palette-alert-text);
 		padding: 0 var(--spacings-XS);
@@ -44,7 +45,7 @@
 
 		&::after {
 			margin-left: 0;
-			margin-top: .75rem;
+			margin-top: 0.75rem;
 			width: 100%;
 		}
 	}
@@ -79,7 +80,8 @@
 	color: var(--components-navSide-compact-palette-selected-text);
 	opacity: 1;
 
-	.navSide-item-alert { // deprecated
+	.navSide-item-alert {
+		// deprecated
 		background-color: var(--components-navSide-compact-palette-selected-alert-color);
 		color: var(--components-navSide-compact-palette-selected-alert-text);
 	}
@@ -111,7 +113,7 @@
 	.navSide-item {
 		&.mod-mobileToggle {
 			height: var(--commons-navSide-mobile-toggle-height);
-			background-color: var(--palettes-primary-800);
+			background-color: var(--palettes-product-800);
 			top: 0;
 			left: 0;
 			right: 0;

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -14,24 +14,24 @@
 
 	--components-navSide-fullwidth-palette-bg-color: var(--palettes-navigation-800);
 	--components-navSide-fullwidth-palette-text: var(--colors-white-color);
-	--components-navSide-fullwidth-palette-selected-bg: var(--palettes-primary-700);
+	--components-navSide-fullwidth-palette-selected-bg: var(--palettes-product-700);
 	--components-navSide-fullwidth-palette-selected-text: var(--colors-white-color);
 	--components-navSide-fullwidth-palette-hovered-bg: var(--palettes-navigation-700);
 	--components-navSide-fullwidth-palette-hovered-text: var(--colors-white-color);
-	--components-navSide-fullwidth-palette-alert-color: var(--palettes-primary-200);
-	--components-navSide-fullwidth-palette-alert-text: var(--palettes-primary-800);
-	--components-navSide-fullwidth-palette-selected-alert-color: var(--palettes-primary-700);
+	--components-navSide-fullwidth-palette-alert-color: var(--palettes-product-200);
+	--components-navSide-fullwidth-palette-alert-text: var(--palettes-product-800);
+	--components-navSide-fullwidth-palette-selected-alert-color: var(--palettes-product-700);
 	--components-navSide-fullwidth-palette-selected-alert-text: var(--colors-white-color);
 
 	--components-navSide-compact-palette-bg-color: var(--palettes-navigation-800);
 	--components-navSide-compact-palette-text: var(--colors-white-color);
-	--components-navSide-compact-palette-selected-bg: var(--palettes-primary-700);
+	--components-navSide-compact-palette-selected-bg: var(--palettes-product-700);
 	--components-navSide-compact-palette-selected-text: var(--colors-white-color);
 	--components-navSide-compact-palette-hovered-bg: var(--palettes-navigation-700);
 	--components-navSide-compact-palette-hovered-text: var(--colors-white-color);
-	--components-navSide-compact-palette-alert-color: var(--palettes-primary-200);
-	--components-navSide-compact-palette-alert-text: var(--palettes-primary-800);
-	--components-navSide-compact-palette-selected-alert-color: var(--palettes-primary-700);
+	--components-navSide-compact-palette-alert-color: var(--palettes-product-200);
+	--components-navSide-compact-palette-alert-text: var(--palettes-product-800);
+	--components-navSide-compact-palette-selected-alert-color: var(--palettes-product-700);
 	--components-navSide-compact-palette-selected-alert-text: var(--colors-white-color);
 	--components-navSide-compact-font-size: 0.875rem;
 
@@ -49,7 +49,7 @@
 
 	--components-navSide-scrollbar-width: var(--spacings-XS);
 	--components-navSide-scrollbar-border-radius: 10px;
-	--components-navSide-scrollbar-bg-color: var(--palettes-primary-800);
-	--components-navSide-scrollbar-thumb-color: var(--palettes-primary-700);
+	--components-navSide-scrollbar-bg-color: var(--palettes-product-800);
+	--components-navSide-scrollbar-thumb-color: var(--palettes-product-700);
 	--components-navSide-scrollbar-arrow-color: var(--colors-white-color);
 }

--- a/packages/scss/src/components/newBadge/component.scss
+++ b/packages/scss/src/components/newBadge/component.scss
@@ -1,10 +1,10 @@
 @mixin component {
-  display: inline-flex;
-  font-size: var(--sizes-XS-fontSize);
-  line-height: var(--sizes-XS-lineHeight);
-  font-weight: 600;
-  background-color: var(--palettes-lucca-700);
-  color: var(--palettes-lucca-text);
-  padding: 0 var(--spacings-XXS);
-  border-radius: var(--commons-borderRadius-M);
+	display: inline-flex;
+	font-size: var(--sizes-XS-fontSize);
+	line-height: var(--sizes-XS-lineHeight);
+	font-weight: 600;
+	background-color: var(--palettes-brand-700);
+	color: var(--palettes-brand-text);
+	padding: 0 var(--spacings-XXS);
+	border-radius: var(--commons-borderRadius-M);
 }

--- a/packages/scss/src/components/notchBox/vars.scss
+++ b/packages/scss/src/components/notchBox/vars.scss
@@ -18,5 +18,5 @@
 	--component-notchbox-badge-height: 48px;
 	--component-notchbox-badge-width: 48px;
 	--component-notchbox-badge-radius: 14px;
-	--component-notchbox-badge-background-color: var(--palettes-700, var(--palettes-primary-700));
+	--component-notchbox-badge-background-color: var(--palettes-700, var(--palettes-product-700));
 }

--- a/packages/scss/src/components/notchBox/vars.scss
+++ b/packages/scss/src/components/notchBox/vars.scss
@@ -11,7 +11,7 @@
 	--component-notchbox-box-radius: 16px;
 	--component-notchbox-box-padding: var(--spacings-S);
 	--component-notchbox-box-background-color: var(--colors-white-color);
-	--component-notchbox-box-shadow: 0 0 4px var(--palettes-grey-200);
+	--component-notchbox-box-shadow: 0 0 4px var(--palettes-neutral-200);
 
 	/** badge */
 	--component-notchbox-badge-offset: 17px;

--- a/packages/scss/src/components/numericBadge/mods.scss
+++ b/packages/scss/src/components/numericBadge/mods.scss
@@ -12,7 +12,7 @@
 	--components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
 }
 
-@mixin primary {
+@mixin product {
 	--components-numericBadge-background: var(--palettes-product-200);
 	--components-numericBadge-color: var(--palettes-product-800);
 }

--- a/packages/scss/src/components/numericBadge/mods.scss
+++ b/packages/scss/src/components/numericBadge/mods.scss
@@ -1,18 +1,18 @@
 @mixin S {
-  --components-numericBadge-size: 1.25rem;
-  --components-numericBadge-borderRadius: 6px;
-  --components-numericBadge-fontSize: var(--sizes-XS-fontSize);
-  --components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
+	--components-numericBadge-size: 1.25rem;
+	--components-numericBadge-borderRadius: 6px;
+	--components-numericBadge-fontSize: var(--sizes-XS-fontSize);
+	--components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
 }
 
 @mixin XS {
-  --components-numericBadge-size: 1rem;
-  --components-numericBadge-borderRadius: var(--commons-borderRadius-M);
-  --components-numericBadge-fontSize: var(--sizes-XS-fontSize);
-  --components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
+	--components-numericBadge-size: 1rem;
+	--components-numericBadge-borderRadius: var(--commons-borderRadius-M);
+	--components-numericBadge-fontSize: var(--sizes-XS-fontSize);
+	--components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
 }
 
 @mixin primary {
-  --components-numericBadge-background: var(--palettes-primary-200);
-  --components-numericBadge-color: var(--palettes-primary-800);
+	--components-numericBadge-background: var(--palettes-product-200);
+	--components-numericBadge-color: var(--palettes-product-800);
 }

--- a/packages/scss/src/components/numericBadge/states.scss
+++ b/packages/scss/src/components/numericBadge/states.scss
@@ -1,4 +1,4 @@
 @mixin disabled {
-  background-color: var(--palettes-grey-200);
-  color: var(--palettes-grey-500);
+	background-color: var(--palettes-neutral-200);
+	color: var(--palettes-neutral-500);
 }

--- a/packages/scss/src/components/numericBadge/vars.scss
+++ b/packages/scss/src/components/numericBadge/vars.scss
@@ -1,8 +1,8 @@
 @mixin vars {
-  --components-numericBadge-background: var(--palettes-200, var(--palettes-grey-200));
-  --components-numericBadge-color: var(--palettes-800, var(--palettes-grey-700));
-  --components-numericBadge-size: 1.5rem;
-  --components-numericBadge-fontSize: var(--sizes-S-fontSize);
-  --components-numericBadge-lineHeight: var(--sizes-S-lineHeight);
-  --components-numericBadge-borderRadius: var(--commons-borderRadius-L);
+	--components-numericBadge-background: var(--palettes-200, var(--palettes-neutral-200));
+	--components-numericBadge-color: var(--palettes-800, var(--palettes-neutral-700));
+	--components-numericBadge-size: 1.5rem;
+	--components-numericBadge-fontSize: var(--sizes-S-fontSize);
+	--components-numericBadge-lineHeight: var(--sizes-S-lineHeight);
+	--components-numericBadge-borderRadius: var(--commons-borderRadius-L);
 }

--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -52,7 +52,7 @@
 		.pageHeader-description {
 			max-width: var(--components-pageHeader-description-max-width);
 			margin-top: var(--spacings-XS);
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 		}
 	}
 }

--- a/packages/scss/src/components/progress/vars.scss
+++ b/packages/scss/src/components/progress/vars.scss
@@ -3,7 +3,7 @@
 	--components-progress-margin-horizontal: 0;
 	--components-progress-height: 0.25rem;
 	--components-progress-background: var(--palettes-grey-100);
-	--components-progress-bar-background: var(--palettes-primary-700);
+	--components-progress-bar-background: var(--palettes-product-700);
 	--components-progress-bar-gradient: linear-gradient(to right, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0.5) 100%);
 	--components-progress-duration: 1.5s;
 }

--- a/packages/scss/src/components/progress/vars.scss
+++ b/packages/scss/src/components/progress/vars.scss
@@ -2,7 +2,7 @@
 	--components-progress-margin-vertical: var(--spacings-S);
 	--components-progress-margin-horizontal: 0;
 	--components-progress-height: 0.25rem;
-	--components-progress-background: var(--palettes-grey-100);
+	--components-progress-background: var(--palettes-neutral-100);
 	--components-progress-bar-background: var(--palettes-product-700);
 	--components-progress-bar-gradient: linear-gradient(to right, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0.5) 100%);
 	--components-progress-duration: 1.5s;

--- a/packages/scss/src/components/radio/component.scss
+++ b/packages/scss/src/components/radio/component.scss
@@ -10,13 +10,13 @@
 		&:not(:disabled) ~ .radio-label {
 			&:hover {
 				&::before {
-					border-color: var(--palettes-grey-600);
+					border-color: var(--palettes-neutral-600);
 				}
 			}
 
 			&:active {
 				&::before {
-					border-color: var(--palettes-grey-800);
+					border-color: var(--palettes-neutral-800);
 				}
 			}
 		}
@@ -50,7 +50,7 @@
 	}
 
 	.radio-label {
-		color: var(--palettes-grey-800);
+		color: var(--palettes-neutral-800);
 		line-height: var(--sizes-M-lineHeight);
 		min-height: var(--sizes-M-lineHeight);
 		padding: var(--components-radio-label-padding);
@@ -74,7 +74,7 @@
 
 		&::before {
 			background-color: var(--colors-white-color);
-			border-color: var(--palettes-grey-700);
+			border-color: var(--palettes-neutral-700);
 			border-width: 2px;
 			border-style: solid;
 		}
@@ -86,7 +86,7 @@
 	}
 
 	.radio-label-helper {
-		color: var(--palettes-grey-700);
+		color: var(--palettes-neutral-700);
 		font-size: var(--sizes-S-fontSize);
 		line-height: var(--sizes-S-lineHeight);
 	}

--- a/packages/scss/src/components/radio/component.scss
+++ b/packages/scss/src/components/radio/component.scss
@@ -23,23 +23,23 @@
 
 		&:checked ~ .radio-label {
 			&::before {
-				border-color: var(--palettes-700, var(--palettes-primary-700));
+				border-color: var(--palettes-700, var(--palettes-product-700));
 			}
 
 			&::after {
 				transform: scale(0.6);
-				background-color: var(--palettes-700, var(--palettes-primary-700));
+				background-color: var(--palettes-700, var(--palettes-product-700));
 			}
 		}
 
 		&:not(:disabled):checked ~ .radio-label {
 			&:hover {
 				&::before {
-					border-color: var(--palettes-700, var(--palettes-primary-700));
+					border-color: var(--palettes-700, var(--palettes-product-700));
 				}
 
 				&::after {
-					background-color: var(--palettes-700, var(--palettes-primary-700));
+					background-color: var(--palettes-700, var(--palettes-product-700));
 				}
 			}
 		}

--- a/packages/scss/src/components/radio/states.scss
+++ b/packages/scss/src/components/radio/states.scss
@@ -1,16 +1,16 @@
 @mixin disabled {
 	~ .radio-label {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 		cursor: default;
 
 		&::before {
-			border-color: var(--palettes-grey-500);
+			border-color: var(--palettes-neutral-500);
 			border-width: 2px;
 			border-style: solid;
 		}
 
 		.radio-label-helper {
-			color: var(--palettes-grey-500);
+			color: var(--palettes-neutral-500);
 		}
 	}
 }
@@ -18,13 +18,13 @@
 @mixin disabledChecked {
 	~ .radio-label {
 		&::before {
-			border-color: var(--palettes-grey-500);
+			border-color: var(--palettes-neutral-500);
 			border-width: 2px;
 			border-style: solid;
 		}
 
 		&::after {
-			background-color: var(--palettes-grey-500);
+			background-color: var(--palettes-neutral-500);
 		}
 	}
 }

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -43,8 +43,8 @@
 			padding: var(--components-radioButtons-padding);
 			font-size: var(--components-radioButtons-font-size);
 			line-height: var(--components-radioButtons-line-height);
-			color: var(--palettes-grey-700);
-			box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-grey-300);
+			color: var(--palettes-neutral-700);
+			box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-neutral-300);
 			transition-duration: var(--commons-animations-durations-fast);
 			transition-property: background-color, color, box-shadow;
 			overflow: hidden;
@@ -57,7 +57,7 @@
 			&:not(:disabled, .is-disabled) {
 				~ .radioButtons-item-label {
 					&:hover {
-						background-color: var(--palettes-grey-50);
+						background-color: var(--palettes-neutral-50);
 					}
 				}
 

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -74,7 +74,7 @@
 						color: var(--palettes-product-800);
 
 						.numericBadge {
-							@include numericBadge.primary;
+							@include numericBadge.product;
 						}
 					}
 				}

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -69,9 +69,9 @@
 
 				&:checked {
 					~ .radioButtons-item-label {
-						background-color: var(--palettes-primary-50);
-						box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-primary-500);
-						color: var(--palettes-primary-800);
+						background-color: var(--palettes-product-50);
+						box-shadow: 0 0 0 var(--commons-divider-width) var(--palettes-product-500);
+						color: var(--palettes-product-800);
 
 						.numericBadge {
 							@include numericBadge.primary;

--- a/packages/scss/src/components/radioButtons/states.scss
+++ b/packages/scss/src/components/radioButtons/states.scss
@@ -2,8 +2,8 @@
 
 @mixin disabled {
 	~ .radioButtons-item-label {
-		box-shadow: 0 0 0 1px var(--palettes-grey-200);
-		color: var(--palettes-grey-500);
+		box-shadow: 0 0 0 1px var(--palettes-neutral-200);
+		color: var(--palettes-neutral-500);
 		cursor: default;
 
 		.numericBadge {
@@ -13,7 +13,7 @@
 
 	&:checked {
 		~ .radioButtons-item-label {
-			background-color: var(--palettes-grey-100);
+			background-color: var(--palettes-neutral-100);
 		}
 	}
 }

--- a/packages/scss/src/components/radioField/component.scss
+++ b/packages/scss/src/components/radioField/component.scss
@@ -8,7 +8,7 @@
 		.radioField-icon {
 			width: var(--component-radioField-size);
 			height: var(--component-radioField-size);
-			border: 2px solid var(--palettes-grey-700);
+			border: 2px solid var(--palettes-neutral-700);
 			border-radius: var(--component-radioField-borderRadius);
 			position: relative;
 			color: var(--colors-white-color);

--- a/packages/scss/src/components/radioField/states.scss
+++ b/packages/scss/src/components/radioField/states.scss
@@ -4,8 +4,8 @@
 
 @mixin checked {
 	~ .radioField-icon {
-		background-color: var(--palettes-primary-700);
-		border-color: var(--palettes-primary-700);
+		background-color: var(--palettes-product-700);
+		border-color: var(--palettes-product-700);
 
 		.radioField-icon-check {
 			transform: scale(1);
@@ -21,15 +21,15 @@
 
 @mixin checkedHover {
 	~ .radioField-icon {
-		background-color: var(--palettes-primary-600);
-		border-color: var(--palettes-primary-600);
+		background-color: var(--palettes-product-600);
+		border-color: var(--palettes-product-600);
 	}
 }
 
 @mixin checkedActive {
 	~ .radioField-icon {
-		background-color: var(--palettes-primary-800);
-		border-color: var(--palettes-primary-800);
+		background-color: var(--palettes-product-800);
+		border-color: var(--palettes-product-800);
 	}
 }
 
@@ -43,8 +43,8 @@
 
 @mixin checkedHover {
 	~ .radioField-icon {
-		background-color: var(--palettes-primary-600);
-		border-color: var(--palettes-primary-600);
+		background-color: var(--palettes-product-600);
+		border-color: var(--palettes-product-600);
 	}
 }
 

--- a/packages/scss/src/components/radioField/states.scss
+++ b/packages/scss/src/components/radioField/states.scss
@@ -15,7 +15,7 @@
 
 @mixin hover {
 	~ .radioField-icon {
-		border-color: var(--palettes-grey-600);
+		border-color: var(--palettes-neutral-600);
 	}
 }
 
@@ -35,9 +35,9 @@
 
 @mixin checkedDisabled {
 	~ .radioField-icon {
-		background-color: var(--palettes-grey-500);
-		border-color: var(--palettes-grey-500);
-		color: var(--palettes-grey-500);
+		background-color: var(--palettes-neutral-500);
+		border-color: var(--palettes-neutral-500);
+		color: var(--palettes-neutral-500);
 	}
 }
 
@@ -57,7 +57,7 @@
 
 @mixin active {
 	~ .radioField-icon {
-		border-color: var(--palettes-grey-800);
+		border-color: var(--palettes-neutral-800);
 	}
 }
 
@@ -65,7 +65,7 @@
 	cursor: default;
 
 	~ .radioField-icon {
-		border-color: var(--palettes-grey-500);
+		border-color: var(--palettes-neutral-500);
 	}
 }
 

--- a/packages/scss/src/components/section/index.scss
+++ b/packages/scss/src/components/section/index.scss
@@ -5,8 +5,10 @@
 	@include vars;
 	@include component;
 
+	// .mod-grey is deprecated
+	&.mod-neutral,
 	&.mod-grey {
-		@include grey;
+		@include neutral;
 	}
 
 	@include media.max('S') {

--- a/packages/scss/src/components/section/mods.scss
+++ b/packages/scss/src/components/section/mods.scss
@@ -1,4 +1,4 @@
-@mixin grey {
+@mixin neutral {
 	background-color: var(--commons-background-base);
 }
 

--- a/packages/scss/src/components/simpleSelect/component.scss
+++ b/packages/scss/src/components/simpleSelect/component.scss
@@ -13,7 +13,7 @@
 	cursor: pointer;
 
 	&:hover {
-		--components-simpleSelect-border-color: var(--palettes-grey-400);
+		--components-simpleSelect-border-color: var(--palettes-neutral-400);
 	}
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/simpleSelect/states.scss
+++ b/packages/scss/src/components/simpleSelect/states.scss
@@ -1,64 +1,64 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin focused {
-  @include a11y.focusVisible($offset: 3px);
+	@include a11y.focusVisible($offset: 3px);
 
-  .simpleSelect-value {
-    color: var(--components-simpleSelect-value-color);
-  }
+	.simpleSelect-value {
+		color: var(--components-simpleSelect-value-color);
+	}
 }
 
 @mixin focusedExpanded {
-  .simpleSelect-value {
-    color: var(--components-simpleSelect-placeholder);
-  }
+	.simpleSelect-value {
+		color: var(--components-simpleSelect-placeholder);
+	}
 
-  .simpleSelect-arrow {
-    transform: rotate(-180deg);
-  }
+	.simpleSelect-arrow {
+		transform: rotate(-180deg);
+	}
 }
 
 @mixin searchFilled {
-  .simpleSelect-value {
-    display: none;
-  }
+	.simpleSelect-value {
+		display: none;
+	}
 }
 
 @mixin selected {
-  .simpleSelect-input {
-    &::placeholder {
-      color: transparent;
-    }
-  }
+	.simpleSelect-input {
+		&::placeholder {
+			color: transparent;
+		}
+	}
 
-  .simpleSelect-value {
-    display: block;
-  }
+	.simpleSelect-value {
+		display: block;
+	}
 }
 
 @mixin selectedSearchFilled {
-  .simpleSelect-input {
-    &::placeholder {
-      color: transparent;
-    }
-  }
+	.simpleSelect-input {
+		&::placeholder {
+			color: transparent;
+		}
+	}
 
-  .simpleSelect-value {
-    display: none;
-  }
+	.simpleSelect-value {
+		display: none;
+	}
 }
 
 @mixin invalid {
-  --components-simpleSelect-border-color: var(--palettes-error-400);
-  --components-simpleSelect-background: var(--palettes-error-50);
-  --components-simpleSelect-placeholder: var(--palettes-error-400);
+	--components-simpleSelect-border-color: var(--palettes-error-400);
+	--components-simpleSelect-background: var(--palettes-error-50);
+	--components-simpleSelect-placeholder: var(--palettes-error-400);
 }
 
 @mixin disabled {
-  --components-simpleSelect-border-color: var(--palettes-grey-300);
-  --components-simpleSelect-background: var(--palettes-grey-100);
-  --components-simpleSelect-placeholder: var(--palettes-grey-400);
-  --components-simpleSelect-value-color: var(--palettes-grey-600);
-  --components-simpleSelect-arrow-color: var(--palettes-grey-500);
-  pointer-events: none;
+	--components-simpleSelect-border-color: var(--palettes-neutral-300);
+	--components-simpleSelect-background: var(--palettes-neutral-100);
+	--components-simpleSelect-placeholder: var(--palettes-neutral-400);
+	--components-simpleSelect-value-color: var(--palettes-neutral-600);
+	--components-simpleSelect-arrow-color: var(--palettes-neutral-500);
+	pointer-events: none;
 }

--- a/packages/scss/src/components/simpleSelect/vars.scss
+++ b/packages/scss/src/components/simpleSelect/vars.scss
@@ -1,11 +1,11 @@
 @mixin vars {
-  --components-simpleSelect-fontSize: var(--sizes-M-fontSize);
-  --components-simpleSelect-lineHeight: var(--sizes-M-lineHeight);
-  --components-simpleSelect-padding: var(--spacings-XS);
-  --components-simpleSelect-gap: var(--spacings-XS);
-  --components-simpleSelect-background: var(--colors-white-color);
-  --components-simpleSelect-value-color: var(--palettes-grey-800);
-  --components-simpleSelect-border-color: var(--palettes-grey-300);
-  --components-simpleSelect-placeholder: var(--palettes-grey-400);
-  --components-simpleSelect-arrow-color: var(--palettes-grey-600);
+	--components-simpleSelect-fontSize: var(--sizes-M-fontSize);
+	--components-simpleSelect-lineHeight: var(--sizes-M-lineHeight);
+	--components-simpleSelect-padding: var(--spacings-XS);
+	--components-simpleSelect-gap: var(--spacings-XS);
+	--components-simpleSelect-background: var(--colors-white-color);
+	--components-simpleSelect-value-color: var(--palettes-neutral-800);
+	--components-simpleSelect-border-color: var(--palettes-neutral-300);
+	--components-simpleSelect-placeholder: var(--palettes-neutral-400);
+	--components-simpleSelect-arrow-color: var(--palettes-neutral-600);
 }

--- a/packages/scss/src/components/skeleton/mods.scss
+++ b/packages/scss/src/components/skeleton/mods.scss
@@ -1,6 +1,6 @@
 @mixin dark {
-	--components-skeleton-gradient-step-one: var(--palettes-grey-200);
-	--components-skeleton-gradient-step-two: var(--palettes-grey-500);
+	--components-skeleton-gradient-step-one: var(--palettes-neutral-200);
+	--components-skeleton-gradient-step-two: var(--palettes-neutral-500);
 }
 
 @mixin skeletonShapeSizing($spacings...) {

--- a/packages/scss/src/components/skeleton/states.scss
+++ b/packages/scss/src/components/skeleton/states.scss
@@ -40,9 +40,9 @@
 		animation: skeletonBackground 1.5s infinite linear;
 		background: linear-gradient(
 			90deg,
-			var(--components-skeleton-gradient-step-one, var(--palettes-grey-50)),
-			var(--components-skeleton-gradient-step-two, var(--palettes-grey-200)),
-			var(--components-skeleton-gradient-step-one, var(--palettes-grey-50))
+			var(--components-skeleton-gradient-step-one, var(--palettes-neutral-50)),
+			var(--components-skeleton-gradient-step-two, var(--palettes-neutral-200)),
+			var(--components-skeleton-gradient-step-one, var(--palettes-neutral-50))
 		);
 		background-size: 150% 100%;
 		background-repeat: repeat-x;

--- a/packages/scss/src/components/skeleton/vars.scss
+++ b/packages/scss/src/components/skeleton/vars.scss
@@ -1,6 +1,6 @@
 @mixin vars {
-	--components-skeleton-gradient-step-one: var(--palettes-grey-50);
-	--components-skeleton-gradient-step-two: var(--palettes-grey-200);
+	--components-skeleton-gradient-step-one: var(--palettes-neutral-50);
+	--components-skeleton-gradient-step-two: var(--palettes-neutral-200);
 	--components-skeleton-shape-height: var(--spacings-M);
 	--components-skeleton-shape-width: var(--spacings-M);
 	--components-skeleton-text-offset: 0.375rem;

--- a/packages/scss/src/components/sortableList/component.scss
+++ b/packages/scss/src/components/sortableList/component.scss
@@ -12,7 +12,7 @@
 			border-bottom-width: var(--commons-divider-width);
 			border-bottom-color: var(--commons-divider-color);
 			border-bottom-style: solid;
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			display: flex;
 			position: relative;
 			text-decoration: none;
@@ -25,7 +25,7 @@
 		}
 
 		.sortableList-item-content {
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			text-decoration: none;
 			width: 100%;
 		}
@@ -38,7 +38,7 @@
 
 		.sortableList-item-content-helper {
 			margin: 0;
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--components-sortableList-helper-fontSize);
 			line-height: var(--components-sortableList-helper-lineHeight);
 		}
@@ -49,9 +49,8 @@
 			padding-left: 0;
 		}
 
-
 		.sortableList-item-handler {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--components-sortableList-handler-size);
 			cursor: move;
 

--- a/packages/scss/src/components/sortableList/mods.scss
+++ b/packages/scss/src/components/sortableList/mods.scss
@@ -5,12 +5,12 @@
 	cursor: pointer;
 
 	&:hover {
-		background-color: var(--palettes-grey-50);
+		background-color: var(--palettes-neutral-50);
 	}
 }
 
 @mixin S {
-	--components-sortableList-padding: .375rem var(--spacings-XS);
+	--components-sortableList-padding: 0.375rem var(--spacings-XS);
 	--components-sortableList-handler-size: var(--sizes-S-lineHeight);
 	--components-sortableList-description-fontSize: var(--sizes-S-fontSize);
 	--components-sortableList-description-lineHeight: var(--sizes-S-lineHeight);

--- a/packages/scss/src/components/status/component.scss
+++ b/packages/scss/src/components/status/component.scss
@@ -41,7 +41,7 @@
 
 		.status-label {
 			font-size: var(--sizes-S-fontSize);
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 		}
 	}
 }

--- a/packages/scss/src/components/statusBadge/component.scss
+++ b/packages/scss/src/components/statusBadge/component.scss
@@ -1,6 +1,6 @@
 @mixin component($atRoot: 'without: rule') {
 	align-items: flex-start;
-	background-color: var(--palettes-100, var(--palettes-primary-100));
+	background-color: var(--palettes-100, var(--palettes-product-100));
 	border-radius: var(--commons-borderRadius-L);
 	display: inline-flex;
 	font-size: var(--components-statusBadge-fontSize);
@@ -11,7 +11,7 @@
 	font-weight: normal;
 
 	&::before {
-		background-color: var(--palettes-700, var(--palettes-primary-700));
+		background-color: var(--palettes-700, var(--palettes-product-700));
 		border-radius: var(--commons-borderRadius-full);
 		content: '';
 		display: block;

--- a/packages/scss/src/components/switch/component.scss
+++ b/packages/scss/src/components/switch/component.scss
@@ -14,7 +14,7 @@
 		.switch-label {
 			padding: 0;
 			padding-left: calc(var(--components-switch-width) + var(--spacings-XS));
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			transition: color var(--commons-animations-durations-fast);
 			display: inline-block;
 			font-size: var(--components-switch-fontSize);
@@ -26,7 +26,7 @@
 				@include icon.generate('sign_close');
 
 				align-items: center;
-				background-color: var(--palettes-grey-500);
+				background-color: var(--palettes-neutral-500);
 				border-radius: var(--commons-borderRadius-full);
 				color: var(--colors-white-color);
 				display: flex;
@@ -59,7 +59,7 @@
 		}
 
 		.switch-label-helper {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--components-switch-helper-fontSize);
 			line-height: var(--components-switch-helper-lineHeight);
 		}

--- a/packages/scss/src/components/switch/states.scss
+++ b/packages/scss/src/components/switch/states.scss
@@ -7,7 +7,7 @@
 			@include icon.generate('sign_confirm');
 
 			display: flex;
-			background-color: var(--palettes-700, var(--palettes-primary-700));
+			background-color: var(--palettes-700, var(--palettes-product-700));
 			padding-left: var(--components-switch-handler-offset);
 		}
 
@@ -21,7 +21,7 @@
 	&:not([disabled], [readonly]) {
 		~ .switch-label {
 			&::before {
-				background-color: var(--palettes-600, var(--palettes-primary-600));
+				background-color: var(--palettes-600, var(--palettes-product-600));
 			}
 		}
 	}
@@ -31,7 +31,7 @@
 	&:not([disabled], [readonly]) {
 		~ .switch-label {
 			&::before {
-				background-color: var(--palettes-800, var(--palettes-primary-800));
+				background-color: var(--palettes-800, var(--palettes-product-800));
 			}
 		}
 	}

--- a/packages/scss/src/components/switch/states.scss
+++ b/packages/scss/src/components/switch/states.scss
@@ -40,7 +40,7 @@
 @mixin hover {
 	~ .switch-label {
 		&::before {
-			background-color: var(--palettes-grey-400);
+			background-color: var(--palettes-neutral-400);
 		}
 	}
 }
@@ -49,7 +49,7 @@
 	&:not([disabled], [readonly]) {
 		~ .switch-label {
 			&::before {
-				background-color: var(--palettes-grey-600);
+				background-color: var(--palettes-neutral-600);
 			}
 		}
 	}
@@ -67,16 +67,16 @@
 
 @mixin disabled {
 	~ .switch-label {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 		cursor: default;
 
 		&::before {
-			background-color: var(--palettes-grey-100);
-			color: var(--palettes-grey-500);
+			background-color: var(--palettes-neutral-100);
+			color: var(--palettes-neutral-500);
 		}
 
 		&::after {
-			background-color: var(--palettes-grey-500);
+			background-color: var(--palettes-neutral-500);
 			box-shadow: none;
 		}
 	}
@@ -85,7 +85,7 @@
 @mixin disabledChecked {
 	~ .switch-label {
 		&::before {
-			background-color: var(--palettes-grey-100);
+			background-color: var(--palettes-neutral-100);
 		}
 	}
 }

--- a/packages/scss/src/components/switchField/component.scss
+++ b/packages/scss/src/components/switchField/component.scss
@@ -11,14 +11,14 @@
 			display: block;
 			width: var(--component-switchField-label-input-width);
 			height: var(--component-switchField-label-input-height);
-			border: 2px solid var(--palettes-grey-500);
+			border: 2px solid var(--palettes-neutral-500);
 			border-radius: var(--component-switchField-label-input-height);
 			position: relative;
 			top: 0.125rem;
 			color: var(--colors-white-color);
 			transition-property: color, border-color, background-color;
 			transition-duration: var(--commons-animations-durations-fast);
-			background-color: var(--palettes-grey-500);
+			background-color: var(--palettes-neutral-500);
 			cursor: pointer;
 
 			&::after {
@@ -73,15 +73,15 @@
 
 			&:hover {
 				~ .switchField-icon {
-					border-color: var(--palettes-grey-400);
-					background-color: var(--palettes-grey-400);
+					border-color: var(--palettes-neutral-400);
+					background-color: var(--palettes-neutral-400);
 				}
 			}
 
 			&:active {
 				~ .switchField-icon {
-					border-color: var(--palettes-grey-600);
-					background-color: var(--palettes-grey-600);
+					border-color: var(--palettes-neutral-600);
+					background-color: var(--palettes-neutral-600);
 				}
 			}
 

--- a/packages/scss/src/components/switchField/states.scss
+++ b/packages/scss/src/components/switchField/states.scss
@@ -25,12 +25,12 @@
 
 @mixin disabled {
 	~ .switchField-icon {
-		background-color: var(--palettes-grey-100);
-		border-color: var(--palettes-grey-100);
-		color: var(--palettes-grey-500);
+		background-color: var(--palettes-neutral-100);
+		border-color: var(--palettes-neutral-100);
+		color: var(--palettes-neutral-500);
 
 		&::before {
-			background-color: var(--palettes-grey-500);
+			background-color: var(--palettes-neutral-500);
 		}
 	}
 }
@@ -38,12 +38,12 @@
 @mixin checkedDisabled {
 	&:disabled {
 		~ .switchField-icon {
-			background-color: var(--palettes-grey-100);
-			border-color: var(--palettes-grey-100);
-			color: var(--palettes-grey-500);
+			background-color: var(--palettes-neutral-100);
+			border-color: var(--palettes-neutral-100);
+			color: var(--palettes-neutral-500);
 
 			&::before {
-				background-color: var(--palettes-grey-500);
+				background-color: var(--palettes-neutral-500);
 			}
 		}
 	}

--- a/packages/scss/src/components/switchField/states.scss
+++ b/packages/scss/src/components/switchField/states.scss
@@ -1,7 +1,7 @@
 @mixin checked {
 	~ .switchField-icon {
-		background-color: var(--palettes-primary-700);
-		border-color: var(--palettes-primary-700);
+		background-color: var(--palettes-product-700);
+		border-color: var(--palettes-product-700);
 
 		&::before {
 			left: 50%;
@@ -10,15 +10,15 @@
 
 	&:hover {
 		~ .switchField-icon {
-			background-color: var(--palettes-primary-600);
-			border-color: var(--palettes-primary-600);
+			background-color: var(--palettes-product-600);
+			border-color: var(--palettes-product-600);
 		}
 	}
 
 	&:active {
 		~ .switchField-icon {
-			background-color: var(--palettes-primary-800);
-			border-color: var(--palettes-primary-800);
+			background-color: var(--palettes-product-800);
+			border-color: var(--palettes-product-800);
 		}
 	}
 }

--- a/packages/scss/src/components/table/component.scss
+++ b/packages/scss/src/components/table/component.scss
@@ -7,7 +7,7 @@
 	display: table;
 	text-align: left;
 	width: 100%;
-	color: var(--palettes-grey-800);
+	color: var(--palettes-neutral-800);
 
 	@at-root ($atRoot) {
 		.table-head {
@@ -24,7 +24,7 @@
 		}
 
 		.table-head-row-cell {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
 			padding: var(--components-table-padding);

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -221,11 +221,10 @@
 		.table-head-row-cell,
 		.table-body-row-cell,
 		.table-foot-row-cell {
-			background-color: var(--palettes-primary-50);
+			background-color: var(--palettes-product-50);
 		}
 	}
 }
-
 
 @mixin clickableSelectable {
 	&:hover {
@@ -233,7 +232,7 @@
 			.table-head-row-cell,
 			.table-body-row-cell,
 			.table-foot-row-cell {
-				background-color: var(--palettes-primary-100);
+				background-color: var(--palettes-product-100);
 			}
 		}
 	}

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -28,7 +28,7 @@
 
 	.table-body-row-cell-action,
 	.table-foot-row-cell-action {
-		color: var(--palettes-grey-800);
+		color: var(--palettes-neutral-800);
 		text-decoration: none;
 
 		&:hover,
@@ -118,8 +118,8 @@
 @mixin parent {
 	.table-body-row-cell,
 	.table-foot-row-cell {
-		color: var(--palettes-grey-700);
-		background-color: var(--palettes-grey-50);
+		color: var(--palettes-neutral-700);
+		background-color: var(--palettes-neutral-50);
 		font-size: var(--sizes-S-fontSize);
 		line-height: var(--sizes-S-lineHeight);
 		font-weight: 600;
@@ -187,7 +187,7 @@
 			&::after {
 				@include icon.generate('dots_drag');
 
-				color: var(--palettes-grey-600);
+				color: var(--palettes-neutral-600);
 				font-size: var(--sizes-M-lineHeight);
 				height: 100%;
 				margin: auto;

--- a/packages/scss/src/components/table/vars.scss
+++ b/packages/scss/src/components/table/vars.scss
@@ -1,8 +1,8 @@
 @mixin vars {
-	--components-table-padding: var(--spacings-XS) .75rem;
+	--components-table-padding: var(--spacings-XS) 0.75rem;
 	--components-table-font-size: var(--sizes-M-fontSize);
 	--components-table-line-height: var(--sizes-M-lineHeight);
 	--components-table-zebra-background: #f5f5f5;
-	--components-table-hover-background: var(--palettes-grey-25);
+	--components-table-hover-background: var(--palettes-neutral-25);
 	--components-table-card-padding: var(--spacings-M);
 }

--- a/packages/scss/src/components/tableOfContent/component.scss
+++ b/packages/scss/src/components/tableOfContent/component.scss
@@ -15,7 +15,7 @@
 			@include reset.button;
 
 			border-radius: var(--commons-borderRadius-M);
-			color: var(--palettes-grey-700);
+			color: var(--palettes-neutral-700);
 			cursor: pointer;
 			display: block;
 			outline: none;

--- a/packages/scss/src/components/tableOfContent/states.scss
+++ b/packages/scss/src/components/tableOfContent/states.scss
@@ -1,18 +1,20 @@
 @mixin hover {
-	background-color: var(--palettes-grey-50);
-	color: var(--palettes-grey-700);
+	background-color: var(--palettes-neutral-50);
+	color: var(--palettes-neutral-700);
 }
 
 @mixin focus {
-	background-color: var(--palettes-grey-50);
-	color: var(--palettes-grey-700);
-	box-shadow: 0 0 0 4px var(--palettes-100, var(--components-tableOfContent-default-palette-100)), inset 0 0 0 1px var(--palettes-300, var(--components-tableOfContent-default-palette-300));
+	background-color: var(--palettes-neutral-50);
+	color: var(--palettes-neutral-700);
+	box-shadow: 0 0 0 4px var(--palettes-100, var(--components-tableOfContent-default-palette-100)),
+		inset 0 0 0 1px var(--palettes-300, var(--components-tableOfContent-default-palette-300));
 }
 
 @mixin active {
-	background-color: var(--palettes-grey-100);
-	color: var(--palettes-grey-700);
-	box-shadow: 0 0 0 4px var(--palettes-200, var(--components-tableOfContent-default-palette-200)), inset 0 0 0 1px var(--palettes-400, var(--components-tableOfContent-default-palette-400));
+	background-color: var(--palettes-neutral-100);
+	color: var(--palettes-neutral-700);
+	box-shadow: 0 0 0 4px var(--palettes-200, var(--components-tableOfContent-default-palette-200)),
+		inset 0 0 0 1px var(--palettes-400, var(--components-tableOfContent-default-palette-400));
 }
 
 @mixin isActive {
@@ -26,16 +28,18 @@
 
 @mixin isActiveFocus {
 	background-color: var(--palettes-100, var(--components-tableOfContent-default-palette-100));
-	box-shadow: 0 0 0 4px var(--palettes-200, var(--components-tableOfContent-default-palette-200)), inset 0 0 0 1px var(--palettes-400, var(--components-tableOfContent-default-palette-400));
+	box-shadow: 0 0 0 4px var(--palettes-200, var(--components-tableOfContent-default-palette-200)),
+		inset 0 0 0 1px var(--palettes-400, var(--components-tableOfContent-default-palette-400));
 }
 
 @mixin isActiveActive {
 	background-color: var(--palettes-200, var(--components-tableOfContent-default-palette-200));
-	box-shadow: 0 0 0 4px var(--palettes-300, var(--components-tableOfContent-default-palette-300)), inset 0 0 0 1px var(--palettes-500, var(--components-tableOfContent-default-palette-500));
-	color: var(--palettes-grey-700);
+	box-shadow: 0 0 0 4px var(--palettes-300, var(--components-tableOfContent-default-palette-300)),
+		inset 0 0 0 1px var(--palettes-500, var(--components-tableOfContent-default-palette-500));
+	color: var(--palettes-neutral-700);
 }
 
 @mixin disabled {
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	pointer-events: none;
 }

--- a/packages/scss/src/components/tableOfContent/vars.scss
+++ b/packages/scss/src/components/tableOfContent/vars.scss
@@ -1,14 +1,14 @@
 @mixin vars {
-	--components-tableOfContent-default-palette-50: var(--palettes-primary-50);
-	--components-tableOfContent-default-palette-100: var(--palettes-primary-100);
-	--components-tableOfContent-default-palette-200: var(--palettes-primary-200);
-	--components-tableOfContent-default-palette-300: var(--palettes-primary-300);
-	--components-tableOfContent-default-palette-400: var(--palettes-primary-400);
-	--components-tableOfContent-default-palette-500: var(--palettes-primary-500);
-	--components-tableOfContent-default-palette-600: var(--palettes-primary-600);
-	--components-tableOfContent-default-palette-700: var(--palettes-primary-700);
-	--components-tableOfContent-default-palette-800: var(--palettes-primary-800);
-	--components-tableOfContent-default-palette-900: var(--palettes-primary-900);
+	--components-tableOfContent-default-palette-50: var(--palettes-product-50);
+	--components-tableOfContent-default-palette-100: var(--palettes-product-100);
+	--components-tableOfContent-default-palette-200: var(--palettes-product-200);
+	--components-tableOfContent-default-palette-300: var(--palettes-product-300);
+	--components-tableOfContent-default-palette-400: var(--palettes-product-400);
+	--components-tableOfContent-default-palette-500: var(--palettes-product-500);
+	--components-tableOfContent-default-palette-600: var(--palettes-product-600);
+	--components-tableOfContent-default-palette-700: var(--palettes-product-700);
+	--components-tableOfContent-default-palette-800: var(--palettes-product-800);
+	--components-tableOfContent-default-palette-900: var(--palettes-product-900);
 	--components-tableOfContent-item-padding: var(--spacings-XS) var(--spacings-S);
 	--components-tableOfContent-item-border-width: 2px;
 }

--- a/packages/scss/src/components/tableSorted/states.scss
+++ b/packages/scss/src/components/tableSorted/states.scss
@@ -2,7 +2,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin sortedLegacy {
-	color: var(--palettes-grey-900);
+	color: var(--palettes-neutral-900);
 
 	&::after {
 		@include icon.generate('arrow_bottom');
@@ -73,7 +73,7 @@
 	padding: 0;
 
 	.table-head-row-cell-sortableButton {
-		color: var(--palettes-grey-900);
+		color: var(--palettes-neutral-900);
 		padding: var(--components-table-padding);
 
 		&::after {

--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -1,14 +1,21 @@
 @mixin component {
-	background-color: var(--palettes-100, var(--palettes-neutral-100));
+	background-color: var(--components-tag-background);
 	border-radius: var(--commons-borderRadius-M);
-	color: var(--palettes-900, var(--palettes-neutral-700));
-	font-size: var(--sizes-S-fontSize);
+	font-size: var(--components-tag-fontSize);
+	line-height: var(--components-tag-lineHeight);
 	padding: 0 var(--spacings-XXS);
-	line-height: var(--sizes-S-lineHeight);
+	text-decoration: var(--components-tag-decoration);
+	box-shadow: 0 0 0 1px var(--components-tag-shadow);
+	cursor: var(--components-tag-cursor);
 	display: inline-block;
 	text-align: center;
-	text-decoration: none;
 	vertical-align: baseline;
 	white-space: nowrap;
 	font-weight: normal;
+	border: 0;
+
+	&,
+	&:is(a, button) {
+		color: var(--components-tag-color);
+	}
 }

--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -1,7 +1,7 @@
 @mixin component {
-	background-color: var(--palettes-100, var(--palettes-grey-100));
+	background-color: var(--palettes-100, var(--palettes-neutral-100));
 	border-radius: var(--commons-borderRadius-M);
-	color: var(--palettes-900, var(--palettes-grey-700));
+	color: var(--palettes-900, var(--palettes-neutral-700));
 	font-size: var(--sizes-S-fontSize);
 	padding: 0 var(--spacings-XXS);
 	line-height: var(--sizes-S-lineHeight);

--- a/packages/scss/src/components/tag/index.scss
+++ b/packages/scss/src/components/tag/index.scss
@@ -4,10 +4,11 @@
 	@include vars;
 	@include component;
 
-	&.mod-L {
-		@include l;
+	&.mod-M {
+		@include M;
 	}
 
+	&:is(a, button),
 	&.mod-clickable {
 		@include clickable;
 	}

--- a/packages/scss/src/components/tag/index.scss
+++ b/packages/scss/src/components/tag/index.scss
@@ -4,10 +4,11 @@
 	@include vars;
 	@include component;
 
-	&.mod-M {
-		@include M;
+	&.mod-L {
+		@include L;
 	}
 
+	// clickable behavior is deprecated
 	&:is(a, button),
 	&.mod-clickable {
 		@include clickable;

--- a/packages/scss/src/components/tag/mods.scss
+++ b/packages/scss/src/components/tag/mods.scss
@@ -13,7 +13,7 @@
 }
 
 @mixin outlined {
-	color: var(--palettes-600, var(--palettes-grey-600));
+	color: var(--palettes-600, var(--palettes-neutral-600));
 	background-color: var(--colors-white-color);
-	box-shadow: 0 0 0 1px var(--palettes-300, var(--palettes-grey-300));
+	box-shadow: 0 0 0 1px var(--palettes-300, var(--palettes-neutral-300));
 }

--- a/packages/scss/src/components/tag/mods.scss
+++ b/packages/scss/src/components/tag/mods.scss
@@ -7,7 +7,7 @@
 	}
 }
 
-@mixin M {
+@mixin L {
 	--components-tag-fontSize: var(--sizes-M-fontSize);
 	--components-tag-lineHeight: var(--sizes-M-lineHeight);
 }

--- a/packages/scss/src/components/tag/mods.scss
+++ b/packages/scss/src/components/tag/mods.scss
@@ -1,19 +1,19 @@
 @mixin clickable {
-	cursor: pointer;
+	--components-tag-cursor: pointer;
 
 	&:hover,
 	&:focus {
-		text-decoration: underline;
+		--components-tag-decoration: underline;
 	}
 }
 
-@mixin l {
-	font-size: var(--sizes-M-fontSize);
-	line-height: var(--sizes-M-lineHeight);
+@mixin M {
+	--components-tag-fontSize: var(--sizes-M-fontSize);
+	--components-tag-lineHeight: var(--sizes-M-lineHeight);
 }
 
 @mixin outlined {
-	color: var(--palettes-600, var(--palettes-neutral-600));
-	background-color: var(--colors-white-color);
-	box-shadow: 0 0 0 1px var(--palettes-300, var(--palettes-neutral-300));
+	--components-tag-color: var(--palettes-600, var(--palettes-neutral-600));
+	--components-tag-background: var(--colors-white-color);
+	--components-tag-shadow: var(--palettes-300, var(--palettes-neutral-300));
 }

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -1,2 +1,9 @@
 @mixin vars {
+	--components-tag-color: var(--palettes-900, var(--palettes-neutral-900));
+	--components-tag-background: var(--palettes-100, var(--palettes-neutral-100));
+	--components-tag-shadow: transparent;
+	--components-tag-fontSize: var(--sizes-S-fontSize);
+	--components-tag-lineHeight: var(--sizes-S-lineHeight);
+	--components-tag-decoration: none;
+	--components-tag-cursor: default;
 }

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -1,5 +1,5 @@
 @mixin vars {
-	--components-tag-color: var(--palettes-900, var(--palettes-neutral-900));
+	--components-tag-color: var(--palettes-800, var(--palettes-neutral-800));
 	--components-tag-background: var(--palettes-100, var(--palettes-neutral-100));
 	--components-tag-shadow: transparent;
 	--components-tag-fontSize: var(--sizes-S-fontSize);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -24,17 +24,17 @@
 			position: relative;
 
 			&:hover {
-				--component-textField-border: var(--palettes-grey-400);
+				--component-textField-border: var(--palettes-neutral-400);
 			}
 
-			&:has(.textField-input-affix-icon ) {
+			&:has(.textField-input-affix-icon) {
 				--component-textField-affix-padding: 2.5rem;
 			}
 
 			&:has(.textField-input-affix-clear) {
 				--component-textField-affix-padding: 2rem;
 
-				&:has(.textField-input-affix-icon ) {
+				&:has(.textField-input-affix-icon) {
 					--component-textField-affix-padding: 4rem;
 				}
 			}
@@ -46,7 +46,8 @@
 			line-height: var(--component-textField-lineHeight);
 			font-size: var(--component-textField-fontSize);
 			width: 100%;
-			padding: var(--component-textField-padding) var(--component-textField-affix-padding) var(--component-textField-padding) var(--component-textField-padding);
+			padding: var(--component-textField-padding) var(--component-textField-affix-padding) var(--component-textField-padding)
+				var(--component-textField-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
 
@@ -66,7 +67,7 @@
 
 		.textField-input-affix-icon {
 			@include icon.M;
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			pointer-events: none;
 		}
 

--- a/packages/scss/src/components/textField/states.scss
+++ b/packages/scss/src/components/textField/states.scss
@@ -1,15 +1,15 @@
 @mixin invalid {
-  --component-textField-border: var(--palettes-error-400);
-  --component-textField-background: var(--palettes-error-50);
-  --component-textField-placeholder: var(--palettes-error-400);
+	--component-textField-border: var(--palettes-error-400);
+	--component-textField-background: var(--palettes-error-50);
+	--component-textField-placeholder: var(--palettes-error-400);
 
-  .textField-input:hover {
-    --component-textField-border: var(--palettes-error-600);
-  }
+	.textField-input:hover {
+		--component-textField-border: var(--palettes-error-600);
+	}
 }
 
 @mixin disabled {
-  --component-textField-border: var(--palettes-grey-300);
-  --component-textField-background: var(--palettes-grey-100);
-  --component-textField-color: var(--palettes-grey-600);
+	--component-textField-border: var(--palettes-neutral-300);
+	--component-textField-background: var(--palettes-neutral-100);
+	--component-textField-color: var(--palettes-neutral-600);
 }

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -1,11 +1,11 @@
 @mixin vars {
-  --component-textField-lineHeight: var(--size-M-lightHeight);
-  --component-textField-fontSize: var(--size-M-fontSize);
-  --component-textField-placeholder: var(--palettes-grey-400);
-  --component-textField-background: var(--colors-white-color);
-  --component-textField-border: var(--palettes-grey-300);
-  --component-textField-color: var(--palettes-grey-800);
-  --component-textField-prefix-color: var(--palettes-grey-600);
-  --component-textField-padding: var(--spacings-XS);
-  --component-textField-affix-padding: var(--component-textField-padding);
+	--component-textField-lineHeight: var(--size-M-lightHeight);
+	--component-textField-fontSize: var(--size-M-fontSize);
+	--component-textField-placeholder: var(--palettes-neutral-400);
+	--component-textField-background: var(--colors-white-color);
+	--component-textField-border: var(--palettes-neutral-300);
+	--component-textField-color: var(--palettes-neutral-800);
+	--component-textField-prefix-color: var(--palettes-neutral-600);
+	--component-textField-padding: var(--spacings-XS);
+	--component-textField-affix-padding: var(--component-textField-padding);
 }

--- a/packages/scss/src/components/textfields/component.scss
+++ b/packages/scss/src/components/textfields/component.scss
@@ -6,7 +6,7 @@
 		.textfield-input {
 			min-width: 0;
 			border: 0;
-			box-shadow: 0 0 0 1px var(--palettes-grey-300);
+			box-shadow: 0 0 0 1px var(--palettes-neutral-300);
 			line-height: var(--sizes-M-lineHeight);
 			-webkit-appearance: none;
 			background-color: var(--colors-white-color);
@@ -16,7 +16,7 @@
 			transition-duration: var(--commons-animations-durations-fast);
 
 			&::placeholder {
-				color: var(--palettes-grey-400);
+				color: var(--palettes-neutral-400);
 				transition-property: color;
 				transition-duration: var(--commons-animations-durations-fast);
 				opacity: 1;
@@ -31,7 +31,7 @@
 		}
 
 		.textfield-suffix {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			top: calc(var(--components-textfield-suffix-top) + var(--components-textfield-input-padding-vertical));
 			right: var(--components-textfield-input-padding-horizontal);
 			position: absolute;

--- a/packages/scss/src/components/textfields/mods.scss
+++ b/packages/scss/src/components/textfields/mods.scss
@@ -44,10 +44,10 @@
 		padding: 0;
 		line-height: 0;
 		border-radius: var(--commons-borderRadius-full);
-		background-color: var(--palettes-grey-700);
+		background-color: var(--palettes-neutral-700);
 
 		&:hover {
-			background-color: var(--palettes-grey-600);
+			background-color: var(--palettes-neutral-600);
 		}
 
 		.lucca-icon {
@@ -218,7 +218,7 @@
 	&::after {
 		@include icon.generate('search_magnifying_glass');
 
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		position: absolute;
 		pointer-events: none;
 		bottom: var(--spacings-XS);
@@ -374,7 +374,7 @@
 	position: relative;
 
 	.textfield-label {
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		left: var(--spacings-S);
 		font-size: var(--sizes-S-fontSize);
 		font-weight: 400;
@@ -394,14 +394,14 @@
 
 		&::after {
 			bottom: var(--spacings-XS);
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-weight: 400;
 		}
 	}
 }
 
 @mixin suffixIcon {
-	color: var(--palettes-grey-600);
+	color: var(--palettes-neutral-600);
 	line-height: var(--sizes-M-lineHeight);
 }
 
@@ -477,7 +477,7 @@
 		z-index: 10;
 		line-height: var(--sizes-M-lineHeight);
 		font-size: var(--sizes-S-fontSize);
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 	}
 
 	.textfield-messages,
@@ -525,7 +525,7 @@
 	.textfield-messages-helper,
 	.radiosfield-messages-helper,
 	.checkboxesfield-messages-helper {
-		background-color: var(--palettes-grey-500);
+		background-color: var(--palettes-neutral-500);
 		color: var(--colors-white-color);
 	}
 }
@@ -546,7 +546,7 @@
 
 @mixin framedSearch {
 	&::after {
-		color: var(--palettes-grey-600);
+		color: var(--palettes-neutral-600);
 		padding: var(--components-field-framed-side-padding);
 		bottom: 0;
 		right: 0;
@@ -575,7 +575,7 @@
 
 		&::placeholder {
 			opacity: 0;
-			color: var(--palettes-grey-400);
+			color: var(--palettes-neutral-400);
 		}
 	}
 
@@ -631,7 +631,7 @@
 
 @mixin materialSearch {
 	&::after {
-		color: var(--palettes-grey-500);
+		color: var(--palettes-neutral-500);
 		bottom: var(--spacings-XS);
 		right: 0;
 	}

--- a/packages/scss/src/components/textfields/states.scss
+++ b/packages/scss/src/components/textfields/states.scss
@@ -226,5 +226,5 @@
 }
 
 @mixin entryHover {
-	background-color: var(--palettes-primary-50);
+	background-color: var(--palettes-product-50);
 }

--- a/packages/scss/src/components/textfields/states.scss
+++ b/packages/scss/src/components/textfields/states.scss
@@ -2,7 +2,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin inputHover {
-	box-shadow: 0 0 0 1px var(--palettes-grey-400);
+	box-shadow: 0 0 0 1px var(--palettes-neutral-400);
 }
 
 @mixin inputFocus {
@@ -12,7 +12,7 @@
 @mixin inputDisabled {
 	background-color: var(--components-textfield-disabled-background);
 	color: var(--components-textfield-disabled-color);
-	box-shadow: 0 0 0 1px var(--palettes-grey-300);
+	box-shadow: 0 0 0 1px var(--palettes-neutral-300);
 	cursor: default;
 
 	&::placeholder {
@@ -20,19 +20,19 @@
 	}
 
 	~ .textfield-clear {
-		--components-clear-cross-color: var(--palettes-grey-500) !important;
+		--components-clear-cross-color: var(--palettes-neutral-500) !important;
 		pointer-events: none;
 	}
 
 	~ .textfield-actionClear {
 		// deprecated
-		color: var(--palettes-grey-500) !important;
+		color: var(--palettes-neutral-500) !important;
 		pointer-events: none;
 	}
 }
 
 @mixin filterHover {
-	background-color: var(--palettes-grey-50);
+	background-color: var(--palettes-neutral-50);
 }
 
 @mixin open {

--- a/packages/scss/src/components/textfields/vars.scss
+++ b/packages/scss/src/components/textfields/vars.scss
@@ -3,7 +3,7 @@
 	--components-textfield-input-padding-horizontal: var(--spacings-XS);
 	--components-textfield-input-padding-vertical: var(--spacings-XS);
 	--components-textfield-disabled-background: var(--commons-disabled-background);
-	--components-textfield-disabled-color: var(--palettes-grey-600);
+	--components-textfield-disabled-color: var(--palettes-neutral-600);
 	--components-textfield-suffix-top: 1.75rem;
 	--components-textfield-suffix-padding-right: var(--spacings-L);
 	--components-textfield-sizes-shortest: 3rem;
@@ -15,9 +15,9 @@
 	--components-textfield-sizes-longest: 28rem;
 
 	--components-textfield-material-padding-top: var(--spacings-S);
-	--components-textfield-material-default-palette-color: var(--palettes-grey-600);
+	--components-textfield-material-default-palette-color: var(--palettes-neutral-600);
 	--components-textfield-material-border-color: #ccc;
-	--components-textfield-material-label-color: var(--palettes-grey-600);
+	--components-textfield-material-label-color: var(--palettes-neutral-600);
 	--components-textfield-material-label-font-size: var(--sizes-M-fontSize);
 	--components-textfield-material-suffix-padding-right: var(--spacings-S);
 

--- a/packages/scss/src/components/timeline/component.scss
+++ b/packages/scss/src/components/timeline/component.scss
@@ -18,7 +18,7 @@
 					content: '';
 					display: flex;
 					flex-grow: 1;
-					border-bottom: 2px solid var(--palettes-grey-200);
+					border-bottom: 2px solid var(--palettes-neutral-200);
 					margin: var(--spacings-XS);
 				}
 			}

--- a/packages/scss/src/components/timeline/component.scss
+++ b/packages/scss/src/components/timeline/component.scss
@@ -32,7 +32,7 @@
 			padding-left: 1.75rem;
 			position: relative;
 			display: block;
-			color: var(--palettes-primary-700);
+			color: var(--palettes-product-700);
 			font-weight: 600;
 			margin: 0;
 			font-size: var(--sizes-M-fontSize);
@@ -44,14 +44,14 @@
 		.timeline-step:not([aria-current='step']):not([aria-current='step'] ~ .timeline-step) .timeline-step-title-icon {
 			&::before {
 				content: '';
-				color: var(--palettes-primary-text);
+				color: var(--palettes-product-text);
 				width: 1rem;
 				height: 1rem;
 				display: flex;
 				align-items: center;
 				justify-content: center;
 				border-radius: var(--commons-borderRadius-full);
-				background-color: var(--palettes-primary-700);
+				background-color: var(--palettes-product-700);
 				position: absolute;
 				left: var(--spacings-XXS);
 				top: 50%;

--- a/packages/scss/src/components/timeline/mods.scss
+++ b/packages/scss/src/components/timeline/mods.scss
@@ -59,7 +59,7 @@
 			bottom: -0.75rem;
 			left: 0.45rem; // magic number
 			margin: 0;
-			border-left: 2px solid var(--palettes-grey-200);
+			border-left: 2px solid var(--palettes-neutral-200);
 		}
 
 		&:not(:last-child)[aria-current='step'] {
@@ -141,7 +141,7 @@
 			height: unset;
 			width: 2px;
 			border: none;
-			background: linear-gradient(180deg, var(--palettes-product-700) var(--progress), var(--palettes-grey-200) var(--progress));
+			background: linear-gradient(180deg, var(--palettes-product-700) var(--progress), var(--palettes-neutral-200) var(--progress));
 		}
 	}
 }
@@ -220,12 +220,12 @@
 			background-image: linear-gradient(
 				90deg,
 				transparent 25%,
-				var(--palettes-grey-200) 25%,
-				var(--palettes-grey-200) 50%,
+				var(--palettes-neutral-200) 25%,
+				var(--palettes-neutral-200) 50%,
 				transparent 50%,
 				transparent 75%,
-				var(--palettes-grey-200) 75%,
-				var(--palettes-grey-200) 100%
+				var(--palettes-neutral-200) 75%,
+				var(--palettes-neutral-200) 100%
 			);
 			background-size: var(--spacings-XS) var(--spacings-XS);
 		}
@@ -273,12 +273,12 @@
 			background-image: linear-gradient(
 				0deg,
 				transparent 25%,
-				var(--palettes-grey-200) 25%,
-				var(--palettes-grey-200) 50%,
+				var(--palettes-neutral-200) 25%,
+				var(--palettes-neutral-200) 50%,
 				transparent 50%,
 				transparent 75%,
-				var(--palettes-grey-200) 75%,
-				var(--palettes-grey-200) 100%
+				var(--palettes-neutral-200) 75%,
+				var(--palettes-neutral-200) 100%
 			);
 			background-size: var(--spacings-XS) var(--spacings-XS);
 		}
@@ -357,7 +357,7 @@
 		&::after {
 			border: none;
 			height: 2px;
-			background: linear-gradient(90deg, var(--palettes-product-700) var(--progress), var(--palettes-grey-200) var(--progress));
+			background: linear-gradient(90deg, var(--palettes-product-700) var(--progress), var(--palettes-neutral-200) var(--progress));
 		}
 	}
 }

--- a/packages/scss/src/components/timeline/mods.scss
+++ b/packages/scss/src/components/timeline/mods.scss
@@ -141,7 +141,7 @@
 			height: unset;
 			width: 2px;
 			border: none;
-			background: linear-gradient(180deg, var(--palettes-primary-700) var(--progress), var(--palettes-grey-200) var(--progress));
+			background: linear-gradient(180deg, var(--palettes-product-700) var(--progress), var(--palettes-grey-200) var(--progress));
 		}
 	}
 }
@@ -175,15 +175,15 @@
 				font-size: var(--components-timeline-icon-size);
 				display: flex;
 				background-color: transparent;
-				color: var(--palettes-primary-700);
+				color: var(--palettes-product-700);
 			}
 			&::before {
-				background-color: var(--palettes-primary-100);
+				background-color: var(--palettes-product-100);
 			}
 		}
 
 		&::after {
-			border-color: var(--palettes-primary-200);
+			border-color: var(--palettes-product-200);
 			border-bottom-style: solid;
 		}
 	}
@@ -246,14 +246,14 @@
 	.timeline-step-title-icon {
 		&::before {
 			content: '';
-			color: var(--palettes-primary-text);
+			color: var(--palettes-product-text);
 			width: 1rem;
 			height: 1rem;
 			display: flex;
 			align-items: center;
 			justify-content: center;
 			border-radius: var(--commons-borderRadius-full);
-			background-color: var(--palettes-primary-700);
+			background-color: var(--palettes-product-700);
 			position: absolute;
 			left: var(--spacings-XXS);
 			top: 50%;
@@ -321,7 +321,7 @@
 
 		&:hover {
 			.timeline-step-title-icon::before {
-				background-color: var(--palettes-primary-600);
+				background-color: var(--palettes-product-600);
 			}
 		}
 
@@ -357,7 +357,7 @@
 		&::after {
 			border: none;
 			height: 2px;
-			background: linear-gradient(90deg, var(--palettes-primary-700) var(--progress), var(--palettes-grey-200) var(--progress));
+			background: linear-gradient(90deg, var(--palettes-product-700) var(--progress), var(--palettes-grey-200) var(--progress));
 		}
 	}
 }
@@ -377,7 +377,7 @@
 @mixin notPastChecked {
 	.timeline-step-title {
 		&::before {
-			background-color: var(--palettes-primary-700);
+			background-color: var(--palettes-product-700);
 			color: var(--colors-white-color);
 		}
 	}

--- a/packages/scss/src/components/timeline/states.scss
+++ b/packages/scss/src/components/timeline/states.scss
@@ -11,11 +11,11 @@
 
 	~ .timeline-step {
 		.timeline-step-title {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 
 			&::before {
-				background-color: var(--palettes-grey-200);
-				color: var(--palettes-grey-600);
+				background-color: var(--palettes-neutral-200);
+				color: var(--palettes-neutral-600);
 			}
 		}
 	}

--- a/packages/scss/src/components/timeline/states.scss
+++ b/packages/scss/src/components/timeline/states.scss
@@ -1,10 +1,10 @@
 @mixin current {
 	.timeline-step-title {
-		color: var(--palettes-primary-700);
+		color: var(--palettes-product-700);
 
 		&::before {
-			background-color: var(--palettes-primary-700);
-			box-shadow: 0 0 0 var(--spacings-XXS) var(--palettes-primary-200);
+			background-color: var(--palettes-product-700);
+			box-shadow: 0 0 0 var(--spacings-XXS) var(--palettes-product-200);
 			color: var(--colors-white-color);
 		}
 	}

--- a/packages/scss/src/components/timepicker/component.scss
+++ b/packages/scss/src/components/timepicker/component.scss
@@ -4,7 +4,7 @@
 	padding: var(--components-timepicker-padding);
 	border: 0;
 	border-radius: var(--commons-borderRadius-M);
-	box-shadow: 0 0 0 1px var(--palettes-grey-300);
+	box-shadow: 0 0 0 1px var(--palettes-neutral-300);
 	display: inline-flex;
 	background-color: var(--colors-white-color);
 	transition: box-shadow var(--commons-animations-durations-fast);
@@ -24,7 +24,7 @@
 			background-color: transparent;
 			border-radius: var(--commons-borderRadius-M);
 			text-align: center;
-			color: var(--palettes-grey-800);
+			color: var(--palettes-neutral-800);
 			width: var(--components-timepicker-input-width);
 			height: var(--components-timepicker-input-height);
 			border: 0;
@@ -53,7 +53,7 @@
 			border: 0;
 			height: 1.25rem;
 			background-color: transparent;
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			display: inline-flex;
 			justify-content: center;
 			align-items: center;
@@ -67,13 +67,13 @@
 			}
 
 			&:hover {
-				background-color: var(--palettes-grey-50);
-				color: var(--palettes-grey-800);
+				background-color: var(--palettes-neutral-50);
+				color: var(--palettes-neutral-800);
 			}
 
 			&:focus {
-				background-color: var(--palettes-grey-100);
-				color: var(--palettes-grey-800);
+				background-color: var(--palettes-neutral-100);
+				color: var(--palettes-neutral-800);
 			}
 
 			.lucca-icon {

--- a/packages/scss/src/components/timepicker/component.scss
+++ b/packages/scss/src/components/timepicker/component.scss
@@ -40,7 +40,7 @@
 			&:hover,
 			&:focus,
 			&:focus-visible {
-				background-color: var(--palettes-100, var(--palettes-primary-100));
+				background-color: var(--palettes-100, var(--palettes-product-100));
 				outline: none;
 			}
 		}

--- a/packages/scss/src/components/timepicker/states.scss
+++ b/packages/scss/src/components/timepicker/states.scss
@@ -1,13 +1,13 @@
 @mixin disabled {
-  background-color: var(--palettes-grey-100);
-  color: var(--palettes-grey-600);
+	background-color: var(--palettes-neutral-100);
+	color: var(--palettes-neutral-600);
 
-  .timepicker-field-input {
-    background: transparent;
-    color: var(--palettes-grey-600);
-  }
+	.timepicker-field-input {
+		background: transparent;
+		color: var(--palettes-neutral-600);
+	}
 
-  .timepicker-field-increment {
-    display: none;
-  }
+	.timepicker-field-increment {
+		display: none;
+	}
 }

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -1,7 +1,7 @@
 @mixin component($suffix: '') {
 	// no suffix here
 	margin-top: 0;
-	color: var(--palettes-grey-900);
+	color: var(--palettes-neutral-900);
 	margin-bottom: var(--spacings-S);
 	text-rendering: geometricPrecision;
 	text-wrap: balance;

--- a/packages/scss/src/components/titleSection/component.scss
+++ b/packages/scss/src/components/titleSection/component.scss
@@ -24,7 +24,7 @@
 
 	@at-root ($atRoot) {
 		.titleSection-sub {
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			font-size: var(--sizes-M-fontSize);
 			line-height: var(--sizes-M-lineHeight);
 			font-weight: 400;

--- a/packages/scss/src/components/toast/vars.scss
+++ b/packages/scss/src/components/toast/vars.scss
@@ -1,5 +1,5 @@
 @mixin vars {
-	--components-toasts-background: var(--palettes-grey-900);
+	--components-toasts-background: var(--palettes-neutral-900);
 	--components-toasts-color: var(--colors-white-color);
 	--components-toasts-top: var(--spacings-M);
 	--components-toasts-right: var(--spacings-M);

--- a/packages/scss/src/components/util/index.scss
+++ b/packages/scss/src/components/util/index.scss
@@ -121,15 +121,15 @@
 }
 
 .u-textLight {
-	color: var(--palettes-grey-600) !important;
+	color: var(--palettes-neutral-600) !important;
 }
 
 .u-textPlaceholder {
-	color: var(--palettes-grey-400) !important;
+	color: var(--palettes-neutral-400) !important;
 }
 
 .u-textDefault {
-	color: var(--palettes-grey-700) !important;
+	color: var(--palettes-neutral-700) !important;
 }
 
 .u-unit {

--- a/packages/scss/src/components/verticalNavigation/component.scss
+++ b/packages/scss/src/components/verticalNavigation/component.scss
@@ -6,7 +6,7 @@
 	@at-root ($atRoot) {
 		.verticalNavigation-sectionTitle {
 			@include title.h5;
-			color: var(--palettes-grey-600);
+			color: var(--palettes-neutral-600);
 			padding: 0 var(--components-verticalNavigation-horizontalPadding);
 			margin-bottom: var(--spacings-XS);
 		}
@@ -34,7 +34,7 @@
 			font-weight: 600;
 
 			&:hover {
-				--components-verticalNavigation-link-background: var(--palettes-grey-50);
+				--components-verticalNavigation-link-background: var(--palettes-neutral-50);
 				color: var(--components-verticalNavigation-link-color);
 			}
 
@@ -43,7 +43,7 @@
 			}
 
 			&:active {
-				--components-verticalNavigation-link-background: var(--palettes-grey-100);
+				--components-verticalNavigation-link-background: var(--palettes-neutral-100);
 			}
 		}
 

--- a/packages/scss/src/components/verticalNavigation/states.scss
+++ b/packages/scss/src/components/verticalNavigation/states.scss
@@ -13,7 +13,7 @@
 
 @mixin disabled {
 	--components-verticalNavigation-link-background: transparent;
-	color: var(--palettes-grey-500);
+	color: var(--palettes-neutral-500);
 	pointer-events: none;
 }
 

--- a/packages/scss/src/components/verticalNavigation/states.scss
+++ b/packages/scss/src/components/verticalNavigation/states.scss
@@ -1,13 +1,13 @@
 @mixin active {
-	--components-verticalNavigation-link-background: var(--palettes-primary-100);
+	--components-verticalNavigation-link-background: var(--palettes-product-100);
 	color: var(--components-verticalNavigation-link-color);
 
-  &:hover {
-  	--components-verticalNavigation-link-background: var(--palettes-primary-200);
-  }
+	&:hover {
+		--components-verticalNavigation-link-background: var(--palettes-product-200);
+	}
 
 	&:active {
-		--components-verticalNavigation-link-background: var(--palettes-primary-300);
+		--components-verticalNavigation-link-background: var(--palettes-product-300);
 	}
 }
 

--- a/packages/scss/src/components/verticalNavigation/vars.scss
+++ b/packages/scss/src/components/verticalNavigation/vars.scss
@@ -1,5 +1,5 @@
 @mixin vars {
-  --components-verticalNavigation-link-background: var(--colors-white-color);
-  --components-verticalNavigation-link-color: var(--palettes-grey-800);
-  --components-verticalNavigation-horizontalPadding: 0.75rem;
+	--components-verticalNavigation-link-background: var(--colors-white-color);
+	--components-verticalNavigation-link-color: var(--palettes-neutral-800);
+	--components-verticalNavigation-horizontalPadding: 0.75rem;
 }

--- a/stories/documentation/actions/button/angular/button-counter.stories.ts
+++ b/stories/documentation/actions/button/angular/button-counter.stories.ts
@@ -1,6 +1,6 @@
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { generateInputs } from 'stories/helpers/stories';
 
 export default {
@@ -13,7 +13,7 @@ export default {
 	],
 	render: ({ luButton, ...inputs }, { argTypes }) => {
 		return {
-			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''} ${generateInputs(inputs, argTypes)}>Click me ! <lu-numeric-badge value="7" palette="primary"></lu-numeric-badge></button>`,
+			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''} ${generateInputs(inputs, argTypes)}>Click me ! <lu-numeric-badge value="7" palette="product"></lu-numeric-badge></button>`,
 		};
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout-disclosure/angular/callout-disclosure.stories.ts
+++ b/stories/documentation/feedback/callout-disclosure/angular/callout-disclosure.stories.ts
@@ -14,7 +14,7 @@ export default {
 	render: (args, { argTypes }) => {
 		return {
 			template: `<lu-callout-disclosure ${generateInputs(args, argTypes)}>
-		<ul lu-callout-feedback-list palette="grey">
+		<ul lu-callout-feedback-list palette="neutral">
 			<li lu-callout-feedback-item>
 				<lu-feedback-item-description>
 					 Feedback description.

--- a/stories/documentation/feedback/callout-disclosure/html&css/basic.stories.ts
+++ b/stories/documentation/feedback/callout-disclosure/html&css/basic.stories.ts
@@ -11,7 +11,7 @@ export default {
 		<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 	</summary>
 	<div class="calloutDisclosure-details">
-		<ul class="calloutFeedbackList palette-grey">
+		<ul class="calloutFeedbackList palette-neutral">
 	  	<li class="calloutFeedbackList-item">
 				<span class="calloutFeedbackList-item-description">Feedback description.</span>
 				<div class="calloutFeedbackList-item-actions">
@@ -28,9 +28,9 @@ export default {
 			</li>
 		</ul>
 	</div>
-</details>`
-		}
-	}
+</details>`,
+		};
+	},
 } as Meta;
 
 export const Basic: StoryObj = {};

--- a/stories/documentation/feedback/callout-disclosure/html&css/iconless.stories.ts
+++ b/stories/documentation/feedback/callout-disclosure/html&css/iconless.stories.ts
@@ -10,7 +10,7 @@ export default {
 		<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 	</summary>
 	<div class="calloutDisclosure-details">
-		<ul class="calloutFeedbackList palette-grey">
+		<ul class="calloutFeedbackList palette-neutral">
 	  	<li class="calloutFeedbackList-item">
 				<span class="calloutFeedbackList-item-description">Feedback description.</span>
 				<div class="calloutFeedbackList-item-actions">
@@ -27,9 +27,9 @@ export default {
 			</li>
 		</ul>
 	</div>
-</details>`
-		}
-	}
+</details>`,
+		};
+	},
 } as Meta;
 
 export const Iconless: StoryObj = {};

--- a/stories/documentation/feedback/callout-disclosure/html&css/size.stories.ts
+++ b/stories/documentation/feedback/callout-disclosure/html&css/size.stories.ts
@@ -11,7 +11,7 @@ export default {
 		<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 	</summary>
 	<div class="calloutDisclosure-details">
-		<ul class="calloutFeedbackList palette-grey">
+		<ul class="calloutFeedbackList palette-neutral">
 	  	<li class="calloutFeedbackList-item">
 				<span class="calloutFeedbackList-item-description">Feedback description.</span>
 				<div class="calloutFeedbackList-item-actions">
@@ -28,9 +28,9 @@ export default {
 			</li>
 		</ul>
 	</div>
-</details>`
-		}
-	}
+</details>`,
+		};
+	},
 } as Meta;
 
 export const Size: StoryObj = {};

--- a/stories/documentation/feedback/callout-disclosure/html&css/status.stories.ts
+++ b/stories/documentation/feedback/callout-disclosure/html&css/status.stories.ts
@@ -4,11 +4,13 @@ export default {
 	title: 'Documentation/Feedback/Callout Disclosure/HTML&CSS',
 	render: () => {
 		return {
-			styles: [`
+			styles: [
+				`
 				.calloutDisclosure {
 					margin-bottom: var(--spacings-XS);
 				}
-			`],
+			`,
+			],
 			template: `<details class="calloutDisclosure palette-success">
   <summary class="calloutDisclosure-summary">
 		<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signSuccess"></span>
@@ -16,7 +18,7 @@ export default {
 		<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 	</summary>
 	<div class="calloutDisclosure-details">
-		<ul class="calloutFeedbackList palette-grey">
+		<ul class="calloutFeedbackList palette-neutral">
 	  	<li class="calloutFeedbackList-item">
 				<span class="calloutFeedbackList-item-description">Feedback description.</span>
 				<div class="calloutFeedbackList-item-actions">
@@ -42,7 +44,7 @@ export default {
 		<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 	</summary>
 	<div class="calloutDisclosure-details">
-		<ul class="calloutFeedbackList palette-grey">
+		<ul class="calloutFeedbackList palette-neutral">
 	  	<li class="calloutFeedbackList-item">
 				<span class="calloutFeedbackList-item-description">Feedback description.</span>
 				<div class="calloutFeedbackList-item-actions">
@@ -68,7 +70,7 @@ export default {
 		<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 	</summary>
 	<div class="calloutDisclosure-details">
-		<ul class="calloutFeedbackList palette-grey">
+		<ul class="calloutFeedbackList palette-neutral">
 	  	<li class="calloutFeedbackList-item">
 				<span class="calloutFeedbackList-item-description">Feedback description.</span>
 				<div class="calloutFeedbackList-item-actions">
@@ -85,9 +87,9 @@ export default {
 			</li>
 		</ul>
 	</div>
-</details>`
-		}
-	}
+</details>`,
+		};
+	},
 } as Meta;
 
 export const Status: StoryObj = {};

--- a/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
+++ b/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
@@ -1,7 +1,7 @@
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { CalloutFeedbackItemComponent, CalloutFeedbackListComponent, CalloutPopoverComponent } from '@lucca-front/ng/callout';
-import { ButtonComponent } from '@lucca-front/ng/button';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { CalloutFeedbackItemComponent, CalloutFeedbackListComponent, CalloutPopoverComponent } from '@lucca-front/ng/callout';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { generateInputs } from 'stories/helpers/stories';
 
 export default {
@@ -15,7 +15,7 @@ export default {
 	render: (args, { argTypes }) => {
 		return {
 			template: `<lu-callout-popover ${generateInputs(args, argTypes)}>
-		<ul lu-callout-feedback-list palette="grey">
+		<ul lu-callout-feedback-list palette="neutral">
 			<li lu-callout-feedback-item>
 				<lu-feedback-item-description>
 					 Feedback description.

--- a/stories/documentation/feedback/callout/html&css/callout-basic.stories.ts
+++ b/stories/documentation/feedback/callout/html&css/callout-basic.stories.ts
@@ -9,7 +9,7 @@ export default {
 	title: 'Documentation/Feedback/Callout/HTML & CSS/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['', 'palette-product', 'palette-neutral', 'palette-success', 'palette-warning', 'palette-error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
@@ -36,8 +36,8 @@ export default {
 	bottomLeftForeground="${bottomLeftForeground}"
 	contentBackgroundColor="${contentBackgroundColor}"
 >
-	<button luButton type="button" palette="primary">Button</button>
-	<button luButton="outlined" type="button" palette="primary">Button</button>
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
 </lu-empty-state-page>`,
 		};
 	},

--- a/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
@@ -18,8 +18,8 @@ export default {
 		return {
 			template: `
 <lu-empty-state-section ${paramIcon} title="${title}" description="${description}" palette="${palette}" ${center ? ' center' : ''}>
-	<button luButton type="button" palette="primary">Button</button>
-	<button luButton="outlined" type="button" palette="primary">Button</button>
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
 </lu-empty-state-section>`,
 		};
 	},

--- a/stories/documentation/forms/fieldset/fieldset-basic.stories.ts
+++ b/stories/documentation/forms/fieldset/fieldset-basic.stories.ts
@@ -93,5 +93,5 @@ Basic.args = {
 	expandable: false,
 	helper: '',
 	title: 'Title',
-	content: '<div class="grid mod-form" style="background-color: var(--palettes-grey-50)"><div class="grid-column" style="--grid-colspan: 4">Lorem ipsum dolor sit amet.</div></div>',
+	content: '<div class="grid mod-form" style="background-color: var(--palettes-neutral-50)"><div class="grid-column" style="--grid-colspan: 4">Lorem ipsum dolor sit amet.</div></div>',
 };

--- a/stories/documentation/forms/framed/framed-basic.stories.ts
+++ b/stories/documentation/forms/framed/framed-basic.stories.ts
@@ -66,7 +66,7 @@ function getTemplate(args: FramedBasicStory): string {
 			<legend class="form-group-legend">Titre Groupe 2</legend>
 			<div class="form-group-line">
 				<div class="form-group-line-col mod-overlay-top">
-					<label class="textfield mod-multiline mod-withSuffix palette-secondary is-required">
+					<label class="textfield mod-multiline mod-withSuffix palette-product is-required">
 						<textarea class="textfield-input" type="text" placeholder="Money Money"></textarea>
 						<span class="textfield-label">Label textfield</span>
 						<span class="textfield-suffix">

--- a/stories/documentation/integration/utilities/text-color.stories.ts
+++ b/stories/documentation/integration/utilities/text-color.stories.ts
@@ -11,8 +11,7 @@ function getTemplate(args: TextColorStory): string {
 		<span class="u-textDefault">Default</span>
 		<span class="u-textLight">Light</span>
 		<span class="u-textPlaceholder">Placeholder</span>
-		<span class="u-textPrimary">Primary</span>
-		<span class="u-textSecondary">Secondary</span>
+		<span class="u-textProduct">Product</span>
 		<span class="u-textSuccess">Success</span>
 		<span class="u-textWarning">Warning</span>
 		<span class="u-textError">Error</span>

--- a/stories/documentation/listings/chip/chip.stories.ts
+++ b/stories/documentation/listings/chip/chip.stories.ts
@@ -1,14 +1,14 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
 interface ChipBasicStory {
-	primary: boolean;
+	product: boolean;
 	disabled: boolean;
 }
 
 export default {
 	title: 'Documentation/Listings/Chip/Basic',
 	argTypes: {
-		primary: {
+		product: {
 			control: {
 				type: 'boolean',
 			},
@@ -22,16 +22,16 @@ export default {
 } as Meta;
 
 function getTemplate(args: ChipBasicStory): string {
-	const primary = args.primary ? `palette-primary` : '';
+	const product = args.product ? `palette-product` : '';
 	const disabled = args.disabled ? `is-disabled` : '';
 	return `
-	<div class="chip ${primary} ${disabled}">
+	<div class="chip ${product} ${disabled}">
 		Label
 		<button type="button" class="chip-kill">
 			<span class="u-mask">delete</span>
 		</button>
 	</div>
-	<div class="chip ${primary} ${disabled}">
+	<div class="chip ${product} ${disabled}">
 		Label
 	</div>
 	`;
@@ -43,4 +43,4 @@ const Template: StoryFn<ChipBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { primary: false, disabled: false };
+Basic.args = { product: false, disabled: false };

--- a/stories/documentation/listings/timelines/timelines-add-vertical.stories.ts
+++ b/stories/documentation/listings/timelines/timelines-add-vertical.stories.ts
@@ -37,7 +37,7 @@ function getTemplate(args: TimelinesAddStepVerticalStory): string {
 		</li>
 		<li class="timeline-step">
 			<div class="timeline-step-title">
-				<button type="button" class="button palette-grey mod-S u-positionStatic">
+				<button type="button" class="button palette-neutral mod-S u-positionStatic">
 					<span class="timeline-step-title-icon" aria-hidden="true"></span>
 					Add step
 				</button>

--- a/stories/documentation/listings/timelines/timelines-add.stories.ts
+++ b/stories/documentation/listings/timelines/timelines-add.stories.ts
@@ -27,7 +27,7 @@ function getTemplate(args: TimelinesAddStepStory): string {
 		</li>
 		<li class="timeline-step">
 			<div class="timeline-step-title">
-				<button type="button" class="button palette-grey mod-S u-positionStatic">
+				<button type="button" class="button palette-neutral mod-S u-positionStatic">
 					<span class="timeline-step-title-icon" aria-hidden="true"></span>
 					Add step
 				</button>

--- a/stories/documentation/loaders/gauge/gauge-basic.stories.ts
+++ b/stories/documentation/loaders/gauge/gauge-basic.stories.ts
@@ -10,7 +10,7 @@ export default {
 	title: 'Documentation/Loaders/Gauge/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['', 'palette-product', 'palette-neutral', 'palette-success', 'palette-warning', 'palette-error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/loaders/gauge/gauge-vertical.stories.ts
+++ b/stories/documentation/loaders/gauge/gauge-vertical.stories.ts
@@ -9,7 +9,7 @@ export default {
 	title: 'Documentation/Loaders/Gauge/Vertical',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['', 'palette-product', 'palette-neutral', 'palette-success', 'palette-warning', 'palette-error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/navigation/menu-secondary/menu-secondary-basic.stories.ts
+++ b/stories/documentation/navigation/menu-secondary/menu-secondary-basic.stories.ts
@@ -72,7 +72,7 @@ function getTemplate(args: MenuSecondaryBasicStory): string {
 							<li class="navSide-item-subMenu-item">
 								<a href="#" class="navSide-item-subMenu-link is-active">
 									Section 2.3
-									<span class="numericBadge palette-primary mod-S"><span class="u-mask">, </span>9</span>
+									<span class="numericBadge palette-product mod-S"><span class="u-mask">, </span>9</span>
 								</a>
 							</li>
 						</ul>
@@ -87,7 +87,7 @@ function getTemplate(args: MenuSecondaryBasicStory): string {
 						<a href="#" class="navSide-item-link">
 							<span aria-hidden="true" class="lucca-icon icon-settingsEqualizer"></span>
 							<span class="navSide-item-link-title">Section 4</span>
-							<span class="numericBadge palette-primary mod-S"><span class="u-mask">, </span>9</span>
+							<span class="numericBadge palette-product mod-S"><span class="u-mask">, </span>9</span>
 						</a>
 					</li>
 				</ul>

--- a/stories/documentation/navigation/skip-links/skip-links-basic.stories.ts
+++ b/stories/documentation/navigation/skip-links/skip-links-basic.stories.ts
@@ -16,9 +16,9 @@ import { Meta, StoryFn } from '@storybook/angular';
 			<button type="button" class="button mod-onlyIcon mod-text" luTooltip="Modifier"><span aria-hidden="true" class="lucca-icon icon-bell"></span></button>
 		</div>
 		<div id="navSide">
-			<button type="button" class="button mod-withIcon palette-secondary"><span aria-hidden="true" class="lucca-icon icon-mailPaperPlane"></span>Internal navigation</button>
-			<button type="button" class="button mod-withIcon palette-secondary"><span aria-hidden="true" class="lucca-icon icon-timeClock"></span>Internal navigation</button>
-			<button type="button" class="button mod-withIcon palette-secondary"><span aria-hidden="true" class="lucca-icon icon-eye"></span>Internal navigation</button>
+			<button type="button" class="button mod-withIcon palette-product"><span aria-hidden="true" class="lucca-icon icon-mailPaperPlane"></span>Internal navigation</button>
+			<button type="button" class="button mod-withIcon palette-product"><span aria-hidden="true" class="lucca-icon icon-timeClock"></span>Internal navigation</button>
+			<button type="button" class="button mod-withIcon palette-product"><span aria-hidden="true" class="lucca-icon icon-eye"></span>Internal navigation</button>
 		</div>
 		<div id="main-content">
 			<a href="#" class="link">Content link</a>

--- a/stories/documentation/structure/box/box-arrow.stories.ts
+++ b/stories/documentation/structure/box/box-arrow.stories.ts
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/angular';
 
 interface ArrowBasicStory {
 	s: boolean;
-	grey: boolean;
+	neutral: boolean;
 	field: string;
 	checked: boolean;
 }
@@ -21,7 +21,7 @@ export default {
 				type: 'boolean',
 			},
 		},
-		grey: {
+		neutral: {
 			control: {
 				type: 'boolean',
 			},
@@ -38,7 +38,7 @@ export default {
 
 function getTemplate(args: ArrowBasicStory): string {
 	const s = args.s ? ' mod-S' : '';
-	const grey = args.grey ? ' mod-grey' : ' ';
+	const neutral = args.neutral ? ' mod-neutral' : ' ';
 	const checked = args.checked ? ' checked' : '';
 
 	if (args.field === 'radio') {
@@ -58,7 +58,7 @@ function getTemplate(args: ArrowBasicStory): string {
 	      <span class="radioField-icon-check"></span>
 	    </span>
 	  </span>
-	  <div class="form-field-arrow${grey}"></div>
+	  <div class="form-field-arrow${neutral}"></div>
 	</div>
 	<div class="form-field mod-withArrow${s}">
 	  <label class="formLabel" for="IDradioB">Label B</label>
@@ -74,10 +74,10 @@ function getTemplate(args: ArrowBasicStory): string {
 	      <span class="radioField-icon-check"></span>
 	    </span>
 	  </span>
-	  <div class="form-field-arrow${grey}"></div>
+	  <div class="form-field-arrow${neutral}"></div>
 	</div>
 </div>
-<div class="box mod-withArrow${grey}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam illo nostrum tenetur expedita. Accusantium cumque nisi excepturi eius corporis, iusto quaerat temporibus dolorum necessitatibus laboriosam quidem quibusdam quae aperiam! Vitae!</div>`;
+<div class="box mod-withArrow${neutral}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam illo nostrum tenetur expedita. Accusantium cumque nisi excepturi eius corporis, iusto quaerat temporibus dolorum necessitatibus laboriosam quidem quibusdam quae aperiam! Vitae!</div>`;
 	} else if (args.field === 'checkbox') {
 		return `<div class="form-field mod-withArrow${s}">
 	<label class="formLabel" for="CB">Label</label>
@@ -85,9 +85,9 @@ function getTemplate(args: ArrowBasicStory): string {
 		<input type="checkbox" class="checkboxField-input" id="CB" aria-labelledby="CB-label"${checked} />
 		<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 	</span>
-	<div class="form-field-arrow${grey}"></div>
+	<div class="form-field-arrow${neutral}"></div>
 </div>
-<div class="box mod-withArrow${grey}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam illo nostrum tenetur expedita. Accusantium cumque nisi excepturi eius corporis, iusto quaerat temporibus dolorum necessitatibus laboriosam quidem quibusdam quae aperiam! Vitae!</div>`;
+<div class="box mod-withArrow${neutral}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam illo nostrum tenetur expedita. Accusantium cumque nisi excepturi eius corporis, iusto quaerat temporibus dolorum necessitatibus laboriosam quidem quibusdam quae aperiam! Vitae!</div>`;
 	} else {
 		return `<div class="form-field mod-withArrow${s}">
 	<label class="formLabel" for="ID">Label</label>
@@ -95,9 +95,9 @@ function getTemplate(args: ArrowBasicStory): string {
 		<input type="checkbox" class="switchField-input" id="ID"${checked} />
 		<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 	</span>
-	<div class="form-field-arrow${grey}"></div>
+	<div class="form-field-arrow${neutral}"></div>
 </div>
-<div class="box mod-withArrow${grey}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam illo nostrum tenetur expedita. Accusantium cumque nisi excepturi eius corporis, iusto quaerat temporibus dolorum necessitatibus laboriosam quidem quibusdam quae aperiam! Vitae!</div>`;
+<div class="box mod-withArrow${neutral}">Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam illo nostrum tenetur expedita. Accusantium cumque nisi excepturi eius corporis, iusto quaerat temporibus dolorum necessitatibus laboriosam quidem quibusdam quae aperiam! Vitae!</div>`;
 	}
 }
 
@@ -107,4 +107,4 @@ const Template: StoryFn<ArrowBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { s: false, grey: true, field: 'radio', checked: true };
+Basic.args = { s: false, neutral: true, field: 'radio', checked: true };

--- a/stories/documentation/structure/box/box-basic.stories.ts
+++ b/stories/documentation/structure/box/box-basic.stories.ts
@@ -1,13 +1,13 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
 interface BoxBasicStory {
-	grey: boolean;
+	neutral: boolean;
 }
 
 export default {
 	title: 'Documentation/Structure/Box/Basic',
 	argTypes: {
-		grey: {
+		neutral: {
 			control: {
 				type: 'boolean',
 			},
@@ -16,10 +16,10 @@ export default {
 } as Meta;
 
 function getTemplate(args: BoxBasicStory): string {
-	const grey = args.grey ? `mod-grey` : '';
+	const neutral = args.neutral ? `mod-neutral` : '';
 
 	return `
-	<div class="box ${grey}">
+	<div class="box ${neutral}">
 	    Jujubes toppin gvueoat cake cake lemon drops chupa chups sweet roll. Macaroon icing tootsie roll bonbon dragée carrot cake sweet roll. Pie gingerbread jelly beans cotton candy tart lollipop bonbon candy. Bonbon chocolate gingerbread pastry.
 	</div>
 	`;
@@ -33,9 +33,9 @@ const Template: StoryFn<BoxBasicStory> = (args) => ({
 		:host {
 			display: block;
 		}`,
-		args.grey === false ? ':host { background-color: #F3F5FC; margin: -15px -15px; padding: 15px 15px; }' : '',
+		args.neutral === false ? ':host { background-color: #F3F5FC; margin: -15px -15px; padding: 15px 15px; }' : '',
 	],
 });
 
 export const Basic = Template.bind({});
-Basic.args = { grey: false };
+Basic.args = { neutral: false };

--- a/stories/documentation/structure/box/box-killable.stories.ts
+++ b/stories/documentation/structure/box/box-killable.stories.ts
@@ -1,13 +1,13 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
 interface BoxKillableStory {
-	grey: boolean;
+	neutral: boolean;
 }
 
 export default {
 	title: 'Documentation/Structure/Box/Killable',
 	argTypes: {
-		grey: {
+		neutral: {
 			control: {
 				type: 'boolean',
 			},
@@ -16,10 +16,10 @@ export default {
 } as Meta;
 
 function getTemplate(args: BoxKillableStory): string {
-	const grey = args.grey ? `mod-grey` : '';
+	const neutral = args.neutral ? `mod-neutral` : '';
 
 	return `
-	<div class="box ${grey}">
+	<div class="box ${neutral}">
 	    <div class="box-close">
 	        <button type="button" class="button mod-onlyIcon mod-text">
 	            <span aria-hidden="true" class="lucca-icon icon-signClose"></span>
@@ -39,9 +39,9 @@ const Template: StoryFn<BoxKillableStory> = (args) => ({
 		:host {
 			display: block;
 		}`,
-		args.grey === false ? ':host { background-color: #F3F5FC; margin: -15px -15px; padding: 15px 15px; }' : '',
+		args.neutral === false ? ':host { background-color: #F3F5FC; margin: -15px -15px; padding: 15px 15px; }' : '',
 	],
 });
 
 export const Killable = Template.bind({});
-Killable.args = { grey: false };
+Killable.args = { neutral: false };

--- a/stories/documentation/structure/box/box-toggle.stories.ts
+++ b/stories/documentation/structure/box/box-toggle.stories.ts
@@ -1,13 +1,13 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
 interface BoxToggleStory {
-	grey: boolean;
+	neutral: boolean;
 }
 
 export default {
 	title: 'Documentation/Structure/Box/Toggle',
 	argTypes: {
-		grey: {
+		neutral: {
 			control: {
 				type: 'boolean',
 			},
@@ -16,14 +16,14 @@ export default {
 } as Meta;
 
 function getTemplate(args: BoxToggleStory): string {
-	const grey = args.grey ? `mod-grey` : '';
+	const neutral = args.neutral ? `mod-neutral` : '';
 
 	return `
 	<div class="switch">
 	    <input class="switch-input" type="checkbox" id="boxSwitch" checked disabled>
 	    <label class="switch-label" for="boxSwitch">Switch</label>
 	</div>
-	<div class="box mod-toggle ${grey}">
+	<div class="box mod-toggle ${neutral}">
 	    Jujubes toppin gvueoat cake cake lemon drops chupa chups sweet roll. Macaroon icing tootsie roll bonbon dragée carrot cake sweet roll. Pie gingerbread jelly beans cotton candy tart lollipop bonbon candy. Bonbon chocolate gingerbread pastry.
 	</div>
 	`;
@@ -37,9 +37,9 @@ const Template: StoryFn<BoxToggleStory> = (args) => ({
 		:host {
 			display: block;
 		}`,
-		args.grey === false ? ':host { background-color: #F3F5FC; margin: -15px -15px; padding: 15px 15px; }' : '',
+		args.neutral === false ? ':host { background-color: #F3F5FC; margin: -15px -15px; padding: 15px 15px; }' : '',
 	],
 });
 
 export const Toggle = Template.bind({});
-Toggle.args = { grey: false };
+Toggle.args = { neutral: false };

--- a/stories/documentation/structure/cards/cards-basic.stories.ts
+++ b/stories/documentation/structure/cards/cards-basic.stories.ts
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/angular';
 
 interface CardsBasicStory {
 	clickable: boolean;
-	grey: boolean;
+	neutral: boolean;
 	disabled: boolean;
 	elevated: boolean;
 }
@@ -26,7 +26,7 @@ export default {
 			},
 			description: 'Deprecated 🦕',
 		},
-		grey: {
+		neutral: {
 			control: {
 				type: 'boolean',
 			},
@@ -37,11 +37,11 @@ export default {
 
 function getTemplate(args: CardsBasicStory): string {
 	const clickable = args.clickable ? `mod-clickable` : '';
-	const grey = args.grey ? `mod-grey` : '';
+	const neutral = args.neutral ? `mod-neutral` : '';
 	const disabled = args.disabled ? `is-disabled` : '';
 	const elevated = args.elevated ? `mod-elevated` : '';
 	return `
-	<div class="card ${clickable} ${grey} ${disabled} ${elevated}">
+	<div class="card ${clickable} ${neutral} ${disabled} ${elevated}">
 		<div class="card-content">
 			<h2 class="card-title">Titre de la carte</h2>
 			<p>Contenu de la carte</p>
@@ -56,4 +56,4 @@ const Template: StoryFn<CardsBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { disabled: false, elevated: false, clickable: false, grey: false };
+Basic.args = { disabled: false, elevated: false, clickable: false, neutral: false };

--- a/stories/documentation/structure/cards/cards-footer.stories.ts
+++ b/stories/documentation/structure/cards/cards-footer.stories.ts
@@ -15,7 +15,7 @@ function getTemplate(args: CardsFooterStory): string {
 		</div>
 		<footer class="card-footer">
 			<div class="card-footer-right">
-				<button type="button" class="button palette-primary">Confirmer</button>
+				<button type="button" class="button palette-product">Confirmer</button>
 				<button type="button" class="button mod-text">Annuler</button>
 			</div>
 		</footer>

--- a/stories/documentation/structure/empty-state-deprecated/empty-state-basic.stories.ts
+++ b/stories/documentation/structure/empty-state-deprecated/empty-state-basic.stories.ts
@@ -11,7 +11,7 @@ function getTemplate(args: EmptyStateBasicStory): string {
 	<section class="emptyState">
 		<h3 class="emptyState-title">Shhh, c'est calme ici</h3>
 		<p class="emptyState-description">Vous pouvez suggérer ici une action à réaliser</p>
-		<button type="button" class="button palette-primary mod-L">Faire une action</button>
+		<button type="button" class="button palette-product mod-L">Faire une action</button>
 	</section>
 	`;
 }

--- a/stories/documentation/structure/grids-legacy/grids-auto-width.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-auto-width.stories.ts
@@ -34,7 +34,7 @@ const Template: StoryFn<GridsLegacyAutoWidthStory> = (args) => ({
 	styles: [
 		`
 		.grid-demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/grids-legacy/grids-basic.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-basic.stories.ts
@@ -69,7 +69,7 @@ const Template: StoryFn<GridsLegacyBasicStory> = (args) => ({
 	styles: [
 		`
 		.demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/grids-legacy/grids-horizontal-alignment.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-horizontal-alignment.stories.ts
@@ -32,7 +32,7 @@ const Template: StoryFn<GridsLegacyHorizontalAlignmentStory> = (args) => ({
 	styles: [
 		`
 		.grid-demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/grids-legacy/grids-justify.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-justify.stories.ts
@@ -39,7 +39,7 @@ const Template: StoryFn<GridsLegacyJustifyStory> = (args) => ({
 	styles: [
 		`
 		.grid-demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/grids-legacy/grids-offset.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-offset.stories.ts
@@ -30,7 +30,7 @@ const Template: StoryFn<GridsLegacyOffsetStory> = (args) => ({
 	styles: [
 		`
 		.grid-demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/grids-legacy/grids-sort.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-sort.stories.ts
@@ -46,7 +46,7 @@ const Template: StoryFn<GridsLegacySortStory> = (args) => ({
 	styles: [
 		`
 		.grid-demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/grids-legacy/grids-vertical-alignment.stories.ts
+++ b/stories/documentation/structure/grids-legacy/grids-vertical-alignment.stories.ts
@@ -41,7 +41,7 @@ const Template: StoryFn<GridsLegacyVerticalAlignmentStory> = (args) => ({
 	styles: [
 		`
 		.grid-demo {
-			background-color: var(--palettes-grey-200);
+			background-color: var(--palettes-neutral-200);
 			margin-bottom: var(--spacings-S);
 			padding: var(--spacings-S);
 			border-radius: var(--commons-borderRadius-full);

--- a/stories/documentation/structure/mobile-header/mobile-header-basic.stories.ts
+++ b/stories/documentation/structure/mobile-header/mobile-header-basic.stories.ts
@@ -22,11 +22,11 @@ function getTemplate(args: MobileHeaderBasicStory): string {
 			<div class="mobileHeader-title-sub">Subtitle</div>
 		</div>
 		<div class="mobileHeader-actions">
-			<button type="button" class="button mod-onlyIcon mod-text palette-primary" luTooltip="Action">
+			<button type="button" class="button mod-onlyIcon mod-text palette-product" luTooltip="Action">
 				<span aria-hidden="true" class="lucca-icon icon-heart"></span>
 				<span class="u-mask">Action</span>
 			</button>
-			<button type="button" class="button mod-onlyIcon mod-text palette-primary" luTooltip="Action">
+			<button type="button" class="button mod-onlyIcon mod-text palette-product" luTooltip="Action">
 			  <span aria-hidden="true" class="lucca-icon icon-heart"></span>
 			  <span class="u-mask">Action</span>
 			</button>

--- a/stories/documentation/texts/clear/clear.stories.ts
+++ b/stories/documentation/texts/clear/clear.stories.ts
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/angular';
 
 interface ClearBasicStory {
 	s: boolean;
-	primary: boolean;
+	product: boolean;
 	disabled: boolean;
 }
 
@@ -14,7 +14,7 @@ export default {
 				type: 'boolean',
 			},
 		},
-		primary: {
+		product: {
 			control: {
 				type: 'boolean',
 			},
@@ -29,10 +29,10 @@ export default {
 
 function getTemplate(args: ClearBasicStory): string {
 	const s = args.s ? `mod-S` : '';
-	const primary = args.primary ? `palette-primary` : '';
+	const product = args.product ? `palette-product` : '';
 	const disabled = args.disabled ? `disabled` : '';
 	return `
-		<a href="#" class="clear ${s} ${primary}" ${disabled}><span class="u-mask">Clear</span></a>
+		<a href="#" class="clear ${s} ${product}" ${disabled}><span class="u-mask">Clear</span></a>
 	`;
 }
 
@@ -42,4 +42,4 @@ const Template: StoryFn<ClearBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { s: false, primary: false, disabled: false };
+Basic.args = { s: false, product: false, disabled: false };

--- a/stories/documentation/texts/icons/HTML&CSS/icon-colors.stories.ts
+++ b/stories/documentation/texts/icons/HTML&CSS/icon-colors.stories.ts
@@ -10,7 +10,7 @@ function getTemplate(args: IconColorStory): string {
 	return `<span aria-hidden="true" class="lucca-icon icon-heart"></span>
 <span aria-hidden="true" class="lucca-icon icon-heart u-textLight"></span>
 <span aria-hidden="true" class="lucca-icon icon-heart u-textPlaceholder"></span>
-<span aria-hidden="true" class="lucca-icon icon-heart u-textPrimary"></span>
+<span aria-hidden="true" class="lucca-icon icon-heart u-textProduct"></span>
 <span aria-hidden="true" class="lucca-icon icon-heart u-textError"></span>
 <span aria-hidden="true" class="lucca-icon icon-heart u-textWarning"></span>
 <span aria-hidden="true" class="lucca-icon icon-heart u-textSuccess"></span>`;

--- a/stories/documentation/texts/labels/label-basic.stories.ts
+++ b/stories/documentation/texts/labels/label-basic.stories.ts
@@ -9,7 +9,7 @@ export default {
 	title: 'Documentation/Texts/Label/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['', 'palette-product', 'palette-neutral', 'palette-success', 'palette-warning', 'palette-error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/numeric-badge/angular/numeric-badge.stories.ts
+++ b/stories/documentation/texts/numeric-badge/angular/numeric-badge.stories.ts
@@ -11,7 +11,7 @@ export default {
 	],
 	argTypes: {
 		palette: {
-			options: ['none', 'primary', 'grey', 'success', 'warning', 'error'],
+			options: ['none', 'product', 'neutral', 'success', 'warning', 'error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/numeric-badge/html&css/numeric-badge-basic.stories.ts
+++ b/stories/documentation/texts/numeric-badge/html&css/numeric-badge-basic.stories.ts
@@ -9,7 +9,7 @@ export default {
 	title: 'Documentation/Texts/NumericBadge/HTML & CSS/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary'],
+			options: ['', 'palette-product'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/status-badge/status-badge-basic.stories.ts
+++ b/stories/documentation/texts/status-badge/status-badge-basic.stories.ts
@@ -9,7 +9,7 @@ export default {
 	title: 'Documentation/Texts/StatusBadge/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['', 'palette-product', 'palette-success', 'palette-warning', 'palette-error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/status/status-basic.stories.ts
+++ b/stories/documentation/texts/status/status-basic.stories.ts
@@ -9,7 +9,7 @@ export default {
 	title: 'Documentation/Texts/Status/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'u-textPrimary', 'u-textSecondary', 'u-textLight', 'u-textError', 'u-textWarning', 'u-textSuccess'],
+			options: ['', 'u-textProduct', 'u-textLight', 'u-textError', 'u-textWarning', 'u-textSuccess'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/status/status-important.stories.ts
+++ b/stories/documentation/texts/status/status-important.stories.ts
@@ -10,7 +10,7 @@ export default {
 	title: 'Documentation/Texts/Status/Important',
 	argTypes: {
 		palette: {
-			options: ['', 'u-textPrimary', 'u-textSecondary', 'u-textLight', 'u-textError', 'u-textWarning', 'u-textSuccess'],
+			options: ['', 'u-textProduct', 'u-textLight', 'u-textError', 'u-textWarning', 'u-textSuccess'],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/tags/tags.stories.ts
+++ b/stories/documentation/texts/tags/tags.stories.ts
@@ -11,7 +11,26 @@ export default {
 	title: 'Documentation/Texts/Tags/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-product', 'palette-neutral', 'palette-success', 'palette-warning', 'palette-error'],
+			options: [
+				'',
+				'palette-product',
+				'palette-neutral',
+				'palette-success',
+				'palette-warning',
+				'palette-error',
+				'palette-kiwi',
+				'palette-lime',
+				'palette-cucumber',
+				'palette-mint',
+				'palette-glacier',
+				'palette-lagoon',
+				'palette-blueberry',
+				'palette-lavender',
+				'palette-grape',
+				'palette-watermelon',
+				'palette-pumpkin',
+				'palette-pineapple',
+			],
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/texts/tags/tags.stories.ts
+++ b/stories/documentation/texts/tags/tags.stories.ts
@@ -3,7 +3,7 @@ import { Meta, StoryFn } from '@storybook/angular';
 interface TagsBasicStory {
 	palette: string;
 	clickable: boolean;
-	M: boolean;
+	L: boolean;
 	outlined: boolean;
 }
 
@@ -40,7 +40,7 @@ export default {
 				type: 'boolean',
 			},
 		},
-		M: {
+		L: {
 			control: {
 				type: 'boolean',
 			},
@@ -59,11 +59,11 @@ function getTemplate(args: TagsBasicStory): string {
 	const classes = [args.palette].filter(Boolean).join(' ');
 
 	const outlined = args.outlined ? `mod-outlined` : '';
-	const M = args.M ? `mod-M` : '';
+	const L = args.L ? `mod-L` : '';
 	if (args.clickable) {
-		return `<a href="#" class="tag ${classes} ${outlined} ${M}">Tag</a> <span class="tag mod-clickable ${classes} ${outlined} ${M}">Tag</span>`;
+		return `<a href="#" class="tag ${classes} ${outlined} ${L}">Tag</a> <span class="tag mod-clickable ${classes} ${outlined} ${L}">Tag</span>`;
 	} else {
-		return `<span class="tag ${classes} ${outlined} ${M}">Tag</span>`;
+		return `<span class="tag ${classes} ${outlined} ${L}">Tag</span>`;
 	}
 }
 
@@ -81,4 +81,4 @@ const Template: StoryFn<TagsBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { outlined: false, M: false, palette: '', clickable: false };
+Basic.args = { outlined: false, L: false, palette: '', clickable: false };

--- a/stories/documentation/texts/tags/tags.stories.ts
+++ b/stories/documentation/texts/tags/tags.stories.ts
@@ -3,7 +3,7 @@ import { Meta, StoryFn } from '@storybook/angular';
 interface TagsBasicStory {
 	palette: string;
 	clickable: boolean;
-	l: boolean;
+	M: boolean;
 	outlined: boolean;
 }
 
@@ -34,18 +34,17 @@ export default {
 			control: {
 				type: 'select',
 			},
-			description: 'Deprecated 🦕',
 		},
 		outlined: {
 			control: {
 				type: 'boolean',
 			},
 		},
-		l: {
+		M: {
 			control: {
 				type: 'boolean',
 			},
-			description: 'Taille : Large',
+			description: 'Taille : Medium',
 		},
 		clickable: {
 			control: {
@@ -58,16 +57,28 @@ export default {
 
 function getTemplate(args: TagsBasicStory): string {
 	const classes = [args.palette].filter(Boolean).join(' ');
-	const clickable = args.clickable ? `mod-clickable` : '';
+
 	const outlined = args.outlined ? `mod-outlined` : '';
-	const l = args.l ? `mod-L` : '';
-	return `<span class="tag ${classes} ${clickable} ${outlined} ${l}">Tag</span>`;
+	const M = args.M ? `mod-M` : '';
+	if (args.clickable) {
+		return `<a href="#" class="tag ${classes} ${outlined} ${M}">Tag</a> <span class="tag mod-clickable ${classes} ${outlined} ${M}">Tag</span>`;
+	} else {
+		return `<span class="tag ${classes} ${outlined} ${M}">Tag</span>`;
+	}
 }
 
 const Template: StoryFn<TagsBasicStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
+	styles: [
+		`
+		:host {
+			display: flex;
+			gap: 0.5rem;
+		}
+	`,
+	],
 });
 
 export const Basic = Template.bind({});
-Basic.args = { outlined: false, l: false, palette: '', clickable: false };
+Basic.args = { outlined: false, M: false, palette: '', clickable: false };

--- a/stories/documentation/texts/tags/tags.stories.ts
+++ b/stories/documentation/texts/tags/tags.stories.ts
@@ -11,7 +11,7 @@ export default {
 	title: 'Documentation/Texts/Tags/Basic',
 	argTypes: {
 		palette: {
-			options: ['', 'palette-primary', 'palette-grey', 'palette-success', 'palette-warning', 'palette-error'],
+			options: ['', 'palette-product', 'palette-neutral', 'palette-success', 'palette-warning', 'palette-error'],
 			control: {
 				type: 'select',
 			},

--- a/stories/helpers/common-arg-types.ts
+++ b/stories/helpers/common-arg-types.ts
@@ -1,5 +1,5 @@
 export const PaletteArgType = {
-	options: ['none', 'primary', 'grey', 'success', 'warning', 'error'],
+	options: ['none', 'product', 'neutral', 'success', 'warning', 'error'],
 	control: {
 		type: 'select',
 	},

--- a/stories/qa/box/box.stories.html
+++ b/stories/qa/box/box.stories.html
@@ -7,7 +7,7 @@
 		Jujubes toppin gvueoat cake cake lemon drops chupa chups sweet roll. Macaroon icing tootsie roll bonbon dragée carrot cake sweet roll.
 		Pie gingerbread jelly beans cotton candy tart lollipop bonbon candy. Bonbon chocolate gingerbread pastry.
 	</div>
-	<div class="box mod-grey">
+	<div class="box mod-neutral">
 		Jujubes toppin gvueoat cake cake lemon drops chupa chups sweet roll. Macaroon icing tootsie roll bonbon dragée carrot cake sweet roll.
 		Pie gingerbread jelly beans cotton candy tart lollipop bonbon candy. Bonbon chocolate gingerbread pastry.
 	</div>
@@ -20,7 +20,7 @@
 		<input class="switch-input" type="checkbox" id="boxSwitch" checked disabled />
 		<label class="switch-label" for="boxSwitch">Switch</label>
 	</div>
-	<div class="box mod-grey mod-toggle">
+	<div class="box mod-neutral mod-toggle">
 		Jujubes toppin gvueoat cake cake lemon drops chupa chups sweet roll. Macaroon icing tootsie roll bonbon dragée carrot cake sweet roll.
 		Pie gingerbread jelly beans cotton candy tart lollipop bonbon candy. Bonbon chocolate gingerbread pastry.
 	</div>
@@ -28,7 +28,7 @@
 
 <section class="contentSection">
 	<h2>Killable</h2>
-	<div class="box mod-grey">
+	<div class="box mod-neutral">
 		<div class="box-close">
 			<button type="button" class="button mod-onlyIcon mod-text">
 				<span aria-hidden="true" class="lucca-icon icon-signClose"></span>

--- a/stories/qa/button/button.stories.html
+++ b/stories/qa/button/button.stories.html
@@ -5,7 +5,7 @@
 	<div class="u-displayFlex u-gapXS u-alignItemsCenter">
 		<button type="button" class="button">Default</button>
 		<button type="button" class="button mod-outlined">Outlined</button>
-		<button type="button" class="button mod-text palette-primary">Text</button>
+		<button type="button" class="button mod-text palette-product">Text</button>
 		<button type="button" class="button mod-text">Text</button>
 		<div style="display: inline-block; background: black; padding: 0.5rem; margin-left: 0.5rem">
 			<button type="button" class="button mod-text mod-invert">Text inverted</button>
@@ -127,12 +127,12 @@
 	<h2>Disabled</h2>
 	<div class="u-displayFlex u-gapXS u-flexWrapWrap u-alignItemsCenter">
 		<button type="button" class="button" disabled>Disabled button</button>
-		<button type="button" class="button palette-primary is-disabled">.is-disabled primary button</button>
+		<button type="button" class="button palette-product is-disabled">.is-disabled product button</button>
 		<button type="button" class="button palette-error mod-outlined" disabled>Critical outlined disabled button</button>
 		<button type="button" class="button is-disabled">Disabled button</button>
 		<button type="button" class="button mod-outlined" disabled>Disabled button</button>
 		<button type="button" class="button mod-text" disabled>Disabled button</button>
-		<button type="button" class="button" disabled>Disabled button<span class="numericBadge palette-primary">7</span></button>
+		<button type="button" class="button" disabled>Disabled button<span class="numericBadge palette-product">7</span></button>
 	</div>
 </section>
 

--- a/stories/qa/callout/callout.stories.html
+++ b/stories/qa/callout/callout.stories.html
@@ -1,220 +1,214 @@
 <h1>Callouts</h1>
 
 <section class="contentSection">
+	<details class="calloutAccordion">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signInfo"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</details>
+	<br />
+	<details class="calloutAccordion palette-success">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signSuccess"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</details>
+	<br />
+	<details class="calloutAccordion palette-warning">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signWarning"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</details>
+	<br />
+	<details class="calloutAccordion palette-error">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signError"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<button type="button" class="button mod-outlined">Button</button>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<button type="button" class="button mod-outlined">Button</button>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
+				</div>
+			</div>
+		</div>
+	</details>
+	<br />
 
-
-<details class="calloutAccordion">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signInfo"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
+	<details class="calloutAccordion mod-S">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signInfo"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-		</div>
-	</div>
-</details>
-<br>
-<details class="calloutAccordion palette-success">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signSuccess"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-</details>
-<br>
-<details class="calloutAccordion palette-warning">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signWarning"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
+	</details>
+	<br />
+	<details class="calloutAccordion mod-S palette-success">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signSuccess"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-		</div>
-	</div>
-</details>
-<br>
-<details class="calloutAccordion palette-error">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signError"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<button type="button" class="button mod-outlined">Button</button>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<button type="button" class="button mod-outlined">Button</button>
-					<button type="button" class="button mod-text">Button</button>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-</details>
-<br>
-
-<details class="calloutAccordion mod-S">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signInfo"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
+	</details>
+	<br />
+	<details class="calloutAccordion mod-S palette-warning">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signWarning"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-		</div>
-	</div>
-</details>
-<br>
-<details class="calloutAccordion mod-S palette-success">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signSuccess"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<a href class="button mod-outlined">Button</a>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-</details>
-<br>
-<details class="calloutAccordion mod-S palette-warning">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signWarning"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
+	</details>
+	<br />
+	<details class="calloutAccordion mod-S palette-error">
+		<summary class="calloutAccordion-summary">
+			<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signError"></span>
+			<span class="calloutAccordion-summary-title">List title</span>
+			<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
+		</summary>
+		<div class="calloutAccordion-details">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<button type="button" class="button mod-outlined">Button</button>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<a href class="button mod-outlined">Button</a>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-		</div>
-	</div>
-</details>
-<br>
-<details class="calloutAccordion mod-S palette-error">
-  <summary class="calloutAccordion-summary">
-		<span aria-hidden="true" class="calloutAccordion-summary-icon lucca-icon icon-signError"></span>
-		<span class="calloutAccordion-summary-title">List title</span>
-		<span aria-hidden="true" class="calloutAccordion-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
-	</summary>
-	<div class="calloutAccordion-details">
-		<div class="calloutFeedbackList palette-grey">
-	  	<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<button type="button" class="button mod-outlined">Button</button>
-					<button type="button" class="button mod-text">Button</button>
-				</div>
-			</div>
-			<div class="calloutFeedbackList-item">
-				<span class="calloutFeedbackList-item-description">Feedback description.</span>
-				<div class="calloutFeedbackList-item-actions">
-					<button type="button" class="button mod-outlined">Button</button>
-					<button type="button" class="button mod-text">Button</button>
+				<div class="calloutFeedbackList-item">
+					<span class="calloutFeedbackList-item-description">Feedback description.</span>
+					<div class="calloutFeedbackList-item-actions">
+						<button type="button" class="button mod-outlined">Button</button>
+						<button type="button" class="button mod-text">Button</button>
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-</details>
-
-
-
-
+	</details>
 
 	<h2>Basics</h2>
 	<!-- Basics -->
@@ -350,14 +344,14 @@
 <section class="contentSection">
 	<h1>Callout accordion</h1>
 	<details class="calloutDisclosure">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signInfo"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -376,14 +370,14 @@
 	</details>
 
 	<details class="calloutDisclosure palette-success">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signSuccess"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -402,14 +396,14 @@
 	</details>
 
 	<details class="calloutDisclosure palette-warning">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signWarning"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -428,14 +422,14 @@
 	</details>
 
 	<details class="calloutDisclosure palette-error">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signError"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -457,14 +451,14 @@
 	<h2>S</h2>
 
 	<details class="calloutDisclosure mod-S">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signInfo"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -483,14 +477,14 @@
 	</details>
 
 	<details class="calloutDisclosure mod-S palette-success">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signSuccess"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -509,14 +503,14 @@
 	</details>
 
 	<details class="calloutDisclosure mod-S palette-warning">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signWarning"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -535,14 +529,14 @@
 	</details>
 
 	<details class="calloutDisclosure mod-S palette-error">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signError"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<ul class="calloutFeedbackList palette-grey">
-		  	<li class="calloutFeedbackList-item">
+			<ul class="calloutFeedbackList palette-neutral">
+				<li class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -559,21 +553,20 @@
 			</ul>
 		</div>
 	</details>
-
 </section>
 
 <section class="contentSection">
 	<h2>Iconless</h2>
 
 	<details class="calloutDisclosure mod-iconless">
-	  <summary class="calloutDisclosure-summary">
+		<summary class="calloutDisclosure-summary">
 			<span aria-hidden="true" class="calloutDisclosure-summary-icon lucca-icon icon-signInfo"></span>
 			<span class="calloutDisclosure-summary-title">List title</span>
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<div class="calloutFeedbackList palette-grey">
-		  	<div class="calloutFeedbackList-item">
+			<div class="calloutFeedbackList palette-neutral">
+				<div class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
 						<a href class="button mod-outlined">Button</a>
@@ -598,7 +591,7 @@
 			<span aria-hidden="true" class="calloutDisclosure-summary-chevron lucca-icon icon-arrowChevronBottom"></span>
 		</summary>
 		<div class="calloutDisclosure-details">
-			<div class="calloutFeedbackList palette-grey">
+			<div class="calloutFeedbackList palette-neutral">
 				<div class="calloutFeedbackList-item">
 					<span class="calloutFeedbackList-item-description">Feedback description.</span>
 					<div class="calloutFeedbackList-item-actions">
@@ -620,24 +613,48 @@
 
 <section class="contentSection">
 	<h1>Popover</h1>
-	<button type="button" class="calloutPopover"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signInfo"></span>1</button>
-	<button type="button" class="calloutPopover palette-success"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signSuccess"></span>1</button>
-	<button type="button" class="calloutPopover palette-warning"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signWarning"></span>1</button>
-	<button type="button" class="calloutPopover palette-error"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signError"></span>1</button>
+	<button type="button" class="calloutPopover">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signInfo"></span>1
+	</button>
+	<button type="button" class="calloutPopover palette-success">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signSuccess"></span>1
+	</button>
+	<button type="button" class="calloutPopover palette-warning">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signWarning"></span>1
+	</button>
+	<button type="button" class="calloutPopover palette-error">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signError"></span>1
+	</button>
 </section>
 <section class="contentSection">
 	<h2>S</h2>
-	<button type="button" class="calloutPopover mod-S"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signInfo"></span>1</button>
-	<button type="button" class="calloutPopover mod-S palette-success"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signSuccess"></span>1</button>
-	<button type="button" class="calloutPopover mod-S palette-warning"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signWarning"></span>1</button>
-	<button type="button" class="calloutPopover mod-S palette-error"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signError"></span>1</button>
+	<button type="button" class="calloutPopover mod-S">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signInfo"></span>1
+	</button>
+	<button type="button" class="calloutPopover mod-S palette-success">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signSuccess"></span>1
+	</button>
+	<button type="button" class="calloutPopover mod-S palette-warning">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signWarning"></span>1
+	</button>
+	<button type="button" class="calloutPopover mod-S palette-error">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signError"></span>1
+	</button>
 </section>
 <section class="contentSection">
 	<h2>XS</h2>
-	<button type="button" class="calloutPopover mod-XS"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signInfo"></span>1</button>
-	<button type="button" class="calloutPopover mod-XS palette-success"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signSuccess"></span>1</button>
-	<button type="button" class="calloutPopover mod-XS palette-warning"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signWarning"></span>1</button>
-	<button type="button" class="calloutPopover mod-XS palette-error"><span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signError"></span>1</button>
+	<button type="button" class="calloutPopover mod-XS">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signInfo"></span>1
+	</button>
+	<button type="button" class="calloutPopover mod-XS palette-success">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signSuccess"></span>1
+	</button>
+	<button type="button" class="calloutPopover mod-XS palette-warning">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signWarning"></span>1
+	</button>
+	<button type="button" class="calloutPopover mod-XS palette-error">
+		<span aria-hidden="true" class="calloutPopover-icon lucca-icon icon-signError"></span>1
+	</button>
 </section>
 
 <section class="contentSection">

--- a/stories/qa/card/card.stories.html
+++ b/stories/qa/card/card.stories.html
@@ -28,10 +28,10 @@
 	</div>
 </section>
 
-<!-- Grey -->
+<!-- Neutral -->
 <section class="contentSection">
-	<h2>Grey</h2>
-	<div class="card mod-grey">
+	<h2>Neutral</h2>
+	<div class="card mod-neutral">
 		<div class="card-content">
 			<h2 class="card-title">Title</h2>
 			<p>I'm a card of content</p>

--- a/stories/qa/card/card.stories.html
+++ b/stories/qa/card/card.stories.html
@@ -49,7 +49,7 @@
 		</div>
 		<footer class="card-footer">
 			<div class="card-footer-right">
-				<button type="button" class="button palette-primary">Confirm</button>
+				<button type="button" class="button palette-product">Confirm</button>
 				<button type="button" class="button mod-text">Cancel</button>
 			</div>
 		</footer>

--- a/stories/qa/chip/chip.stories.html
+++ b/stories/qa/chip/chip.stories.html
@@ -25,8 +25,8 @@
 
 <!-- Palette -->
 <section class="contentSection">
-	<h2>Basics</h2>
-	<div class="chip">
+	<h2>Palette</h2>
+	<div class="chip palette-product">
 		John Doe
 		<button type="button" class="chip-kill">
 			<span class="u-mask">delete</span>

--- a/stories/qa/chip/chip.stories.html
+++ b/stories/qa/chip/chip.stories.html
@@ -26,19 +26,19 @@
 <!-- Palette -->
 <section class="contentSection">
 	<h2>Basics</h2>
-	<div class="chip palette-primary">
+	<div class="chip">
 		John Doe
 		<button type="button" class="chip-kill">
 			<span class="u-mask">delete</span>
 		</button>
 	</div>
-	<div class="chip palette-primary">
+	<div class="chip palette-product">
 		John Doe
 		<button type="button" class="chip-kill">
 			<span class="u-mask">delete</span>
 		</button>
 	</div>
-	<div class="chip palette-primary">
+	<div class="chip palette-product">
 		John Doe
 		<button type="button" class="chip-kill">
 			<span class="u-mask">delete</span>
@@ -67,13 +67,13 @@
 			</button>
 		</div>
 		<div class="chip is-disabled">John Doe</div>
-		<div class="chip is-disabled palette-primary">
+		<div class="chip is-disabled palette-product">
 			John Doe
 			<button type="button" class="chip-kill">
 				<span class="u-mask">delete</span>
 			</button>
 		</div>
-		<div class="chip is-disabled palette-primary">John Doe</div>
+		<div class="chip is-disabled palette-product">John Doe</div>
 	</div>
 </section>
 

--- a/stories/qa/colors/colors.stories.html
+++ b/stories/qa/colors/colors.stories.html
@@ -48,16 +48,16 @@
 	</div>
 	<h2 class="u-margin0">Neutral</h2>
 	<div class="demo">
-		<div class="demo-color" style="background-color: var(--palettes-grey-50)">50</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-100)">100</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-200)">200</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-300)">300</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-600); color: white">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-700); color: white">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-800); color: white">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-900); color: white">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-50)">50</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-100)">100</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-200)">200</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-300)">300</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-400)">400</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-500)">500</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-neutral-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Success</h2>
 	<div class="demo">

--- a/stories/qa/colors/colors.stories.html
+++ b/stories/qa/colors/colors.stories.html
@@ -27,7 +27,7 @@
 		<div class="demo-color" style="background-color: var(--palettes-lucca-800); color: white">800</div>
 		<div class="demo-color" style="background-color: var(--palettes-lucca-900); color: white">900</div>
 	</div>
-	<h2 class="u-margin0">Primary</h2>
+	<h2 class="u-margin0">Product</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-product-50)">50</div>
 		<div class="demo-color" style="background-color: var(--palettes-product-100)">100</div>

--- a/stories/qa/colors/colors.stories.html
+++ b/stories/qa/colors/colors.stories.html
@@ -16,16 +16,16 @@
 <section class="contentSection">
 	<h2 class="u-margin0">Lucca</h2>
 	<div class="demo">
-		<div class="demo-color" style="background-color: var(--palettes-lucca-50)">50</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-100)">100</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-200)">200</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-300)">300</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-600); color: white">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-700); color: white">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-800); color: white">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-900); color: white">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-50)">50</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-100)">100</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-200)">200</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-300)">300</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-400)">400</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-500)">500</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-brand-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Product</h2>
 	<div class="demo">

--- a/stories/qa/colors/colors.stories.html
+++ b/stories/qa/colors/colors.stories.html
@@ -22,29 +22,29 @@
 		<div class="demo-color" style="background-color: var(--palettes-lucca-300)">300</div>
 		<div class="demo-color" style="background-color: var(--palettes-lucca-400)">400</div>
 		<div class="demo-color" style="background-color: var(--palettes-lucca-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-lucca-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-lucca-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-lucca-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-lucca-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-lucca-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Primary</h2>
 	<div class="demo">
-		<div class="demo-color" style="background-color: var(--palettes-primary-50)">50</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-100)">100</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-200)">200</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-300)">300</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-primary-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-50)">50</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-100)">100</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-200)">200</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-300)">300</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-400)">400</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-500)">500</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-product-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Navigation</h2>
 	<div class="demo">
-		<div class="demo-color" style="background-color: var(--palettes-navigation-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-navigation-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-navigation-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-navigation-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-navigation-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-navigation-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Neutral</h2>
 	<div class="demo">
@@ -54,10 +54,10 @@
 		<div class="demo-color" style="background-color: var(--palettes-grey-300)">300</div>
 		<div class="demo-color" style="background-color: var(--palettes-grey-400)">400</div>
 		<div class="demo-color" style="background-color: var(--palettes-grey-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-grey-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-grey-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-grey-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-grey-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-grey-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Success</h2>
 	<div class="demo">
@@ -67,10 +67,10 @@
 		<div class="demo-color" style="background-color: var(--palettes-success-300)">300</div>
 		<div class="demo-color" style="background-color: var(--palettes-success-400)">400</div>
 		<div class="demo-color" style="background-color: var(--palettes-success-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-success-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-success-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-success-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-success-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-success-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-success-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-success-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-success-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Warning</h2>
 	<div class="demo">
@@ -80,10 +80,10 @@
 		<div class="demo-color" style="background-color: var(--palettes-warning-300)">300</div>
 		<div class="demo-color" style="background-color: var(--palettes-warning-400)">400</div>
 		<div class="demo-color" style="background-color: var(--palettes-warning-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-warning-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-warning-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-warning-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-warning-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-warning-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-warning-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-warning-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-warning-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Error</h2>
 	<div class="demo">
@@ -93,83 +93,82 @@
 		<div class="demo-color" style="background-color: var(--palettes-error-300)">300</div>
 		<div class="demo-color" style="background-color: var(--palettes-error-400)">400</div>
 		<div class="demo-color" style="background-color: var(--palettes-error-500)">500</div>
-		<div class="demo-color" style="background-color: var(--palettes-error-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-error-700); color: white;">700</div>
-		<div class="demo-color" style="background-color: var(--palettes-error-800); color: white;">800</div>
-		<div class="demo-color" style="background-color: var(--palettes-error-900); color: white;">900</div>
+		<div class="demo-color" style="background-color: var(--palettes-error-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-error-700); color: white">700</div>
+		<div class="demo-color" style="background-color: var(--palettes-error-800); color: white">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-error-900); color: white">900</div>
 	</div>
 	<h2 class="u-margin0">Kiwi</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-kiwi-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-kiwi-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-kiwi-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-kiwi-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-kiwi-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-kiwi-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Lime</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-lime-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-lime-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-lime-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-lime-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-lime-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-lime-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Cucumber</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-cucumber-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-cucumber-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-cucumber-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-cucumber-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-cucumber-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-cucumber-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Glacier</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-glacier-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-glacier-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-glacier-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-glacier-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-glacier-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-glacier-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Lagoon</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-lagoon-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-lagoon-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-lagoon-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-lagoon-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-lagoon-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-lagoon-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Blueberry</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-blueberry-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-blueberry-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-blueberry-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-blueberry-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-blueberry-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-blueberry-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Lavender</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-lavender-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-lavender-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-lavender-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-lavender-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-lavender-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-lavender-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Grape</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-grape-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-grape-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-grape-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-grape-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-grape-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-grape-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Watermelon</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-watermelon-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-watermelon-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-watermelon-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-watermelon-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-watermelon-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-watermelon-800); color: white">800</div>
 	</div>
 	<h2 class="u-margin0">Pumpkin</h2>
 	<div class="demo">
 		<div class="demo-color" style="background-color: var(--palettes-pumpkin-200)">200</div>
 		<div class="demo-color" style="background-color: var(--palettes-pumpkin-400)">400</div>
-		<div class="demo-color" style="background-color: var(--palettes-pumpkin-600); color: white;">600</div>
-		<div class="demo-color" style="background-color: var(--palettes-pumpkin-800); color: white;">800</div>
+		<div class="demo-color" style="background-color: var(--palettes-pumpkin-600); color: white">600</div>
+		<div class="demo-color" style="background-color: var(--palettes-pumpkin-800); color: white">800</div>
 	</div>
 </section>
-
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->
 <span id="ready"></span>

--- a/stories/qa/empty-state-deprecated/empty-state-deprecated.stories.html
+++ b/stories/qa/empty-state-deprecated/empty-state-deprecated.stories.html
@@ -4,7 +4,7 @@
 	<section class="emptyState">
 		<h3 class="emptyState-title">Shhh, this is quiet here</h3>
 		<p class="emptyState-description">You can use this block when you have nothing to display.</p>
-		<button type="button" class="button palette-primary mod-L">Do something?</button>
+		<button type="button" class="button palette-product mod-L">Do something?</button>
 	</section>
 </section>
 

--- a/stories/qa/forms/checkbox-legacy.stories.html
+++ b/stories/qa/forms/checkbox-legacy.stories.html
@@ -92,11 +92,7 @@
 <!-- Palette -->
 <section class="contentSection">
 	<h2>Palette</h2>
-	<label class="checkbox palette-primary">
-		<input class="checkbox-input" type="checkbox" checked />
-		<span class="checkbox-label">Label</span>
-	</label>
-	<label class="checkbox palette-secondary">
+	<label class="checkbox palette-product">
 		<input class="checkbox-input" type="checkbox" checked />
 		<span class="checkbox-label">Label</span>
 	</label>

--- a/stories/qa/forms/radio-legacy.stories.html
+++ b/stories/qa/forms/radio-legacy.stories.html
@@ -142,11 +142,7 @@
 <!-- Palette -->
 <section class="contentSection">
 	<h2>Palette</h2>
-	<label class="radio palette-primary">
-		<input class="radio-input" type="radio" checked />
-		<span class="radio-label">Label</span>
-	</label>
-	<label class="radio palette-secondary">
+	<label class="radio palette-product">
 		<input class="radio-input" type="radio" checked />
 		<span class="radio-label">Label</span>
 	</label>

--- a/stories/qa/gauge/gauge.stories.html
+++ b/stories/qa/gauge/gauge.stories.html
@@ -53,7 +53,7 @@
 		<tbody class="table-body">
 			<tr class="table-body-row">
 				<td class="table-body-row-cell u-nowrap">default-palette</td>
-				<td class="table-body-row-cell">_getMap("palettes.primary")</td>
+				<td class="table-body-row-cell">_getMap("palettes.product")</td>
 				<td class="table-body-row-cell u-textLight"></td>
 			</tr>
 			<tr class="table-body-row">

--- a/stories/qa/icon/icon.stories.html
+++ b/stories/qa/icon/icon.stories.html
@@ -21,8 +21,7 @@
 <!-- Colors -->
 <section class="contentSection">
 	<h2>Icons colors</h2>
-	<span aria-hidden="true" class="lucca-icon icon-heart u-textPrimary"></span>
-	<span aria-hidden="true" class="lucca-icon icon-heart u-textSecondary"></span>
+	<span aria-hidden="true" class="lucca-icon icon-heart u-textProduct"></span>
 	<span aria-hidden="true" class="lucca-icon icon-heart u-textError"></span>
 	<span aria-hidden="true" class="lucca-icon icon-heart u-textWarning"></span>
 	<span aria-hidden="true" class="lucca-icon icon-heart u-textSuccess"></span>
@@ -92,10 +91,7 @@
 <!-- Palette -->
 <section class="contentSection">
 	<h2>Palette</h2>
-	<button type="button" class="button mod-onlyIcon mod-text palette-primary">
-		<span aria-hidden="true" class="lucca-icon icon-arrowRight"></span><span class="u-mask">Next</span>
-	</button>
-	<button type="button" class="button mod-onlyIcon mod-text palette-secondary">
+	<button type="button" class="button mod-onlyIcon mod-text">
 		<span aria-hidden="true" class="lucca-icon icon-arrowRight"></span><span class="u-mask">Next</span>
 	</button>
 	<button type="button" class="button mod-onlyIcon mod-text palette-success">

--- a/stories/qa/label/label.stories.html
+++ b/stories/qa/label/label.stories.html
@@ -3,12 +3,11 @@
 <!-- Basics -->
 <section class="contentSection">
 	<h2>Basics</h2>
-	<span class="label">Primary</span>
-	<span class="label palette-secondary">Secondary</span>
+	<span class="label">Product</span>
 	<span class="label palette-success">Success</span>
 	<span class="label palette-warning">Warning</span>
 	<span class="label palette-error">Error</span>
-	<span class="label palette-grey">Grey</span>
+	<span class="label palette-neutral">Neutral</span>
 </section>
 
 <!-- Mod icon -->
@@ -18,10 +17,6 @@
 		<span class="lucca-icon icon-signInfo label-icon" aria-hidden="true"></span>
 		Label
 	</span>
-	<span class="label palette-secondary">
-		<span class="lucca-icon icon-signInfo label-icon" aria-hidden="true"></span>
-		Label
-	</span>
 	<span class="label palette-success">
 		<span class="lucca-icon icon-signSuccess label-icon" aria-hidden="true"></span>
 		Label
@@ -34,7 +29,7 @@
 		<span class="lucca-icon icon-signError label-icon" aria-hidden="true"></span>
 		Label
 	</span>
-	<span class="label palette-grey">
+	<span class="label palette-neutral">
 		<span class="lucca-icon icon-signInfo label-icon" aria-hidden="true"></span>
 		Label
 	</span>
@@ -43,10 +38,6 @@
 		Label
 		<span class="lucca-icon icon-signInfo label-icon" aria-hidden="true"></span>
 	</span>
-	<span class="label palette-secondary">
-		Label
-		<span class="lucca-icon icon-signInfo label-icon" aria-hidden="true"></span>
-	</span>
 	<span class="label palette-success">
 		Label
 		<span class="lucca-icon icon-signSuccess label-icon" aria-hidden="true"></span>
@@ -59,7 +50,7 @@
 		Label
 		<span class="lucca-icon icon-signError label-icon" aria-hidden="true"></span>
 	</span>
-	<span class="label palette-grey">
+	<span class="label palette-neutral">
 		Label
 		<span class="lucca-icon icon-signInfo label-icon" aria-hidden="true"></span>
 	</span>
@@ -69,11 +60,11 @@
 <section class="contentSection">
 	<h2>Number</h2>
 	<span class="label mod-number">1</span>
-	<span class="label mod-number palette-secondary">2</span>
+	<span class="label mod-number palette-product">2</span>
 	<span class="label mod-number palette-success">3</span>
 	<span class="label mod-number palette-warning">4</span>
 	<span class="label mod-number palette-error">5</span>
-	<span class="label mod-number palette-grey">6</span>
+	<span class="label mod-number palette-neutral">6</span>
 	<span class="label mod-number">99</span>
 </section>
 
@@ -81,11 +72,11 @@
 <section class="contentSection">
 	<h2>Number + mod-S</h2>
 	<span class="label mod-number mod-S">1</span>
-	<span class="label mod-number mod-S palette-secondary">2</span>
+	<span class="label mod-number mod-S palette-product">2</span>
 	<span class="label mod-number mod-S palette-success">3</span>
 	<span class="label mod-number mod-S palette-warning">4</span>
 	<span class="label mod-number mod-S palette-error">5</span>
-	<span class="label mod-number mod-S palette-grey">6</span>
+	<span class="label mod-number mod-S palette-neutral">6</span>
 	<span class="label mod-number mod-S">99</span>
 </section>
 
@@ -93,11 +84,11 @@
 <section class="contentSection">
 	<h2>Number + mod-XS</h2>
 	<span class="label mod-number mod-XS">1</span>
-	<span class="label mod-number mod-XS palette-secondary">2</span>
+	<span class="label mod-number mod-XS palette-product">2</span>
 	<span class="label mod-number mod-XS palette-success">3</span>
 	<span class="label mod-number mod-XS palette-warning">4</span>
 	<span class="label mod-number mod-XS palette-error">5</span>
-	<span class="label mod-number mod-XS palette-grey">6</span>
+	<span class="label mod-number mod-XS palette-neutral">6</span>
 	<span class="label mod-number mod-XS">99</span>
 </section>
 

--- a/stories/qa/main-menu/main-menu.stories.html
+++ b/stories/qa/main-menu/main-menu.stories.html
@@ -15,7 +15,7 @@
 					<nav class="navSide-item-subMenu">
 						<a href="#" class="navSide-item-subMenu-link">Subsection #1.1</a>
 						<a href="#" class="navSide-item-subMenu-link"
-							>Subsection #1.2 with large name <span class="numericBadge palette-primary mod-S"><span class="u-mask">, </span>9</span></a
+							>Subsection #1.2 with large name <span class="numericBadge palette-product mod-S"><span class="u-mask">, </span>9</span></a
 						>
 					</nav>
 				</div>
@@ -30,7 +30,7 @@
 						<a href="#" class="navSide-item-subMenu-link">Section #2.2</a>
 						<a href="#" class="navSide-item-subMenu-link is-active">Section #2.3</a>
 						<a href="#" class="navSide-item-subMenu-link"
-							>Section #2.4 <span class="numericBadge palette-primary mod-S"><span class="u-mask">, </span>9</span></a
+							>Section #2.4 <span class="numericBadge palette-product mod-S"><span class="u-mask">, </span>9</span></a
 						>
 					</nav>
 				</div>
@@ -44,7 +44,7 @@
 					<a href="#" class="navSide-item-link">
 						<span aria-hidden="true" class="lucca-icon icon-settingsEqualizer"></span>
 						<span class="navSide-item-link-title">Section #4</span>
-						<span class="numericBadge palette-primary mod-S"><span class="u-mask">, </span>9</span>
+						<span class="numericBadge palette-product mod-S"><span class="u-mask">, </span>9</span>
 						<span aria-hidden="true" class="navSide-item-arrow lucca-icon icon-arrowChevronRight"></span>
 					</a>
 					<nav class="navSide-item-subMenu">

--- a/stories/qa/mobile-header/mobile-header.stories.html
+++ b/stories/qa/mobile-header/mobile-header.stories.html
@@ -9,11 +9,11 @@
 			<div class="mobileHeader-title-sub">Subtitle</div>
 		</div>
 		<div class="mobileHeader-actions">
-			<button type="button" class="button mod-onlyIcon mod-text palette-primary" luTooltip="Action">
+			<button type="button" class="button mod-onlyIcon mod-text palette-product" luTooltip="Action">
 				<span aria-hidden="true" class="lucca-icon icon-heart"></span>
 				<span class="u-mask">Action</span>
 			</button>
-			<button type="button" class="button mod-onlyIcon mod-text palette-primary" luTooltip="Action">
+			<button type="button" class="button mod-onlyIcon mod-text palette-product" luTooltip="Action">
 				<span aria-hidden="true" class="lucca-icon icon-heart"></span>
 				<span class="u-mask">Action</span>
 			</button>
@@ -30,11 +30,11 @@
 			<div class="mobileHeader-title-sub">Subtitle</div>
 		</div>
 		<div class="mobileHeader-actions">
-			<button type="button" class="button mod-onlyIcon mod-text palette-primary" luTooltip="Action">
+			<button type="button" class="button mod-onlyIcon mod-text palette-product" luTooltip="Action">
 				<span aria-hidden="true" class="lucca-icon icon-heart"></span>
 				<span class="u-mask">Action</span>
 			</button>
-			<button type="button" class="button mod-onlyIcon mod-text palette-primary" luTooltip="Action">
+			<button type="button" class="button mod-onlyIcon mod-text palette-product" luTooltip="Action">
 				<span aria-hidden="true" class="lucca-icon icon-heart"></span>
 				<span class="u-mask">Action</span>
 			</button>

--- a/stories/qa/numeric-badge/numeric-badge.stories.html
+++ b/stories/qa/numeric-badge/numeric-badge.stories.html
@@ -1,10 +1,10 @@
 <section class="contentSection">
-<span class="numericBadge">7</span>
-<span class="numericBadge mod-S">7</span>
-<span class="numericBadge mod-XS">7</span>
-<span class="numericBadge palette-primary">7</span>
-<span class="numericBadge palette-primary mod-S">7</span>
-<span class="numericBadge palette-primary mod-XS">7</span>
+	<span class="numericBadge">7</span>
+	<span class="numericBadge mod-S">7</span>
+	<span class="numericBadge mod-XS">7</span>
+	<span class="numericBadge palette-product">7</span>
+	<span class="numericBadge palette-product mod-S">7</span>
+	<span class="numericBadge palette-product mod-XS">7</span>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/status-badge/status-badge.stories.html
+++ b/stories/qa/status-badge/status-badge.stories.html
@@ -2,7 +2,7 @@
 
 <section class="contentSection">
 	<div class="statusBadge">Status</div>
-	<div class="statusBadge palette-grey">Status</div>
+	<div class="statusBadge palette-neutral">Status</div>
 	<div class="statusBadge palette-success">Status</div>
 	<div class="statusBadge palette-warning">Status</div>
 	<div class="statusBadge palette-error">Status</div>
@@ -10,7 +10,7 @@
 
 <section class="contentSection">
 	<div class="statusBadge mod-L">Status</div>
-	<div class="statusBadge mod-L palette-grey">Status</div>
+	<div class="statusBadge mod-L palette-neutral">Status</div>
 	<div class="statusBadge mod-L palette-success">Status</div>
 	<div class="statusBadge mod-L palette-warning">Status</div>
 	<div class="statusBadge mod-L palette-error">Status</div>

--- a/stories/qa/tags/tags.stories.html
+++ b/stories/qa/tags/tags.stories.html
@@ -3,28 +3,101 @@
 <!-- Basics -->
 <section class="contentSection">
 	<h2>Tags</h2>
-	<span class="tag">Text</span>
-	<span class="tag">Text</span>
-	<span class="tag">Text</span>
+	<div class="u-displayFlex u-flexWrapWrap u-gapXS">
+		<span class="tag palette-product">Text</span>
+		<span class="tag palette-neutral">Text</span>
+		<span class="tag palette-success">Text</span>
+		<span class="tag palette-warning">Text</span>
+		<span class="tag palette-error">Text</span>
+		<span class="tag palette-kiwi">Text</span>
+		<span class="tag palette-lime">Text</span>
+		<span class="tag palette-cucumber">Text</span>
+		<span class="tag palette-mint">Text</span>
+		<span class="tag palette-glacier">Text</span>
+		<span class="tag palette-lagoon">Text</span>
+		<span class="tag palette-blueberry">Text</span>
+		<span class="tag palette-lavender">Text</span>
+		<span class="tag palette-grape">Text</span>
+		<span class="tag palette-watermelon">Text</span>
+		<span class="tag palette-pumpkin">Text</span>
+		<span class="tag palette-pineapple">Text</span>
+	</div>
 </section>
 
-<!-- Basics -->
-<section class="contentSection">
-	<h2>Clickable</h2>
-	<span class="tag mod-clickable">Text</span>
-</section>
-
-<!-- Outlines -->
+<!-- Outlined -->
 <section class="contentSection">
 	<h2>Outlined</h2>
-	<span class="tag mod-outlined">Text</span>
+	<div class="u-displayFlex u-flexWrapWrap u-gapXS">
+		<span class="tag mod-outlined palette-product">Text</span>
+		<span class="tag mod-outlined palette-neutral">Text</span>
+		<span class="tag mod-outlined palette-success">Text</span>
+		<span class="tag mod-outlined palette-warning">Text</span>
+		<span class="tag mod-outlined palette-error">Text</span>
+		<span class="tag mod-outlined palette-kiwi">Text</span>
+		<span class="tag mod-outlined palette-lime">Text</span>
+		<span class="tag mod-outlined palette-cucumber">Text</span>
+		<span class="tag mod-outlined palette-mint">Text</span>
+		<span class="tag mod-outlined palette-glacier">Text</span>
+		<span class="tag mod-outlined palette-lagoon">Text</span>
+		<span class="tag mod-outlined palette-blueberry">Text</span>
+		<span class="tag mod-outlined palette-lavender">Text</span>
+		<span class="tag mod-outlined palette-grape">Text</span>
+		<span class="tag mod-outlined palette-watermelon">Text</span>
+		<span class="tag mod-outlined palette-pumpkin">Text</span>
+		<span class="tag mod-outlined palette-pineapple">Text</span>
+	</div>
 </section>
 
-<!-- Large -->
+<!-- Clickable -->
 <section class="contentSection">
-	<h2>Large</h2>
-	<span class="tag mod-L">Text</span>
-	<span class="tag mod-L mod-outlined">Text</span>
+	<h2>Clickable</h2>
+	<div class="u-displayFlex u-flexWrapWrap u-gapXS u-marginBottomXS">
+		<a href="#" class="tag mod-clickable palette-product">Text</a>
+		<a href="#" class="tag mod-clickable palette-neutral">Text</a>
+		<a href="#" class="tag mod-clickable palette-success">Text</a>
+		<a href="#" class="tag mod-clickable palette-warning">Text</a>
+		<a href="#" class="tag mod-clickable palette-error">Text</a>
+		<a href="#" class="tag mod-clickable palette-kiwi">Text</a>
+		<a href="#" class="tag mod-clickable palette-lime">Text</a>
+		<a href="#" class="tag mod-clickable palette-cucumber">Text</a>
+		<a href="#" class="tag mod-clickable palette-mint">Text</a>
+		<a href="#" class="tag mod-clickable palette-glacier">Text</a>
+		<a href="#" class="tag mod-clickable palette-lagoon">Text</a>
+		<a href="#" class="tag mod-clickable palette-blueberry">Text</a>
+		<a href="#" class="tag mod-clickable palette-lavender">Text</a>
+		<a href="#" class="tag mod-clickable palette-grape">Text</a>
+		<a href="#" class="tag mod-clickable palette-watermelon">Text</a>
+		<a href="#" class="tag mod-clickable palette-pumpkin">Text</a>
+		<a href="#" class="tag mod-clickable palette-pineapple">Text</a>
+	</div>
+	<div class="u-displayFlex u-flexWrapWrap u-gapXS">
+		<button type="button" class="tag mod-outlined mod-clickable palette-product">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-neutral">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-success">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-warning">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-error">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-kiwi">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-lime">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-cucumber">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-mint">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-glacier">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-lagoon">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-blueberry">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-lavender">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-grape">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-watermelon">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-pumpkin">Text</button>
+		<button type="button" class="tag mod-outlined mod-clickable palette-pineapple">Text</button>
+	</div>
+</section>
+
+<!-- Medium -->
+<section class="contentSection">
+	<h2>Medium</h2>
+	<div class="u-displayFlex u-flexWrapWrap u-gapXS">
+		<span class="tag mod-M">Text</span>
+		<span class="tag mod-M mod-outlined">Text</span>
+	</div>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/tags/tags.stories.html
+++ b/stories/qa/tags/tags.stories.html
@@ -95,8 +95,8 @@
 <section class="contentSection">
 	<h2>Medium</h2>
 	<div class="u-displayFlex u-flexWrapWrap u-gapXS">
-		<span class="tag mod-M">Text</span>
-		<span class="tag mod-M mod-outlined">Text</span>
+		<span class="tag mod-L">Text</span>
+		<span class="tag mod-L mod-outlined">Text</span>
 	</div>
 </section>
 

--- a/stories/qa/timelines/timelines.stories.html
+++ b/stories/qa/timelines/timelines.stories.html
@@ -425,7 +425,7 @@
 		</li>
 		<li class="timeline-step">
 			<div class="timeline-step-title">
-				<button type="button" class="button palette-grey mod-S u-positionStatic">
+				<button type="button" class="button palette-neutral mod-S u-positionStatic">
 					<span class="timeline-step-title-icon" aria-hidden="true"></span>
 					Add step
 				</button>
@@ -446,7 +446,7 @@
 		</li>
 		<li class="timeline-step">
 			<div class="timeline-step-title">
-				<button type="button" class="button palette-grey mod-S u-positionStatic">
+				<button type="button" class="button palette-neutral mod-S u-positionStatic">
 					<span class="timeline-step-title-icon" aria-hidden="true"></span>
 					Add step
 				</button>


### PR DESCRIPTION
## Description

- [x] Include product palettes in LF and avoid overloading.
- [x] Ability to add additional palettes to your product palettes.
- [x] Replace grey with neutral.
- [x] Replace primary and secondary with product.
- [x] Applies decorative palettes to tag component.

-----

```scss
@use 'config' with (
  $product: 'cleemy',
  $palettesDecorative: ('watermelon'),
  $palettesOtherProduct: ('pagga', 'timmi'),
  $palettesDeprecated: ('primary'),
);
```

[An example of use here.](https://codepen.io/vincent-valentin/project/editor/DQmzRB)

Many files are modified, but most of the work is done in the [config.scss](https://github.com/LuccaSA/lucca-front/pull/2561/files#diff-ec89534739d2dcee303553d2bafe79cd78a1bc7d9e8a08d2c2ab86e16c7279e2) file.

Note: in the future, it will be necessary to separate the product part from the framework.

fix #2569 

-----

![Capture d’écran 2024-02-16 à 11 37 30](https://github.com/LuccaSA/lucca-front/assets/64789527/13eb46c5-b2f3-43cb-a916-c7295c48c09e)
![Capture d’écran 2024-02-16 à 11 37 46](https://github.com/LuccaSA/lucca-front/assets/64789527/f55ba767-f09d-4c9d-abf4-22731a620285)


