### PR TITLE
[Index Table] Prevent row to go over sticky header

### DIFF
--- a/packages/scss/src/components/indexTable/mods.scss
+++ b/packages/scss/src/components/indexTable/mods.scss
@@ -70,7 +70,7 @@
     .indexTable-head {
         position: sticky;
         top: var(--components-indexTable-row-spacing);
-        z-index: 2;
+        z-index: 3;
     }
 
     //hide box-shadow from underneath rows that slighly appear on edges of the sticky header when scrolling


### PR DESCRIPTION
## Description

Prevent rows to go over sticky header while hovering it

-----

https://github.com/LuccaSA/lucca-front/assets/25581936/fba87cdb-11dc-4ad8-8ae6-c0b9d1b31b73

-----
