### PR TITLE
feat(form-field): label can now be a ng-template or a string

### DIFF
--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -6,7 +6,9 @@
 	[class.u-mask]="hiddenLabel"
 	attr.aria-hidden="{{hiddenLabel}}"
 >
-	{{label}}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
+	<ng-container *luPortal="label"></ng-container
+	><!--
+	--><sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
 	<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
 </label>
 <ng-content></ng-content>

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -6,7 +6,7 @@ import { BehaviorSubject } from 'rxjs';
 import { InlineMessageComponent, InlineMessageState } from '@lucca-front/ng/inline-message';
 import { SafeHtml } from '@angular/platform-browser';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { LuClass } from '@lucca-front/ng/core';
+import { LuClass, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { NG_VALIDATORS, NgControl, ReactiveFormsModule, RequiredValidator, Validator, Validators } from '@angular/forms';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { FORM_FIELD_INSTANCE } from './form-field.token';
@@ -16,7 +16,7 @@ let nextId = 0;
 @Component({
 	selector: 'lu-form-field',
 	standalone: true,
-	imports: [NgIf, NgSwitch, NgSwitchCase, NgTemplateOutlet, InlineMessageComponent, LuTooltipModule, ReactiveFormsModule, IconComponent],
+	imports: [NgIf, NgSwitch, NgSwitchCase, NgTemplateOutlet, InlineMessageComponent, LuTooltipModule, ReactiveFormsModule, IconComponent, PortalDirective],
 	templateUrl: './form-field.component.html',
 	styleUrls: ['./form-field.component.scss'],
 	providers: [
@@ -55,7 +55,7 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 	@Input({
 		required: true,
 	})
-	label: string;
+	label: PortalContent;
 
 	@Input({
 		transform: booleanAttribute,


### PR DESCRIPTION
## Description

This PR changes the input type of `label` to `PortalContent` so it can be a `string | TemplateRef`, allowing `ng-template` inputs.

-----

-----
