### PR TITLE
fix(dialog): fix result$ type being `T | void` while it shouldn't

### DIFF
--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -13,11 +13,8 @@ export type LuDialogData<T> = {
 	[K in keyof T]: T[K] extends ɵDialogDataFlag ? Omit<T[K], typeof ɵdialogData> : never;
 }[keyof T];
 
-export type LuDialogResult<C> = keyof C extends never
-	? void
-	: {
-			[K in keyof C]: C[K] extends ɵDialogResultFlag<infer R> ? R : void;
-	  }[keyof C];
+type DialogRefProps<C> = { [K in keyof C]: C[K] extends ɵDialogResultFlag<unknown> ? K : never }[keyof C] & keyof C;
+export type LuDialogResult<C> = DialogRefProps<C> extends never ? void : C[DialogRefProps<C>] extends ɵDialogResultFlag<infer T> ? T : void;
 
 interface BaseLuDialogConfig<C> {
 	/**

--- a/stories/documentation/overlays/dialog/dialog-service.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-service.stories.ts
@@ -1,0 +1,83 @@
+import { Component, inject } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import {
+	configureLuDialog,
+	DialogComponent,
+	DialogContentComponent,
+	DialogDismissDirective,
+	DialogFooterComponent,
+	DialogHeaderComponent,
+	injectDialogData,
+	injectDialogRef,
+	LuDialogRef,
+	LuDialogService,
+	provideLuDialog,
+} from '@lucca-front/ng/dialog';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+
+@Component({
+	selector: 'sb-dialog-content',
+	template: `
+		<lu-dialog>
+			<lu-dialog-header>Header</lu-dialog-header>
+
+			<lu-dialog-content>Content</lu-dialog-content>
+
+			<lu-dialog-footer>
+				<div class="footer-content">Optional footer text</div>
+				<div class="footer-actions">
+					<button type="button" luButton (click)="close()">Confirm</button>
+					<button type="button" luButton="text" luDialogDismiss>Cancel</button>
+				</div>
+			</lu-dialog-footer>
+		</lu-dialog>
+	`,
+	imports: [DialogFooterComponent, DialogContentComponent, DialogHeaderComponent, DialogComponent, ButtonComponent, DialogDismissDirective],
+	standalone: true,
+})
+export class DialogContentStoryComponent {
+	ref = injectDialogRef<string>();
+	data = injectDialogData<number>();
+
+	close(): void {
+		this.ref.close(this.data.toString());
+	}
+}
+
+@Component({
+	selector: 'lu-dialog-story',
+	standalone: true,
+	template: ` <button luButton (click)="openDialog()">Open dialog</button>`,
+	imports: [ButtonComponent],
+	providers: [provideLuDialog()],
+})
+export class DialogStory {
+	dialog = inject(LuDialogService);
+
+	openDialog(): void {
+		const ref: LuDialogRef<DialogContentStoryComponent> = this.dialog.open({
+			content: DialogContentStoryComponent,
+			data: 5,
+		});
+
+		const res = ref.result$;
+	}
+}
+
+export default {
+	title: 'Documentation/Overlays/Dialog/[Test] Angular Service usage',
+	component: DialogStory,
+	decorators: [
+		applicationConfig({
+			providers: [configureLuDialog()],
+		}),
+	],
+} as Meta;
+
+export const Basic: StoryObj = {
+	args: {
+		size: 'S',
+		alert: false,
+		mode: 'default',
+	},
+};


### PR DESCRIPTION
## Description

In dialogs, the `LuDialogRef.result$` property was typed as `Observable<T | void>`, while `void` isn't possible in the event of `ref` being present and typed.

This was due to a hiccup in typescript, caused by inference in a wrong spot and logic not being split enough, which is what this PR fixes.

-----

-----
