### PR TITLE
fix(simple-select): disabled state not applied visually until new cd cycle

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -189,6 +189,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	setDisabledState(isDisabled: boolean): void {
 		this.disabled = isDisabled;
+		this.changeDetectorRef.markForCheck();
 	}
 
 	ngOnDestroy(): void {


### PR DESCRIPTION
## Description

Disabling a `FormControl` applied to a `lu-simple-select` wasn't being applied visually until a new change detector cycle was started, this PR fixes the behavior by adding a `markForCheck` call when disabled is applied.

-----

-----
