### PR TITLE
Stronger sticky header for dialogs

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -34,6 +34,8 @@
 	}
 
 	@at-root ($atRoot) {
+		// .dialog-form is deprecated
+		.dialog-formOptionnal,
 		.dialog-form,
 		.dialog-inside {
 			display: flex;
@@ -57,6 +59,8 @@
 		.dialog-inside-content {
 			padding: var(--spacings-S) var(--spacings-M);
 			flex-grow: 1;
+			position: relative;
+			z-index: 0;
 		}
 
 		.dialog-inside-header-container {


### PR DESCRIPTION
## Description

Addition of a relative position and z-index on dialog content, so that any positioning within this container does not override the header.

I'm also taking this opportunity to rename the optional form in line with the latest guidelines.


-----

