### PR TITLE
feat(modal&dialog): Add German and Portuguese translations

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.translate.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.translate.ts
@@ -22,4 +22,7 @@ export const luDialogHeaderTranslations: ILuTranslation<LuDialogHeaderTranslatio
 	es: {
 		close: 'Cerrar',
 	},
+	pt: {
+		close: 'Fechar',
+	},
 };

--- a/packages/ng/modal/modal.translate.ts
+++ b/packages/ng/modal/modal.translate.ts
@@ -22,9 +22,19 @@ export const luModalTranslations: ILuTranslation<ILuModalLabel> = {
 		cancel: 'Annuler',
 		close: 'Fermer',
 	},
+	de: {
+		submit: 'Ok',
+		cancel: 'Abbrechen',
+		close: 'Schließen',
+	},
 	es: {
 		submit: 'Ok',
 		cancel: 'Cancelar',
 		close: 'Cerrar',
+	},
+	pt: {
+		submit: 'Ok',
+		cancel: 'Cancelar',
+		close: 'Fechar',
 	},
 };


### PR DESCRIPTION
## Description

Missing translations for modal and dialog components for German and Portuguese languages.

-----
