### PR TITLE
fix(empty-state): http request for icon still fired even when it's null

### DIFF
--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
@@ -8,9 +8,9 @@
 >
 	<div class="emptyState-container">
 		<div class="emptyState-content">
-			<div class="emptyState-content-icon" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
+			<div *ngIf="icon" class="emptyState-content-icon" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
 			<div class="emptyState-content-text">
-				<h1 class="emptyState-content-heading">{{title}}</h1>
+				<h1 class="emptyState-content-heading">{{ title }}</h1>
 				<p>
 					<ng-container *luPortal="description"></ng-container>
 				</p>

--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
@@ -1,4 +1,4 @@
-import { CommonModule } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
@@ -6,7 +6,7 @@ import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
 @Component({
 	selector: 'lu-empty-state-page',
 	standalone: true,
-	imports: [CommonModule, LuSafeExternalSvgPipe, PortalDirective],
+	imports: [NgIf, LuSafeExternalSvgPipe, PortalDirective],
 	templateUrl: './empty-state-page.component.html',
 	styleUrl: './empty-state-page.component.scss',
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.html
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.html
@@ -1,9 +1,9 @@
 <section class="emptyState" [class.mod-center]="center">
 	<div class="emptyState-container">
 		<div class="emptyState-content">
-			<div class="emptyState-content-icon palette-{{palette}}" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
+			<div *ngIf="icon" class="emptyState-content-icon palette-{{palette}}" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
 			<div class="emptyState-content-text">
-				<h3 class="emptyState-content-heading">{{title}}</h3>
+				<h3 class="emptyState-content-heading">{{ title }}</h3>
 				<p>
 					<ng-container *luPortal="description"></ng-container>
 				</p>

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -1,12 +1,12 @@
-import { CommonModule } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
+import { NgIf } from '@angular/common';
 
 @Component({
 	selector: 'lu-empty-state-section',
 	standalone: true,
-	imports: [CommonModule, LuSafeExternalSvgPipe, PortalDirective],
+	imports: [NgIf, LuSafeExternalSvgPipe, PortalDirective],
 	templateUrl: './empty-state-section.component.html',
 	styleUrl: './empty-state-section.component.scss',
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/ng/safe-content/safe-external-svg.pipe.ts
+++ b/packages/ng/safe-content/safe-external-svg.pipe.ts
@@ -18,7 +18,7 @@ export class LuSafeExternalSvgPipe implements PipeTransform {
 	#subscription?: Subscription;
 
 	transform(url: string): SafeHtml {
-		if (url !== this.#lastSvgUrl) {
+		if (url && url !== this.#lastSvgUrl) {
 			this.#lastSvgUrl = url;
 			this.#subscribeToSvg(url);
 		}


### PR DESCRIPTION
## Description

Empty state components have an optional icon but when it's not provided, the request is still fired, creating an error.

This is fixed by only showing icon when it's here and handling null gracefully in safe svg pipe to handle possible async pipe use cases.

-----


-----
