### PR TITLE
feat(checkbox): mixed input

### DIFF
--- a/packages/ng/forms/checkbox-input/checkbox-input.component.html
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.html
@@ -1,2 +1,2 @@
-<input luInput type="checkbox" class="checkboxField-input" [formControl]="ngControl.control" />
+<input luInput type="checkbox" class="checkboxField-input" [formControl]="ngControl.control" [attr.aria-checked]="mixed ? 'mixed' : null" />
 <span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, Component, inject, Input, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { injectNgControl } from '../inject-ng-control';
@@ -20,6 +20,12 @@ export class CheckboxInputComponent {
 	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
 
 	ngControl = injectNgControl();
+
+	@Input({ transform: booleanAttribute })
+	/**
+	 * Should set aria-checked='mixed' attribute ?
+	 */
+	mixed = false;
 
 	constructor() {
 		if (this.formField) {

--- a/stories/documentation/forms/fields/checkbox/angular/checkboxfield.stories.ts
+++ b/stories/documentation/forms/fields/checkbox/angular/checkboxfield.stories.ts
@@ -62,6 +62,7 @@ export const Basic: StoryObj<CheckboxInputComponent & FormFieldComponent> = {
 		tooltip: 'Tooltip message',
 		hiddenLabel: false,
 		required: true,
+		mixed: false,
 		inlineMessage: 'Helper Text',
 		inlineMessageState: 'default',
 	},


### PR DESCRIPTION
## Description

Closes #2677 : add a `mixed` boolean input for checkbox-field component. 
When the input is `true`, the attribute `aria-check` is set to `mixed`.

-----
-----
