### PR TITLE
feat(fields): new radio wrapper components

### DIFF
--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -1,18 +1,38 @@
-<label
-	class="formLabel"
-	[class.is-error]="invalid"
-	id="{{id}}-label"
-	for="{{id}}"
-	[class.u-mask]="hiddenLabel"
-	attr.aria-hidden="{{hiddenLabel}}"
->
-	{{ label }}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
-	<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
-</label>
-<ng-content></ng-content>
-<lu-inline-message
-	id="{{id}}-message"
-	*ngIf="inlineMessage"
-	[label]="inlineMessage"
-	[state]="invalid ? 'error' : inlineMessageState"
-></lu-inline-message>
+<fieldset class="form-fieldset" *ngIf="layout === 'fieldset'; else defaultTpl">
+	<legend class="formLabel" [class.u-mask]="hiddenLabel" attr.aria-hidden="{{hiddenLabel}}">
+		{{ label }}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
+		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+	</legend>
+	<ng-container *ngTemplateOutlet="projectionTpl"></ng-container>
+	<lu-inline-message
+		id="{{id}}-message"
+		*ngIf="inlineMessage"
+		[label]="inlineMessage"
+		[state]="invalid ? 'error' : inlineMessageState"
+	></lu-inline-message>
+</fieldset>
+
+<ng-template #defaultTpl>
+	<label
+		class="formLabel"
+		[class.is-error]="invalid"
+		id="{{id}}-label"
+		for="{{id}}"
+		[class.u-mask]="hiddenLabel"
+		attr.aria-hidden="{{hiddenLabel}}"
+	>
+		{{ label }}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
+		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+	</label>
+	<ng-container *ngTemplateOutlet="projectionTpl"></ng-container>
+	<lu-inline-message
+		id="{{id}}-message"
+		*ngIf="inlineMessage"
+		[label]="inlineMessage"
+		[state]="invalid ? 'error' : inlineMessageState"
+	></lu-inline-message>
+</ng-template>
+
+<ng-template #projectionTpl>
+	<ng-content></ng-content>
+</ng-template>

--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -1,4 +1,4 @@
-<fieldset class="form-fieldset" *ngIf="layout === 'fieldset'; else defaultTpl">
+<fieldset class="form-fieldset" *ngIf="layout === 'fieldset'; else defaultTpl" [class.mod-S]="size === 'S'">
 	<legend class="formLabel" [class.u-mask]="hiddenLabel" attr.aria-hidden="{{hiddenLabel}}">
 		{{ label }}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
 		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>

--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -3,8 +3,7 @@
 		<ng-container *luPortal="label"></ng-container
 		><!--
 	--><sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
-		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip"
-		         [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
 	</legend>
 	<ng-container *ngTemplateOutlet="projectionTpl"></ng-container>
 	<lu-inline-message
@@ -27,8 +26,7 @@
 		<ng-container *luPortal="label"></ng-container
 		><!--
 	--><sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
-		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip"
-		         [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+		<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
 	</label>
 	<ng-container *ngTemplateOutlet="projectionTpl"></ng-container>
 	<lu-inline-message

--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -6,7 +6,7 @@
 	[class.u-mask]="hiddenLabel"
 	attr.aria-hidden="{{hiddenLabel}}"
 >
-	{{label}}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
+	{{ label }}<sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
 	<lu-icon icon="helpOutline" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
 </label>
 <ng-content></ng-content>

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Component, ContentChildren, DoCheck, forwardRef, HostBinding, inject, Input, OnChanges, OnDestroy, QueryList, Renderer2, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, Component, ContentChildren, DoCheck, forwardRef, inject, Input, OnChanges, OnDestroy, QueryList, Renderer2, ViewEncapsulation } from '@angular/core';
 import { NgIf, NgSwitch, NgSwitchCase, NgTemplateOutlet } from '@angular/common';
 import { InputDirective } from './input.directive';
 import { FormFieldSize } from './form-field-size';
@@ -43,9 +43,6 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 	@ContentChildren(NgControl)
 	controls: NgControl[] = [];
 
-	@HostBinding('class')
-	clazz = 'form-field';
-
 	@Input({
 		required: true,
 	})
@@ -61,6 +58,7 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 
 	required = false;
 
+	@Input()
 	invalid = false;
 
 	@Input()
@@ -76,7 +74,7 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 	size: FormFieldSize;
 
 	@Input()
-	layout: 'default' | 'checkable' = 'default';
+	layout: 'default' | 'checkable' | 'fieldset' = 'default';
 
 	#inputs: InputDirective[] = [];
 
@@ -111,7 +109,9 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 			this.#ariaLabelledBy = [...this.#ariaLabelledBy, id];
 		}
 		this.#inputs.forEach((input) => {
-			this.#renderer.setAttribute(input.host.nativeElement, 'aria-labelledby', this.#ariaLabelledBy.join(' '));
+			if (!input.standalone) {
+				this.#renderer.setAttribute(input.host.nativeElement, 'aria-labelledby', this.#ariaLabelledBy.join(' '));
+			}
 		});
 	}
 
@@ -120,9 +120,15 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 	}
 
 	ngOnChanges(): void {
+		console.log({
+			[`mod-${this.size}`]: true,
+			'mod-checkable': this.layout === 'checkable',
+			'form-field': this.layout !== 'fieldset',
+		});
 		this.#luClass.setState({
 			[`mod-${this.size}`]: true,
-			[`mod-checkable`]: this.layout === 'checkable',
+			'mod-checkable': this.layout === 'checkable',
+			'form-field': this.layout !== 'fieldset',
 		});
 		this.updateAria();
 	}
@@ -145,7 +151,9 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 		this.#inputs.forEach((input) => {
 			this.#renderer.setAttribute(input.host.nativeElement, 'aria-invalid', this.invalid.toString());
 			this.#renderer.setAttribute(input.host.nativeElement, 'aria-required', this.required.toString());
-			this.#renderer.setAttribute(input.host.nativeElement, 'aria-describedby', `${input.host.nativeElement.id}-message`);
+			if (!input.standalone) {
+				this.#renderer.setAttribute(input.host.nativeElement, 'aria-describedby', `${input.host.nativeElement.id}-message`);
+			}
 		});
 		if (this.id) {
 			this.addLabelledBy(`${this.id}-label`);

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -132,10 +132,12 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 		if (this.#inputs.length === 0) {
 			throw new Error('Missing input for form field, make sure to set `luInput` to your input inside lu-form-field');
 		}
-		this.inputs.forEach((input) => {
-			const inputId = `${input.host.nativeElement.tagName.toLowerCase()}-${++nextId}`;
-			this.#renderer.setAttribute(input.host.nativeElement, 'id', inputId);
-		});
+		this.inputs
+			.filter((input) => !input.standalone)
+			.forEach((input) => {
+				const inputId = `${input.host.nativeElement.tagName.toLowerCase()}-${++nextId}`;
+				this.#renderer.setAttribute(input.host.nativeElement, 'id', inputId);
+			});
 		// We're using the id from the first input available
 		this.id = this.#inputs[0].host.nativeElement.id;
 		this.updateAria();

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -120,11 +120,6 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 	}
 
 	ngOnChanges(): void {
-		console.log({
-			[`mod-${this.size}`]: true,
-			'mod-checkable': this.layout === 'checkable',
-			'form-field': this.layout !== 'fieldset',
-		});
 		this.#luClass.setState({
 			[`mod-${this.size}`]: true,
 			'mod-checkable': this.layout === 'checkable',

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -174,7 +174,7 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 				: control.control.hasValidator(Validators.required) || control.control.hasValidator(Validators.requiredTrue);
 
 			// If stuff changed, update aria attributes
-			if (this.#nativeInputRef && (this.invalid !== previousInvalid || this.required !== previousRequired)) {
+			if (this.invalid !== previousInvalid || this.required !== previousRequired) {
 				this.updateAria();
 			}
 		});

--- a/packages/ng/form-field/input.directive.ts
+++ b/packages/ng/form-field/input.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, inject, OnInit } from '@angular/core';
+import { booleanAttribute, Directive, ElementRef, inject, Input, OnInit } from '@angular/core';
 import { FORM_FIELD_INSTANCE } from './form-field.token';
 
 @Directive({
@@ -13,6 +13,12 @@ export class InputDirective implements OnInit {
 	public readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	public readonly formFieldRef = inject(FORM_FIELD_INSTANCE, { optional: true });
+
+	/**
+	 * prevents message and label ids from being propagated, useful if the input holds its own message and label (like for radios)
+	 */
+	@Input({ transform: booleanAttribute, alias: 'luInputStandalone' })
+	standalone = false;
 
 	ngOnInit(): void {
 		// If the field is used as standalone, we won't have the ref provided so it'll crash

--- a/packages/ng/form-field/input.directive.ts
+++ b/packages/ng/form-field/input.directive.ts
@@ -17,7 +17,7 @@ export class InputDirective implements OnInit {
 	ngOnInit(): void {
 		// If the field is used as standalone, we won't have the ref provided so it'll crash
 		if (this.formFieldRef) {
-			this.formFieldRef.input = this;
+			this.formFieldRef.addInput(this);
 		}
 	}
 }

--- a/packages/ng/forms/public-api.ts
+++ b/packages/ng/forms/public-api.ts
@@ -5,3 +5,5 @@ export * from './form-field-id.directive';
 export * from './text-input/text-input.component';
 export * from './checkbox-input/checkbox-input.component';
 export * from './switch-input/switch-input.component';
+export * from './radio-group-input/radio-group-input.component';
+export * from './radio-group-input/radio/radio.component';

--- a/packages/ng/forms/radio-group-input/radio-group-input.component.ts
+++ b/packages/ng/forms/radio-group-input/radio-group-input.component.ts
@@ -1,0 +1,39 @@
+import { ChangeDetectionStrategy, Component, forwardRef, inject, Input, ViewEncapsulation } from '@angular/core';
+import { FormFieldComponent } from '../../form-field/form-field.component';
+import { FORM_FIELD_INSTANCE } from '../../form-field/form-field.token';
+import { injectNgControl } from '../inject-ng-control';
+import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
+import { InputDirective } from '../../form-field/input.directive';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RADIO_GROUP_INSTANCE } from './radio-group-token';
+
+@Component({
+	selector: 'lu-radio-group-input',
+	standalone: true,
+	imports: [InputDirective, ReactiveFormsModule],
+	hostDirectives: [NoopValueAccessorDirective],
+	template: '<ng-content></ng-content>',
+	styleUrl: './radio-group-input.component.scss',
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: RADIO_GROUP_INSTANCE,
+			useExisting: forwardRef(() => RadioGroupInputComponent),
+		},
+	],
+})
+export class RadioGroupInputComponent {
+	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
+
+	ngControl = injectNgControl();
+
+	@Input()
+	size: 'S' | 'M';
+
+	constructor() {
+		if (this.formField) {
+			this.formField.layout = 'fieldset';
+		}
+	}
+}

--- a/packages/ng/forms/radio-group-input/radio-group-input.component.ts
+++ b/packages/ng/forms/radio-group-input/radio-group-input.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, Component, forwardRef, inject, Input, ViewEncapsulation } from '@angular/core';
-import { FormFieldComponent } from '../../form-field/form-field.component';
-import { FORM_FIELD_INSTANCE } from '../../form-field/form-field.token';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { FORM_FIELD_INSTANCE } from '@lucca-front/ng/form-field';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
-import { InputDirective } from '../../form-field/input.directive';
+import { InputDirective } from '@lucca-front/ng/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RADIO_GROUP_INSTANCE } from './radio-group-token';
 

--- a/packages/ng/forms/radio-group-input/radio-group-token.ts
+++ b/packages/ng/forms/radio-group-input/radio-group-token.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { RadioGroupInputComponent } from './radio-group-input.component';
+
+export const RADIO_GROUP_INSTANCE = new InjectionToken<RadioGroupInputComponent>('RADIO_GROUP_INSTANCE');

--- a/packages/ng/forms/radio-group-input/radio/radio.component.html
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.html
@@ -1,0 +1,19 @@
+<label class="formLabel" id="{{id}}-label" for="{{id}}">{{ label }}</label>
+<span class="radioField">
+	<input
+		[formControl]="formControl"
+		[attr.disabled]="formControl.disabled || disabled"
+		type="radio"
+		class="radioField-input"
+		id="{{id}}"
+		[value]="value"
+		luInput
+		luInputStandalone
+		attr.aria-labelledby="{{id}}-label"
+		attr.aria-describedby="{{id}}-message"
+	/>
+	<span class="radioField-icon" aria-hidden="true">
+		<span class="radioField-icon-check"></span>
+	</span>
+</span>
+<lu-inline-message *ngIf="inlineMessage" [label]="inlineMessage" id="{{id}}-message"></lu-inline-message>

--- a/packages/ng/forms/radio-group-input/radio/radio.component.html
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.html
@@ -1,4 +1,6 @@
-<label class="formLabel" id="{{id}}-label" for="{{id}}">{{ label }}</label>
+<label class="formLabel" id="{{id}}-label" for="{{id}}">
+	<ng-content></ng-content>
+</label>
 <span class="radioField">
 	<input
 		[formControl]="formControl"

--- a/packages/ng/forms/radio-group-input/radio/radio.component.html
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.html
@@ -1,4 +1,4 @@
-<label class="formLabel" id="{{id}}-label" for="{{id}}">
+<label class="formLabel" id="{{id}}-label" for="{{id}}-input">
 	<ng-content></ng-content>
 </label>
 <span class="radioField">
@@ -7,7 +7,7 @@
 		[attr.disabled]="formControl.disabled || disabled"
 		type="radio"
 		class="radioField-input"
-		id="{{id}}"
+		id="{{id}}-input"
 		[value]="value"
 		luInput
 		luInputStandalone

--- a/packages/ng/forms/radio-group-input/radio/radio.component.scss
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.scss
@@ -1,0 +1,1 @@
+@use '@lucca-front/scss/src/components/radioField';

--- a/packages/ng/forms/radio-group-input/radio/radio.component.ts
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.ts
@@ -25,9 +25,6 @@ export class RadioComponent<T = unknown> implements OnChanges {
 	#luClass = inject(LuClass);
 
 	@Input({ required: true })
-	label: string;
-
-	@Input({ required: true })
 	value: T;
 
 	@Input({ transform: booleanAttribute })

--- a/packages/ng/forms/radio-group-input/radio/radio.component.ts
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.ts
@@ -1,0 +1,53 @@
+import { booleanAttribute, ChangeDetectionStrategy, Component, HostBinding, inject, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { InputDirective } from '@lucca-front/ng/form-field';
+import { InlineMessageComponent } from '@lucca-front/ng/inline-message';
+import { NgIf } from '@angular/common';
+import { RADIO_GROUP_INSTANCE } from '../radio-group-token';
+import { LuClass } from '@lucca-front/ng/core';
+
+let nextId = 0;
+
+@Component({
+	selector: 'lu-radio',
+	standalone: true,
+	imports: [ReactiveFormsModule, InputDirective, InlineMessageComponent, NgIf],
+	templateUrl: './radio.component.html',
+	styleUrl: './radio.component.scss',
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	host: {
+		class: 'form-field',
+	},
+	providers: [LuClass],
+})
+export class RadioComponent<T = unknown> implements OnChanges {
+	#luClass = inject(LuClass);
+
+	@Input({ required: true })
+	label: string;
+
+	@Input({ required: true })
+	value: T;
+
+	@Input({ transform: booleanAttribute })
+	disabled: boolean;
+
+	@Input()
+	inlineMessage: string;
+
+	#parentGroup = inject(RADIO_GROUP_INSTANCE);
+
+	public get formControl() {
+		return this.#parentGroup.ngControl.control;
+	}
+
+	@HostBinding('id')
+	id = `radio-${++nextId}`;
+
+	ngOnChanges(): void {
+		this.#luClass.setState({
+			[`mod-${this.#parentGroup.size}`]: true,
+		});
+	}
+}

--- a/packages/scss/src/components/form/index.scss
+++ b/packages/scss/src/components/form/index.scss
@@ -8,6 +8,12 @@
 	@include component;
 }
 
+.form-fieldset {
+	&.mod-S {
+		@include S;
+	}
+}
+
 .form-field {
 	&.mod-S {
 		@include S;

--- a/stories/documentation/forms/fields/radio/angular/radiofield.stories.ts
+++ b/stories/documentation/forms/fields/radio/angular/radiofield.stories.ts
@@ -1,0 +1,69 @@
+import { RadioComponent, RadioGroupInputComponent } from '@lucca-front/ng/forms';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { FormsModule } from '@angular/forms';
+import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+export default {
+	title: 'Documentation/Forms/Fields/RadioField/Angular',
+	decorators: [
+		moduleMetadata({
+			imports: [RadioGroupInputComponent, RadioComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+		}),
+	],
+	argTypes: {
+		size: {
+			options: ['M', 'S'],
+			control: {
+				type: 'radio',
+			},
+		},
+		inlineMessageState: {
+			options: ['default', 'success', 'warning', 'error'],
+			control: {
+				type: 'select',
+			},
+		},
+	},
+} as Meta;
+
+export const Basic: StoryObj<RadioGroupInputComponent & FormFieldComponent> = {
+	render: (args, { argTypes }) => {
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
+		return {
+			props: {
+				example: false,
+			},
+			template: cleanupTemplate(`<lu-form-field ${generateInputs(
+				{
+					label,
+					hiddenLabel,
+					tooltip,
+					inlineMessage,
+					inlineMessageState,
+					size,
+				},
+				argTypes,
+			)}>
+	<lu-radio-group-input ${generateInputs(inputArgs, argTypes)}
+	[(ngModel)]="example">
+		<lu-radio label="Option 1" [value]="1" inlineMessage="I am option 1"></lu-radio>
+		<lu-radio label="Option 2" [value]="2" inlineMessage="I am option 2"></lu-radio>
+		<lu-radio label="Option 3" [value]="3" inlineMessage="I am option 3 and I'm disabled" disabled></lu-radio>
+	</lu-radio-group-input>
+</lu-form-field>
+
+{{example}}`),
+		};
+	},
+	args: {
+		size: 'M',
+		label: 'Label',
+		tooltip: 'Tooltip message',
+		hiddenLabel: false,
+		required: true,
+		inlineMessage: 'Helper Text',
+		inlineMessageState: 'default',
+	},
+};

--- a/stories/documentation/forms/fields/radio/angular/radiofield.stories.ts
+++ b/stories/documentation/forms/fields/radio/angular/radiofield.stories.ts
@@ -48,9 +48,9 @@ export const Basic: StoryObj<RadioGroupInputComponent & FormFieldComponent> = {
 			)}>
 	<lu-radio-group-input ${generateInputs(inputArgs, argTypes)}
 	[(ngModel)]="example">
-		<lu-radio label="Option 1" [value]="1" inlineMessage="I am option 1"></lu-radio>
-		<lu-radio label="Option 2" [value]="2" inlineMessage="I am option 2"></lu-radio>
-		<lu-radio label="Option 3" [value]="3" inlineMessage="I am option 3 and I'm disabled" disabled></lu-radio>
+		<lu-radio [value]="1" inlineMessage="I am option 1">Option 1</lu-radio>
+		<lu-radio [value]="2" inlineMessage="I am option 2">Option 2</lu-radio>
+		<lu-radio [value]="3" inlineMessage="I am option 3 and I'm disabled" disabled>Option 3</lu-radio>
 	</lu-radio-group-input>
 </lu-form-field>
 

--- a/stories/documentation/forms/fields/radio/html&css/radiofield-size.stories.ts
+++ b/stories/documentation/forms/fields/radio/html&css/radiofield-size.stories.ts
@@ -9,11 +9,11 @@ export default {
 
 function getTemplate(args: RadioSizeStory): string {
 	return `
-<fieldset class="form-fieldset">
+<fieldset class="form-fieldset mod-S">
 	<legend class="formLabel">
 		Text<sup class="formLabel-required" aria-hidden="true">*</sup>
 	</legend>
-	<div class="form-field mod-S">
+	<div class="form-field">
 		<label class="formLabel" for="IDradioA">Label A</label>
 		<span class="radioField">
 			<input type="radio" class="radioField-input" id="IDradioA" name="radioName1" aria-describedby="IDmessageRadioA" checked />
@@ -21,7 +21,7 @@ function getTemplate(args: RadioSizeStory): string {
 		</span>
 		<div class="inlineMessage" id="IDmessageRadioA">Helper text</div>
 	</div>
-	<div class="form-field mod-S">
+	<div class="form-field">
 		<label class="formLabel" for="IDradioB">Label B</label>
 		<span class="radioField">
 			<input type="radio" class="radioField-input" id="IDradioB" name="radioName1" aria-describedby="IDmessageRadioB" />


### PR DESCRIPTION
## Description

New `lu-radio-group` and `lu-radio` components to create `fieldset` structures that will hold `input[type=radio]` components, managing UX, a11y and control linking as with every input component.

Example use:

```html
<lu-form-field label="Option example">
	<lu-radio-group-input [(ngModel)]="example">
		<lu-radio [value]="1" inlineMessage="I am option 1">Option 1</lu-radio>
		<lu-radio [value]="2" inlineMessage="I am option 2">Option 2</lu-radio>
		<lu-radio [value]="3" inlineMessage="I am option 3 and I'm disabled" disabled>Option 3</lu-radio>
	</lu-radio-group-input>
</lu-form-field>
```

In order to make this work as a template, I had to add a `fieldset` structure for `lu-form-field`, which is filled by the `lu-radio-group` itself so you don't have to do anything manually (like with checkbox for instance)

-----


-----
