### PR TITLE
chore: add mandatory button type eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -144,7 +144,8 @@
           {
             "endOfLine": "auto"
           }
-        ]
+        ],
+        "@angular-eslint/template/button-has-type": "error"
       }
     },
     {

--- a/packages/ng/forms/text-input/text-input.component.html
+++ b/packages/ng/forms/text-input/text-input.component.html
@@ -41,7 +41,7 @@
 			#inputElement
 		/>
 		<div class="textField-input-affix">
-			<button class="textField-input-affix-clear clear" (click)="clearValue()" *ngIf="hasClearer && inputElement.value">
+			<button class="textField-input-affix-clear clear" type="button" (click)="clearValue()" *ngIf="hasClearer && inputElement.value">
 				<span aria-hidden="true" class="lucca-icon icon-close"></span>
 				<span class="u-mask">{{ intl.clear }}</span>
 			</button>

--- a/packages/ng/multi-select/input/select-input.component.html
+++ b/packages/ng/multi-select/input/select-input.component.html
@@ -3,6 +3,7 @@
 <button
 	*ngIf="hasValue && clearable && (disabled$ | async) === false"
 	role="button"
+	type="button"
 	class="multipleSelect-clear clear"
 	(click)="clearValue($event)"
 >


### PR DESCRIPTION
## Description

Using clearable `lu-text-input` or `lu-multi-select` inside a `form` leads to clearing value instead of submitting the form.

This PR also add an Eslint rule to avoid this problem in the future.

-----

