### PR TITLE
fix(lu-modal): panelClass settings + old select deprecation

### DIFF
--- a/packages/ng/callout/callout-feedback-item/callout-feedback-item.component.ts
+++ b/packages/ng/callout/callout-feedback-item/callout-feedback-item.component.ts
@@ -1,4 +1,11 @@
-import { Component, ViewEncapsulation } from '@angular/core';
+import { Component, Directive, ViewEncapsulation } from '@angular/core';
+
+@Directive({
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'lu-feedback-item-description',
+	standalone: true,
+})
+export class CalloutFeedbackItemDescriptionDirective {}
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector

--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -31,7 +31,7 @@ export class LuDialogService {
 			role: config.alert ? 'alertdialog' : 'dialog',
 			restoreFocus: true,
 			backdropClass: 'dialog_backdrop',
-			panelClass: ['dialog', `mod-${config.size || 'M'}`, ...modeClasses],
+			panelClass: ['dialog', `mod-${config.size || 'M'}`, ...modeClasses, ...(config.panelClasses || [])],
 			ariaLabel: config.ariaLabel,
 			// If focus is first-input, focus dialog and let the component do the rest
 			// Else, just set it to config value or default to first-tabbable

--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -72,9 +72,20 @@ interface BaseLuDialogConfig<C> {
 	 */
 	canClose?: (comp: C) => boolean | Observable<boolean>;
 
+	/**
+	 * The size of the panel used for the dialog
+	 */
 	size?: 'XS' | 'S' | 'M' | 'L' | 'XL' | 'fitContent' | `maxContent` | 'fullScreen';
 
+	/**
+	 * Should it be a modal (default), a drawer? a drawer from bottom?
+	 */
 	mode?: 'default' | 'drawer' | 'drawer-from-bottom';
+
+	/**
+	 * Classes to add to the panel
+	 */
+	panelClasses?: string[];
 }
 
 export type LuDialogConfig<T> = LuDialogData<T> extends never ? Omit<BaseLuDialogConfig<T>, 'data'> : BaseLuDialogConfig<T>;

--- a/packages/ng/establishment/establishment.module.ts
+++ b/packages/ng/establishment/establishment.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuEstablishmentSelectModule } from './select/index';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with establishments directive
+ */
 @NgModule({
 	imports: [LuEstablishmentSelectModule],
 	exports: [LuEstablishmentSelectModule],

--- a/packages/ng/establishment/select/establishment-select.module.ts
+++ b/packages/ng/establishment/select/establishment-select.module.ts
@@ -5,6 +5,9 @@ import { LuLegalUnitSelectorDirective } from './legal-unit-selector/index';
 import { LuEstablishmentSearcherComponent } from './searcher';
 import { LuEstablishmentSelectAllComponent } from './select-all/index';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with establishments directive
+ */
 @NgModule({
 	imports: [LuEstablishmentSelectInputComponent, LuEstablishmentSearcherComponent, LuForLegalUnitsDirective, LuLegalUnitSelectorDirective, LuEstablishmentSelectAllComponent],
 	exports: [LuEstablishmentSelectInputComponent, LuEstablishmentSearcherComponent, LuForLegalUnitsDirective, LuLegalUnitSelectorDirective, LuEstablishmentSelectAllComponent],

--- a/packages/ng/establishment/select/input/establishment-select-input.component.ts
+++ b/packages/ng/establishment/select/input/establishment-select-input.component.ts
@@ -17,6 +17,9 @@ import { LuEstablishmentSearcherComponent } from '../searcher';
 import { LuEstablishmentSelectAllComponent } from '../select-all';
 import { LU_ESTABLISHMENT_SELECT_INPUT_TRANSLATIONS } from './establishment-select-input.translate';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with establishments directive
+ */
 @Component({
 	selector: 'lu-establishment-select',
 	templateUrl: './establishment-select-input.component.html',
@@ -51,9 +54,6 @@ import { LU_ESTABLISHMENT_SELECT_INPUT_TRANSLATIONS } from './establishment-sele
 		},
 	],
 })
-/**
- * @deprecated prefer SimpleSelect or MultipleSelect with establishments directive
- */
 export class LuEstablishmentSelectInputComponent<
 		D extends import('../../establishment.model').ILuEstablishment = import('../../establishment.model').ILuEstablishment,
 		P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>,

--- a/packages/ng/establishment/select/input/establishment-select-input.component.ts
+++ b/packages/ng/establishment/select/input/establishment-select-input.component.ts
@@ -51,6 +51,9 @@ import { LU_ESTABLISHMENT_SELECT_INPUT_TRANSLATIONS } from './establishment-sele
 		},
 	],
 })
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with establishments directive
+ */
 export class LuEstablishmentSelectInputComponent<
 		D extends import('../../establishment.model').ILuEstablishment = import('../../establishment.model').ILuEstablishment,
 		P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>,

--- a/packages/ng/modal/modal.service.ts
+++ b/packages/ng/modal/modal.service.ts
@@ -27,6 +27,7 @@ export class LuModal {
 			alert: extendedConfig.undismissable,
 			size: extendedConfig.size as LuDialogConfig<unknown>['size'],
 			mode,
+			panelClasses: Array.isArray(extendedConfig.panelClass) ? extendedConfig.panelClass : [extendedConfig.panelClass],
 		});
 		return new DialogRefAdapter<D, T>(dialogRef);
 	}

--- a/packages/ng/qualification/qualification.module.ts
+++ b/packages/ng/qualification/qualification.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuQualificationSelectModule } from './select/qualification-select.module';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with jobQualifications directive
+ */
 @NgModule({
 	imports: [LuQualificationSelectModule],
 	exports: [LuQualificationSelectModule],

--- a/packages/ng/qualification/select/input/qualification-select-input.component.ts
+++ b/packages/ng/qualification/select/input/qualification-select-input.component.ts
@@ -11,6 +11,9 @@ import { ALuSelectInputComponent } from '@lucca-front/ng/select';
 import { ILuQualification } from '../../qualification.model';
 import { LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS } from './qualification-select-input.translate';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with jobQualifications directive
+ */
 @Component({
 	selector: 'lu-qualification-select',
 	templateUrl: './qualification-select-input.component.html',
@@ -26,9 +29,6 @@ import { LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS } from './qualification-sele
 		},
 	],
 })
-/**
- * @deprecated prefer SimpleSelect or MultipleSelect with jobQualifications directive
- */
 export class LuQualificationSelectInputComponent<
 		D extends import('../../qualification.model').ILuQualification = import('../../qualification.model').ILuQualification,
 		P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>,

--- a/packages/ng/qualification/select/input/qualification-select-input.component.ts
+++ b/packages/ng/qualification/select/input/qualification-select-input.component.ts
@@ -26,6 +26,9 @@ import { LU_QUALIFICATION_SELECT_INPUT_TRANSLATIONS } from './qualification-sele
 		},
 	],
 })
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with jobQualifications directive
+ */
 export class LuQualificationSelectInputComponent<
 		D extends import('../../qualification.model').ILuQualification = import('../../qualification.model').ILuQualification,
 		P extends ILuOptionPickerPanel<D> = ILuOptionPickerPanel<D>,

--- a/packages/ng/qualification/select/input/qualification-select-input.module.ts
+++ b/packages/ng/qualification/select/input/qualification-select-input.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuQualificationSelectInputComponent } from './qualification-select-input.component';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with jobQualifications directive
+ */
 @NgModule({
 	imports: [LuQualificationSelectInputComponent],
 	exports: [LuQualificationSelectInputComponent],

--- a/packages/ng/qualification/select/qualification-select.module.ts
+++ b/packages/ng/qualification/select/qualification-select.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuQualificationSelectInputModule } from './input/index';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with jobQualifications directive
+ */
 @NgModule({
 	imports: [LuQualificationSelectInputModule],
 	exports: [LuQualificationSelectInputModule],

--- a/packages/ng/select/input/select-input.component.ts
+++ b/packages/ng/select/input/select-input.component.ts
@@ -40,6 +40,7 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 	@Input('placeholder') set inputPlaceholder(p: string) {
 		this._placeholder = p;
 	}
+
 	@Input('multiple') set inputMultiple(m: boolean | string) {
 		if (m === '') {
 			// allows to have multiple = true when writing
@@ -49,6 +50,7 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 			this.multiple = !!m;
 		}
 	}
+
 	/** Event emitted when the associated popover is opened. */
 	@Output() onOpen = new EventEmitter<void>();
 	/** Event emitted when the associated popover is closed. */
@@ -63,17 +65,21 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 	) {
 		super(_changeDetectorRef, _overlay, _elementRef, _viewContainerRef, _renderer);
 	}
+
 	@HostBinding('class.is-disabled')
 	get isDisabled() {
 		return this.disabled;
 	}
+
 	@Input('disabled') set inputDisabled(d: boolean) {
 		this._disabled = d;
 	}
+
 	@HostBinding('class.is-focused')
 	get isFocused() {
 		return this._popoverOpen && !this.target.overlap;
 	}
+
 	@HostBinding('class.mod-multiple')
 	get modMultiple() {
 		return this._multiple;
@@ -83,6 +89,7 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 	get isClearable() {
 		return !!this._clearer;
 	}
+
 	/**
 	 * popover trigger class extension
 	 */
@@ -101,22 +108,27 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 	override onClick() {
 		super.onClick();
 	}
+
 	@HostListener('mouseenter')
 	override onMouseEnter() {
 		super.onMouseEnter();
 	}
+
 	@HostListener('mouseleave')
 	override onMouseLeave() {
 		super.onMouseLeave();
 	}
+
 	@HostListener('focus')
 	override onFocus() {
 		super.onFocus();
 	}
+
 	@HostListener('blur')
 	override onBlur() {
 		super.onBlur();
 	}
+
 	@HostListener('keydown.space', ['$event'])
 	@HostListener('keydown.enter', ['$event'])
 	onKeydown($event: KeyboardEvent) {
@@ -163,9 +175,11 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 		this.destroyPopover();
 		this.onDestroy();
 	}
+
 	protected _emitOpen(): void {
 		this.onOpen.emit();
 	}
+
 	protected _emitClose(): void {
 		this.onClose.emit();
 	}
@@ -173,6 +187,8 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 
 /**
  * select input
+ *
+ * @deprecated prefer SimpleSelect or MultipleSelect
  */
 @Component({
 	selector: 'lu-select',
@@ -193,6 +209,7 @@ export class LuSelectInputComponent<T> extends ALuSelectInputComponent<T> implem
 	get modMultipleView() {
 		return this.useMultipleViews();
 	}
+
 	constructor(
 		protected override _changeDetectorRef: ChangeDetectorRef,
 		protected override _overlay: Overlay,
@@ -202,11 +219,13 @@ export class LuSelectInputComponent<T> extends ALuSelectInputComponent<T> implem
 	) {
 		super(_changeDetectorRef, _overlay, _elementRef, _viewContainerRef, _renderer);
 	}
+
 	// display clearer
 	@ContentChild(ALuClearer, { read: ElementRef, static: false })
 	clearerEltRef: ElementRef<HTMLElement>;
 	@ViewChild('suffix', { read: ElementRef, static: true })
 	suffixEltRef: ElementRef<HTMLElement>;
+
 	displayClearer() {
 		if (this.clearerEltRef) {
 			this._renderer.appendChild(this.suffixEltRef.nativeElement, this.clearerEltRef.nativeElement);

--- a/packages/ng/select/input/select-input.module.ts
+++ b/packages/ng/select/input/select-input.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuSelectInputComponent } from './select-input.component';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect
+ */
 @NgModule({
 	imports: [LuSelectInputComponent],
 	exports: [LuSelectInputComponent],

--- a/packages/ng/select/select.module.ts
+++ b/packages/ng/select/select.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuSelectInputModule } from './input/index';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect
+ */
 @NgModule({
 	imports: [LuSelectInputModule],
 	exports: [LuSelectInputModule],

--- a/packages/ng/user/select/input/user-select-input.component.ts
+++ b/packages/ng/user/select/input/user-select-input.component.ts
@@ -14,7 +14,7 @@ import { LuUserPagedSearcherComponent } from '../searcher';
 import { LU_USER_SELECT_INPUT_TRANSLATIONS } from './user-select-input.translate';
 
 /**
- * Displays user'picture or a placeholder with his/her initials and random bg color'
+ * @deprecated prefer SimpleSelect or MultipleSelect with luCustomUsers directive
  */
 @Component({
 	selector: 'lu-user-select',
@@ -45,9 +45,6 @@ import { LU_USER_SELECT_INPUT_TRANSLATIONS } from './user-select-input.translate
 		},
 	],
 })
-/**
- * @deprecated prefer SimpleSelect or MultipleSelect with luCustomUsers directive
- */
 export class LuUserSelectInputComponent<U extends import('../../user.model').ILuUser = import('../../user.model').ILuUser>
 	extends ALuSelectInputComponent<U>
 	implements ControlValueAccessor, ILuInputWithPicker<U>, AfterViewInit

--- a/packages/ng/user/select/input/user-select-input.component.ts
+++ b/packages/ng/user/select/input/user-select-input.component.ts
@@ -45,13 +45,17 @@ import { LU_USER_SELECT_INPUT_TRANSLATIONS } from './user-select-input.translate
 		},
 	],
 })
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with luCustomUsers directive
+ */
 export class LuUserSelectInputComponent<U extends import('../../user.model').ILuUser = import('../../user.model').ILuUser>
 	extends ALuSelectInputComponent<U>
 	implements ControlValueAccessor, ILuInputWithPicker<U>, AfterViewInit
 {
 	searchFormat = LuDisplayFullname.lastfirst;
 
-	@Input('placeholder') override set inputPlaceholder(p: string) {
+	@Input('placeholder')
+	override set inputPlaceholder(p: string) {
 		this._placeholder = p;
 	}
 
@@ -68,6 +72,7 @@ export class LuUserSelectInputComponent<U extends import('../../user.model').ILu
 	byId: LuOptionComparer<U> = (option1: U, option2: U) => option1 && option2 && option1.id === option2.id;
 
 	public intl = getIntl(LU_USER_SELECT_INPUT_TRANSLATIONS);
+
 	constructor(
 		protected override _changeDetectorRef: ChangeDetectorRef,
 		protected override _overlay: Overlay,

--- a/packages/ng/user/select/input/user-select-input.module.ts
+++ b/packages/ng/user/select/input/user-select-input.module.ts
@@ -1,6 +1,9 @@
 import { NgModule } from '@angular/core';
 import { LuUserSelectInputComponent } from './user-select-input.component';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with luCustomUsers directive
+ */
 @NgModule({
 	imports: [LuUserSelectInputComponent],
 	exports: [LuUserSelectInputComponent],

--- a/packages/ng/user/select/user-select.module.ts
+++ b/packages/ng/user/select/user-select.module.ts
@@ -4,6 +4,9 @@ import { LuUserSearcherModule } from './searcher/index';
 import { LuUserHomonymsModule } from './homonyms/index';
 import { LuUserMeOptionModule } from './me/index';
 
+/**
+ * @deprecated prefer SimpleSelect or MultipleSelect with luCustomUsers directive
+ */
 @NgModule({
 	imports: [LuUserSelectInputModule, LuUserSearcherModule, LuUserHomonymsModule, LuUserMeOptionModule],
 	exports: [LuUserSelectInputModule, LuUserSearcherModule, LuUserHomonymsModule, LuUserMeOptionModule],


### PR DESCRIPTION
## Description

Add deprecated with alternative to:

- establishment-select
- qualification-select
- user-select
- lu-select

Fix panelClass and size not applied to `LuModal` dialogs.
-----

-----
