### PR TITLE
fix(core-select): stop escape propagation

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -157,6 +157,11 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	onKeyDownNavigation($event: KeyboardEvent): void {
 		switch ($event.key) {
 			case 'Escape':
+				if (this.isPanelOpen) {
+					$event.stopPropagation();
+				}
+				this.panelRef?.close();
+				break;
 			case 'Tab':
 				this.panelRef?.close();
 				break;


### PR DESCRIPTION
## Description

When closing the panel with escape, do not close the englobing dialog.

-----
