### PR TITLE
fix(establishment): wrong query filter (use search instead of clue)

### DIFF
--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -79,7 +79,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 	]).pipe(
 		map(([filters, clue, operationIds, appInstanceId]) => ({
 			...filters,
-			...(clue ? { clue: sanitizeClueFilter(clue) } : {}),
+			...(clue ? { search: sanitizeClueFilter(clue) } : {}),
 			...(operationIds ? { operationIds: operationIds.join(',') } : {}),
 			...(appInstanceId ? { appInstanceId } : {}),
 		})),

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -53,7 +53,7 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 	protected override params$: Observable<Record<string, string | number | boolean>> = combineLatest([toObservable(this._filters), this.clue$]).pipe(
 		map(([filters, clue]) => ({
 			...filters,
-			...(clue ? { clue: sanitizeClueFilter(clue) } : {}),
+			...(clue ? { search: sanitizeClueFilter(clue) } : {}),
 		})),
 	);
 


### PR DESCRIPTION
## Description

These APIs use `search` and not `clue` .

-----
