### PR TITLE
fix(schematics): template schematics skipping control flow blocks

### DIFF
--- a/packages/ng/schematics/lib/html-ast.ts
+++ b/packages/ng/schematics/lib/html-ast.ts
@@ -85,6 +85,10 @@ export class HtmlAstVisitor<TNode extends TemplateNode> {
 					// If we have an @empty block, visit its children too
 					this.visit(cb, node.empty.children);
 				}
+			} else if (node instanceof this.lib.TmplAstSwitchBlock) {
+				node.cases.forEach((caseNode) => {
+					this.visit(cb, caseNode.children);
+				});
 			} else if (node instanceof this.lib.TmplAstDeferredBlock || node instanceof this.lib.TmplAstElement || node instanceof this.lib.TmplAstTemplate) {
 				// Visit @defer and classic AST elements
 				this.visit(cb, node.children);

--- a/packages/ng/schematics/lib/html-ast.ts
+++ b/packages/ng/schematics/lib/html-ast.ts
@@ -84,7 +84,7 @@ export class HtmlAstVisitor<TNode extends TemplateNode> {
 				if (node.empty) {
 					// If we have an @empty block, visit its children too
 					this.visit(cb, node.empty.children);
-				} 
+				}
 			} else if (node instanceof this.lib.TmplAstDeferredBlock || node instanceof this.lib.TmplAstElement || node instanceof this.lib.TmplAstTemplate) {
 				// Visit @defer and classic AST elements
 				this.visit(cb, node.children);

--- a/packages/ng/schematics/lib/html-ast.ts
+++ b/packages/ng/schematics/lib/html-ast.ts
@@ -78,13 +78,13 @@ export class HtmlAstVisitor<TNode extends TemplateNode> {
 					this.visit(cb, branch.children);
 				});
 			} else if (node instanceof this.lib.TmplAstForLoopBlock) {
+				// Visit @for's children
+				this.visit(cb, node.children);
+
 				if (node.empty) {
 					// If we have an @empty block, visit its children too
-					this.visit(cb, [...node.children, ...node.empty.children]);
-				} else {
-					// Else, just visit @for's children
-					this.visit(cb, node.children);
-				}
+					this.visit(cb, node.empty.children);
+				} 
 			} else if (node instanceof this.lib.TmplAstDeferredBlock || node instanceof this.lib.TmplAstElement || node instanceof this.lib.TmplAstTemplate) {
 				// Visit @defer and classic AST elements
 				this.visit(cb, node.children);

--- a/packages/ng/schematics/tokens-spacing/tests/template.input.html
+++ b/packages/ng/schematics/tokens-spacing/tests/template.input.html
@@ -11,7 +11,11 @@
 <div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
 } @empty {
 <div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
-}
+} @switch (foo) { @case ("bar") {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+} @default {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+} }
 <!-- basic class -->
 <div class="u-gapXL"></div>
 <div [class]="'u-gapXL'"></div>

--- a/packages/ng/schematics/tokens-spacing/tests/template.input.html
+++ b/packages/ng/schematics/tokens-spacing/tests/template.input.html
@@ -1,3 +1,17 @@
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+@if (foo) {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+} @else if (bar) {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+} @else {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+}
+<span></span>
+@for (foo of bar; track foo.baz) {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+} @empty {
+<div class="timeline mod-number u-paddingLeftXL u-paddingRightXL u-paddingTopS u-paddingBottomL"></div>
+}
 <!-- basic class -->
 <div class="u-gapXL"></div>
 <div [class]="'u-gapXL'"></div>

--- a/packages/ng/schematics/tokens-spacing/tests/template.output.html
+++ b/packages/ng/schematics/tokens-spacing/tests/template.output.html
@@ -1,3 +1,17 @@
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+@if (foo) {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+} @else if (bar) {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+} @else {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+}
+<span></span>
+@for (foo of bar; track foo.baz) {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+} @empty {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+}
 <!-- basic class -->
 <div class="pr-u-gap600"></div>
 <div [class]="'pr-u-gap600'"></div>

--- a/packages/ng/schematics/tokens-spacing/tests/template.output.html
+++ b/packages/ng/schematics/tokens-spacing/tests/template.output.html
@@ -11,7 +11,11 @@
 <div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
 } @empty {
 <div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
-}
+} @switch (foo) { @case ("bar") {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+} @default {
+<div class="timeline mod-number pr-u-paddingLeft600 pr-u-paddingRight600 pr-u-paddingTop200 pr-u-paddingBottom400"></div>
+} }
 <!-- basic class -->
 <div class="pr-u-gap600"></div>
 <div [class]="'pr-u-gap600'"></div>


### PR DESCRIPTION
## Description

With new control flow syntax, Angular added new nodes to the `AngularCompilerLib`, which aren't `TmplAstTemplate`, meaning that the visit methods were just skipping them.

This PR adds proper handling of these node types in the `HtmlAst.visit` method so every `visitXXX` method will now just see their content.

Parsing the `BlockNode`s themselves can be added, not sure it's relevant since it'd mean that we're making a schematic that has something to do in these blocks, but adding a method to visit them is quite trivial.

-----

-----
