### PR TITLE
Fix overflow for table card with clickable lines

### DIFF
--- a/packages/scss/src/components/card/component.scss
+++ b/packages/scss/src/components/card/component.scss
@@ -10,10 +10,6 @@
 	transition-duration: var(--commons-animations-durations-fast);
 	transition-property: background-color, box-shadow, color;
 
-	&:has(.table) {
-		overflow: hidden;
-	}
-
 	@at-root ($atRoot) {
 		.card-content {
 			padding: var(--components-card-content-padding);

--- a/packages/scss/src/components/card/component.scss
+++ b/packages/scss/src/components/card/component.scss
@@ -10,6 +10,10 @@
 	transition-duration: var(--commons-animations-durations-fast);
 	transition-property: background-color, box-shadow, color;
 
+	&:has(.table) {
+		overflow: hidden;
+	}
+
 	@at-root ($atRoot) {
 		.card-content {
 			padding: var(--components-card-content-padding);

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -53,6 +53,40 @@
 @mixin card {
 	border-top: 0;
 
+	:where(.table-head, .table-body, .table-foot) {
+		&:first-child {
+			:where(.table-head-row, .table-body-row, .table-foot-row) {
+				&:first-child {
+					:where(.table-head-row-cell, .table-body-row-cell) {
+						&:first-child {
+							border-top-left-radius: var(--components-card-border-radius);
+						}
+
+						&:last-child {
+							border-top-right-radius: var(--components-card-border-radius);
+						}
+					}
+				}
+			}
+		}
+
+		&:last-child {
+			:where(.table-head-row, .table-body-row, .table-foot-row) {
+				&:last-child {
+					:where(.table-head-row-cell, .table-body-row-cell) {
+						&:first-child {
+							border-bottom-left-radius: var(--components-card-border-radius);
+						}
+
+						&:last-child {
+							border-bottom-right-radius: var(--components-card-border-radius);
+						}
+					}
+				}
+			}
+		}
+	}
+
 	.table-head-row-cell {
 		border-top: 0;
 	}

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -73,7 +73,7 @@
 		&:last-child {
 			:where(.table-head-row, .table-body-row, .table-foot-row) {
 				&:last-child {
-					:where(.table-head-row-cell, .table-body-row-cell) {
+					:where(.table-body-row-cell, .table-foot-row-cell) {
 						&:first-child {
 							border-bottom-left-radius: var(--components-card-border-radius);
 						}

--- a/stories/documentation/listings/table/table-card.stories.ts
+++ b/stories/documentation/listings/table/table-card.stories.ts
@@ -35,6 +35,30 @@ function getTemplate(args: TableCardStory): string {
 			</tbody>
 		</table>
 	</div>
+	<div class="card">
+		<table class="table mod-card mod-clickable">
+			<tbody class="table-body">
+				<tr class="table-body-row">
+					<td class="table-body-row-cell">
+						<a href="#" class="table-body-row-cell-action">Table cell</a>
+					</td>
+					<td class="table-body-row-cell">Table cell</td>
+				</tr>
+				<tr class="table-body-row">
+					<td class="table-body-row-cell">
+						<a href="#" class="table-body-row-cell-action">Table cell</a>
+					</td>
+					<td class="table-body-row-cell">Table cell</td>
+				</tr>
+				<tr class="table-body-row">
+					<td class="table-body-row-cell">
+						<a href="#" class="table-body-row-cell-action">Table cell</a>
+					</td>
+					<td class="table-body-row-cell">Table cell</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
 	`;
 }
 


### PR DESCRIPTION
## Description



-----

Other options considered but abandoned:
- `overflow: hidden` on `.card` (too risky);
- selectors `> *` (too risky on arrays are poorly constructed and contrary to our guidelines);
- don't use `:where` (too verbose when compiling CSS).

-----

Before: 
![Capture d’écran 2024-02-29 à 15 31 41](https://github.com/LuccaSA/lucca-front/assets/64789527/605679c8-b6fb-43dc-8e34-90e3ee8c348c)


After: 
![Capture d’écran 2024-02-29 à 15 31 22](https://github.com/LuccaSA/lucca-front/assets/64789527/0768efef-7433-44ef-a5fa-510c3e6e27dd)

