### PR TITLE
[Navside] Reset numericBadge position in Compact mod

### DIFF
--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -26,6 +26,10 @@
 		display: none;
 	}
 
+	.numericBadge {
+		margin-left: inherit;
+	}
+
 	.navSide-item-alert {
 		// deprecated
 		background-color: var(--components-navSide-compact-palette-alert-color);


### PR DESCRIPTION
## Description

Reset numericBadge position in Compact mod

-----

![image](https://github.com/LuccaSA/lucca-front/assets/25581936/769cb017-cb99-42af-99c0-202837d49616)
![image](https://github.com/LuccaSA/lucca-front/assets/25581936/5933a014-5415-4397-91c1-094f3951d6be)

-----
