### PR TITLE
fix(schematics): export schema.json during build

### DIFF
--- a/build.js
+++ b/build.js
@@ -79,7 +79,7 @@ runTask('Lucca Front compilation', async () => {
 	await runTask('Schematics TS compilation', () => compileTypescript(SCHEMATICS, OUTPUT_SCHEMATICS));
 	await runTask('Schematics copy', () => {
 		copyFiles({
-			patterns: ['collection.json', 'migrations.json', 'lib/local-deps/package.json', 'lib/local-deps/package-lock.json'],
+			patterns: ['collection.json', 'migrations.json', 'lib/local-deps/package.json', 'lib/local-deps/package-lock.json', '**/schema.json'],
 			context: SCHEMATICS,
 			output: OUTPUT_SCHEMATICS,
 		});


### PR DESCRIPTION
## Description

Exports the `schema.json` required by `nx` during the build process.

-----

