### PR TITLE
fix(select): position not updating when new options are set

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -1,12 +1,14 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
 import { OverlayConfig, OverlayContainer } from '@angular/cdk/overlay';
 import {
+	booleanAttribute,
 	ChangeDetectorRef,
 	Directive,
 	ElementRef,
 	EventEmitter,
 	HostBinding,
 	HostListener,
+	inject,
 	Input,
 	OnDestroy,
 	OnInit,
@@ -14,8 +16,6 @@ import {
 	TemplateRef,
 	Type,
 	ViewChild,
-	booleanAttribute,
-	inject,
 } from '@angular/core';
 import { BehaviorSubject, ReplaySubject, Subject } from 'rxjs';
 import { LuOptionGrouping, LuSimpleSelectDefaultOptionComponent } from '../option';
@@ -83,6 +83,13 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	@Input() set options(options: TOption[]) {
 		this.options$.next(options);
+		if (this.panelRef) {
+			// We have to put it in a setTimeout so it'll be triggered AFTER the DOM is updated and not right now,
+			// which is before the panel size has been modified by the arrival of the new options
+			setTimeout(() => {
+				this.panelRef.updatePosition();
+			});
+		}
 	}
 
 	@Input() optionComparer: (option1: TOption, option2: TOption) => boolean = (option1, option2) => JSON.stringify(option1) === JSON.stringify(option2);

--- a/packages/ng/core-select/panel/panel.models.ts
+++ b/packages/ng/core-select/panel/panel.models.ts
@@ -10,6 +10,8 @@ export abstract class LuSelectPanelRef<TOption, TValue> {
 	activeOptionIdChanged = new EventEmitter<string>();
 	options$: Observable<TOption>;
 
+	abstract updatePosition(): void;
+
 	abstract handleKeyManagerEvent(event: KeyboardEvent): void;
 
 	abstract emitValue(value: TValue): void;

--- a/packages/ng/multi-select/input/panel.model.ts
+++ b/packages/ng/multi-select/input/panel.model.ts
@@ -4,6 +4,4 @@ export abstract class LuMultiSelectPanelRef<T> extends LuSelectPanelRef<T, T[]> 
 	abstract updateSelectedOptions(selectedOptions: T[]): void;
 
 	abstract useDefaultPosition(): void;
-
-	abstract updatePosition(): void;
 }

--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -52,6 +52,10 @@ class SelectPanelRef<T> extends LuSelectPanelRef<T, T> {
 		this.emitValue(this.instance.keyManager.activeItem?.option);
 		this.close();
 	}
+
+	updatePosition(): void {
+		this.overlayRef.updatePosition();
+	}
 }
 
 @Injectable()


### PR DESCRIPTION
## Description

Fixed a bug that happened with options were set after the panel is opened, which happens quite often with `*apiV4`.
When options are set, if the panel is too far on the right hand side of the screen and the data requires the panel to be larger than the select input's width, then it would expand to the right no matter what, at least when opening it for the first time.

This was due to the panel's position not being updated after new options are set, which is what this PR fixes.

-----
-----
