### PR TITLE
fix(multi-select): placeholder not showing on custom displayers

### DIFF
--- a/packages/ng/multi-select/displayer/displayer-input.directive.ts
+++ b/packages/ng/multi-select/displayer/displayer-input.directive.ts
@@ -1,7 +1,7 @@
 import { DestroyRef, Directive, ElementRef, HostBinding, inject, OnInit } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ILuOptionContext, LU_OPTION_CONTEXT } from '@lucca-front/ng/core-select';
-import { map, startWith, switchMap } from 'rxjs/operators';
+import { startWith, switchMap } from 'rxjs/operators';
 import { LuMultiSelectInputComponent } from '../input';
 import { of } from 'rxjs';
 

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -100,7 +100,7 @@ export const WithMultiDisplayer = generateStory({
 	},
 	storyPartial: {
 		args: {
-			selectedLegumes: allLegumes.slice(0, 5),
+			selectedLegumes: [],
 		},
 	},
 });


### PR DESCRIPTION
## Description

Placeholder wan't updated properly because it was returning... a setter reference.

This PR fixes that so everytime someone uses the `luMultiSelectDisplayerInput` directive, aria-* attributes and placeholder are properly connected.

It also fixes a CD issue with activedescendant update.

-----

-----
