### PR TITLE
feat: Better sorting and display for grouped select

### DIFF
--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -1,5 +1,5 @@
 import { delay, http, HttpResponse } from 'msw';
-import { applyFilter, applyV3Paging, applyV4Paging, genericHandler, handleFieldsRoot } from './helpers';
+import { applyFilter, applyV3Paging, applyV4Paging, applyV4Sorting, genericHandler, handleFieldsRoot } from './helpers';
 import { mockAxisSectionsV3, mockDepartmentsTree, mockEstablishments, mockJobQualifications, mockLegalUnits, mockMe, mockProjectUsers, mockUsers } from './mocks';
 
 const usersSearchHandler = genericHandler(
@@ -10,11 +10,12 @@ const usersSearchHandler = genericHandler(
 		search: (search) => search.toLowerCase(),
 		id: (ids) => ids.split(',').map((id) => parseInt(id)),
 	},
-	// Apply filters to items
 	{
-		paging: applyV3Paging,
+		// Apply filters to items
 		search: applyFilter((user, { search }) => `${user.firstName} ${user.lastName}`.includes(search)),
 		id: applyFilter((user, { id }) => id.includes(user.id)),
+		// Then paging/limiting
+		paging: applyV3Paging,
 	},
 	(items) => ({
 		data: {
@@ -33,13 +34,17 @@ export const handlers = [
 				page: (p) => parseInt(p),
 				limit: (l) => parseInt(l),
 				search: (s) => s.toLowerCase(),
+				sort: (s) => s,
 				'fields.root': (f) => f,
 			},
-			// Apply filters to items
 			{
+				// Apply filters to items
+				search: applyFilter((lu, { search }) => lu.name.toLowerCase().includes(search)),
+				// Then sorting
+				sort: (items, { sort }) => applyV4Sorting(items, sort),
+				// Then paging/limiting
 				page: applyV4Paging,
 				limit: (items, { limit }) => items.slice(0, limit),
-				search: applyFilter((lu, { search }) => lu.name.toLowerCase().includes(search)),
 			},
 			handleFieldsRoot(mockLegalUnits.length),
 		),
@@ -55,14 +60,18 @@ export const handlers = [
 				limit: (l) => parseInt(l),
 				legalUnitId: (l) => parseInt(l),
 				search: (s) => s.toLowerCase(),
+				sort: (s) => s,
 				'fields.root': (f) => f,
 			},
-			// Apply filters to items
 			{
-				page: applyV4Paging,
-				limit: (items, { limit }) => items.slice(0, limit),
+				// Apply filters to items
 				legalUnitId: (items, { legalUnitId }) => items.filter((e) => e.legalUnitId === legalUnitId),
 				search: applyFilter((e, { search }) => e.name.toLowerCase().includes(search)),
+				// Then sorting
+				sort: (items, { sort }) => applyV4Sorting(items, sort),
+				// Then paging/limiting
+				page: applyV4Paging,
+				limit: (items, { limit }) => items.slice(0, limit),
 			},
 			handleFieldsRoot(mockEstablishments.length),
 		),
@@ -77,12 +86,16 @@ export const handlers = [
 				page: (p) => parseInt(p),
 				limit: (l) => parseInt(l),
 				search: (s) => s.toLowerCase(),
+				sort: (s) => s,
 				'fields.root': (f) => f,
 			},
-			// Apply filters to items
 			{
-				page: applyV4Paging,
+				// Apply filters to items
 				search: applyFilter((jq, { search }) => jq.name.toLowerCase().includes(search)),
+				// Then sorting
+				sort: (items, { sort }) => applyV4Sorting(items, sort),
+				// Then paging/limiting
+				page: applyV4Paging,
 				limit: (items, { limit }) => items.slice(0, limit),
 			},
 			handleFieldsRoot(mockJobQualifications.length),
@@ -109,10 +122,11 @@ export const handlers = [
 				paging: (p) => p,
 				name: (n) => decodeURIComponent(n.replace('like,', '')),
 			},
-			// Apply filters to items
 			{
-				paging: applyV3Paging,
+				// Apply filters to items
 				name: applyFilter((as, { name }) => as.name.toLowerCase().includes(name.toLowerCase())),
+				// Then paging/limiting
+				paging: applyV3Paging,
 			},
 			(items) => ({ data: { items } }),
 		),
@@ -127,10 +141,11 @@ export const handlers = [
 				paging: (p) => p,
 				search: (s) => s.toLowerCase(),
 			},
-			// Apply filters to items
 			{
-				paging: applyV3Paging,
+				// Apply filters to items
 				search: applyFilter((user, { search }) => `${user.firstName} ${user.lastName}`.includes(search)),
+				// Then paging/limiting
+				paging: applyV3Paging,
 			},
 			(items) => ({ data: { items } }),
 		),
@@ -152,10 +167,11 @@ export const handlers = [
 				paging: (p) => p,
 				id: (ids) => ids.split(',').map((id) => parseInt(id)),
 			},
-			// Apply filters to items
 			{
-				paging: applyV3Paging,
+				// Apply filters to items
 				id: applyFilter((user, { id }) => id.includes(user.id)),
+				// Then paging/limiting
+				paging: applyV3Paging,
 			},
 			(items) => ({ data: { items } }),
 		),

--- a/.storybook/msw/helpers.ts
+++ b/.storybook/msw/helpers.ts
@@ -44,6 +44,27 @@ export function applyV4Paging<T>(items: T[], { page, limit }: { page: number; li
 	return items.slice((page - 1) * limit, page * limit);
 }
 
+export function applyV4Sorting<T>(items: T[], by: string): T[] {
+	const bys = by.split(',');
+	const selector = (item: T, by: string) => {
+		const path = by.split('.');
+		let value: unknown = item;
+		for (const p of path) {
+			const prop = Object.keys(value).find((k) => k.toLowerCase() === p.toLowerCase());
+			value = value && prop ? value[prop] : value;
+		}
+		return value;
+	};
+
+	return items
+		.map((item) => ({
+			item,
+			sorting: bys.map((by) => selector(item, by)).join('__'),
+		}))
+		.sort((a, b) => a.sorting.localeCompare(b.sorting))
+		.map((a) => a.item);
+}
+
 export function applyFilter<T, TParam>(predicate: (item: T, filterValue: TParam) => boolean): (items: T[], filterValue: TParam) => T[] {
 	return (items, filterValue) => items.filter((item) => predicate(item, filterValue));
 }

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -79,7 +79,11 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 	]).pipe(
 		map(([filters, clue, operationIds, appInstanceId]) => ({
 			...filters,
-			...(clue ? { search: sanitizeClueFilter(clue) } : {}),
+			...(clue
+				? // When the clue is not empty, sort establishments by name
+				  { search: sanitizeClueFilter(clue), sort: 'name' }
+				: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
+				  { sort: 'legalunit.name,name' }),
 			...(operationIds ? { operationIds: operationIds.join(',') } : {}),
 			...(appInstanceId ? { appInstanceId } : {}),
 		})),

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -115,6 +115,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	}
 
 	public clueChanged(clue: string): void {
+		this.clue = clue;
+
 		if (!this.isPanelOpen) {
 			this.openPanel(clue);
 		} else if (this.lastEmittedClue !== clue) {
@@ -165,9 +167,13 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 					this.panelRef?.handleKeyManagerEvent($event);
 				}
 				break;
-			case 'Space':
+			case ' ':
 			case 'ArrowDown':
 			case 'ArrowUp':
+				// Initial space should just open the panel, not trigger a clue change
+				if (!this.clue && $event.key === ' ') {
+					$event.preventDefault();
+				}
 				if (this.isPanelOpen) {
 					this.panelRef?.handleKeyManagerEvent($event);
 				} else {

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -53,7 +53,7 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 	protected override params$: Observable<Record<string, string | number | boolean>> = combineLatest([toObservable(this._filters), this.clue$]).pipe(
 		map(([filters, clue]) => ({
 			...filters,
-			...(clue ? { search: sanitizeClueFilter(clue) } : {}),
+			...(clue ? { search: sanitizeClueFilter(clue), sort: 'name' } : { sort: 'job.name,level.position' }),
 		})),
 	);
 

--- a/packages/ng/core-select/option/group.pipe.ts
+++ b/packages/ng/core-select/option/group.pipe.ts
@@ -1,3 +1,4 @@
+import { Pipe, PipeTransform } from '@angular/core';
 import { LuOptionGroup } from '../select.model';
 
 /**
@@ -28,4 +29,16 @@ export function generateGroups<T, TGroup>(options: T[], selector: (option: T) =>
 	}
 
 	return groups;
+}
+
+@Pipe({
+	name: 'luOptionGroup',
+	standalone: true,
+})
+export class LuOptionGroupPipe<T, TGroup> implements PipeTransform {
+	public transform(options: T[], selector: (option: T) => TGroup): LuOptionGroup<T, TGroup>[];
+	public transform(options: T, selector: (option: T) => TGroup): LuOptionGroup<T, TGroup>;
+	public transform(options: T[] | T, selector: (option: T) => TGroup): LuOptionGroup<T, TGroup>[] | LuOptionGroup<T, TGroup> {
+		return Array.isArray(options) ? generateGroups(options, selector) : generateGroups([options], selector)[0];
+	}
 }

--- a/packages/ng/core-select/option/index.ts
+++ b/packages/ng/core-select/option/index.ts
@@ -1,6 +1,7 @@
 export * from './default-option.component';
 export * from './disabled.directive';
 export * from './group.directive';
+export { LuOptionGroupPipe as ɵLuOptionGroupPipe, generateGroups as ɵgenerateGroups } from './group.pipe';
 export { LuOptionOutletDirective as ɵLuOptionOutletDirective } from './option-outlet.directive';
 export { LuOptionComponent as ɵLuOptionComponent } from './option.component';
 export * from './option.directive';

--- a/packages/ng/core-select/option/option.component.html
+++ b/packages/ng/core-select/option/option.component.html
@@ -5,5 +5,9 @@
 	[class.is-disabled]="disabled"
 	(click)="selectOption($event)"
 >
-	<ng-container *luOptionOutlet="optionTpl; value: option"></ng-container>
+	<ng-container *luOptionOutlet="optionTpl; value: option" />
+</div>
+
+<div *ngIf="grouping" class="optionItem-group">
+	<ng-container *luPortal="grouping.content; context: { $implicit: option | luOptionGroup:grouping.selector }" />
 </div>

--- a/packages/ng/core-select/option/option.component.html
+++ b/packages/ng/core-select/option/option.component.html
@@ -6,8 +6,8 @@
 	(click)="selectOption($event)"
 >
 	<ng-container *luOptionOutlet="optionTpl; value: option" />
-</div>
 
-<div *ngIf="grouping" class="optionItem-group">
-	<ng-container *luPortal="grouping.content; context: { $implicit: option | luOptionGroup:grouping.selector }" />
+	<div *ngIf="grouping" class="optionItem-value-group">
+		<ng-container *luPortal="grouping.content; context: { $implicit: option | luOptionGroup:grouping.selector }" />
+	</div>
 </div>

--- a/packages/ng/core-select/option/option.component.scss
+++ b/packages/ng/core-select/option/option.component.scss
@@ -14,3 +14,11 @@
 		background-color: inherit;
 	}
 }
+
+// TODO @Jérémie: Move elsewhere
+.optionItem-group {
+	color: var(--palettes-neutral-600) !important;
+	font-size: var(--sizes-S-fontSize);
+	line-height: var(--sizes-S-lineHeight);
+	padding: var(--components-options-item-padding-vertical) var(--components-options-item-padding-horizontal);
+}

--- a/packages/ng/core-select/option/option.component.scss
+++ b/packages/ng/core-select/option/option.component.scss
@@ -14,11 +14,3 @@
 		background-color: inherit;
 	}
 }
-
-// TODO @Jérémie: Move elsewhere
-.optionItem-group {
-	color: var(--palettes-neutral-600) !important;
-	font-size: var(--sizes-S-fontSize);
-	line-height: var(--sizes-S-lineHeight);
-	padding: var(--components-options-item-padding-vertical) var(--components-options-item-padding-horizontal);
-}

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,8 +1,11 @@
 import { Highlightable } from '@angular/cdk/a11y';
-import { AsyncPipe } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, inject, Input, OnDestroy, TemplateRef, Type, ViewChild } from '@angular/core';
-import { asyncScheduler, BehaviorSubject, observeOn, Subscription } from 'rxjs';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Input, OnDestroy, TemplateRef, Type, ViewChild, inject } from '@angular/core';
+import { PortalDirective } from '@lucca-front/ng/core';
+import { BehaviorSubject, Subscription, asyncScheduler, observeOn } from 'rxjs';
 import { LuOptionContext, SELECT_ID } from '../select.model';
+import { LuOptionGrouping } from './group.directive';
+import { LuOptionGroupPipe } from './group.pipe';
 import { LuOptionOutletDirective } from './option-outlet.directive';
 import { ILuOptionContext, LU_OPTION_CONTEXT } from './option.token';
 
@@ -14,7 +17,7 @@ export const MAGIC_OPTION_SCROLL_DELAY = 15;
 	styleUrls: ['./option.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
-	imports: [AsyncPipe, LuOptionOutletDirective],
+	imports: [AsyncPipe, LuOptionOutletDirective, NgIf, PortalDirective, LuOptionGroupPipe],
 })
 export class LuOptionComponent<T> implements Highlightable, AfterViewInit, OnDestroy {
 	@HostBinding('class.optionItem')
@@ -28,6 +31,7 @@ export class LuOptionComponent<T> implements Highlightable, AfterViewInit, OnDes
 	isSelected = false;
 
 	@Input() option?: T;
+	@Input() grouping?: LuOptionGrouping<T, unknown>;
 
 	@Input()
 	public optionIndex = 0;

--- a/packages/ng/core-select/panel/index.ts
+++ b/packages/ng/core-select/panel/index.ts
@@ -1,1 +1,2 @@
 export * from './panel.models';
+export { getGroupTemplateLocation as ɵgetGroupTemplateLocation } from './panel.utils';

--- a/packages/ng/core-select/panel/index.ts
+++ b/packages/ng/core-select/panel/index.ts
@@ -1,2 +1,1 @@
 export * from './panel.models';
-export { generateGroups as ɵgenerateGroups } from './panel.utils';

--- a/packages/ng/core-select/panel/panel.utils.ts
+++ b/packages/ng/core-select/panel/panel.utils.ts
@@ -1,0 +1,24 @@
+import { Observable, distinctUntilChanged, map, of, skip, startWith, switchMap, take } from 'rxjs';
+
+export type GroupTemplateLocation = 'group-header' | 'option' | 'none';
+
+/**
+ * In order to avoid a blinking when we go from empty clue to a clue
+ * We need to delay the change of group displayer location by waiting for the options to be updated.
+ */
+export function getGroupTemplateLocation(hasGrouping: boolean, clueChange$: Observable<string>, options$: Observable<unknown[]>): Observable<GroupTemplateLocation> {
+	return hasGrouping
+		? clueChange$.pipe(
+				map((clue) => !!clue),
+				distinctUntilChanged(),
+				switchMap((hasClue) =>
+					options$.pipe(
+						skip(1),
+						take(1),
+						map((): GroupTemplateLocation => (hasClue ? 'option' : 'group-header')),
+					),
+				),
+				startWith('group-header' as const),
+		  )
+		: of('none' as const);
+}

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -1,7 +1,10 @@
 <div
 	class="lu-picker-panel lu-option-picker-panel mod-multiple"
 	role="dialog"
-	*ngIf="{ options: (options$ | async) || [], clue: clueChange$ | async } as ctx"
+	*ngIf="{
+		options: (options$ | async) || [],
+		groupTemplateLocation: groupTemplateLocation$ | async,
+	} as ctx"
 >
 	<div
 		class="lu-picker-content"
@@ -13,7 +16,7 @@
 		(scroll)="onScroll($event)"
 	>
 		<div class="lu-picker-content-option">
-			<ng-container *ngIf="grouping && !ctx.clue">
+			<ng-container *ngIf="grouping && ctx.groupTemplateLocation === 'group-header'">
 				<div
 					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"
 					class="lu-picker-content-group"
@@ -35,7 +38,7 @@
 					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />
 				</div>
 			</ng-container>
-			<ng-container *ngIf="!grouping || ctx.clue">
+			<ng-container *ngIf="!grouping || ctx.groupTemplateLocation !== 'group-header'">
 				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
 			</ng-container>
 
@@ -45,7 +48,7 @@
 					[option]="option"
 					[optionTpl]="optionTpl"
 					[optionIndex]="index"
-					[grouping]="grouping && ctx.clue ? grouping : undefined"
+					[grouping]="ctx.groupTemplateLocation === 'option' ? grouping : undefined"
 					[scrollIntoViewOptions]="{ block: 'nearest' }"
 					[isSelected]="option | luIsOptionSelected:optionComparer:selectedOptions"
 					(click)="toggleOption(option)"

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -1,4 +1,8 @@
-<div class="lu-picker-panel lu-option-picker-panel mod-multiple" role="dialog" *ngIf="{ options: (options$ | async) || [] } as ctx">
+<div
+	class="lu-picker-panel lu-option-picker-panel mod-multiple"
+	role="dialog"
+	*ngIf="{ options: (options$ | async) || [], clue: clueChange$ | async } as ctx"
+>
 	<div
 		class="lu-picker-content"
 		[class.is-loading]="loading$ | async"
@@ -9,9 +13,9 @@
 		(scroll)="onScroll($event)"
 	>
 		<div class="lu-picker-content-option">
-			<ng-container *ngIf="grouping">
+			<ng-container *ngIf="grouping && !ctx.clue">
 				<div
-					*ngFor="let group of groups$ | async"
+					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"
 					class="lu-picker-content-group"
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
@@ -31,7 +35,7 @@
 					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />
 				</div>
 			</ng-container>
-			<ng-container *ngIf="!grouping">
+			<ng-container *ngIf="!grouping || ctx.clue">
 				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
 			</ng-container>
 
@@ -41,6 +45,7 @@
 					[option]="option"
 					[optionTpl]="optionTpl"
 					[optionIndex]="index"
+					[grouping]="grouping && ctx.clue ? grouping : undefined"
 					[scrollIntoViewOptions]="{ block: 'nearest' }"
 					[isSelected]="option | luIsOptionSelected:optionComparer:selectedOptions"
 					(click)="toggleOption(option)"

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -3,7 +3,7 @@ import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
+import { SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
 import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
 import { debounceTime, startWith, switchMap } from 'rxjs/operators';
 import { LuMultiSelectInputComponent } from '../input';
@@ -57,6 +57,8 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 	}
 
 	public clueChange$ = this.selectInput.clueChange.pipe(startWith(this.selectInput.clue));
+
+	groupTemplateLocation$ = ɵgetGroupTemplateLocation(!!this.grouping, this.clueChange$, this.options$);
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -3,9 +3,9 @@ import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { SELECT_ID, ɵLuOptionComponent, ɵLuOptionOutletDirective, ɵgenerateGroups } from '@lucca-front/ng/core-select';
-import { EMPTY, asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
-import { debounceTime, switchMap } from 'rxjs/operators';
+import { SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
+import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
+import { debounceTime, startWith, switchMap } from 'rxjs/operators';
 import { LuMultiSelectInputComponent } from '../input';
 import { LuMultiSelectPanelRef } from '../input/panel.model';
 import { MULTI_SELECT_INPUT } from '../select.model';
@@ -28,6 +28,7 @@ import { ɵLuMultiSelectSelectedChipDirective } from './selected-chip.directive'
 		NgIf,
 		NgFor,
 		ɵLuOptionComponent,
+		ɵLuOptionGroupPipe,
 		ɵLuOptionOutletDirective,
 		ɵLuMultiSelectSelectedChipDirective,
 		NgTemplateOutlet,
@@ -43,7 +44,6 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 
 	options$ = this.selectInput.options$;
 	grouping = this.selectInput.grouping;
-	groups$ = this.grouping ? this.options$.pipe(map((options) => ɵgenerateGroups(options, this.grouping.selector))) : EMPTY;
 	loading$ = this.selectInput.loading$;
 	optionComparer = this.selectInput.optionComparer;
 	selectedOptions: T[] = this.selectInput.value || [];
@@ -55,6 +55,8 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 	public get keyManager(): ActiveDescendantKeyManager<ɵLuOptionComponent<T>> {
 		return this._keyManager;
 	}
+
+	public clueChange$ = this.selectInput.clueChange.pipe(startWith(this.selectInput.clue));
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {

--- a/packages/ng/simple-select/input/select-input.component.html
+++ b/packages/ng/simple-select/input/select-input.component.html
@@ -7,7 +7,7 @@
 	[attr.aria-expanded]="isPanelOpen"
 	[attr.aria-controls]="ariaControls"
 	placeholder="{{inputPlaceholder}}"
-	[(ngModel)]="clue"
+	[ngModel]="clue"
 	(ngModelChange)="clueChanged($event)"
 	[readonly]="!searchable"
 	[disabled]="disabled"

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -1,12 +1,15 @@
 <div
 	class="lu-picker-panel lu-option-picker-panel"
 	cdkTrapFocus
-	*ngIf="{ options: (options$ | async) || [], clue: clueChange$ | async } as ctx"
+	*ngIf="{
+		options: (options$ | async) || [],
+		groupTemplateLocation: groupTemplateLocation$ | async,
+	} as ctx"
 	[cdkTrapFocusAutoCapture]="true"
 >
 	<div class="lu-picker-content" [class.is-loading]="loading$ | async" (scroll)="onScroll($event)">
 		<div class="lu-picker-content-option" role="listbox">
-			<ng-container *ngIf="grouping && !ctx.clue">
+			<ng-container *ngIf="grouping && ctx.groupTemplateLocation === 'group-header'">
 				<div
 					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"
 					class="lu-picker-content-option-group"
@@ -19,7 +22,7 @@
 					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />
 				</div>
 			</ng-container>
-			<ng-container *ngIf="!grouping || ctx.clue">
+			<ng-container *ngIf="!grouping || ctx.groupTemplateLocation !== 'group-header'">
 				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
 			</ng-container>
 
@@ -29,7 +32,7 @@
 					[option]="option"
 					[optionTpl]="optionTpl"
 					[optionIndex]="index"
-					[grouping]="grouping && ctx.clue ? grouping : undefined"
+					[grouping]="ctx.groupTemplateLocation === 'option' ? grouping : undefined"
 					[scrollIntoViewOptions]="{ block: 'center' }"
 					[isSelected]="option | luIsOptionSelected:optionComparer:selected"
 					(click)="panelRef.emitValue(option)"

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -8,7 +8,7 @@
 	[cdkTrapFocusAutoCapture]="true"
 >
 	<div class="lu-picker-content" [class.is-loading]="loading$ | async" (scroll)="onScroll($event)">
-		<div class="lu-picker-content-option" role="listbox">
+		<div role="listbox">
 			<ng-container *ngIf="grouping && ctx.groupTemplateLocation === 'group-header'">
 				<div
 					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -1,14 +1,14 @@
 <div
 	class="lu-picker-panel lu-option-picker-panel"
 	cdkTrapFocus
-	*ngIf="{ options: (options$ | async) || [] } as ctx"
+	*ngIf="{ options: (options$ | async) || [], clue: clueChange$ | async } as ctx"
 	[cdkTrapFocusAutoCapture]="true"
 >
 	<div class="lu-picker-content" [class.is-loading]="loading$ | async" (scroll)="onScroll($event)">
 		<div class="lu-picker-content-option" role="listbox">
-			<ng-container *ngIf="grouping">
+			<ng-container *ngIf="grouping && !ctx.clue">
 				<div
-					*ngFor="let group of groups$ | async"
+					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"
 					class="lu-picker-content-option-group"
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
@@ -19,7 +19,7 @@
 					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />
 				</div>
 			</ng-container>
-			<ng-container *ngIf="!grouping">
+			<ng-container *ngIf="!grouping || ctx.clue">
 				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
 			</ng-container>
 
@@ -29,10 +29,11 @@
 					[option]="option"
 					[optionTpl]="optionTpl"
 					[optionIndex]="index"
+					[grouping]="grouping && ctx.clue ? grouping : undefined"
 					[scrollIntoViewOptions]="{ block: 'center' }"
 					[isSelected]="option | luIsOptionSelected:optionComparer:selected"
 					(click)="panelRef.emitValue(option)"
-				></lu-select-option>
+				/>
 			</ng-template>
 			<div class="lu-picker-content-option-emptyState" *ngIf="ctx.options.length === 0 && (loading$ | async) === false">
 				{{intl.emptyResults}}

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -3,9 +3,9 @@ import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { LuSelectPanelRef, SELECT_ID, ɵLuOptionComponent, ɵgenerateGroups } from '@lucca-front/ng/core-select';
-import { EMPTY, asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
-import { debounceTime, switchMap } from 'rxjs/operators';
+import { LuSelectPanelRef, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe } from '@lucca-front/ng/core-select';
+import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
+import { debounceTime, startWith, switchMap } from 'rxjs/operators';
 import { LuSimpleSelectInputComponent } from '../input/select-input.component';
 import { SIMPLE_SELECT_INPUT } from '../select.model';
 import { LU_SIMPLE_SELECT_TRANSLATIONS } from '../select.translate';
@@ -17,7 +17,7 @@ import { LuIsOptionSelectedPipe } from './option-selected.pipe';
 	styleUrls: ['./panel.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
-	imports: [A11yModule, AsyncPipe, FormsModule, NgIf, NgFor, NgTemplateOutlet, ɵLuOptionComponent, LuIsOptionSelectedPipe, PortalDirective],
+	imports: [A11yModule, AsyncPipe, FormsModule, NgIf, NgFor, NgTemplateOutlet, ɵLuOptionGroupPipe, ɵLuOptionComponent, LuIsOptionSelectedPipe, PortalDirective],
 })
 export class LuSelectPanelComponent<T> implements AfterViewInit {
 	public selectInput = inject<LuSimpleSelectInputComponent<T>>(SIMPLE_SELECT_INPUT);
@@ -27,7 +27,6 @@ export class LuSelectPanelComponent<T> implements AfterViewInit {
 
 	options$ = this.selectInput.options$;
 	grouping = this.selectInput.grouping;
-	groups$ = this.grouping ? this.options$.pipe(map((options) => ɵgenerateGroups(options, this.grouping.selector))) : EMPTY;
 	loading$ = this.selectInput.loading$;
 	optionComparer = this.selectInput.optionComparer;
 	initialValue: T | undefined = this.selectInput.value;
@@ -43,6 +42,8 @@ export class LuSelectPanelComponent<T> implements AfterViewInit {
 	public get selected(): T | undefined {
 		return this.initialValue;
 	}
+
+	public clueChange$ = this.selectInput.clueChange.pipe(startWith(this.selectInput.clue));
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -3,7 +3,7 @@ import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { LuSelectPanelRef, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe } from '@lucca-front/ng/core-select';
+import { LuSelectPanelRef, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
 import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
 import { debounceTime, startWith, switchMap } from 'rxjs/operators';
 import { LuSimpleSelectInputComponent } from '../input/select-input.component';
@@ -44,6 +44,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit {
 	}
 
 	public clueChange$ = this.selectInput.clueChange.pipe(startWith(this.selectInput.clue));
+	public groupTemplateLocation$ = ɵgetGroupTemplateLocation(!!this.grouping, this.clueChange$, this.options$);
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {

--- a/packages/ng/styles/components/_picker.scss
+++ b/packages/ng/styles/components/_picker.scss
@@ -43,7 +43,7 @@
 	display: flex;
 	gap: var(--spacings-XS);
 	justify-content: space-between;
-	box-shadow: 0 calc(var(--spacings-XXS) * -1) 0 var(--spacings-XXS) var(--pr-t-elevation-surface-raised); // Mask background options scrolling behind
+	box-shadow:  calc(var(--spacings-XXS) * -0.5) calc(var(--spacings-XXS) * -0.5) 0 2px var(--pr-t-elevation-surface-raised); // Mask background options scrolling behind
 }
 
 .lu-picker-content-add {

--- a/packages/ng/styles/components/_picker.scss
+++ b/packages/ng/styles/components/_picker.scss
@@ -30,6 +30,10 @@
 	text-align: center;
 }
 
+.lu-picker-content-option-group {
+	margin-bottom: var(--spacings-XXS);
+}
+
 .lu-picker-content-option-group-title {
 	font-size: var(--sizes-S-fontSize);
 	line-height: var(--sizes-S-lineHeight);

--- a/packages/ng/styles/components/_picker.scss
+++ b/packages/ng/styles/components/_picker.scss
@@ -43,7 +43,7 @@
 	display: flex;
 	gap: var(--spacings-XS);
 	justify-content: space-between;
-	box-shadow:  calc(var(--spacings-XXS) * -0.5) calc(var(--spacings-XXS) * -0.5) 0 2px var(--pr-t-elevation-surface-raised); // Mask background options scrolling behind
+	box-shadow: calc(var(--spacings-XXS) * -0.5) calc(var(--spacings-XXS) * -0.5) 0 2px var(--pr-t-elevation-surface-raised); // Mask background options scrolling behind
 }
 
 .lu-picker-content-add {
@@ -106,4 +106,10 @@
 	.lu-picker-content {
 		max-height: none;
 	}
+}
+
+.lu-picker-content-group {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacings-XXS);
 }

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -87,6 +87,12 @@
 		}
 	}
 
+	.optionItem-value-group {
+		color: var(--palettes-neutral-600);
+		font-size: var(--sizes-S-fontSize);
+		line-height: var(--sizes-S-lineHeight);
+	}
+
 	:host-context(.lu-select-value) {
 		.optionItem-value {
 			padding: 0;

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -12,7 +12,7 @@ import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { Meta, applicationConfig, moduleMetadata } from '@storybook/angular';
 import { HiddenArgType } from 'stories/helpers/common-arg-types';
 import { getStoryGenerator } from 'stories/helpers/stories';
-import { FilterLegumesPipe, ILegume, LuCoreSelectInputStoryComponent, allLegumes, colorNameByColor, coreSelectStory } from './select.utils';
+import { FilterLegumesPipe, ILegume, LuCoreSelectInputStoryComponent, SortLegumesPipe, allLegumes, colorNameByColor, coreSelectStory } from './select.utils';
 
 type LuMultiSelectInputStoryComponent = LuCoreSelectInputStoryComponent & {
 	selectedLegumes: ILegume[];
@@ -277,7 +277,7 @@ export const GroupBy = generateStory({
 		class="textfield-input"
 		placeholder="Placeholder..."
 		[(ngModel)]="selectedLegumes"
-		[options]="legumes | filterLegumes:clue"
+		[options]="legumes | filterLegumes:clue | sortLegumes:(clue ? ['name', legumeColor] : [legumeColor])"
 		(clueChange)="clue = $event"
 		[maxValuesShown]="maxValuesShown"
 	>
@@ -292,7 +292,6 @@ export const GroupBy = generateStory({
 	},
 	storyPartial: {
 		args: {
-			legumes: [...allLegumes].sort((a, b) => colorNameByColor[a.color].localeCompare(colorNameByColor[b.color])),
 			legumeColor: (legume: ILegume) => legume.color,
 			colorNameByColor,
 		},
@@ -308,6 +307,7 @@ const meta: Meta<LuMultiSelectInputStoryComponent> = {
 				I18nPluralPipe,
 				FormsModule,
 				FilterLegumesPipe,
+				SortLegumesPipe,
 				LuMultiSelectInputComponent,
 				LuMultiDisplayerDirective,
 				LuOptionDirective,

--- a/stories/documentation/forms/select/select.utils.ts
+++ b/stories/documentation/forms/select/select.utils.ts
@@ -90,3 +90,13 @@ export class FilterLegumesPipe implements PipeTransform {
 		return clue ? legumes.filter((legume) => legume.name.toLowerCase().includes(clue.toLowerCase())) : legumes;
 	}
 }
+
+@Pipe({ name: 'sortLegumes', standalone: true })
+export class SortLegumesPipe implements PipeTransform {
+	transform(legumes: ILegume[], by: Array<((l: ILegume) => string) | keyof ILegume>): ILegume[] {
+		return legumes
+			.map((legume) => ({ legume, key: by.map((key) => (typeof key === 'string' ? legume[key] : key(legume))).join('') }))
+			.sort((a, b) => a.key.localeCompare(b.key))
+			.map((a) => a.legume);
+	}
+}

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -1,6 +1,5 @@
 import { I18nPluralPipe, SlicePipe } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
-import { Pipe, PipeTransform } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { LuDisabledOptionDirective, LuDisplayerDirective, LuOptionDirective, LuOptionGroupDirective } from '@lucca-front/ng/core-select';
 import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-front/ng/core-select/api';
@@ -15,7 +14,7 @@ import { getStoryGenerator, useDocumentationStory } from 'stories/helpers/storie
 import { provideCoreSelectCurrentUserId } from '../../../../packages/ng/core-select/user/me.provider';
 import { LuCoreSelectCustomEstablishmentsDirective } from './custom-establishment-example.component';
 import { LuCoreSelectCustomUsersDirective } from './custom-user-example.component';
-import { ILegume, LuCoreSelectInputStoryComponent, allLegumes, colorNameByColor, coreSelectStory } from './select.utils';
+import { FilterLegumesPipe, ILegume, LuCoreSelectInputStoryComponent, SortLegumesPipe, allLegumes, colorNameByColor, coreSelectStory } from './select.utils';
 
 export type LuSimpleSelectInputStoryComponent = LuCoreSelectInputStoryComponent & {
 	selectedLegume: ILegume | null;
@@ -327,7 +326,7 @@ export const GroupBy = generateStory({
 		class="textfield-input"
 		placeholder="Placeholder..."
 		[(ngModel)]="selectedLegume"
-		[options]="legumes | filterLegumes:clue"
+		[options]="legumes | filterLegumes:clue | sortLegumes:(clue ? ['name', legumeColor] : [legumeColor])"
 		(clueChange)="clue = $event"
 	>
 		<ng-container *luOptionGroup="let group by legumeColor; select: selectRef">
@@ -341,19 +340,11 @@ export const GroupBy = generateStory({
 	},
 	storyPartial: {
 		args: {
-			legumes: [...allLegumes].sort((a, b) => colorNameByColor[a.color].localeCompare(colorNameByColor[b.color])),
 			legumeColor: (legume: ILegume) => legume.color,
 			colorNameByColor,
 		},
 	},
 });
-
-@Pipe({ name: 'filterLegumes', standalone: true })
-class FilterLegumesPipe implements PipeTransform {
-	transform(legumes: ILegume[], clue: string): ILegume[] {
-		return clue ? legumes.filter((legume) => legume.name.toLowerCase().includes(clue.toLowerCase())) : legumes;
-	}
-}
 
 const meta: Meta<LuSimpleSelectInputStoryComponent> = {
 	title: 'Documentation/Forms/SimpleSelect',
@@ -367,6 +358,7 @@ const meta: Meta<LuSimpleSelectInputStoryComponent> = {
 				LuOptionDirective,
 				LuUserDisplayPipe,
 				FilterLegumesPipe,
+				SortLegumesPipe,
 				SlicePipe,
 				LuCoreSelectApiV3Directive,
 				LuCoreSelectApiV4Directive,


### PR DESCRIPTION
## Description

Grouped options, with empty clue:

![image](https://github.com/LuccaSA/lucca-front/assets/12662533/7744e802-8555-43ae-9e18-9cd8021119c7)

Grouped options, wit clue:

![image](https://github.com/LuccaSA/lucca-front/assets/12662533/1ac543a1-036d-4485-a942-ea956dcec9e6)

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
