### PR TITLE
chore(rc): fixes for issues noticed with rc.2 tests

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -27,7 +27,12 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	@ViewChild('inputElement')
 	private inputElementRef: ElementRef<HTMLInputElement>;
 
-	@Input() placeholder = '';
+	public placeholder$ = new BehaviorSubject('');
+
+	@Input()
+	set placeholder(value: string) {
+		this.placeholder$.next(value);
+	}
 
 	@Input({ transform: booleanAttribute })
 	@HostBinding('class.is-clearable')

--- a/packages/ng/dialog/dialog.provider.ts
+++ b/packages/ng/dialog/dialog.provider.ts
@@ -1,7 +1,0 @@
-import { EnvironmentProviders, importProvidersFrom, makeEnvironmentProviders } from '@angular/core';
-import { DialogModule } from '@angular/cdk/dialog';
-import { LuDialogService } from './dialog.service';
-
-export function provideLuDialog(): EnvironmentProviders {
-	return makeEnvironmentProviders([importProvidersFrom(DialogModule), LuDialogService]);
-}

--- a/packages/ng/dialog/dialog.providers.ts
+++ b/packages/ng/dialog/dialog.providers.ts
@@ -1,0 +1,11 @@
+import { EnvironmentProviders, importProvidersFrom, makeEnvironmentProviders, Provider } from '@angular/core';
+import { DialogModule } from '@angular/cdk/dialog';
+import { LuDialogService } from './dialog.service';
+
+export function configureLuDialog(): EnvironmentProviders {
+	return makeEnvironmentProviders([importProvidersFrom(DialogModule)]);
+}
+
+export function provideLuDialog(): Provider {
+	return LuDialogService;
+}

--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { inject, Injectable, Injector } from '@angular/core';
 import { LuDialogConfig, LuDialogRef, LuDialogResult } from './model';
 import { Dialog, DialogRef } from '@angular/cdk/dialog';
 import { isObservable, merge, of, take } from 'rxjs';
@@ -8,6 +8,8 @@ import { DISMISSED_VALUE } from './model/dialog-ref';
 @Injectable()
 export class LuDialogService {
 	#cdkDialog = inject(Dialog);
+
+	#injector = inject(Injector);
 
 	open<C>(config: LuDialogConfig<C>): LuDialogRef<C> {
 		let luDialogRef: LuDialogRef<C>;
@@ -35,6 +37,7 @@ export class LuDialogService {
 			// Else, just set it to config value or default to first-tabbable
 			autoFocus: config.autoFocus === 'first-input' ? 'dialog' : config.autoFocus ?? 'first-tabbable',
 			templateContext: () => ({ dialogRef: luDialogRef }),
+			injector: this.#injector,
 			providers: (ref: DialogRef<LuDialogResult<C>, C>) => {
 				luDialogRef = new LuDialogRef(ref, config);
 				return [

--- a/packages/ng/dialog/dialog/dialog.component.scss
+++ b/packages/ng/dialog/dialog/dialog.component.scss
@@ -2,4 +2,5 @@
 
 .dialog .cdk-dialog-container {
 	display: flex;
+	flex-direction: column;
 }

--- a/packages/ng/dialog/public-api.ts
+++ b/packages/ng/dialog/public-api.ts
@@ -1,5 +1,5 @@
 export * from './model';
-export * from './dialog.provider';
+export * from './dialog.providers';
 export * from './dialog.service';
 export * from './dialog/dialog.component';
 export * from './dialog-header/dialog-header.component';

--- a/packages/ng/form-field/form-field.component.scss
+++ b/packages/ng/form-field/form-field.component.scss
@@ -1,2 +1,3 @@
 @use '@lucca-front/scss/src/components/textField';
 @use '@lucca-front/scss/src/components/formLabel';
+@use '@lucca-front/scss/src/components/form';

--- a/packages/ng/modal/modal.module.ts
+++ b/packages/ng/modal/modal.module.ts
@@ -4,6 +4,7 @@ import { LuModalRefFactory } from './modal-ref.factory';
 import { LuModal } from './modal.service';
 import { LU_MODAL_REF_FACTORY } from './modal.token';
 import { LuDialogService } from '@lucca-front/ng/dialog';
+import { DialogModule } from '@angular/cdk/dialog';
 
 /**
  * Provide LuModal.
@@ -14,7 +15,7 @@ export function provideLuModal(): Provider[] {
 }
 
 @NgModule({
-	imports: [OverlayModule],
-	providers: [provideLuModal()],
+	imports: [OverlayModule, DialogModule],
+	providers: [provideLuModal(), LuDialogService],
 })
 export class LuModalModule {}

--- a/packages/ng/modal/modal.service.ts
+++ b/packages/ng/modal/modal.service.ts
@@ -4,7 +4,7 @@ import { LuModalConfig } from './modal-config.model';
 import { ILuModalRef } from './modal-ref.model';
 import { ILuModalContent, LuModalContentResult } from './modal.model';
 import { LU_MODAL_CONFIG, LU_MODAL_REF_FACTORY } from './modal.token';
-import { LuDialogService } from '@lucca-front/ng/dialog';
+import { LuDialogConfig, LuDialogService } from '@lucca-front/ng/dialog';
 import { DialogRefAdapter } from './dialog-adapter/dialog-ref-adapter';
 import { DialogContentAdapterComponent } from './dialog-adapter/dialog-content-adapter/dialog-content-adapter.component';
 
@@ -16,6 +16,12 @@ export class LuModal {
 
 	open<T extends ILuModalContent, D>(component: ComponentType<T>, data: D = undefined, config: Partial<LuModalConfig> = {}): ILuModalRef<D, LuModalContentResult<T>> {
 		const extendedConfig = { ...this._config, ...config } as LuModalConfig;
+
+		const mode = ({
+			sidepanel: 'drawer',
+			modal: 'modal',
+		}[extendedConfig.mode] || 'modal') as LuDialogConfig<unknown>['mode'];
+
 		const dialogRef = this.luDialogService.open({
 			content: DialogContentAdapterComponent<D, T>,
 			data: {
@@ -24,6 +30,7 @@ export class LuModal {
 			},
 			modal: !extendedConfig.noBackdrop,
 			alert: extendedConfig.undismissable,
+			mode: mode,
 		});
 		return new DialogRefAdapter<D, T>(dialogRef);
 	}

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -6,9 +6,10 @@ import { getIntl } from '@lucca-front/ng/core';
 import { ILuOptionContext, LU_OPTION_CONTEXT, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { map } from 'rxjs/operators';
+import { map, switchMap } from 'rxjs/operators';
 import { LuMultiSelectInputComponent } from '../input/select-input.component';
 import { LU_MULTI_SELECT_DISPLAYER_TRANSLATIONS } from './default-displayer.translate';
+import { of } from 'rxjs';
 
 @Component({
 	selector: 'lu-multi-select-default-displayer',
@@ -69,11 +70,11 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 	context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
 
 	placeholder$ = this.context.option$.pipe(
-		map((options) => {
+		switchMap((options) => {
 			if ((options || []).length > 0) {
-				return '';
+				return of('');
 			}
-			return this.select.placeholder;
+			return this.select.placeholder$;
 		}),
 	);
 
@@ -113,6 +114,7 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 			this.select.panelRef?.updateSelectedOptions(this.value);
 		}
 	}
+
 	ngOnInit(): void {
 		this.select.focusInput$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data?: { keepClue: true }) => {
 			// Everytime we want to focus, we need to reset the input

--- a/stories/documentation/overlays/dialog/dialog.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog.stories.ts
@@ -1,4 +1,4 @@
-import { Component, inject } from '@angular/core';
+import { Component, inject, InjectionToken } from '@angular/core';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import {
@@ -11,6 +11,7 @@ import {
 	LuDialogService,
 	injectDialogRef,
 	provideLuDialog,
+	configureLuDialog,
 } from '@lucca-front/ng/dialog';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { DialogCloseDirective, DialogDismissDirective } from '@lucca-front/ng/dialog';
@@ -53,7 +54,8 @@ class TestDialogContent {
 	selector: 'dialog-story',
 	template: ` <button luButton (click)="open()">Open Dialog</button> `,
 	standalone: true,
-	imports: [DialogFooterComponent, CheckboxInputComponent, FormFieldComponent, TextInputComponent, DialogContentComponent, DialogHeaderComponent, DialogComponent, ButtonComponent, FormsModule],
+	imports: [ButtonComponent],
+	providers: [provideLuDialog()],
 })
 class TestDialogStory {
 	dialog = inject(LuDialogService);
@@ -75,7 +77,7 @@ export default {
 	component: TestDialogStory,
 	decorators: [
 		applicationConfig({
-			providers: [provideLuDialog()],
+			providers: [configureLuDialog()],
 		}),
 		moduleMetadata({
 			imports: [

--- a/stories/documentation/overlays/modal/modal.stories.ts
+++ b/stories/documentation/overlays/modal/modal.stories.ts
@@ -1,23 +1,15 @@
-import { Component, Input, Type, inject } from '@angular/core';
+import { Component, inject, Input, Type } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { ILuModalContent, LU_MODAL_DATA, LuModal, LuModalConfig, LuModalModule } from '@lucca-front/ng/modal';
 import { LuToastsModule, LuToastsService } from '@lucca-front/ng/toast';
-import { Meta, applicationConfig, moduleMetadata } from '@storybook/angular';
-import { map, of, shareReplay, timer } from 'rxjs';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
+import { map, shareReplay, timer } from 'rxjs';
 import { generateMarkdownCodeBlock, getStoryGenerator, useDocumentationStory } from 'stories/helpers/stories';
-import { delay } from 'rxjs/operators';
 import { ButtonComponent } from '../../../../packages/ng/button/button.component';
 
 type StoryComponent = LuModalConfig & { useDynamicContent: boolean; message: string };
 
 const globalArgTypes = {
-	position: {
-		options: ['left', 'right'],
-		control: {
-			type: 'select',
-		},
-		if: { arg: 'mode', eq: 'sidepanel' },
-	},
 	mode: {
 		options: ['modal', 'sidepanel'],
 		control: {
@@ -208,7 +200,6 @@ export const ModalSidepanelMode = generateStory({
 		},
 		argTypes: {
 			mode: { table: { disable: true } },
-			position: globalArgTypes.position,
 		},
 	},
 });


### PR DESCRIPTION
## Description

This PR fixes:
- Missing scss import in `lu-form-field` resulting in size not being applied properly
- Wrong injector used in `LuDialogService`, resulting in issues in any dialog component that needs injection (hello transloco)
- Wrong injector used for `LuModal` adapter, resulting in the same as above for `LuModal` boxes
- Placeholder label updates not being applied properly in `lu-multi-select`, breaking transloco usages for placeholders

-----
-----
