### PR TITLE
text-wrap: balance -> pretty

### DIFF
--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -4,7 +4,7 @@
 	color: var(--palettes-neutral-900);
 	margin-bottom: var(--spacings-S);
 	text-rendering: geometricPrecision;
-	text-wrap: balance;
+	text-wrap: pretty;
 
 	// suffix here
 	font-weight: var(--components-title-weight, 600) #{$suffix};


### PR DESCRIPTION
## Description

Sometimes the balanced formatting on titles looks strange, so we prefer a prettier management of line breaks.

-----



-----
