### PR TITLE
fix(schematics): missing required schema.json

### DIFF
--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -3,11 +3,13 @@
 	"schematics": {
 		"ng-add": {
 			"description": "Add my lucca-front to the project.",
-			"factory": "./ng-add/index#ngAdd"
+			"factory": "./ng-add/index#ngAdd",
+			"schema": "./ng-add/schema.json"
 		},
 		"new-icons": {
 			"description": "Replace old icon names with new ones.",
-			"factory": "./new-icons/index"
+			"factory": "./new-icons/index",
+			"schema": "./new-icons/schema.json"
 		}
 	}
 }

--- a/packages/ng/schematics/new-icons/schema.json
+++ b/packages/ng/schematics/new-icons/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "LuccaFrontNewIcons",
+	"title": "Lucca Front New Icons Schema",
+	"type": "object",
+	"properties": {}
+}

--- a/packages/ng/schematics/ng-add/schema.json
+++ b/packages/ng/schematics/ng-add/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "LuccaFrontNgAdd",
+	"title": "Lucca Front NgAdd Schema",
+	"type": "object",
+	"properties": {}
+}


### PR DESCRIPTION
## Description

The current generators are not working with an nx workspace :

![Screenshot 2024-03-29 at 15 42 48](https://github.com/LuccaSA/lucca-front/assets/2089620/06df8600-c13f-422e-98d2-c38f97c92ada)

This is because `nx` is looking for the mandatory schema.json file that's supposed to be part of the schematic (https://angular.io/guide/schematics-for-libraries#configure-the-new-schematic)

This can be seen here : https://github.com/nrwl/nx/blob/ef81455b6492fee266c0d6ddfc41a79dc2041f8b/packages/nx/src/command-line/generate/generator-utils.ts#L41-L45

Schematics without parameters can simply be declared with an empty object (as is the case here)

-----
