### PR TITLE
Transparent background for outlined tags

### DIFF
--- a/packages/scss/src/components/tag/mods.scss
+++ b/packages/scss/src/components/tag/mods.scss
@@ -14,6 +14,6 @@
 
 @mixin outlined {
 	--components-tag-color: var(--palettes-600, var(--palettes-neutral-600));
-	--components-tag-background: var(--colors-white-color);
 	--components-tag-shadow: var(--palettes-300, var(--palettes-neutral-300));
+	--components-tag-background: transparent;
 }


### PR DESCRIPTION
## Description

Closes #2606 

-----


-----

![Capture d’écran 2024-02-28 à 16 35 53](https://github.com/LuccaSA/lucca-front/assets/64789527/0090baa9-ea35-4c42-ac42-ecf722e0b573)
