### PR TITLE
Tabindex focus-visible

### DIFF
--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -94,6 +94,10 @@
 			font-weight: 600;
 		}
 
+		*:where([tabindex='0']:focus-visible) {
+			@include a11y.focusVisible($borderRadius: var(--commons-borderRadius-M));
+		}
+
 		@each $palette in list.join(config.$palettes, config.$states) {
 			$paletteExists: map.get(config.$palettesInterpolation, $palette);
 


### PR DESCRIPTION
## Description

A default style for focusable elements via a tabindex. (This is particularly useful for tooltips.)

-----

The `:where` keeps specificity of the selector at 0.

-----
