### PR TITLE
feat(text-field): add `step` input and `noSpinButtons` flag to remove spin buttons

### DIFF
--- a/packages/ng/forms/text-input/text-input.component.html
+++ b/packages/ng/forms/text-input/text-input.component.html
@@ -1,7 +1,7 @@
 <div class="textField">
 	<ng-template #textfieldAddon let-addon="addon" let-type="type">
 		<span class="textField-{{type}}" luFormFieldId="{{type}}" *ngIf="addon.content">
-			<span class="textField-label-{{type}}-item" [attr.aria-label]="addon.ariaLabel">{{addon.content}}</span>
+			<span class="textField-label-{{type}}-item" [attr.aria-label]="addon.ariaLabel">{{ addon.content }}</span>
 		</span>
 		<span class="textField-{{type}}" luFormFieldId="{{type}}" *ngIf="addon.icon">
 			<span class="textField-label-{{type}}-item" [attr.aria-label]="addon.ariaLabel"
@@ -36,12 +36,14 @@
 			class="textField-input-value"
 			[placeholder]="placeholder"
 			[formControl]="ngControl.control"
+			[step]="step"
+			[class.u-noSpinButtons]="noSpinButtons"
 			#inputElement
 		/>
 		<div class="textField-input-affix">
 			<button class="textField-input-affix-clear clear" (click)="clearValue()" *ngIf="hasClearer && inputElement.value">
 				<span aria-hidden="true" class="lucca-icon icon-close"></span>
-				<span class="u-mask">{{intl.clear}}</span>
+				<span class="u-mask">{{ intl.clear }}</span>
 			</button>
 			<span aria-hidden="true" class="textField-input-affix-icon lucca-icon icon-{{searchIcon}}" *ngIf="hasSearchIcon"></span>
 			<button
@@ -52,7 +54,7 @@
 				*ngIf="hasTogglePasswordVisibilityIcon()"
 			>
 				<span aria-hidden="true" class="lucca-icon icon-{{showPassword ? 'unwatch' : 'watch'}}"></span>
-				<span class="u-mask">{{intl.togglePasswordVisibility}}</span>
+				<span class="u-mask">{{ intl.togglePasswordVisibility }}</span>
 			</button>
 		</div>
 	</div>

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Component, ElementRef, Input, ViewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, Component, ElementRef, Input, numberAttribute, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
@@ -25,6 +25,12 @@ export class TextInputComponent {
 
 	@Input()
 	placeholder: string;
+
+	@Input({ transform: numberAttribute })
+	step: number = 1;
+
+	@Input({ transform: booleanAttribute })
+	noSpinButtons = false;
 
 	@Input({ transform: booleanAttribute })
 	hasClearer = false;

--- a/stories/documentation/forms/fields/text/angular/textfield.stories.ts
+++ b/stories/documentation/forms/fields/text/angular/textfield.stories.ts
@@ -81,6 +81,8 @@ export const Basic: StoryObj<TextInputComponent & { disabled: boolean } & FormFi
 		type: 'text',
 		placeholder: 'Placeholder',
 		tooltip: "Je suis un message d'aide",
+		noSpinButtons: false,
+		step: 1,
 	},
 };
 


### PR DESCRIPTION
## Description

When setting a `lu-text-input` `type` to `number`, we had no ways to provide a value for `step` in order to customize it, this PR adds a `step` button for this.

Additionally, it's also adding a `noSpingButtons` boolean input that can be used to put the `u-noSpinButtons` class on the native input to hide native number input spin buttons.

-----
-----
