### PR TITLE
Fix icon size fallback

### DIFF
--- a/packages/icons/src/icon/component.scss
+++ b/packages/icons/src/icon/component.scss
@@ -3,7 +3,7 @@
 
 @mixin component($atRoot: 'without: rule') {
 	font-weight: 400;
-	font-size: var(--icon-size);
+	font-size: var(--icon-size, var(--icon-sizeFallback));
 	direction: ltr;
 	display: inline-block;
 	font-family: config.$font-name;

--- a/packages/icons/src/icon/component.scss
+++ b/packages/icons/src/icon/component.scss
@@ -3,7 +3,7 @@
 
 @mixin component($atRoot: 'without: rule') {
 	font-weight: 400;
-	font-size: var(--icon-size, var(--icon-sizeFallback));
+	font-size: var(--icon-size, var(--icon-sizeDefault));
 	direction: ltr;
 	display: inline-block;
 	font-family: config.$font-name;

--- a/packages/icons/src/icon/vars.scss
+++ b/packages/icons/src/icon/vars.scss
@@ -1,4 +1,4 @@
 @mixin vars {
 	--icon-content: none;
-	--icon-size: 1.5rem;
+	--icon-sizeFallback: 1.5rem;
 }

--- a/packages/icons/src/icon/vars.scss
+++ b/packages/icons/src/icon/vars.scss
@@ -1,4 +1,4 @@
 @mixin vars {
 	--icon-content: none;
-	--icon-sizeFallback: 1.5rem;
+	--icon-sizeDefault: 1.5rem;
 }


### PR DESCRIPTION
## Description

The `--icon-size` variable remains undefined so that it can be overloaded, so we use another variable name for the fallback.

-----


-----
