### PR TITLE
fix(core-select): wrong users loading params and too much nextPage events

### DIFF
--- a/.storybook/msw/mocks.ts
+++ b/.storybook/msw/mocks.ts
@@ -350,50 +350,25 @@ export const mockProjectUsers = [
 	},
 ];
 
-export const mockUsers = [
-	{
-		id: 6,
-		firstName: 'Chloe',
-		lastName: 'Alibert',
+const firstNames = ['Chloe', 'Marie-Françoise', 'Laurence', 'Gaspard', 'Jean', 'Pierre', 'Paul', 'Jacques', 'Marie', 'Sophie', 'Julie', 'Julien'];
+const lastNames = ['Alibert', 'Archer', 'Atali', 'Bouvier', 'Lefevre', 'Durand', 'Dupont', 'Martin', 'Bernard', 'Robert', 'Richard', 'Petit'];
+const departments = ['Direction', 'Support', 'Commercial'];
+
+export const mockUsers = firstNames
+	.flatMap((firstName) => lastNames.flatMap((lastName) => ({ firstName, lastName })))
+	.map((user, index) => ({
+		id: index + 1,
 		picture: null,
-		department: {
-			id: 1,
-			name: 'Direction',
-		},
-	},
-	{
-		id: 7,
-		firstName: 'Marie-Françoise',
-		lastName: 'Archer',
-		picture: {
-			href: 'https://demo-ux1.ilucca.net/getFile.ashx?id=e845a0ca-dbd9-452d-adc0-c873a847a37d',
-		},
-		department: {
-			id: 1,
-			name: 'Direction',
-		},
-	},
-	{
-		id: 49,
-		firstName: 'Laurence',
-		lastName: 'Atali',
-		picture: null,
-		department: {
-			id: 2,
-			name: 'Support',
-		},
-	},
-	{
-		id: 66,
-		firstName: 'Chloe',
-		lastName: 'Alibert',
-		picture: null,
-		department: {
-			id: 3,
-			name: 'Commercial',
-		},
-	},
-];
+		department: { id: (index % departments.length) + 1, name: departments[index % departments.length] },
+		...user,
+	}));
+
+// Create homonym in different department
+mockUsers.unshift({
+	...mockUsers[0],
+	id: mockUsers.length + 1,
+	department: { id: 2, name: 'Commercial' },
+});
 
 export const mockMe = {
 	id: 35,

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -1,14 +1,12 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
 import { OverlayConfig, OverlayContainer } from '@angular/cdk/overlay';
 import {
-	booleanAttribute,
 	ChangeDetectorRef,
 	Directive,
 	ElementRef,
 	EventEmitter,
 	HostBinding,
 	HostListener,
-	inject,
 	Input,
 	OnDestroy,
 	OnInit,
@@ -16,12 +14,14 @@ import {
 	TemplateRef,
 	Type,
 	ViewChild,
+	booleanAttribute,
+	inject,
 } from '@angular/core';
-import { BehaviorSubject, ReplaySubject, Subject } from 'rxjs';
+import { ControlValueAccessor } from '@angular/forms';
+import { BehaviorSubject, Observable, ReplaySubject, Subject, switchMap, take } from 'rxjs';
 import { LuOptionGrouping, LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
 import { LuOptionContext, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
-import { ControlValueAccessor } from '@angular/forms';
 
 @Directive()
 export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDestroy, OnInit, ControlValueAccessor {
@@ -248,8 +248,10 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		}
 
 		this.panelRef.valueChanged.subscribe((value) => this.updateValue(value));
-		this.panelRef.nextPage.subscribe(() => this.nextPage.emit());
-		this.panelRef.previousPage.subscribe(() => this.previousPage.emit());
+
+		this.#pageChanged(this.panelRef.nextPage).subscribe(() => this.nextPage.emit());
+		this.#pageChanged(this.panelRef.previousPage).subscribe(() => this.previousPage.emit());
+
 		this.panelRef.activeOptionIdChanged.subscribe((optionId) => {
 			this.activeDescendant$.next(optionId);
 			this.changeDetectorRef.markForCheck();
@@ -293,5 +295,10 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		this.clueChanged('', skipPanelOpen);
 		this.onChange?.(value);
 		this.onTouched?.();
+	}
+
+	// Ensure nextPage/previousPage does not emit too often
+	#pageChanged(pageEmitter: EventEmitter<void>): Observable<void> {
+		return this.options$.pipe(switchMap(() => pageEmitter.pipe(take(1))));
 	}
 }

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -158,11 +158,10 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			shareReplay({ bufferSize: 1, refCount: true }),
 		);
 
-		const options$ = super.buildOptions();
+		const meFilter$ = displayMe$.pipe(switchMap((displayMe) => (displayMe ? me$ : of(null))));
 
-		return displayMe$.pipe(
-			switchMap((displayMe) => combineLatest([options$, displayMe ? me$ : of(null)])),
-			map(([options, me]) => (me ? [me, ...(options ?? []).filter((o) => o.id !== me.id)] : options)),
+		return combineLatest([super.buildOptions(), meFilter$]).pipe(
+			map(([options, meFilter]) => (meFilter ? [meFilter, ...(options ?? []).filter((o) => o.id !== meFilter.id)] : options)),
 			switchMap((users) => this.#userHomonymsService.handleHomonyms(users, this.displayFormat)),
 		);
 	}


### PR DESCRIPTION
## Description

- clue was sometimes missing in `users` directive
- nextPage was emitting to often (two by two)
- cache homonyms information 

-----
