### PR TITLE
fix(input + dialog): undefined placeholder and modal flag

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -23,7 +23,7 @@ export class LuDialogService {
 				break;
 		}
 		const cdkRef = this.#cdkDialog.open(config.content, {
-			ariaModal: config.modal,
+			ariaModal: config.modal ?? true,
 			hasBackdrop: config.modal ?? true,
 			data: 'data' in config ? config.data : null,
 			disableClose: true,

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -24,7 +24,7 @@ export class TextInputComponent {
 	ngControl = injectNgControl();
 
 	@Input()
-	placeholder: string;
+	placeholder: string = '';
 
 	@Input({ transform: numberAttribute })
 	step: number = 1;


### PR DESCRIPTION
## Description

- `placeholder` now defaults to `''` in `lu-text-input`
- `dialog` instances are now properly marked as `aria-modal`

-----

-----
