### PR TITLE
fix(select): panel position not updating on api data changes 

### DIFF
--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -37,7 +37,9 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 
 	public ngOnInit(): void {
 		this.select.optionComparer = this.optionComparer;
-		this.buildOptions().pipe(takeUntil(this.destroy$)).subscribe(this.select.options$);
+		this.buildOptions()
+			.pipe(takeUntil(this.destroy$))
+			.subscribe((options) => (this.select.options = options));
 	}
 
 	protected buildOptions(): Observable<TOption[]> {

--- a/stories/documentation/overlays/dialog/dialog-service.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-service.stories.ts
@@ -14,6 +14,10 @@ import {
 	provideLuDialog,
 } from '@lucca-front/ng/dialog';
 import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+import { FormFieldComponent } from '../../../../packages/ng/form-field/form-field.component';
+import { LuSimpleSelectInputComponent } from '../../../../packages/ng/simple-select/input';
+import { FormsModule } from '@angular/forms';
+import { allLegumes } from '@/stories/forms/select/select.utils';
 
 @Component({
 	selector: 'sb-dialog-content',
@@ -21,7 +25,20 @@ import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 		<lu-dialog>
 			<lu-dialog-header>Header</lu-dialog-header>
 
-			<lu-dialog-content>Content</lu-dialog-content>
+			<lu-dialog-content>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+			</lu-dialog-content>
 
 			<lu-dialog-footer>
 				<div class="footer-content">Optional footer text</div>
@@ -32,12 +49,24 @@ import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 			</lu-dialog-footer>
 		</lu-dialog>
 	`,
-	imports: [DialogFooterComponent, DialogContentComponent, DialogHeaderComponent, DialogComponent, ButtonComponent, DialogDismissDirective],
+	imports: [
+		DialogFooterComponent,
+		DialogContentComponent,
+		DialogHeaderComponent,
+		DialogComponent,
+		ButtonComponent,
+		DialogDismissDirective,
+		FormFieldComponent,
+		LuSimpleSelectInputComponent,
+		FormsModule,
+	],
 	standalone: true,
 })
 export class DialogContentStoryComponent {
 	ref = injectDialogRef<string>();
 	data = injectDialogData<number>();
+
+	legumes = allLegumes;
 
 	close(): void {
 		this.ref.close(this.data.toString());


### PR DESCRIPTION
## Description

This was caused by the fact that we directly connected data source to `options$` instead of using the setter, which is also updating panel position.

-----

-----
