### PR TITLE
Add animation for submenus

### DIFF
--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/loading';
+@use '@lucca-front/scss/src/components/keyframe/exports' as keyframe;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icon;
 
@@ -124,6 +125,8 @@
 		}
 
 		.navSide-item-arrow {
+			@include icon.S;
+
 			transition-duration: var(--commons-animations-durations-fast);
 			transition-property: transform;
 			transition-timing-function: ease-out;
@@ -134,10 +137,10 @@
 			flex-shrink: 0;
 			transform-origin: 50% 50%;
 			transform: rotate(90deg);
-			@include icon.S;
 		}
 
 		.navSide-item-subMenu {
+			animation-duration: var(--commons-animations-durations-standard);
 			font-size: var(--components-navSide-sub-font-size);
 			margin: 0;
 			padding: 0;
@@ -150,6 +153,27 @@
 			padding: var(--spacings-XS) var(--spacings-S) var(--spacings-XS) var(--spacings-XL);
 			font-size: var(--sizes-S-fontSize);
 			line-height: var(--sizes-S-lineHeight);
+		}
+
+		.navSide-item-subMenu-item {
+			@include keyframe.slideInLeft;
+
+			opacity: 0;
+			animation-fill-mode: forwards;
+			animation-name: slideInLeft;
+			animation-duration: var(--commons-animations-durations-fast);
+			animation-delay: var(--delay);
+
+			@media (prefers-reduced-motion) {
+				animation: none;
+				opacity: 1;
+			}
+
+			@for $i from 0 through 10 {
+				&:nth-child(#{$i}n) {
+					--delay: #{$i * 25ms};
+				}
+			}
 		}
 
 		.navSide-bottomSection {
@@ -177,8 +201,8 @@
 				}
 			}
 
+			// .navSide-item-alert is deprecated
 			.navSide-item-alert {
-				// deprecated
 				background-color: var(--components-navSide-bottom-section-palette-alert-color);
 				color: var(--components-navSide-bottom-section-palette-alert-text);
 			}

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -140,7 +140,6 @@
 		}
 
 		.navSide-item-subMenu {
-			animation-duration: var(--commons-animations-durations-standard);
 			font-size: var(--components-navSide-sub-font-size);
 			margin: 0;
 			padding: 0;

--- a/stories/documentation/navigation/menu-secondary/menu-secondary-basic.stories.ts
+++ b/stories/documentation/navigation/menu-secondary/menu-secondary-basic.stories.ts
@@ -70,9 +70,24 @@ function getTemplate(args: MenuSecondaryBasicStory): string {
 								<a href="#" class="navSide-item-subMenu-link">Section 2.1</a>
 							</li>
 							<li class="navSide-item-subMenu-item">
+								<a href="#" class="navSide-item-subMenu-link">
+									Section 2.2
+								</a>
+							</li>
+							<li class="navSide-item-subMenu-item">
 								<a href="#" class="navSide-item-subMenu-link is-active">
 									Section 2.3
 									<span class="numericBadge palette-product mod-S"><span class="u-mask">, </span>9</span>
+								</a>
+							</li>
+							<li class="navSide-item-subMenu-item">
+								<a href="#" class="navSide-item-subMenu-link">
+									Section 2.4
+								</a>
+							</li>
+							<li class="navSide-item-subMenu-item">
+								<a href="#" class="navSide-item-subMenu-link">
+									Section 2.5
 								</a>
 							</li>
 						</ul>

--- a/stories/documentation/navigation/menu-secondary/menu-secondary-basic.stories.ts
+++ b/stories/documentation/navigation/menu-secondary/menu-secondary-basic.stories.ts
@@ -32,7 +32,7 @@ function getTemplate(args: MenuSecondaryBasicStory): string {
 	const banner = args.banner ? `mod-withBanner` : '';
 	const open = args.open ? `is-open` : '';
 	return `
-	<div class="navSide ${compact} ${banner} ${open}">
+	<div class="navSide ${compact} ${banner}">
 		<nav role="navigation" aria-label="Nom application" class="navSide-wrapper">
 			<div class="navSide-mainSection">
 				<div class="navSide-item mod-mobileToggle">
@@ -59,7 +59,7 @@ function getTemplate(args: MenuSecondaryBasicStory): string {
 							</li>
 						</ul>
 					</li>
-					<li class="navSide-item is-open">
+					<li class="navSide-item ${open}">
 						<button type="button" class="navSide-item-link" aria-expanded="true">
 							<span aria-hidden="true" class="lucca-icon icon-peoplePerson"></span>
 							<span class="navSide-item-link-title">Section#2 with a larger name</span>


### PR DESCRIPTION
## Description

Reinstates an animation for the appearance of sub-menus that had disappeared by mistake a long time ago.

Fixes #2603 

-----


-----

![2024-02-29 14 26 51](https://github.com/LuccaSA/lucca-front/assets/64789527/b8cd78a5-ed5d-4271-8159-c02e4b826960)

