### PR TITLE
fix(core-select): do not submit englobing form when hitting enter

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -167,6 +167,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 				break;
 			case 'Enter':
 				if (this.isPanelOpen) {
+					// Prevent form submission when selecting a value with Enter
+					$event.preventDefault();
 					this.panelRef.selectCurrentlyHighlightedValue();
 				} else {
 					this.panelRef?.handleKeyManagerEvent($event);


### PR DESCRIPTION
## Description

Do not submit englobing form when selecting an option using enter key.

-----

