### PR TITLE
test(dialog): new testing entrypoint for data testing provider

### DIFF
--- a/packages/ng/dialog/testing/ng-package.json
+++ b/packages/ng/dialog/testing/ng-package.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "public-api.ts",
+		"styleIncludePaths": []
+	}
+}

--- a/packages/ng/dialog/testing/providers.ts
+++ b/packages/ng/dialog/testing/providers.ts
@@ -1,0 +1,9 @@
+import { DIALOG_DATA } from '@angular/cdk/dialog';
+import { LuDialogData } from '@lucca-front/ng/dialog';
+
+export function provideLuDialogDataTesting<T = unknown>(data: LuDialogData<T>) {
+	return {
+		provide: DIALOG_DATA,
+		useValue: data,
+	};
+}

--- a/packages/ng/dialog/testing/public-api.ts
+++ b/packages/ng/dialog/testing/public-api.ts
@@ -1,0 +1,1 @@
+export * from './providers';


### PR DESCRIPTION
## Description

Add `provideLuDialogDataTesting` to provide `DIALOG_DATA` for testing context in order to be able to test components that are meant to be used as dialog content.

It's added in a new entrypoint called `@lucca-front/ng/dialog/testing` in order to not include it in the main dialog bundle used for production.

-----

-----
