### PR TITLE
feat(schematics): new CssMapper class for easy CSS schematics along with 3 schematics

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.html
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.html
@@ -1,5 +1,5 @@
 <button class="dialog-inside-header-button" type="button" luButton (click)="close()" *ngIf="dismissible">
-	<lu-icon icon="close"></lu-icon>
+	<lu-icon icon="signClose"></lu-icon>
 	<span class="u-mask">{{ intl.close }}</span>
 </button>
 

--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -7,7 +7,7 @@
 	attr.aria-hidden="{{hiddenLabel}}"
 >
 	{{label}}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
-	<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+	<lu-icon icon="signHelp" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
 </label>
 <ng-content></ng-content>
 <lu-inline-message

--- a/packages/ng/forms/text-input/text-input.component.html
+++ b/packages/ng/forms/text-input/text-input.component.html
@@ -40,7 +40,7 @@
 		/>
 		<div class="textField-input-affix">
 			<button class="textField-input-affix-clear clear" (click)="clearValue()" *ngIf="hasClearer && inputElement.value">
-				<span aria-hidden="true" class="lucca-icon icon-close"></span>
+				<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
 				<span class="u-mask">{{intl.clear}}</span>
 			</button>
 			<span aria-hidden="true" class="textField-input-affix-icon lucca-icon icon-{{searchIcon}}" *ngIf="hasSearchIcon"></span>

--- a/packages/ng/schematics/action-icon/index.ts
+++ b/packages/ng/schematics/action-icon/index.ts
@@ -1,0 +1,40 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { migrateFile } from '../lib/schematics';
+import { migrateHTMLFile, migrateScssFile } from './migration';
+
+export default (options?: { skipInstallation?: boolean }): Rule => {
+	const skipInstallation = options?.skipInstallation ?? false;
+
+	return async (tree, context) => {
+		if (!skipInstallation) {
+			context.logger.info('Installing dependencies...');
+
+			try {
+				spawnSync('npm', ['ci'], {
+					cwd: path.join(__dirname, '../../lib/local-deps'),
+				});
+				context.logger.info('Installing dependencies... Done!');
+			} catch (e) {
+				// eslint-disable-next-line
+				context.logger.error('Failed to install dependencies', (e as any).toString());
+			}
+		}
+
+		const postCssScss = await import('../lib/local-deps/postcss-scss.js');
+		const angularCompiler = await import('@angular/compiler');
+
+		tree.visit((path, entry) => {
+			if (path.includes('node_modules') || !entry) {
+				return;
+			}
+			if (path.endsWith('.scss')) {
+				migrateFile(path, entry, tree, (content) => migrateScssFile(content, postCssScss));
+			}
+			if (path.endsWith('.html')) {
+				migrateFile(path, entry, tree, (content) => migrateHTMLFile(content, angularCompiler));
+			}
+		});
+	};
+};

--- a/packages/ng/schematics/action-icon/migration.spec.ts
+++ b/packages/ng/schematics/action-icon/migration.spec.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as path from 'path';
+import { createTreeFromFiles, expectTree, runSchematic } from '../lib/migration-test.js';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.json'));
+const testsRoot = path.join(__dirname, 'tests');
+const files = fs.readdirSync(testsRoot);
+
+describe('actionIcon Migration', () => {
+	it('should update files', async () => {
+		// Arrange
+		const tree = createTreeFromFiles(testsRoot, files, '.input.');
+		const expectedTree = createTreeFromFiles(testsRoot, files, '.output.');
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'action-icon', { skipInstallation: true }, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+
+	// Use this to migrate @lucca-front/* packages
+	it.skip('should migrate @lucca-front/*', async () => {
+		// Arrange
+		const lfRoot = path.normalize(path.join(__dirname, '..', '..', '..', '..'));
+		const lfFiles = [
+			...glob.sync('packages/icons/**/*.scss', { cwd: lfRoot, nodir: true }),
+			...glob.sync('packages/scss/**/*.scss', { cwd: lfRoot, nodir: true }),
+			...glob.sync('packages/ng/**/*', { cwd: lfRoot, nodir: true, ignore: ['**/schematics/**'] }),
+			...glob.sync('stories/**', { cwd: lfRoot, nodir: true }),
+		];
+
+		const treeOriginalTree = createTreeFromFiles(lfRoot, lfFiles, '.');
+		const tree = createTreeFromFiles(lfRoot, lfFiles, '.');
+
+		// Act
+		await runSchematic('collection', collectionPath, 'action-icon', { skipInstallation: true }, tree);
+
+		// Assert
+		tree.visit((p, entry) => {
+			const original = treeOriginalTree.get(p)?.content.toString() || '';
+			const updated = entry?.content.toString() || '';
+
+			if (original !== updated) {
+				const fromRootPath = path.join(lfRoot, p);
+				fs.writeFileSync(fromRootPath, updated);
+			}
+		});
+	});
+});

--- a/packages/ng/schematics/action-icon/migration.ts
+++ b/packages/ng/schematics/action-icon/migration.ts
@@ -1,0 +1,38 @@
+import { updateContent } from '../lib/file-update.js';
+import { AngularCompilerLib, HtmlAst } from '../lib/html-ast.js';
+import { PostCssScssLib } from '../lib/scss-ast.js';
+
+export function migrateScssFile(content: string, postCssScss: PostCssScssLib): string {
+	const root = postCssScss.parse(content);
+
+	root.walkRules((rule) => {
+		if (rule.selector.includes('actionIcon')) {
+			rule.raws.before =
+				(rule.raws.before || '') + '// Schematics Lucca Front 17.4.0 migrer actionIcon ("button mod-onlyIcon mod-text" ou "button mod-onlyIcon mod-outlined" si vous avez mod-outlined déjà présent)\n';
+		}
+	});
+
+	return root.toResult({ syntax: { stringify: postCssScss.stringify } }).css;
+}
+
+export function migrateHTMLFile(content: string, angularCompiler: AngularCompilerLib): string {
+	return updateContent(content, (updates) => {
+		const htmlAst = new HtmlAst(content, angularCompiler);
+		htmlAst.visitElementWithAttribute(/.*/, 'class', (elem, attr) => {
+			const classes = attr.value;
+			if (classes.includes('actionIcon') && attr.valueSpan) {
+				let newClasses: string;
+				if (classes.includes('mod-outlined')) {
+					newClasses = classes.replace('actionIcon', 'button mod-onlyIcon');
+				} else {
+					newClasses = classes.replace('actionIcon', 'button mod-onlyIcon mod-text');
+				}
+				updates.push({
+					position: attr.valueSpan.start.offset,
+					oldContent: attr.value,
+					newContent: newClasses,
+				});
+			}
+		});
+	});
+}

--- a/packages/ng/schematics/action-icon/schema.json
+++ b/packages/ng/schematics/action-icon/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "LuccaFrontActionIcon",
+	"title": "Lucca Front Action Icon Schema",
+	"type": "object",
+	"properties": {}
+}

--- a/packages/ng/schematics/action-icon/tests/component.input.scss
+++ b/packages/ng/schematics/action-icon/tests/component.input.scss
@@ -1,0 +1,7 @@
+.actionIcon {
+	color: lime;
+}
+
+.actionIcon .mod-outlined {
+	color: red;
+}

--- a/packages/ng/schematics/action-icon/tests/component.output.scss
+++ b/packages/ng/schematics/action-icon/tests/component.output.scss
@@ -1,0 +1,9 @@
+// Schematics Lucca Front 17.4.0 migrer actionIcon ("button mod-onlyIcon mod-text" ou "button mod-onlyIcon mod-outlined" si vous avez mod-outlined déjà présent)
+.actionIcon {
+	color: lime;
+}
+
+// Schematics Lucca Front 17.4.0 migrer actionIcon ("button mod-onlyIcon mod-text" ou "button mod-onlyIcon mod-outlined" si vous avez mod-outlined déjà présent)
+.actionIcon .mod-outlined {
+	color: red;
+}

--- a/packages/ng/schematics/action-icon/tests/template.input.html
+++ b/packages/ng/schematics/action-icon/tests/template.input.html
@@ -1,0 +1,2 @@
+<span class="actionIcon"></span>
+<span class="actionIcon mod-outlined"></span>

--- a/packages/ng/schematics/action-icon/tests/template.output.html
+++ b/packages/ng/schematics/action-icon/tests/template.output.html
@@ -1,0 +1,2 @@
+<span class="button mod-onlyIcon mod-text"></span>
+<span class="button mod-onlyIcon mod-outlined"></span>

--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -12,6 +12,10 @@
 		"tokens-spacings": {
 			"description": "Replace tokens with new names.",
 			"factory": "./tokens-spacing/index"
+		},
+		"palettes": {
+			"description": "Replace palettes with new names.",
+			"factory": "./palettes/index"
 		}
 	}
 }

--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -8,6 +8,10 @@
 		"new-icons": {
 			"description": "Replace old icon names with new ones.",
 			"factory": "./new-icons/index"
+		},
+		"tokens-spacings": {
+			"description": "Replace tokens with new names.",
+			"factory": "./tokens-spacing/index"
 		}
 	}
 }

--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -11,15 +11,18 @@
 		},
 		"tokens-spacings": {
 			"description": "Replace tokens with new names.",
-			"factory": "./tokens-spacing/index"
+			"factory": "./tokens-spacing/index",
+			"schema": "./tokens-spacing/schema.json"
 		},
 		"palettes": {
 			"description": "Replace palettes with new names.",
-			"factory": "./palettes/index"
+			"factory": "./palettes/index",
+			"schema": "./palettes/schema.json"
 		},
 		"action-icon": {
 			"description": "Replace actionIcon usages with button mod-onlyIcon",
-			"factory": "./action-icon/index"
+			"factory": "./action-icon/index",
+			"schema": "./action-icon/schema.json"
 		}
 	}
 }

--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -16,6 +16,10 @@
 		"palettes": {
 			"description": "Replace palettes with new names.",
 			"factory": "./palettes/index"
+		},
+		"action-icon": {
+			"description": "Replace actionIcon usages with button mod-onlyIcon",
+			"factory": "./action-icon/index"
 		}
 	}
 }

--- a/packages/ng/schematics/lib/css-mapper.ts
+++ b/packages/ng/schematics/lib/css-mapper.ts
@@ -1,0 +1,176 @@
+import { migrateFile } from './schematics';
+import { Tree } from '@angular-devkit/schematics';
+import { PostCssScssLib, PostCssSelectorParserLib, updateCSSClassNamesInRules, updateCSSVariableNames, updateMixinNames } from './scss-ast';
+import type { ValueParser } from 'postcss-value-parser';
+import { AngularCompilerLib, HtmlAst, HtmlAstVisitor, updateCssClassNames } from './html-ast';
+import { applyUpdates, FileUpdate, updateContent } from './file-update';
+import { createSourceFile, forEachChild, isStringLiteral, ScriptTarget } from 'typescript';
+import { replaceStringLiterals } from './typescript-ast';
+import { createVisitor, extractNgTemplates } from './angular-template';
+
+interface Mappings {
+	classes: Record<string, string>;
+	variables: Record<string, string>;
+	mixins: Record<string, string>;
+}
+
+export class CssMapper {
+	private mappings: Mappings = {
+		classes: this.expand(this.rawMappings.classes),
+		variables: this.expand(this.rawMappings.variables),
+		mixins: this.expand(this.rawMappings.mixins),
+	};
+	private classesToUpdate = new Set(Object.keys(this.mappings.classes));
+	private varsToUpdate = new Set(Object.keys(this.mappings.variables));
+
+	constructor(private tree: Tree, private rawMappings: Mappings, private mappingProps?: Record<string, Record<string, string>>) {}
+
+	async run() {
+		const postCssScss = await import('../lib/local-deps/postcss-scss.js');
+		const angularCompiler = await import('@angular/compiler');
+		const { postcssValueParser } = await import('../lib/local-deps/postcss-value-parser.js');
+		const { postcssSelectorParser } = await import('../lib/local-deps/postcss-selector-parser.js');
+		this.tree.visit((path, entry) => {
+			if (path.includes('node_modules') || !entry) {
+				return;
+			}
+			if (path.endsWith('.scss')) {
+				migrateFile(path, entry, this.tree, (content) => this.migrateScssFile(content, postCssScss, postcssValueParser, postcssSelectorParser));
+			}
+			if (path.endsWith('.html')) {
+				migrateFile(path, entry, this.tree, (content) => this.migrateHTMLFile(content, angularCompiler));
+			}
+			if (path.endsWith('.ts')) {
+				migrateFile(path, entry, this.tree, (content) => this.migrateTsFile(path, content, angularCompiler));
+			}
+		});
+	}
+
+	private migrateScssFile(content: string, postCssScss: PostCssScssLib, postcssValueParser: ValueParser, postcssSelectorParser: PostCssSelectorParserLib): string {
+		const root = postCssScss.parse(content);
+
+		updateMixinNames(root, this.mappings.mixins);
+		updateCSSVariableNames(root, this.mappings.variables, postcssValueParser);
+		updateCSSClassNamesInRules(root, this.mappings.classes, postcssSelectorParser);
+
+		return root.toResult({ syntax: { stringify: postCssScss.stringify } }).css;
+	}
+
+	private migrateHTMLFile(content: string, angularCompiler: AngularCompilerLib): string {
+		content = updateCssClassNames(content, this.mappings.classes, angularCompiler);
+
+		return updateContent(content, (updates) => {
+			const htmlAst = new HtmlAst(content, angularCompiler);
+			htmlAst.visitElements(/.*/, (elem) => {
+				const elAst = new HtmlAstVisitor(elem, angularCompiler);
+				elAst.visitBoundAttribute(/.*/, (attr) => {
+					if (attr.valueSpan && attr.value instanceof angularCompiler.ASTWithSource) {
+						const attrValue = attr.value.source || '';
+						const sourcefile = createSourceFile('', attrValue, ScriptTarget.ESNext);
+
+						updates.push(
+							...replaceStringLiterals(sourcefile, this.mappings.classes).map((update) => ({
+								...update,
+								position: (attr.valueSpan?.start.offset ?? 0) + update.position,
+							})),
+						);
+					}
+				});
+				elem.attributes.forEach((attr) => {
+					if (attr.name === 'class' && attr.valueSpan) {
+						updates.push({
+							position: attr.valueSpan.start.offset,
+							oldContent: attr.value,
+							newContent: this.updateCssText(attr.value),
+						});
+					}
+				});
+			});
+		});
+	}
+
+	private migrateTsFile(fileName: string, content: string, angularCompiler: AngularCompilerLib): string {
+		const sourcefile = createSourceFile(fileName, content, ScriptTarget.ESNext);
+		const templates = extractNgTemplates(sourcefile);
+
+		const updates: FileUpdate[] = templates.map((tpl) => ({
+			position: tpl.offsetStart,
+			oldContent: tpl.content,
+			newContent: updateCssClassNames(tpl.content, this.mappings.classes, angularCompiler),
+		}));
+
+		forEachChild(
+			sourcefile,
+			createVisitor(isStringLiteral, (node) => {
+				const newText = this.updateCssText(node.text);
+				if (newText !== node.text) {
+					const position = node.pos + node.getLeadingTriviaWidth(sourcefile) /* Spaces before the single/double quote */ + 1; /* Single or double quote before the string content */
+					updates.push({
+						position,
+						oldContent: node.text,
+						newContent: newText,
+					});
+				}
+			}),
+		);
+
+		return applyUpdates(content, updates);
+	}
+
+	private updateCssText(text: string): string {
+		const withoutClass = text.replace('class.', '');
+		const withoutStyle = text.replace('style.', '');
+		if (this.classesToUpdate.has(text)) {
+			return this.mappings.classes[text];
+		}
+		if (this.classesToUpdate.has(withoutClass)) {
+			return 'class.' + this.mappings.classes[withoutClass];
+		}
+		if (this.varsToUpdate.has(text)) {
+			return this.mappings.variables[text] || text;
+		}
+		if (this.varsToUpdate.has(withoutStyle)) {
+			return 'style.' + this.mappings.variables[withoutStyle] || text;
+		}
+		const splitWithSpace = text.split(' ');
+		if (splitWithSpace.length > 1) {
+			return splitWithSpace.map((entry) => this.updateCssText(entry)).join(' ');
+		}
+		return text;
+	}
+
+	private camelize(str: string): string {
+		return str[0].toLowerCase() + str.slice(1);
+	}
+
+	private pascalize(str: string): string {
+		return str[0].toUpperCase() + str.slice(1);
+	}
+
+	private expand(rawMapping: Record<string, string>): Record<string, string> {
+		const props = this.mappingProps || {};
+
+		const replaceValue = (oldValue: string, map: string, newValue: string) => {
+			return oldValue.replace(`{${map}}`, newValue).replace(`{${this.pascalize(map)}}`, this.pascalize(newValue));
+		};
+
+		return Object.fromEntries(
+			Object.entries(rawMapping).flatMap(([oldTemplate, newTemplate]) => {
+				const placeholders = [...oldTemplate.matchAll(/\{(\w*)}/g)].map(([, template]) => template);
+				let values = [[oldTemplate, newTemplate]];
+
+				for (const placeholder of placeholders) {
+					const map = this.camelize(placeholder);
+
+					if (!map || !(map in props)) {
+						throw new Error(`No mapping for ${map} found`);
+					}
+
+					values = values.flatMap(([oldVal, newVal]) => Object.entries(props[map]).map(([key, value]) => [replaceValue(oldVal, map, key), replaceValue(newVal, map, value)]));
+				}
+
+				return values;
+			}),
+		) as Record<string, string>;
+	}
+}

--- a/packages/ng/schematics/palettes/index.ts
+++ b/packages/ng/schematics/palettes/index.ts
@@ -1,0 +1,59 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { CssMapper } from '../lib/css-mapper';
+
+export default (options?: { skipInstallation?: boolean }): Rule => {
+	const skipInstallation = options?.skipInstallation ?? false;
+
+	return async (tree, context) => {
+		if (!skipInstallation) {
+			context.logger.info('Installing dependencies...');
+
+			try {
+				spawnSync('npm', ['ci'], {
+					cwd: path.join(__dirname, '../../lib/local-deps'),
+				});
+				context.logger.info('Installing dependencies... Done!');
+			} catch (e) {
+				// eslint-disable-next-line
+				context.logger.error('Failed to install dependencies', (e as any).toString());
+			}
+		}
+
+		await new CssMapper(
+			tree,
+			{
+				classes: {
+					'palette-grey': 'palette-neutral',
+					'palette-primary': 'palette-product',
+					'palette-secondary': 'palette-product',
+					'palette-lucca': 'palette-brand',
+				},
+				variables: {
+					'--palettes-grey-{val}': `--palettes-neutral-{val}`,
+					'--palettes-primary-{val}': `--palettes-product-{val}`,
+					'--palettes-secondary-{val}': `--palettes-product-{val}`,
+					'--palettes-lucca-{val}': `--palettes-brand-{val}`,
+					'--colors-grey-{val}': `--colors-neutral-{val}`,
+				},
+				mixins: {},
+			},
+			{
+				val: {
+					25: '25',
+					50: '50',
+					100: '100',
+					200: '200',
+					300: '300',
+					400: '400',
+					500: '500',
+					600: '600',
+					700: '700',
+					800: '800',
+					900: '900',
+				},
+			},
+		).run();
+	};
+};

--- a/packages/ng/schematics/palettes/migration.spec.ts
+++ b/packages/ng/schematics/palettes/migration.spec.ts
@@ -7,7 +7,7 @@ const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.jso
 const testsRoot = path.join(__dirname, 'tests');
 const files = fs.readdirSync(testsRoot);
 
-describe('Tokens spacing Migration', () => {
+describe('Palettes Migration', () => {
 	it('should update files', async () => {
 		// Arrange
 		const tree = createTreeFromFiles(testsRoot, files, '.input.');
@@ -15,7 +15,7 @@ describe('Tokens spacing Migration', () => {
 
 		// Act
 		try {
-			await runSchematic('collection', collectionPath, 'tokens-spacings', { skipInstallation: true }, tree);
+			await runSchematic('collection', collectionPath, 'palettes', { skipInstallation: true }, tree);
 		} catch (error) {
 			// eslint-disable-next-line no-console
 			console.log(error);
@@ -24,7 +24,6 @@ describe('Tokens spacing Migration', () => {
 		// Assert
 		expectTree(tree).toMatchTree(expectedTree);
 	});
-
 	// Use this to migrate @lucca-front/* packages
 	it.skip('should migrate @lucca-front/*', async () => {
 		// Arrange
@@ -40,7 +39,7 @@ describe('Tokens spacing Migration', () => {
 		const tree = createTreeFromFiles(lfRoot, lfFiles, '.');
 
 		// Act
-		await runSchematic('collection', collectionPath, 'tokens-spacings', { skipInstallation: true }, tree);
+		await runSchematic('collection', collectionPath, 'palettes', { skipInstallation: true }, tree);
 
 		// Assert
 		tree.visit((p, entry) => {

--- a/packages/ng/schematics/palettes/schema.json
+++ b/packages/ng/schematics/palettes/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "LuccaFrontPalettes",
+	"title": "Lucca Front Palettes Schema",
+	"type": "object",
+	"properties": {}
+}

--- a/packages/ng/schematics/palettes/tests/component.input.scss
+++ b/packages/ng/schematics/palettes/tests/component.input.scss
@@ -1,0 +1,6 @@
+.css-vars {
+	background-color: var(--palettes-grey-25);
+	color: var(--palettes-primary-500);
+}
+
+

--- a/packages/ng/schematics/palettes/tests/component.input.ts
+++ b/packages/ng/schematics/palettes/tests/component.input.ts
@@ -1,0 +1,28 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+	selector: 'lu-test',
+	template: `I'm an inline template with a class to migrate <span class="palette-primary"></span>`,
+	host: {
+		class: 'palette-grey',
+	},
+})
+export class TestComponent {}
+
+export const byProp = {
+	classes: 'palette-secondary',
+};
+
+@Component({
+	selector: 'lu-test2',
+	templateUrl: './template.input.html',
+})
+export class Test2Component {
+	@HostBinding('class.palette-lucca') a = true;
+
+	classes = ['palette-grey', 'palette-lucca'];
+
+	byProp = {
+		classes: 'palette-grey palette-lucca',
+	};
+}

--- a/packages/ng/schematics/palettes/tests/component.output.scss
+++ b/packages/ng/schematics/palettes/tests/component.output.scss
@@ -1,0 +1,6 @@
+.css-vars {
+	background-color: var(--palettes-neutral-25);
+	color: var(--palettes-product-500);
+}
+
+

--- a/packages/ng/schematics/palettes/tests/component.output.ts
+++ b/packages/ng/schematics/palettes/tests/component.output.ts
@@ -1,0 +1,28 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+	selector: 'lu-test',
+	template: `I'm an inline template with a class to migrate <span class="palette-product"></span>`,
+	host: {
+		class: 'palette-neutral',
+	},
+})
+export class TestComponent {}
+
+export const byProp = {
+	classes: 'palette-product',
+};
+
+@Component({
+	selector: 'lu-test2',
+	templateUrl: './template.input.html',
+})
+export class Test2Component {
+	@HostBinding('class.palette-brand') a = true;
+
+	classes = ['palette-neutral', 'palette-brand'];
+
+	byProp = {
+		classes: 'palette-neutral palette-brand',
+	};
+}

--- a/packages/ng/schematics/palettes/tests/template.input.html
+++ b/packages/ng/schematics/palettes/tests/template.input.html
@@ -1,0 +1,11 @@
+<!-- basic class -->
+<div class="palette-grey"></div>
+<div [class]="'palette-grey'"></div>
+<div [class]="condition ? 'palette-grey' : 'palette-secondary'"></div>
+
+<!-- NgClass -->
+<span aria-hidden="true" [ngClass]="{ 'palette-lucca': showBillingInfos, 'palette-primary': !showBillingInfos }"></span>
+<span aria-hidden="true" [ngClass]="event.expanded ? 'palette-grey' : 'palette-lucca'"></span>
+
+<!-- Class bound attribute -->
+<span [class.palette-grey]="!showDetails"></span>

--- a/packages/ng/schematics/palettes/tests/template.output.html
+++ b/packages/ng/schematics/palettes/tests/template.output.html
@@ -1,0 +1,11 @@
+<!-- basic class -->
+<div class="palette-neutral"></div>
+<div [class]="'palette-neutral'"></div>
+<div [class]="condition ? 'palette-neutral' : 'palette-product'"></div>
+
+<!-- NgClass -->
+<span aria-hidden="true" [ngClass]="{ 'palette-brand': showBillingInfos, 'palette-product': !showBillingInfos }"></span>
+<span aria-hidden="true" [ngClass]="event.expanded ? 'palette-neutral' : 'palette-brand'"></span>
+
+<!-- Class bound attribute -->
+<span [class.palette-neutral]="!showDetails"></span>

--- a/packages/ng/schematics/tokens-spacing/index.ts
+++ b/packages/ng/schematics/tokens-spacing/index.ts
@@ -1,0 +1,66 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { CssMapper } from '../lib/css-mapper';
+
+export default (options?: { skipInstallation?: boolean }): Rule => {
+	const skipInstallation = options?.skipInstallation ?? false;
+
+	return async (tree, context) => {
+		if (!skipInstallation) {
+			context.logger.info('Installing dependencies...');
+
+			try {
+				spawnSync('npm', ['ci'], {
+					cwd: path.join(__dirname, '../../lib/local-deps'),
+				});
+				context.logger.info('Installing dependencies... Done!');
+			} catch (e) {
+				// eslint-disable-next-line
+				context.logger.error('Failed to install dependencies', (e as any).toString());
+			}
+		}
+
+		await new CssMapper(
+			tree,
+			{
+				classes: {
+					'u-margin{tshirt}': 'pr-u-margin{tshirt}',
+					'u-marginTop{tshirt}': 'pr-u-marginTop{tshirt}',
+					'u-marginBottom{tshirt}': 'pr-u-marginBottom{tshirt}',
+					'u-marginLeft{tshirt}': 'pr-u-marginLeft{tshirt}',
+					'u-marginRight{tshirt}': 'pr-u-marginRight{tshirt}',
+					'u-marginInline{tshirt}': 'pr-u-marginInline{tshirt}',
+					'u-marginBlock{tshirt}': 'pr-u-marginBlock{tshirt}',
+					'u-padding{tshirt}': 'pr-u-padding{tshirt}',
+					'u-paddingTop{tshirt}': 'pr-u-paddingTop{tshirt}',
+					'u-paddingBottom{tshirt}': 'pr-u-paddingBottom{tshirt}',
+					'u-paddingLeft{tshirt}': 'pr-u-paddingLeft{tshirt}',
+					'u-paddingRight{tshirt}': 'pr-u-paddingRight{tshirt}',
+					'u-paddingInline{tshirt}': 'pr-u-paddingInline{tshirt}',
+					'u-paddingBlock{tshirt}': 'pr-u-paddingBlock{tshirt}',
+					'u-gap{tshirt}': 'pr-u-gap{tshirt}',
+					'u-rowGap{tshirt}': 'pr-u-rowGap{tshirt}',
+					'u-columnGap{tshirt}': 'pr-u-columnGap{tshirt}',
+				},
+				variables: {
+					'--spacings-{tshirt}': `--pr-t-spacings-{tshirt}`,
+				},
+				mixins: {},
+			},
+			{
+				tshirt: {
+					Auto: 'Auto',
+					0: '0',
+					XXS: '50',
+					XS: '100',
+					S: '200',
+					M: '300',
+					L: '400',
+					XL: '600',
+					XXL: '800',
+				},
+			},
+		).run();
+	};
+};

--- a/packages/ng/schematics/tokens-spacing/migration.spec.ts
+++ b/packages/ng/schematics/tokens-spacing/migration.spec.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as path from 'path';
+import { createTreeFromFiles, expectTree, runSchematic } from '../lib/migration-test.js';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.json'));
+const testsRoot = path.join(__dirname, 'tests');
+const files = fs.readdirSync(testsRoot);
+
+describe('New icons Migration', () => {
+	it('should update files', async () => {
+		// Arrange
+		const tree = createTreeFromFiles(testsRoot, files, '.input.');
+		const expectedTree = createTreeFromFiles(testsRoot, files, '.output.');
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'tokens-spacings', { skipInstallation: true }, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+
+	// Use this to migrate @lucca-front/* packages
+	it.skip('should migrate @lucca-front/*', async () => {
+		// Arrange
+		const lfRoot = path.normalize(path.join(__dirname, '..', '..', '..', '..'));
+		const lfFiles = [
+			...glob.sync('packages/icons/**/*.scss', { cwd: lfRoot, nodir: true }),
+			...glob.sync('packages/scss/**/*.scss', { cwd: lfRoot, nodir: true }),
+			...glob.sync('packages/ng/**/*', { cwd: lfRoot, nodir: true, ignore: ['**/schematics/**'] }),
+			...glob.sync('stories/**', { cwd: lfRoot, nodir: true }),
+		];
+
+		const treeOriginalTree = createTreeFromFiles(lfRoot, lfFiles, '.');
+		const tree = createTreeFromFiles(lfRoot, lfFiles, '.');
+
+		// Act
+		await runSchematic('collection', collectionPath, 'new-icons', { skipInstallation: true }, tree);
+
+		// Assert
+		tree.visit((p, entry) => {
+			const original = treeOriginalTree.get(p)?.content.toString() || '';
+			const updated = entry?.content.toString() || '';
+
+			if (original !== updated) {
+				const fromRootPath = path.join(lfRoot, p);
+				fs.writeFileSync(fromRootPath, updated);
+			}
+		});
+	});
+});

--- a/packages/ng/schematics/tokens-spacing/schema.json
+++ b/packages/ng/schematics/tokens-spacing/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "LuccaFrontTokensSpacing",
+	"title": "Lucca Front Tokens Spacing Schema",
+	"type": "object",
+	"properties": {}
+}

--- a/packages/ng/schematics/tokens-spacing/tests/component.input.scss
+++ b/packages/ng/schematics/tokens-spacing/tests/component.input.scss
@@ -1,0 +1,5 @@
+.css-vars {
+	margin: var(--spacings-L);
+}
+
+

--- a/packages/ng/schematics/tokens-spacing/tests/component.input.ts
+++ b/packages/ng/schematics/tokens-spacing/tests/component.input.ts
@@ -1,0 +1,29 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+	selector: 'lu-test',
+	template: `I'm an inline template with a class to migrate <span class="u-marginL u-rowGapM"></span>`,
+	host: {
+		class: 'u-paddingL',
+	},
+})
+export class TestComponent {}
+
+export const byProp = {
+	classes: 'u-paddingL u-columnGapS',
+	class: 'u-paddingL',
+};
+
+@Component({
+	selector: 'lu-test2',
+	templateUrl: './template.input.html',
+})
+export class Test2Component {
+	@HostBinding('class.u-paddingL') a = true;
+
+	classes = ['u-padding0', 'u-columnGapXXL'];
+
+	byProp = {
+		classes: 'u-paddingL u-columnGapS',
+	};
+}

--- a/packages/ng/schematics/tokens-spacing/tests/component.output.scss
+++ b/packages/ng/schematics/tokens-spacing/tests/component.output.scss
@@ -1,0 +1,5 @@
+.css-vars {
+	margin: var(--pr-t-spacings-400);
+}
+
+

--- a/packages/ng/schematics/tokens-spacing/tests/component.output.ts
+++ b/packages/ng/schematics/tokens-spacing/tests/component.output.ts
@@ -1,0 +1,29 @@
+import { Component, HostBinding } from '@angular/core';
+
+@Component({
+	selector: 'lu-test',
+	template: `I'm an inline template with a class to migrate <span class="pr-u-margin400 pr-u-rowGap300"></span>`,
+	host: {
+		class: 'pr-u-padding400',
+	},
+})
+export class TestComponent {}
+
+export const byProp = {
+	classes: 'pr-u-padding400 pr-u-columnGap200',
+	class: 'pr-u-padding400',
+};
+
+@Component({
+	selector: 'lu-test2',
+	templateUrl: './template.input.html',
+})
+export class Test2Component {
+	@HostBinding('class.pr-u-padding400') a = true;
+
+	classes = ['pr-u-padding0', 'pr-u-columnGap800'];
+
+	byProp = {
+		classes: 'pr-u-padding400 pr-u-columnGap200',
+	};
+}

--- a/packages/ng/schematics/tokens-spacing/tests/template.input.html
+++ b/packages/ng/schematics/tokens-spacing/tests/template.input.html
@@ -1,0 +1,11 @@
+<!-- basic class -->
+<div class="u-gapXL"></div>
+<div [class]="'u-gapXL'"></div>
+<div [class]="condition ? 'u-gapXL' : 'u-marginS'"></div>
+
+<!-- NgClass -->
+<span aria-hidden="true" [ngClass]="{ 'u-gapXS': showBillingInfos, 'u-marginXXL': !showBillingInfos }"></span>
+<span aria-hidden="true" [ngClass]="event.expanded ? 'u-gapXL' : 'u-gapM'"></span>
+
+<!-- Class bound attribute -->
+<span [class.u-paddingXXL]="!showDetails"></span>

--- a/packages/ng/schematics/tokens-spacing/tests/template.output.html
+++ b/packages/ng/schematics/tokens-spacing/tests/template.output.html
@@ -1,0 +1,11 @@
+<!-- basic class -->
+<div class="pr-u-gap600"></div>
+<div [class]="'pr-u-gap600'"></div>
+<div [class]="condition ? 'pr-u-gap600' : 'pr-u-margin200'"></div>
+
+<!-- NgClass -->
+<span aria-hidden="true" [ngClass]="{ 'pr-u-gap100': showBillingInfos, 'pr-u-margin800': !showBillingInfos }"></span>
+<span aria-hidden="true" [ngClass]="event.expanded ? 'pr-u-gap600' : 'pr-u-gap300'"></span>
+
+<!-- Class bound attribute -->
+<span [class.pr-u-padding800]="!showDetails"></span>

--- a/stories/documentation/navigation/vertical-navigation/vertical-navigation-iconless.stories.ts
+++ b/stories/documentation/navigation/vertical-navigation/vertical-navigation-iconless.stories.ts
@@ -11,7 +11,7 @@ function getTemplate(args: VerticalNavigationIconlessStory): string {
 	<h3 class="verticalNavigation-sectionTitle">Section title</h3>
 	<ul class="verticalNavigation-list">
 		<li class="verticalNavigation-list-item">
-			<button class="verticalNavigation-list-item-link" aria-expanded="false">Item<span aria-hidden="true" class="lucca-icon icon-southArrow verticalNavigation-list-item-link-arrow"></span></button>
+			<button class="verticalNavigation-list-item-link" aria-expanded="false">Item<span aria-hidden="true" class="lucca-icon icon-arrowChevronBottom verticalNavigation-list-item-link-arrow"></span></button>
 			<ul class="verticalNavigation-list mod-child">
 				<li class="verticalNavigation-list-item">
 					<a href="#" class="verticalNavigation-list-item-link">Item</a>
@@ -22,7 +22,7 @@ function getTemplate(args: VerticalNavigationIconlessStory): string {
 			</ul>
 		</li>
 		<li class="verticalNavigation-list-item">
-			<button class="verticalNavigation-list-item-link" aria-expanded="true">Item<span aria-hidden="true" class="lucca-icon icon-southArrow verticalNavigation-list-item-link-arrow"></span></button>
+			<button class="verticalNavigation-list-item-link" aria-expanded="true">Item<span aria-hidden="true" class="lucca-icon icon-arrowChevronBottom verticalNavigation-list-item-link-arrow"></span></button>
 			<ul class="verticalNavigation-list mod-child">
 				<li class="verticalNavigation-list-item">
 					<a href="#" class="verticalNavigation-list-item-link" aria-current="page">Item</a>

--- a/stories/qa/vertical-navigation/vertical-navigation.stories.html
+++ b/stories/qa/vertical-navigation/vertical-navigation.stories.html
@@ -95,7 +95,7 @@ We need 2 Angular components :
 		<h3 class="verticalNavigation-sectionTitle">Section title</h3>
 		<ul class="verticalNavigation-list">
 			<li class="verticalNavigation-list-item">
-				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-southArrow"></span></button>
+				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-arrowChevronBottom"></span></button>
 				<ul class="verticalNavigation-list mod-child" id="childList1">
 					<li class="verticalNavigation-list-item">
 						<a href="#" class="verticalNavigation-list-item-link">Item</a>
@@ -106,7 +106,7 @@ We need 2 Angular components :
 				</ul>
 			</li>
 			<li class="verticalNavigation-list-item">
-				<button class="verticalNavigation-list-item-link" aria-expanded="true"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-southArrow"></span></button>
+				<button class="verticalNavigation-list-item-link" aria-expanded="true"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-arrowChevronBottom"></span></button>
 				<ul class="verticalNavigation-list mod-child" id="childList2">
 					<li class="verticalNavigation-list-item">
 						<a href="#" class="verticalNavigation-list-item-link">Item</a>
@@ -123,7 +123,7 @@ We need 2 Angular components :
 				<a href="#" class="verticalNavigation-list-item-link"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item</a>
 			</li>
 			<li class="verticalNavigation-list-item">
-				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-southArrow"></span></button>
+				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-arrowChevronBottom"></span></button>
 				<ul class="verticalNavigation-list mod-child" id="childList1">
 					<li class="verticalNavigation-list-item">
 						<a href="#" class="verticalNavigation-list-item-link">Item</a>
@@ -144,7 +144,7 @@ We need 2 Angular components :
 		<h3 class="verticalNavigation-sectionTitle">Section title</h3>
 		<ul class="verticalNavigation-list">
 			<li class="verticalNavigation-list-item">
-				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-southArrow"></span></button>
+				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-arrowChevronBottom"></span></button>
 				<ul class="verticalNavigation-list mod-child" id="childList1">
 					<li class="verticalNavigation-list-item">
 						<a href="#" class="verticalNavigation-list-item-link">Item</a>
@@ -155,7 +155,7 @@ We need 2 Angular components :
 				</ul>
 			</li>
 			<li class="verticalNavigation-list-item">
-				<button class="verticalNavigation-list-item-link" aria-expanded="true"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-southArrow"></span></button>
+				<button class="verticalNavigation-list-item-link" aria-expanded="true"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-arrowChevronBottom"></span></button>
 				<ul class="verticalNavigation-list mod-child" id="childList2">
 					<li class="verticalNavigation-list-item">
 						<a href="#" class="verticalNavigation-list-item-link">Item</a>
@@ -172,7 +172,7 @@ We need 2 Angular components :
 				<a href="#" class="verticalNavigation-list-item-link"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item</a>
 			</li>
 			<li class="verticalNavigation-list-item">
-				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-southArrow"></span></button>
+				<button class="verticalNavigation-list-item-link" aria-expanded="false"><span aria-hidden="true" class="verticalNavigation-list-item-link-icon lucca-icon icon-heart"></span>Item<span aria-hidden="true" class="verticalNavigation-list-item-link-arrow lucca-icon icon-arrowChevronBottom"></span></button>
 				<ul class="verticalNavigation-list mod-child" id="childList1">
 					<li class="verticalNavigation-list-item">
 						<a href="#" class="verticalNavigation-list-item-link">Item</a>


### PR DESCRIPTION
## Description

This PR adds three new schematics:

- `action-icon` which migrates basic uses of `actionIcon` in HTML afiles and puts a comment on top of the `actionIcon` uses in SCSS.
- `palettes` which migrates old palette names to new ones everywhere (TS/HTML/SCSS).
- `tokens-spacing` which migrates CSS vars and classes for the new tokens system regarding spacing everywhere.

-----

In order to make it easier to create schematics for basic SCSS replacements in the future, I created the `CssMapper` class which does all that with just a config as parameter, it's also handling internal requires so we don't have to do it ourselves.

This means that schematics such as `palettes` and `tokens-spacing` are made using a single file containing the usual setup calls and the CssMapper config like so:

```ts
		await new CssMapper(
			tree,
			{
				classes: {
					'palette-grey': 'palette-neutral',
					'palette-primary': 'palette-product',
					'palette-secondary': 'palette-product',
					'palette-lucca': 'palette-brand',
				},
				variables: {
					'--palettes-grey-{val}': `--palettes-neutral-{val}`,
					'--palettes-primary-{val}': `--palettes-product-{val}`,
					'--palettes-secondary-{val}': `--palettes-product-{val}`,
					'--palettes-lucca-{val}': `--palettes-brand-{val}`,
					'--colors-grey-{val}': `--colors-neutral-{val}`,
				},
				mixins: {},
			},
			{
				val: {
					25: '25',
					50: '50',
					100: '100',
					200: '200',
					300: '300',
					400: '400',
					500: '500',
					600: '600',
					700: '700',
					800: '800',
					900: '900',
				},
			},
		).run();
```

-----
