### PR TITLE
feat(form-fields): new textarea-input wrapper

### DIFF
--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -172,7 +172,7 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 				: this.#control.control.hasValidator(Validators.required) || this.#control.control.hasValidator(Validators.requiredTrue);
 
 			// If stuff changed, update aria attributes
-			if (this.invalid !== previousInvalid || this.required !== previousRequired) {
+			if (this.#nativeInputRef && (this.invalid !== previousInvalid || this.required !== previousRequired)) {
 				this.updateAria();
 			}
 		}

--- a/packages/ng/forms/public-api.ts
+++ b/packages/ng/forms/public-api.ts
@@ -5,3 +5,4 @@ export * from './form-field-id.directive';
 export * from './text-input/text-input.component';
 export * from './checkbox-input/checkbox-input.component';
 export * from './switch-input/switch-input.component';
+export * from './textarea-input/textarea-input.component';

--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -1,0 +1,12 @@
+<div class="textField">
+	<div class="textField-input">
+		<textarea
+			luInput
+			class="textField-input-value"
+			[formControl]="ngControl.control"
+			[placeholder]="placeholder"
+			[rows]="rows"
+			[cols]="cols"
+		></textarea>
+	</div>
+</div>

--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -1,12 +1,5 @@
 <div class="textField">
 	<div class="textField-input">
-		<textarea
-			luInput
-			class="textField-input-value"
-			[formControl]="ngControl.control"
-			[placeholder]="placeholder"
-			[rows]="rows"
-			[cols]="cols"
-		></textarea>
+		<textarea luInput class="textField-input-value" [formControl]="ngControl.control" [placeholder]="placeholder"></textarea>
 	</div>
 </div>

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -1,0 +1,31 @@
+import { ChangeDetectionStrategy, Component, Input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { InputDirective } from '@lucca-front/ng/form-field';
+import { ReactiveFormsModule } from '@angular/forms';
+import { injectNgControl } from '../inject-ng-control';
+import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
+
+@Component({
+	selector: 'lu-textarea-input',
+	standalone: true,
+	imports: [InputDirective, ReactiveFormsModule],
+	templateUrl: './textarea-input.component.html',
+	hostDirectives: [NoopValueAccessorDirective],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TextareaInputComponent {
+	ngControl = injectNgControl();
+
+	@Input()
+	placeholder: string;
+
+	@Input({
+		transform: numberAttribute,
+	})
+	cols: number;
+
+	@Input({
+		transform: numberAttribute,
+	})
+	rows: number;
+}

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { injectNgControl } from '../inject-ng-control';
@@ -18,14 +18,4 @@ export class TextareaInputComponent {
 
 	@Input()
 	placeholder: string;
-
-	@Input({
-		transform: numberAttribute,
-	})
-	cols: number;
-
-	@Input({
-		transform: numberAttribute,
-	})
-	rows: number;
 }

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -54,6 +54,12 @@
 			&::placeholder {
 				color: var(--component-textField-placeholder);
 			}
+
+			&:is(textarea) {
+				resize: vertical;
+				min-height: calc(2lh + var(--component-textField-padding) * 2);
+				height: calc(3lh + var(--component-textField-padding) * 2);
+			}
 		}
 
 		.textField-input-affix {

--- a/stories/documentation/forms/fields/textarea/angular/textarea.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textarea.stories.ts
@@ -62,8 +62,6 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 	},
 	args: {
 		label: 'Label',
-		cols: 50,
-		rows: 3,
 		required: true,
 		hiddenLabel: false,
 		disabled: false,

--- a/stories/documentation/forms/fields/textarea/angular/textarea.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textarea.stories.ts
@@ -1,0 +1,76 @@
+import { TextareaInputComponent } from '@lucca-front/ng/forms';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+
+export default {
+	title: 'Documentation/Forms/Fields/TextAreaField/Angular',
+	decorators: [
+		moduleMetadata({
+			imports: [TextareaInputComponent, FormFieldComponent, FormsModule, ReactiveFormsModule, BrowserAnimationsModule],
+		}),
+	],
+	argTypes: {
+		tooltip: {
+			type: 'string',
+		},
+		size: {
+			options: ['M', 'S', 'XS'],
+			control: {
+				type: 'radio',
+			},
+		},
+		inlineMessageState: {
+			options: ['default', 'success', 'warning', 'error'],
+			control: {
+				type: 'select',
+			},
+		},
+	},
+} as Meta;
+
+export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & FormFieldComponent> = {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
+		return {
+			template: cleanupTemplate(`<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
+
+	<lu-textarea-input
+	${generateInputs(inputArgs, argTypes)}
+		[(ngModel)]="example">
+	</lu-textarea-input>
+
+</lu-form-field>
+
+{{example}}`),
+			moduleMetadata: {
+				imports: [TextareaInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+			},
+		};
+	},
+	args: {
+		label: 'Label',
+		cols: 50,
+		rows: 3,
+		required: true,
+		hiddenLabel: false,
+		disabled: false,
+		inlineMessage: 'Helper Text',
+		inlineMessageState: 'default',
+		size: 'M',
+		placeholder: 'Placeholder',
+		tooltip: "Je suis un message d'aide",
+	},
+};


### PR DESCRIPTION
## Description

New `lu-textarea-input` component that makes it easy to create form fields with a text area.

Example:

```html
<lu-form-field
  label="Label"
  tooltip="Je suis un message d'aide"
  inlineMessage="Helper Text"
  inlineMessageState="default"
  size="M"
>
  <lu-textarea-input
    cols="50"
    rows="3"
    required
    placeholder="Placeholder"
    [(ngModel)]="example"
  ></lu-textarea-input>
</lu-form-field>
```

-----
-----
