### PR TITLE
fix(core-select): fix operations query filter on users API

### DIFF
--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -105,7 +105,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			...filters,
 			...(orderBy ? { orderBy } : {}),
 			...(clue ? { clue: sanitizeClueFilter(clue) } : {}),
-			...(operationIds ? { operationIds: operationIds.join(',') } : {}),
+			...(operationIds ? { operations: operationIds.join(',') } : {}),
 			...(appInstanceId ? { appInstanceId } : {}),
 			...(enableFormerEmployees ? { enableFormerEmployees } : {}),
 		})),


### PR DESCRIPTION
## Description

`operationIds` does not exist on users API. Use `operations` instead.

-----

