### PR TITLE
fix(dialog): header missing customisation possibilities

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.html
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.html
@@ -1,8 +1,8 @@
 <button class="dialog-inside-header-button" type="button" luButton (click)="close()" *ngIf="dismissible">
 	<lu-icon icon="close"></lu-icon>
-	<span class="u-mask">{{intl.close}}</span>
+	<span class="u-mask">{{ intl.close }}</span>
 </button>
 
-<h1 class="dialog-inside-header-title" [attr.id]="id">
+<div class="dialog-inside-header-container">
 	<ng-content></ng-content>
-</h1>
+</div>

--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -1,5 +1,5 @@
 import { NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, OnInit, Renderer2, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LuDialogRef } from '../model';
@@ -32,6 +32,10 @@ export class DialogHeaderComponent implements OnInit {
 
 	dismissible = !this.#ref.config.alert;
 
+	#elementRef = inject(ElementRef);
+
+	#renderer = inject(Renderer2);
+
 	close(): void {
 		this.#ref.dismiss();
 	}
@@ -41,6 +45,11 @@ export class DialogHeaderComponent implements OnInit {
 		setTimeout(() => {
 			if (!this.id) {
 				this.id = `lu-dialog-header-${nextId++}`;
+			}
+			const header = this.#elementRef.nativeElement.querySelector('h1');
+			if (header) {
+				this.#renderer.setAttribute(header, 'id', this.id);
+				this.#renderer.addClass(header, 'dialog-inside-header-container-title');
 			}
 			// TODO change this to _addAriaLabelledBy once cdk is > 17.1
 			(this.#ref.cdkRef.containerInstance as CdkDialogContainer)._ariaLabelledByQueue.push(this.id);

--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -32,7 +32,7 @@ export class DialogHeaderComponent implements OnInit {
 
 	dismissible = !this.#ref.config.alert;
 
-	#elementRef = inject(ElementRef);
+	#elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	#renderer = inject(Renderer2);
 

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.html
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.html
@@ -1,5 +1,5 @@
 <lu-dialog>
-	<lu-dialog-header>{{ title$ | async }}</lu-dialog-header>
+	<lu-dialog-header><h1>{{ title$ | async }}</h1></lu-dialog-header>
 	<lu-dialog-content>
 		<ng-container #contentProjectionRef></ng-container>
 	</lu-dialog-content>

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -59,13 +59,16 @@
 			flex-grow: 1;
 		}
 
-		.dialog-inside-header-title {
+		.dialog-inside-header-container {
+			grid-area: container;
+		}
+
+		.dialog-inside-header-container-title {
 			@include title.h2;
 
 			padding: var(--components-dialog-insideHeaderTitlePadding);
 			text-align: var(--components-dialog-insideHeaderTitleAlign);
 			margin: 0;
-			grid-area: title;
 		}
 
 		.dialog-inside-footer {

--- a/packages/scss/src/components/dialog/vars.scss
+++ b/packages/scss/src/components/dialog/vars.scss
@@ -7,7 +7,7 @@
 	--components-dialog-borderRadius: var(--commons-borderRadius-L);
 	--components-dialog-inset: 0;
 	--components-dialog-animationOpening: scaleIn;
-	--components-dialog-insideHeaderAreas: 'title title close';
+	--components-dialog-insideHeaderAreas: 'container container close';
 	--components-dialog-insideHeaderTitleAlign: left;
 	--components-dialog-insideHeaderTitlePadding: calc(var(--spacings-XXS) / 2) 0;
 	--components-dialog-insideHeaderButtonDisplay: flex;

--- a/stories/documentation/overlays/dialog/dialog-basic.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-basic.stories.ts
@@ -15,7 +15,9 @@ function getTemplate(args: DialogBasicStory): string {
 					<span class="lucca-icon icon-signClose" aria-hidden="true"></span>
 					<span class="u-mask">Fermer</span>
 				</button>
-				<h1 class="dialog-inside-header-title" id="dialogInsideHeaderTitle1">Title</h1>
+				<div class="dialog-inside-header-container">
+					<h1 class="dialog-inside-header-container-title" id="dialogInsideHeaderTitle1">Title</h1>
+				</div>
 			</header>
 			<div class="dialog-inside-content">dialog</div>
 			<footer class="dialog-inside-footer footer">

--- a/stories/documentation/overlays/dialog/dialog-drawer.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-drawer.stories.ts
@@ -14,7 +14,9 @@ function getTemplate(args: DialogDrawerStory): string {
 				<span class="lucca-icon icon-signClose" aria-hidden="true"></span>
 				<span class="u-mask">Fermer</span>
 			</button>
-			<h1 class="dialog-inside-header-title" id="dialogInsideHeaderTitle1">Title</h1>
+			<div class="dialog-inside-header-container">
+				<h1 class="dialog-inside-header-container-title" id="dialogInsideHeaderTitle1">Title</h1>
+			</div>
 		</header>
 		<div class="dialog-inside-content">dialog</div>
 		<footer class="dialog-inside-footer footer">

--- a/stories/documentation/overlays/dialog/dialog-drawerFromBottom.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-drawerFromBottom.stories.ts
@@ -14,7 +14,9 @@ function getTemplate(args: DialogDrawerFromBottomStory): string {
 				<span class="lucca-icon icon-signClose" aria-hidden="true"></span>
 				<span class="u-mask">Fermer</span>
 			</button>
-			<h1 class="dialog-inside-header-title" id="dialogInsideHeaderTitle1">Title</h1>
+			<div class="dialog-inside-header-container">
+				<h1 class="dialog-inside-header-container-title" id="dialogInsideHeaderTitle1">Title</h1>
+			</div>
 		</header>
 		<div class="dialog-inside-content">dialog</div>
 		<footer class="dialog-inside-footer footer">

--- a/stories/documentation/overlays/dialog/dialog.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog.stories.ts
@@ -51,7 +51,7 @@ export default {
 
 <ng-template #dialogTpl>
 	<lu-dialog #dialog>
-		<lu-dialog-header>Template driven header</lu-dialog-header>
+		<lu-dialog-header><h1>Template driven header</h1> You can also add more content in header</lu-dialog-header>
 
 		<lu-dialog-content>Template-driven content</lu-dialog-content>
 


### PR DESCRIPTION
## Description

Allow customisation of the new dialog's header slot to allow more content than just everything wrapped in `h1`.

⚠️ This means that you have to put a `h1` inside `lu-dialog-header` for it to render as a title.

-----
-----
