### PR TITLE
chore(form-field): stories improvement and change detection fixes

### DIFF
--- a/packages/ng/form-field/form-field.component.scss
+++ b/packages/ng/form-field/form-field.component.scss
@@ -1,1 +1,2 @@
 @use '@lucca-front/scss/src/components/textField';
+@use '@lucca-front/scss/src/components/formLabel';

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -88,7 +88,12 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 
 	public set input(input: InputDirective) {
 		this._input = input;
-		this.prepareInput();
+		/* We have to put this in the next cycle to make sure it'll be applied properly
+		 * and that it won't trigger a change detection error
+		 */
+		setTimeout(() => {
+			this.prepareInput();
+		});
 	}
 
 	public get input(): InputDirective {

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
@@ -10,6 +10,7 @@ import { injectNgControl } from '../inject-ng-control';
 	imports: [ReactiveFormsModule, InputDirective],
 	hostDirectives: [NoopValueAccessorDirective],
 	templateUrl: './checkbox-input.component.html',
+	encapsulation: ViewEncapsulation.None,
 	host: {
 		class: 'checkboxField',
 	},

--- a/packages/ng/forms/switch-input/switch-input.component.ts
+++ b/packages/ng/forms/switch-input/switch-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
 import { ReactiveFormsModule } from '@angular/forms';
@@ -10,6 +10,7 @@ import { injectNgControl } from '../inject-ng-control';
 	imports: [FormFieldComponent, ReactiveFormsModule, InputDirective],
 	templateUrl: './switch-input.component.html',
 	hostDirectives: [NoopValueAccessorDirective],
+	encapsulation: ViewEncapsulation.None,
 	host: {
 		class: 'switchField',
 	},

--- a/packages/ng/forms/text-input/text-input.component.scss
+++ b/packages/ng/forms/text-input/text-input.component.scss
@@ -1,0 +1,1 @@
+@use '@lucca-front/scss/src/components/clear';

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Component, ElementRef, Input, ViewChild } from '@angular/core';
+import { booleanAttribute, Component, ElementRef, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
@@ -18,6 +18,7 @@ type TextFieldType = 'text' | 'email' | 'password' | 'number';
 	imports: [FormFieldComponent, InputDirective, NgIf, ReactiveFormsModule, FormFieldIdDirective, NgTemplateOutlet],
 	templateUrl: './text-input.component.html',
 	hostDirectives: [NoopValueAccessorDirective],
+	encapsulation: ViewEncapsulation.None,
 })
 export class TextInputComponent {
 	ngControl = injectNgControl();

--- a/stories/documentation/forms/fields/form-field.stories.ts
+++ b/stories/documentation/forms/fields/form-field.stories.ts
@@ -19,7 +19,6 @@ export default {
 			<div class="textField-input">
 				<textarea
 					type="text"
-					id="description"
 					luInput
 					class="textField-input-value"
 					${required ? 'required' : ''}

--- a/stories/documentation/forms/fields/form-field.stories.ts
+++ b/stories/documentation/forms/fields/form-field.stories.ts
@@ -1,27 +1,33 @@
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule } from '@angular/forms';
 
 export default {
 	title: 'Documentation/Forms/Fields/Form Field',
 	component: FormFieldComponent,
 	decorators: [
 		moduleMetadata({
-			imports: [FormFieldComponent, InputDirective, BrowserAnimationsModule],
+			imports: [FormFieldComponent, InputDirective, BrowserAnimationsModule, FormsModule],
 		}),
 	],
-	render: ({ label, required, inlineMessage, hiddenLabel, size, invalid, inlineMessageState, tooltip }) => {
+	render: ({ label, required, inlineMessage, hiddenLabel, size, inlineMessageState, tooltip }) => {
 		return {
-			template: `<lu-form-field label="${label}" ${required ? 'required' : ''} ${invalid ? 'invalid' : ''}  ${
-				hiddenLabel ? 'hiddenLabel' : ''
-			} inlineMessage="${inlineMessage}" inlineMessageState="${inlineMessageState}" size="${size}" tooltip="${tooltip}">
-		<input luInput type="text" placeholder="Placeholder"/>
-</lu-form-field>
-
-<lu-form-field label="${label}" ${required ? 'required' : ''} ${
-				hiddenLabel ? 'hiddenLabel' : ''
-			} inlineMessage="${inlineMessage}" inlineMessageState="${inlineMessageState}" layout="checkbox" tooltip="${tooltip}">
-		<input type="checkbox" class="checkboxField-input" luInput/>
+			template: `
+<lu-form-field label="${label}" ${hiddenLabel ? 'hiddenLabel' : ''} inlineMessage="${inlineMessage}" inlineMessageState="${inlineMessageState}" tooltip="${tooltip}">
+	<div class="textField">
+			<div class="textField-input">
+				<textarea
+					type="text"
+					id="description"
+					luInput
+					class="textField-input-value"
+					${required ? 'required' : ''}
+					[(ngModel)]="example"
+					placeholder="Placeholder">
+				</textarea>
+			</div>
+	</div>
 </lu-form-field>`,
 		};
 	},
@@ -32,7 +38,6 @@ export const Template: StoryObj<FormFieldComponent> = {
 		label: 'Label',
 		required: true,
 		hiddenLabel: false,
-		invalid: false,
 		inlineMessage: 'Helper Text',
 		size: 'M',
 		inlineMessageState: 'default',


### PR DESCRIPTION
## Description

Modified the `lu-form-field` stories to show an example of a custom component inside `lu-form-field` instead of the non-functionnal demos we previously had.

This PR also bring a fix to the `Expression has changed after it was checked` error showing when the `input` was created during a detection cycle, which means anytime but at page init.

-----
-----
