### PR TITLE
Remove rgba colors – Add transparentize function

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -19,11 +19,11 @@
 		}
 
 		.sb-main-fullscreen .sb-anchor:not(:last-child) {
-		    margin-bottom: 40px;
+			margin-bottom: 40px;
 		}
 
 		.sb-main-fullscreen .sbdocs-title + .sb-anchor {
-		    margin-bottom: 0 !important;
+			margin-bottom: 0 !important;
 		}
 
 		.sb-main-fullscreen .sbdocs.sbdocs-wrapper {
@@ -52,7 +52,7 @@
 		.sb-main-fullscreen .css-s7utv5 {
 			font-size: 13px;
 			font-weight: 800;
-			color: #2E3438;
+			color: #2e3438;
 			letter-spacing: normal;
 		}
 
@@ -62,7 +62,7 @@
 
 		.sb-main-fullscreen .docblock-argstable-body {
 			border-radius: 4px !important;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1) !important;
+			box-shadow: inset 0 0 0 1px rgb(0 0 0 / 0.1) !important;
 		}
 
 		.sb-main-fullscreen .docblock-argstable-head tr {
@@ -132,10 +132,10 @@
 </template>
 
 <script>
-	const isInsideStorybook = window.frameElement?.getAttribute('data-is-storybook') === 'true';
+	const isInsideStorybook = window.frameElement?.getAttribute("data-is-storybook") === "true";
 
 	if (!isInsideStorybook) {
-		const template = document.getElementById('outsideStorybookStyle');
+		const template = document.getElementById("outsideStorybookStyle");
 		document.head.appendChild(template.content.cloneNode(true));
 	}
 </script>

--- a/packages/ng/styles/components/cdk/_overlay.scss
+++ b/packages/ng/styles/components/cdk/_overlay.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/components/keyframe/exports' as keyframe;
+@use '@lucca-front/scss/src/commons/utils/color';
 
 :root {
 	--components-cdk-backdrop-opacity: 0.4;
@@ -46,7 +47,7 @@
 	}
 
 	&.cdk-overlay-dark-backdrop {
-		background-color: rgba(var(--colors-neutral-900-rgb), 0.6);
+		background-color: color.transparentize(var(--palettes-neutral-900), 0.4);
 	}
 	&.cdk-overlay-transparent-backdrop {
 		background: 0 0;

--- a/packages/ng/styles/components/cdk/_overlay.scss
+++ b/packages/ng/styles/components/cdk/_overlay.scss
@@ -47,7 +47,7 @@
 	}
 
 	&.cdk-overlay-dark-backdrop {
-		background-color: color.transparentize(var(--palettes-neutral-900), 0.4);
+		background-color: color.transparentize(var(--palettes-neutral-900), 0.6);
 	}
 	&.cdk-overlay-transparent-backdrop {
 		background: 0 0;

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,4 +1,5 @@
 @use 'sass:list';
+@use '@lucca-front/scss/src/commons/utils/color';
 
 $product: 'brand' !default;
 $palettesShades: text, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900;
@@ -317,13 +318,14 @@ $colors: (
 	'black': #121212,
 );
 
-// grey-900 is deprecated
+// $colorsRgb are deprecated
 $colorsRgb: (
 	'white': '255, 255, 255',
 	'grey-400': '172, 187, 215',
+	'neutral-400': '172, 187, 215',
 	'grey-900': '19, 29, 53',
 	'neutral-900': '19, 29, 53',
-);
+) !default;
 
 // switch case
 $prod: map-get(
@@ -436,49 +438,55 @@ $borderRadius: (
 	'full': 9999px,
 ) !default;
 
+// $elevations are deprecated
 $elevations: (
-	// deprecated
-	'1': '0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.06), 0px 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04)',
+	'1':
+		'0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0px 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}',
 	'2':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.02), 0 2px 6px rgba(var(--colors-neutral-900-rgb), 0.05)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 2px 6px #{color.transparentize(var(--palettes-neutral-900), 0.95)}',
 	'3':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 2px 4px rgba(var(--colors-neutral-900-rgb), 0.02), 0 4px 10px rgba(var(--colors-neutral-900-rgb), 0.06)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 4px 10px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
 	'4':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 3px 6px rgba(var(--colors-neutral-900-rgb), 0.04), 0 4px 16px rgba(var(--colors-neutral-900-rgb), 0.08)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 3px 6px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, 0 4px 16px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
 	'5':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 4px 8px rgba(var(--colors-neutral-900-rgb), 0.06), 0 12px 32px rgba(var(--colors-neutral-900-rgb), 0.08)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0 12px 32px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
 	'6':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), -2px 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04), -12px 6px 24px rgba(var(--colors-neutral-900-rgb), 0.06)'
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, -2px 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, -12px 6px 24px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
 );
 
+// $boxShadows are deprecated
 $boxShadows: (
-	// deprecated
-	'XXS': '0 2px 8px rgba(var(--colors-neutral-900-rgb), .2), 0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.15)',
-	'XS': '0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.06), 0 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04)',
+	'XXS':
+		'0 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.85)}',
+	'XS':
+		'0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}',
 	'S':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 1px 2px rgba(var(--colors-neutral-900-rgb), 0.02), 0 2px 6px rgba(var(--colors-neutral-900-rgb), 0.06)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 2px 6px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
 	'M':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 2px 4px rgba(var(--colors-neutral-900-rgb), 0.02), 0 4px 10px rgba(var(--colors-neutral-900-rgb), 0.06)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 4px 10px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
 	'L':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 3px 6px rgba(var(--colors-neutral-900-rgb), 0.04), 0 4px 16px rgba(var(--colors-neutral-900-rgb), 0.08)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 3px 6px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, 0 4px 16px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
 	'XL':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), 0 4px 8px rgba(var(--colors-neutral-900-rgb), 0.06), 0 12px 32px rgba(var(--colors-neutral-900-rgb), 0.08)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0 12px 32px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
 	'XXL':
-		'0 0 0 1px rgba(var(--colors-neutral-900-rgb), 0.03), -2px 2px 8px rgba(var(--colors-neutral-900-rgb), 0.04), -12px 6px 24px rgba(var(--colors-neutral-900-rgb), 0.06)',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, -2px 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, -12px 6px 24px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
 );
 
 $elevation: (
 	surface: (
-		'sunken': 'var(--palettes-grey-50)',
-		'default': 'var(--palettes-grey-25)',
-		'raised': 'var(--colors-white-color)',
-		'backdrop': 'rgba(var(--colors-grey-400-rgb), 0.4)',
+		'sunken': var(--palettes-neutral-50),
+		'default': var(--palettes-neutral-25),
+		'raised': var(--colors-white-color),
+		'backdrop': color.transparentize(var(--palettes-neutral-400), 0.6),
 	),
 	shadow: (
-		'raised': '0 0 0 1px rgba(var(--colors-grey-400-rgb), 0.08), 0 1px 2px rgba(var(--colors-grey-400-rgb), 0.4), 0 2px 4px rgba(var(--colors-grey-400-rgb), 0.2)',
-		'overflow': '0 0 0 1px rgba(var(--colors-grey-400-rgb), 0.08), 0 0 4px rgba(var(--colors-grey-400-rgb), 0.32), 0 0 8px rgba(var(--colors-grey-400-rgb), 0.24)',
-		'overlay': '0 0 0 1px rgba(var(--colors-grey-400-rgb), 0.08), 0 4px 8px rgba(var(--colors-grey-400-rgb), 0.24), 0 4px 12px 2px rgba(var(--colors-grey-400-rgb), 0.08)',
-	)
+		'raised':
+			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.92)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.6)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-400), 0.8)}',
+		'overflow':
+			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.92)}, 0 0 4px #{color.transparentize(var(--palettes-neutral-300), 0.68)}, 0 0 8px #{color.transparentize(var(--palettes-neutral-400), 0.76)}',
+		'overlay':
+			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.92)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-400), 0.76)}, 0 4px 12px 2px #{color.transparentize(var(--palettes-neutral-400), 0.92)}',
+	),
 );
 
 $disabled: (

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -441,35 +441,35 @@ $borderRadius: (
 // $elevations are deprecated
 $elevations: (
 	'1':
-		'0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0px 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}',
+		'0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.06)}, 0px 2px 8px #{color.transparentize(var(--palettes-neutral-400), 0.04)}',
 	'2':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 2px 6px #{color.transparentize(var(--palettes-neutral-900), 0.95)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.02)}, 0 2px 6px #{color.transparentize(var(--palettes-neutral-400), 0.05)}',
 	'3':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 4px 10px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-400), 0.02)}, 0 4px 10px #{color.transparentize(var(--palettes-neutral-400), 0.06)}',
 	'4':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 3px 6px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, 0 4px 16px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 3px 6px #{color.transparentize(var(--palettes-neutral-400), 0.04)}, 0 4px 16px #{color.transparentize(var(--palettes-neutral-400), 0.08)}',
 	'5':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0 12px 32px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-400), 0.06)}, 0 12px 32px #{color.transparentize(var(--palettes-neutral-400), 0.08)}',
 	'6':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, -2px 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, -12px 6px 24px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, -2px 2px 8px #{color.transparentize(var(--palettes-neutral-400), 0.04)}, -12px 6px 24px #{color.transparentize(var(--palettes-neutral-400), 0.06)}',
 );
 
 // $boxShadows are deprecated
 $boxShadows: (
 	'XXS':
-		'0 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.85)}',
+		'0 2px 8px #{color.transparentize(var(--palettes-neutral-400), 0.2)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.15)}',
 	'XS':
-		'0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}',
+		'0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.06)}, 0 2px 8px #{color.transparentize(var(--palettes-neutral-400), 0.04)}',
 	'S':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 2px 6px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.02)}, 0 2px 6px #{color.transparentize(var(--palettes-neutral-400), 0.06)}',
 	'M':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-900), 0.98)}, 0 4px 10px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-400), 0.02)}, 0 4px 10px #{color.transparentize(var(--palettes-neutral-400), 0.06)}',
 	'L':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 3px 6px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, 0 4px 16px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 3px 6px #{color.transparentize(var(--palettes-neutral-400), 0.04)}, 0 4px 16px #{color.transparentize(var(--palettes-neutral-400), 0.08)}',
 	'XL':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-900), 0.94)}, 0 12px 32px #{color.transparentize(var(--palettes-neutral-900), 0.92)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-400), 0.06)}, 0 12px 32px #{color.transparentize(var(--palettes-neutral-400), 0.08)}',
 	'XXL':
-		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-900), 0.97)}, -2px 2px 8px #{color.transparentize(var(--palettes-neutral-900), 0.96)}, -12px 6px 24px #{color.transparentize(var(--palettes-neutral-900), 0.94)}',
+		'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.03)}, -2px 2px 8px #{color.transparentize(var(--palettes-neutral-400), 0.04)}, -12px 6px 24px #{color.transparentize(var(--palettes-neutral-400), 0.06)}',
 );
 
 $elevation: (
@@ -477,15 +477,15 @@ $elevation: (
 		'sunken': var(--palettes-neutral-50),
 		'default': var(--palettes-neutral-25),
 		'raised': var(--colors-white-color),
-		'backdrop': color.transparentize(var(--palettes-neutral-400), 0.6),
+		'backdrop': color.transparentize(var(--palettes-neutral-400), 0.4),
 	),
 	shadow: (
 		'raised':
-			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.92)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.6)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-400), 0.8)}',
+			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.08)}, 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.4)}, 0 2px 4px #{color.transparentize(var(--palettes-neutral-400), 0.2)}',
 		'overflow':
-			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.92)}, 0 0 4px #{color.transparentize(var(--palettes-neutral-300), 0.68)}, 0 0 8px #{color.transparentize(var(--palettes-neutral-400), 0.76)}',
+			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.08)}, 0 0 4px #{color.transparentize(var(--palettes-neutral-400), 0.32)}, 0 0 8px #{color.transparentize(var(--palettes-neutral-400), 0.24)}',
 		'overlay':
-			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.92)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-400), 0.76)}, 0 4px 12px 2px #{color.transparentize(var(--palettes-neutral-400), 0.92)}',
+			'0 0 0 1px #{color.transparentize(var(--palettes-neutral-400), 0.08)}, 0 4px 8px #{color.transparentize(var(--palettes-neutral-400), 0.24)}, 0 4px 12px 2px #{color.transparentize(var(--palettes-neutral-400), 0.08)}',
 	),
 );
 

--- a/packages/scss/src/commons/utils/color.scss
+++ b/packages/scss/src/commons/utils/color.scss
@@ -1,3 +1,6 @@
-@function transparentize($color, $amount: 0.5, $space: var(--commons-colorSpace, srgb)) {
-	@return color-mix(in $space, $color, transparent $amount * 100%);
+@function transparentize($color, $amount: 50%, $space: var(--commons-colorSpace, srgb)) {
+	@if unit($amount) != '%' {
+		$amount: $amount * 100%;
+	}
+	@return color-mix(in $space, $color $amount, transparent);
 }

--- a/packages/scss/src/commons/utils/color.scss
+++ b/packages/scss/src/commons/utils/color.scss
@@ -1,0 +1,3 @@
+@function transparentize($color, $amount: 0.5, $space: var(--commons-colorSpace, srgb)) {
+	@return color-mix(in $space, $color, transparent $amount * 100%);
+}

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -7,3 +7,4 @@
 @forward 'form' as form-*; // 0 Ko
 @forward 'loading' as loading-*; // 0 Ko
 @forward 'text' as text-*; // 0 Ko
+@forward 'color' as color-*; // 0 Ko

--- a/packages/scss/src/commons/utils/loading.scss
+++ b/packages/scss/src/commons/utils/loading.scss
@@ -1,3 +1,4 @@
+@use '@lucca-front/scss/src/commons/utils/color';
 @use '@lucca-front/scss/src/components/keyframe/exports' as keyframe;
 
 @mixin spinner($size: 1.5rem) {
@@ -24,7 +25,7 @@
 	}
 }
 
-@mixin gradient($backgroundColor: transparent, $color: rgba(var(--colors-neutral-900-rgb), 0.1)) {
+@mixin gradient($backgroundColor: transparent, $color: color.transparentize(var(--colors-neutral-900), 0.9)) {
 	@keyframes loadingGradient {
 		0% {
 			background-position: 100% 0%;

--- a/packages/scss/src/commons/utils/loading.scss
+++ b/packages/scss/src/commons/utils/loading.scss
@@ -25,7 +25,7 @@
 	}
 }
 
-@mixin gradient($backgroundColor: transparent, $color: color.transparentize(var(--colors-neutral-900), 0.9)) {
+@mixin gradient($backgroundColor: transparent, $color: color.transparentize(var(--colors-neutral-900), 0.1)) {
 	@keyframes loadingGradient {
 		0% {
 			background-position: 100% 0%;

--- a/packages/scss/src/components/actionIcon/mods.scss
+++ b/packages/scss/src/components/actionIcon/mods.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/color';
 @use '@lucca-front/icons/src/icon/exports' as icons;
 
 @mixin invert {
@@ -8,11 +9,11 @@
 		&:hover,
 		&:focus {
 			color: var(--colors-white-color);
-			background-color: rgba(255, 255, 255, 0.1);
+			background-color: color.transparentize(var(--colors-white-color), 0.9);
 		}
 
 		&:active {
-			background-color: rgba(255, 255, 255, 0.2);
+			background-color: color.transparentize(var(--colors-white-color), 0.8);
 		}
 	}
 }

--- a/packages/scss/src/components/actionIcon/mods.scss
+++ b/packages/scss/src/components/actionIcon/mods.scss
@@ -9,11 +9,11 @@
 		&:hover,
 		&:focus {
 			color: var(--colors-white-color);
-			background-color: color.transparentize(var(--colors-white-color), 0.9);
+			background-color: color.transparentize(var(--colors-white-color), 0.1);
 		}
 
 		&:active {
-			background-color: color.transparentize(var(--colors-white-color), 0.8);
+			background-color: color.transparentize(var(--colors-white-color), 0.2);
 		}
 	}
 }

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -29,7 +29,7 @@
 				display: block;
 				margin-right: var(--spacings-XS);
 				margin-top: 2px;
-				border: var(--components-checkbox-input-border-width) solid var(--palettes-grey-700);
+				border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-700);
 			}
 
 			&::after {

--- a/packages/scss/src/components/file/states.scss
+++ b/packages/scss/src/components/file/states.scss
@@ -72,7 +72,7 @@
 }
 
 @mixin legacyDroppable {
-	background-color: var(--palettes-grey-25);
+	background-color: var(--palettes-neutral-25);
 
 	.file-icon {
 		color: var(--palettes-product-500);

--- a/packages/scss/src/components/header/component.scss
+++ b/packages/scss/src/components/header/component.scss
@@ -49,7 +49,7 @@
 			text-decoration: none;
 
 			&:hover {
-				background-color: var(--palettes-grey-25);
+				background-color: var(--palettes-neutral-25);
 				color: var(--palettes-neutral-800);
 			}
 

--- a/packages/scss/src/components/loading/mods.scss
+++ b/packages/scss/src/components/loading/mods.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/utils/color';
+
 @mixin L {
 	height: var(--components-loading-size-big);
 	padding: var(--components-loading-size-big) 0 0;
@@ -72,7 +74,7 @@
 	color: var(--colors-white-color);
 
 	&::after {
-		border-color:  rgba(255, 255, 255, 0.66);
+		border-color: color.transparentize(var(--colors-white-color), 0.44);
 		border-top-color: transparent;
 	}
 }

--- a/packages/scss/src/components/loading/mods.scss
+++ b/packages/scss/src/components/loading/mods.scss
@@ -74,7 +74,7 @@
 	color: var(--colors-white-color);
 
 	&::after {
-		border-color: color.transparentize(var(--colors-white-color), 0.44);
+		border-color: color.transparentize(var(--colors-white-color), 0.66);
 		border-top-color: transparent;
 	}
 }

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/loading';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/color';
 @use '@lucca-front/icons/src/icon/exports' as icon;
 
 @mixin component($atRoot: 'without: rule') {
@@ -196,7 +197,7 @@
 			}
 
 			&::before {
-				background-color: rgba(var(--colors-neutral-900-rgb), 0.15);
+				background-color: color.transparentize(var(--palettes-neutral-900), 0.85);
 				border-radius: 1em;
 				height: 1em;
 				width: 1em;

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -197,7 +197,7 @@
 			}
 
 			&::before {
-				background-color: color.transparentize(var(--palettes-neutral-900), 0.85);
+				background-color: color.transparentize(var(--palettes-neutral-900), 0.15);
 				border-radius: 1em;
 				height: 1em;
 				width: 1em;

--- a/packages/scss/src/components/progress/vars.scss
+++ b/packages/scss/src/components/progress/vars.scss
@@ -8,7 +8,7 @@
 	--components-progress-bar-background: var(--palettes-product-700);
 	--components-progress-bar-gradient: linear-gradient(
 		to right,
-		color.transparentize(var(--colors-white-color), 0.2) 0%,
+		color.transparentize(var(--colors-white-color), 0.8) 0%,
 		color.transparentize(var(--colors-white-color), 0.5) 100%
 	);
 	--components-progress-duration: 1.5s;

--- a/packages/scss/src/components/progress/vars.scss
+++ b/packages/scss/src/components/progress/vars.scss
@@ -1,9 +1,15 @@
+@use '@lucca-front/scss/src/commons/utils/color';
+
 @mixin vars {
 	--components-progress-margin-vertical: var(--spacings-S);
 	--components-progress-margin-horizontal: 0;
 	--components-progress-height: 0.25rem;
 	--components-progress-background: var(--palettes-neutral-100);
 	--components-progress-bar-background: var(--palettes-product-700);
-	--components-progress-bar-gradient: linear-gradient(to right, rgba(255, 255, 255, 0.8) 0%, rgba(255, 255, 255, 0.5) 100%);
+	--components-progress-bar-gradient: linear-gradient(
+		to right,
+		color.transparentize(var(--colors-white-color), 0.2) 0%,
+		color.transparentize(var(--colors-white-color), 0.5) 100%
+	);
 	--components-progress-duration: 1.5s;
 }

--- a/packages/scss/src/components/textfields/states.scss
+++ b/packages/scss/src/components/textfields/states.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/color';
 
 @mixin inputHover {
 	box-shadow: 0 0 0 1px var(--palettes-neutral-400);
@@ -197,7 +198,11 @@
 }
 
 @mixin materialInputDisabled {
-	background-image: linear-gradient(to right, var(--components-textfield-material-border-color) 33%, rgba(255, 255, 255, 0) 0%);
+	background-image: linear-gradient(
+		to right,
+		var(--components-textfield-material-border-color) 33%,
+		color.transparentize(var(--colors-white-color), 1) 0%
+	);
 	background-size: 3px 1px;
 	background-color: transparent;
 	background-position: bottom;

--- a/packages/scss/src/components/textfields/states.scss
+++ b/packages/scss/src/components/textfields/states.scss
@@ -201,7 +201,7 @@
 	background-image: linear-gradient(
 		to right,
 		var(--components-textfield-material-border-color) 33%,
-		color.transparentize(var(--colors-white-color), 1) 0%
+		color.transparentize(var(--colors-white-color), 0) 0%
 	);
 	background-size: 3px 1px;
 	background-color: transparent;

--- a/stories/documentation/feedback/empty-state/html&css/empty-state-page.stories.ts
+++ b/stories/documentation/feedback/empty-state/html&css/empty-state-page.stories.ts
@@ -1,9 +1,8 @@
-import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+import { HttpClientModule } from '@angular/common/http';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
-import { HttpClientModule } from "@angular/common/http";
+import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
 
-interface EmptyStatePageStory {
-}
+interface EmptyStatePageStory {}
 
 export default {
 	title: 'Documentation/Feedback/Empty State/HTML&CSS/Page',
@@ -12,12 +11,11 @@ export default {
 			imports: [LuSafeExternalSvgPipe, HttpClientModule],
 		}),
 	],
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: EmptyStatePageStory): string {
-	return `<section class="emptyState mod-page" [style.--components-emptyState-background-color]="'var(--palettes-grey-25)'">
+	return `<section class="emptyState mod-page" [style.--components-emptyState-background-color]="'var(--palettes-neutral-25)'">
 	<div class="emptyState-container">
 		<div class="emptyState-content">
 			<div
@@ -44,4 +42,4 @@ const Template: StoryFn<EmptyStatePageStory> = (args: EmptyStatePageStory) => ({
 });
 
 export const Page = Template.bind({});
-Page.args = { };
+Page.args = {};

--- a/stories/documentation/integration/utilities/borders-radius.stories.ts
+++ b/stories/documentation/integration/utilities/borders-radius.stories.ts
@@ -29,7 +29,7 @@ const Template: StoryFn<BorderRadiusStory> = (args) => ({
 			float: left;
       text-align: center;
       padding: var(--spacings-S);
-      border: 1px solid var(--palettes-grey-200);
+      border: 1px solid var(--palettes-neutral-200);
       margin: 0 var(--spacings-S) var(--spacings-S) 0;
 		}`,
 	],

--- a/stories/documentation/integration/utilities/borders.stories.ts
+++ b/stories/documentation/integration/utilities/borders.stories.ts
@@ -24,7 +24,7 @@ const Template: StoryFn<BorderStory> = (args) => ({
 			float: left;
 			text-align: center;
 			padding: var(--spacings-S);
-			border: 1px solid var(--palettes-grey-200);
+			border: 1px solid var(--palettes-neutral-200);
 			margin: 0 var(--spacings-S) var(--spacings-S) 0;
 		}`,
 	],

--- a/stories/documentation/toolbox/animations/animations.scss
+++ b/stories/documentation/toolbox/animations/animations.scss
@@ -6,7 +6,7 @@
 
 .animated-block {
 	background-color: var(--colors-white-color);
-	border: 1px solid var(--palettes-grey-200);
+	border: 1px solid var(--palettes-neutral-200);
 	padding: 0.5em 1em;
 	height: 60px;
 	width: 100%;

--- a/stories/qa/tokens/tokens.stories.html
+++ b/stories/qa/tokens/tokens.stories.html
@@ -2,52 +2,71 @@
 <h3>Surface</h3>
 <section class="contentSection">
 	<div class="demo-block">
-		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-sunken);">Sunken</div>
-		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-default);">Default</div>
-		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-raised);">Raised</div>
-		<div class="demo-surfaceWrapper"><div class="demo-surface-under"></div><div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-backdrop);">Backdrop</div></div>
+		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-sunken)">Sunken</div>
+		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-default)">Default</div>
+		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-raised)">Raised</div>
+		<div class="demo-surfaceWrapper">
+			<div class="demo-surface-under"></div>
+			<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-backdrop)">Backdrop</div>
+		</div>
 	</div>
 </section>
 <h3>Shadow</h3>
 <section class="contentSection">
 	<div class="demo-block">
-		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-raised); box-shadow: var(--pr-t-elevation-shadow-raised);">Raised</div>
-		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-raised); box-shadow: var(--pr-t-elevation-shadow-overflow);">Overflow</div>
-		<div class="demo-surface" style="background-color: var(--pr-t-elevation-surface-raised); box-shadow: var(--pr-t-elevation-shadow-overlay);">Overlay</div>
+		<div
+			class="demo-surface"
+			style="background-color: var(--pr-t-elevation-surface-raised); box-shadow: var(--pr-t-elevation-shadow-raised)"
+		>
+			Raised
+		</div>
+		<div
+			class="demo-surface"
+			style="background-color: var(--pr-t-elevation-surface-raised); box-shadow: var(--pr-t-elevation-shadow-overflow)"
+		>
+			Overflow
+		</div>
+		<div
+			class="demo-surface"
+			style="background-color: var(--pr-t-elevation-surface-raised); box-shadow: var(--pr-t-elevation-shadow-overlay)"
+		>
+			Overlay
+		</div>
 	</div>
 </section>
 
 <style>
-.demo-block {
-	display: flex;
-	background: var(--palettes-grey-25);
-	padding: var(--spacings-S);
-	gap: var(--spacings-XS);
-}
+	.demo-block {
+		display: flex;
+		background: var(--palettes-neutral-25);
+		padding: var(--spacings-S);
+		gap: var(--spacings-XS);
+	}
 
-.demo-surface, .demo-surfaceWrapper {
-	position: relative;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	height: 5rem;
-	width: 5rem;
-	border-radius: var(--commons-borderRadius-L);
-}
+	.demo-surface,
+	.demo-surfaceWrapper {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		height: 5rem;
+		width: 5rem;
+		border-radius: var(--commons-borderRadius-L);
+	}
 
-.demo-surface {
-	z-index: 1;
-}
+	.demo-surface {
+		z-index: 1;
+	}
 
-.demo-surface-under {
-	width: 2rem;
-	height: 2rem;
-	position: absolute;
-	top: -1rem;
-	right: -1rem;
-	background: var(--colors-white-color);
-	border-radius: var(--commons-borderRadius-full);
-}
+	.demo-surface-under {
+		width: 2rem;
+		height: 2rem;
+		position: absolute;
+		top: -1rem;
+		right: -1rem;
+		background: var(--colors-white-color);
+		border-radius: var(--commons-borderRadius-full);
+	}
 </style>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->


### PR DESCRIPTION
## Description

- [x] Replace `grey` by `neutral` in a few places.
- [x] Depreciates rgb colors.
- [x] Introduces a `transparentize` function that works with `color-mix`. 
- [x] Replaces all calls to rgb colors with the function `transparentize`.

-----



-----

![Capture d’écran 2024-02-26 à 10 51 04](https://github.com/LuccaSA/lucca-front/assets/64789527/ad47f63c-4119-4b1f-ab44-6370616959b8)

![Capture d’écran 2024-02-26 à 10 51 45](https://github.com/LuccaSA/lucca-front/assets/64789527/6e6e6e48-c6fe-4627-809c-2fa1f2a80e10)

