### PR TITLE
ref(user): use a more specific type for user related components

### DIFF
--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -1,12 +1,16 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
-import { ILuUser } from '../user.model';
-import { LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials, LU_DEFAULT_DISPLAY_POLICY } from './display-format.model';
+import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
+
+export interface LuUserDisplayInput {
+	firstName: string;
+	lastName: string;
+}
 
 /**
  * Displays a user name according to specified format. Supported formats: f for first name,
  * F for first initial, l for last name, L for last initial.
  */
-export function luUserDisplay(user: ILuUser, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
+export function luUserDisplay(user: LuUserDisplayInput, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
 	let result = '';
 	if (!!user && !!user.firstName && !!user.lastName) {
 		switch (format) {
@@ -61,7 +65,7 @@ export function luUserDisplay(user: ILuUser, format: LuDisplayFormat = LuDisplay
 export class LuUserDisplayPipe implements PipeTransform {
 	private readonly defaultFormat = inject(LU_DEFAULT_DISPLAY_POLICY);
 
-	public transform(user: ILuUser, format: LuDisplayFormat = this.defaultFormat): string {
+	public transform(user: LuUserDisplayInput, format: LuDisplayFormat = this.defaultFormat): string {
 		return luUserDisplay(user, format);
 	}
 }

--- a/packages/ng/user/picture/index.ts
+++ b/packages/ng/user/picture/index.ts
@@ -1,2 +1,2 @@
-export { LuUserPictureComponent } from './user-picture.component';
+export { LuUserPictureComponent, LuUserPictureUserInput } from './user-picture.component';
 export { LuUserPictureModule } from './user-picture.module';

--- a/packages/ng/user/picture/user-picture.component.ts
+++ b/packages/ng/user/picture/user-picture.component.ts
@@ -1,6 +1,12 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, Optional } from '@angular/core';
 import { LuDisplayFullname, LuDisplayInitials, LuUserDisplayPipe } from '../display';
-import { ILuUser } from '../user.model';
+
+export interface LuUserPictureUserInput {
+	picture?: { href: string } | null;
+	pictureHref?: string | null;
+	firstName: string;
+	lastName: string;
+}
 
 /**
  * Displays user's picture or a placeholder with his/her initials and random bg color'
@@ -29,12 +35,12 @@ export class LuUserPictureComponent {
 	}
 
 	/**
-	 * ILuUser whose picture you want to display.
+	 * UserPictureUserInput whose picture you want to display.
 	 */
-	private _user: ILuUser;
+	private _user: LuUserPictureUserInput;
 
 	@Input()
-	set user(user: ILuUser) {
+	set user(user: LuUserPictureUserInput) {
 		this._user = user;
 		this.initials = this.displayPipe.transform(user, this.displayFormat);
 		const pictureHref = user?.picture?.href || user?.pictureHref;

--- a/packages/ng/user/tile/user-tile.component.ts
+++ b/packages/ng/user/tile/user-tile.component.ts
@@ -1,9 +1,16 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 import { LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from '../display/index';
-import { ILuUser } from '../user.model';
+
+export interface LuUserTileUserInput {
+	picture?: { href: string } | null;
+	pictureHref?: string | null;
+	firstName: string;
+	lastName: string;
+	jobTitle?: string | null;
+}
 
 /**
- * Displays user picture and name. ILuUser's role can be specified, and the footer is customizable.
+ * Displays user picture and name. LuUserTileUserInput's role can be specified, and the footer is customizable.
  */
 @Component({
 	selector: 'lu-user-tile',
@@ -12,17 +19,17 @@ import { ILuUser } from '../user.model';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LuUserTileComponent {
-	private _user: ILuUser;
+	private _user: LuUserTileUserInput;
 	/**
-	 * ILuUser to display.
+	 * LuUserTileUserInput to display.
 	 */
 	@Input()
-	set user(user: ILuUser) {
+	set user(user: LuUserTileUserInput) {
 		this._user = user;
 		this._changeDetector.markForCheck();
 	}
 
-	get user(): ILuUser {
+	get user(): LuUserTileUserInput {
 		return this._user;
 	}
 
@@ -35,7 +42,7 @@ export class LuUserTileComponent {
 
 	private _role: string;
 	/**
-	 * ILuUser role to display
+	 * LuUserTileUserInput role to display
 	 */
 	@Input()
 	set role(role: string) {


### PR DESCRIPTION
## Description

Use a narrower type of user in `luUserDisplay`, `LuUserDisplayPipe`, `LuUserPictureComponent` and `LuUserTileComponent`.

Support both `null` and `undefined` for optional properties.

-----

