### PR TITLE
[EmptyState] Tweaks for narrow views

### DIFF
--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,3 +1,6 @@
+@use '@lucca-front/scss/src/commons/utils/media';
+@use '@lucca-front/scss/src/components/title/exports' as title;
+
 @mixin component($atRoot: 'without: rule') {
 	display: flex;
 	flex-direction: column;
@@ -33,6 +36,10 @@
 
 		.emptyState-content-heading {
 			margin-bottom: 0;
+
+			@include media.max('XXS') {
+				@include title.h2;
+			}
 		}
 
 		.emptyState-actions {
@@ -42,6 +49,10 @@
 
 			.button {
 				margin: 0;
+
+				@include media.max('XXS') {
+					flex-basis: 100%;
+				}
 			}
 		}
 	}

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,6 +1,3 @@
-@use '@lucca-front/scss/src/commons/utils/media';
-@use '@lucca-front/scss/src/components/title/exports' as title;
-
 @mixin component($atRoot: 'without: rule') {
 	display: flex;
 	flex-direction: column;
@@ -36,10 +33,6 @@
 
 		.emptyState-content-heading {
 			margin-bottom: 0;
-
-			@include media.max('XXS') {
-				@include title.h2;
-			}
 		}
 
 		.emptyState-actions {
@@ -49,10 +42,6 @@
 
 			.button {
 				margin: 0;
-
-				@include media.max('XXS') {
-					flex-basis: 100%;
-				}
 			}
 		}
 	}

--- a/packages/scss/src/components/emptyState/mods.scss
+++ b/packages/scss/src/components/emptyState/mods.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/media';
+@use '@lucca-front/scss/src/components/title/exports' as title;
 
 @mixin page {
 	background-image: var(--components-emptyState-illustration-foreground-bottom-left),
@@ -17,6 +18,20 @@
 	.emptyState-content {
 		background-color: var(--components-emptyState-background-color);
 		box-shadow: 0 0 8px 4px var(--components-emptyState-background-color);
+	}
+
+	.emptyState-content-heading {
+		@include media.max('XXS') {
+			@include title.h2;
+		}
+	}
+
+	.emptyState-actions {
+		.button {
+			@include media.max('XXS') {
+				flex-basis: 100%;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION


## Description

* Reduce heading to match `h2` styles.
* Address buttons based on the mockups provided.

Closes #2520.

-----


https://github.com/LuccaSA/lucca-front/assets/144820795/d93e5326-50ec-4a9b-9ee7-311cb79b5aba


-----
