### PR TITLE
fixed(lu-dialog): handled canClose option in LuDialogService

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -26,7 +26,7 @@ export class LuDialogService {
 			ariaModal: config.modal ?? true,
 			hasBackdrop: config.modal ?? true,
 			data: 'data' in config ? config.data : null,
-			disableClose: true,
+			disableClose: false,
 			closeOnDestroy: true,
 			role: config.alert ? 'alertdialog' : 'dialog',
 			restoreFocus: true,
@@ -57,7 +57,7 @@ export class LuDialogService {
 
 		if (!config.alert) {
 			// Setup close listeners on backdrop click and escape key by ourselves so we can hook the `canClose` method to it.
-			merge(cdkRef.backdropClick, cdkRef.keydownEvents.pipe(filter((e) => e.key === 'Escape' && !e.defaultPrevented)))
+			merge(cdkRef.backdropClick.pipe(filter(() => !config.cdkConfigOverride.disableClose)), cdkRef.keydownEvents.pipe(filter((e) => e.key === 'Escape' && !e.defaultPrevented)))
 				.pipe(
 					switchMap(() => {
 						const canClose = config.canClose?.(cdkRef.componentInstance) ?? true;

--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -33,9 +33,9 @@ interface BaseLuDialogConfig<C> {
 	modal?: boolean;
 
 	/**
-	 * Can this dialog box be dismissed by clicking on the backdrop or pressing escape?
+	 * Is this dialog a blocking popup that cannot be dismissed ?
 	 *
-	 * Defaults to true, setting this to false will also remove the close button in the header
+	 * Defaults to false, setting this to true will also remove the close button in the header
 	 * if you're using `lu-dialog-header`.
 	 */
 	alert?: boolean;


### PR DESCRIPTION
## Description

Handled `cdkConfigOverride.canClose` option in `LuDialogService`

-----

Fixed JsDoc for `alert` property.

-----
