### PR TITLE
fix(front): indexTable inconsistent cell padding

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -3,216 +3,232 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 
 @mixin component($atRoot: 'without: rule') {
-    position: relative;
-    display: table;
-    width: 100%;
-    padding: 0 var(--components-indexTable-padding) calc(var(--components-indexTable-padding) - var(--components-indexTable-row-spacing));
-    border-collapse: separate;
-    border-spacing: 0 var(--components-indexTable-row-spacing);
-    border-radius: var(--components-indexTable-border-radius);
-    background-color: var(--components-indexTable-background-color);
-    color: var(--palettes-neutral-800);
+	position: relative;
+	display: table;
+	width: 100%;
+	padding: 0 var(--components-indexTable-padding) calc(var(--components-indexTable-padding) - var(--components-indexTable-row-spacing));
+	border-collapse: separate;
+	border-spacing: 0 var(--components-indexTable-row-spacing);
+	border-radius: var(--components-indexTable-border-radius);
+	background-color: var(--components-indexTable-background-color);
+	color: var(--palettes-neutral-800);
 
-    @at-root ($atRoot) {
-        .indexTable-head {
-            display: table-header-group;
-            vertical-align: bottom;
-        }
+	@at-root ($atRoot) {
+		.indexTable-head {
+			display: table-header-group;
+			vertical-align: bottom;
+		}
 
-        .indexTable-body {
-            display: table-row-group;
-        }
+		.indexTable-body {
+			display: table-row-group;
+		}
 
-        //There might be more than one footer
-        .indexTable-foot {
-            display: table-row-group;
-            &:is(tfoot) {
-                display: table-footer-group;
-            }
-        }
+		//There might be more than one footer
+		.indexTable-foot {
+			display: table-row-group;
+			&:is(tfoot) {
+				display: table-footer-group;
+			}
+		}
 
-        .indexTable-head-row,
-        .indexTable-body-row,
-        .indexTable-foot-row {
-            display: table-row;
-        }
+		.indexTable-head-row,
+		.indexTable-body-row,
+		.indexTable-foot-row {
+			display: table-row;
+		}
 
-        .indexTable-body-row {
-            border-radius: var(--commons-borderRadius-L);
-            cursor: pointer;
-        }
+		.indexTable-body-row {
+			border-radius: var(--commons-borderRadius-L);
+			cursor: pointer;
+		}
 
-        .indexTable-head-row-transparentCell,
-        .indexTable-body-row-transparentCell,
-        .indexTable-head-row-cell,
-        .indexTable-body-row-cell,
-        .indexTable-foot-row-cell {
-            display: table-cell;
-            text-align: left;
-            font-weight: 400;
-        }
+		.indexTable-head-row-transparentCell,
+		.indexTable-body-row-transparentCell,
+		.indexTable-head-row-cell,
+		.indexTable-body-row-cell,
+		.indexTable-foot-row-cell {
+			display: table-cell;
+			text-align: left;
+			font-weight: 400;
+		}
 
-        .indexTable-head-row-transparentCell,
-        .indexTable-body-row-transparentCell {
-            vertical-align: middle;
-            padding: var(--pr-t-spacings-50) 0;
-            &:not(:first-child) {
-                padding-right: var(--components-indexTable-cell-padding);
-            }
-        }
+		.indexTable-head-row-transparentCell,
+		.indexTable-body-row-transparentCell {
+			vertical-align: middle;
+			padding: var(--pr-t-spacings-50) 0;
+			&:not(:first-child) {
+				padding-right: var(--components-indexTable-cell-padding);
+			}
+		}
 
-        .indexTable-head-row-cell,
-        .indexTable-body-row-cell,
-        .indexTable-foot-row-cell {
-            vertical-align: top;
-            // Because outlined cell apparence can be cropped we need a bigger padding-right. To compensate we also need a smaller padding left
-            padding: var(--components-indexTable-cell-padding);
-            padding-left: var(--components-indexTable-cell-padding-left, var(--components-indexTable-cell-padding));
-            padding-right: var(--components-indexTable-cell-padding-right, var(--components-indexTable-cell-padding));
-        }
+		.indexTable-head-row-cell,
+		.indexTable-body-row-cell,
+		.indexTable-foot-row-cell {
+			vertical-align: top;
 
-        .indexTable-head-row-cell {
-            color: var(--palettes-neutral-700);
-        }
+			// Because outlined cell apparence can be cropped we need a bigger padding-right. To compensate we also need a smaller padding-left
+			padding: var(--components-indexTable-cell-padding);
+			padding-left: var(--components-indexTable-cell-padding-left, var(--components-indexTable-cell-padding));
+			padding-right: var(--components-indexTable-cell-padding-right, var(--components-indexTable-cell-padding));
 
-        .indexTable-foot-row-cell {
-            padding-top: var(--pr-t-spacings-50);
-            padding-bottom: var(--pr-t-spacings-50);
-        }
+			--components-indexTable-cell-padding-right: calc(var(--components-indexTable-cell-padding) + 4px);
+			~ .indexTable-head-row-cell,
+			~ .indexTable-body-row-cell,
+			~ .indexTable-foot-row-cell {
+				--components-indexTable-cell-padding-left: calc(var(--components-indexTable-cell-padding) - 4px);
+			}
 
-        .indexTable-body-row-cell {
-            position: relative;
-            z-index: var(--components-indexTable-cell-z-index, 1);
-            border-radius: var(--components-table-cardList-cell-border-radius);
-            border: var(--commons-divider-width) 0 solid transparent;
+			&:last-child {
+				--components-indexTable-cell-padding-right: var(--components-indexTable-cell-padding);
+			}
+		}
 
-            // Apparence of the first cell with a card apparence.
-            // We do this because there migh be one or two cells before without background and containing a checkbox
-            --components-indexTable-cell-inset-x-left: var(--components-indexTable-cell-inset-x);
-            --components-indexTable-cell-border-radius-left: var(--components-indexTable-cell-border-radius);
-            --components-indexTable-cell-border-radius-right: 0;
-            --components-indexTable-outline-border-radius-left: var(--components-indexTable-outline-border-radius);
-            --components-indexTable-outline-border-radius-right: 0;
-            --components-indexTable-outline-border-width-left: var(--components-indexTable-outline-border-width);
-            --components-indexTable-outline-border-width-right: 0;
-            --components-indexTable-cell-padding-right: calc(var(--components-indexTable-cell-padding) + 4px);
+		.indexTable-head-row-cell {
+			color: var(--palettes-neutral-700);
+		}
 
-            // Apparence of the nexts cells
-            ~ .indexTable-body-row-cell {
-                --components-indexTable-cell-inset-x-left: 0px;
-                --components-indexTable-shadow-mask: calc(var(--pr-t-spacings-100) * -1) 0px 0px 0px var(--components-indexTable-cell-background-color, var(--components-indexTable-cell-background-color-default));
-                --components-indexTable-cell-border-radius-left: 0;
-                --components-indexTable-outline-border-radius-left: 0;
-                --components-indexTable-outline-border-width-left: 0;
-                --components-indexTable-cell-padding-left: calc(var(--components-indexTable-cell-padding) - 4px);
-            }
+		.indexTable-foot-row-cell {
+			padding-top: var(--pr-t-spacings-50);
+			padding-bottom: var(--pr-t-spacings-50);
+		}
 
-            // Apparence of the last cell with a card apparence
-            &:last-child {
-                --components-indexTable-cell-inset-x-right: var(--components-indexTable-cell-inset-x);
-                --components-indexTable-cell-border-radius-right: var(--components-indexTable-cell-border-radius);
-                --components-indexTable-outline-border-radius-right: var(--components-indexTable-outline-border-radius);
-                --components-indexTable-outline-border-width-right: var(--components-indexTable-outline-border-width);
-                --components-indexTable-cell-padding-right: var(--components-indexTable-cell-padding);
-            }
+		.indexTable-body-row-cell {
+			position: relative;
+			z-index: var(--components-indexTable-cell-z-index, 1);
+			border-radius: var(--components-table-cardList-cell-border-radius);
+			border: var(--commons-divider-width) 0 solid transparent;
 
-            &::before,
-            &::after {
-                content: '';
-                position: absolute;
-                z-index: -1;
-                transition-duration: var(--commons-animations-durations-fast);
-            }
+			// Apparence of the first cell with a card apparence.
+			// We do this because there migh be one or two cells before without background and containing a checkbox
+			--components-indexTable-cell-inset-x-left: var(--components-indexTable-cell-inset-x);
+			--components-indexTable-cell-border-radius-left: var(--components-indexTable-cell-border-radius);
+			--components-indexTable-cell-border-radius-right: 0;
+			--components-indexTable-outline-border-radius-left: var(--components-indexTable-outline-border-radius);
+			--components-indexTable-outline-border-radius-right: 0;
+			--components-indexTable-outline-border-width-left: var(--components-indexTable-outline-border-width);
+			--components-indexTable-outline-border-width-right: 0;
 
-            // The "card" apparence is put on a ::before pseudo element
-            &::before {
-                inset: var(--components-indexTable-cell-inset-y, 0) var(--components-indexTable-cell-inset-x-right, 0) var(--components-indexTable-cell-inset-y, 0) var(--components-indexTable-cell-inset-x-left, 0);
-                border-radius: var(--components-indexTable-cell-border-radius-left) var(--components-indexTable-cell-border-radius-right) var(--components-indexTable-cell-border-radius-right) var(--components-indexTable-cell-border-radius-left);
-                background-color: var(--components-indexTable-cell-background-color, var(--components-indexTable-cell-background-color-default));
-                // shadow-mask : since the card apparence is put on every cell (du to a Safari bug), we need to hide the left part of the box shadow for everycell exept the first one.
-                // We do this with a rectangular white box-shadow above it.
-                box-shadow: var(--components-indexTable-shadow-mask, 0 0 0 0), var(--components-indexTable-cell-shadow, var(--components-indexTable-cell-shadow-default));
-                transition-property: inset, box-shadow, background-color;
-            }
+			// Apparence of the nexts cells
+			~ .indexTable-body-row-cell {
+				--components-indexTable-cell-inset-x-left: 0px;
+				--components-indexTable-shadow-mask: calc(var(--pr-t-spacings-100) * -1) 0px 0px 0px
+					var(--components-indexTable-cell-background-color, var(--components-indexTable-cell-background-color-default));
+				--components-indexTable-cell-border-radius-left: 0;
+				--components-indexTable-outline-border-radius-left: 0;
+				--components-indexTable-outline-border-width-left: 0;
+			}
 
-            // The focus outline, when needed
-            &::after {
-                inset: calc(var(--components-indexTable-cell-inset-y, 0px) - var(--components-indexTable-outline-offset)) calc(var(--components-indexTable-cell-inset-x-right, 0px) - var(--components-indexTable-outline-offset))
-                    calc(var(--components-indexTable-cell-inset-y, 0px) - var(--components-indexTable-outline-offset)) calc(var(--components-indexTable-cell-inset-x-left, 0px) - var(--components-indexTable-outline-offset));
-                border-radius: var(--components-indexTable-outline-border-radius-left) var(--components-indexTable-outline-border-radius-right) var(--components-indexTable-outline-border-radius-right)
-                    var(--components-indexTable-outline-border-radius-left);
-                border-width: var(--components-indexTable-outline-border-width) var(--components-indexTable-outline-border-width-right) var(--components-indexTable-outline-border-width) var(--components-indexTable-outline-border-width-left);
-                border-style: solid;
-                border-color: var(--components-indexTable-outline-color);
-                opacity: var(--components-indexTable-outline-opacity, 0);
-                transition-property: inset;
-            }
+			// Apparence of the last cell with a card apparence
+			&:last-child {
+				--components-indexTable-cell-inset-x-right: var(--components-indexTable-cell-inset-x);
+				--components-indexTable-cell-border-radius-right: var(--components-indexTable-cell-border-radius);
+				--components-indexTable-outline-border-radius-right: var(--components-indexTable-outline-border-radius);
+				--components-indexTable-outline-border-width-right: var(--components-indexTable-outline-border-width);
+			}
 
-            // No shadow if the row contain an emptyState
-            &:has(.emptyState) {
-                --components-indexTable-cell-shadow: none;
-            }
-        }
+			&::before,
+			&::after {
+				content: '';
+				position: absolute;
+				z-index: -1;
+				transition-duration: var(--commons-animations-durations-fast);
+			}
 
-        .indexTable-body-row-cell-checkbox,
-        .indexTable-head-row-cell-checkbox {
-            display: block;
-            margin: 2px 0 0 var(--pr-t-spacings-50);
-        }
+			// The "card" apparence is put on a ::before pseudo element
+			&::before {
+				inset: var(--components-indexTable-cell-inset-y, 0) var(--components-indexTable-cell-inset-x-right, 0)
+					var(--components-indexTable-cell-inset-y, 0) var(--components-indexTable-cell-inset-x-left, 0);
+				border-radius: var(--components-indexTable-cell-border-radius-left) var(--components-indexTable-cell-border-radius-right)
+					var(--components-indexTable-cell-border-radius-right) var(--components-indexTable-cell-border-radius-left);
+				background-color: var(--components-indexTable-cell-background-color, var(--components-indexTable-cell-background-color-default));
+				// shadow-mask : since the card apparence is put on every cell (du to a Safari bug), we need to hide the left part of the box shadow for everycell exept the first one.
+				// We do this with a rectangular white box-shadow above it.
+				box-shadow: var(--components-indexTable-shadow-mask, 0 0 0 0),
+					var(--components-indexTable-cell-shadow, var(--components-indexTable-cell-shadow-default));
+				transition-property: inset, box-shadow, background-color;
+			}
 
-        // Hidden element that take focus when the row is focused
-        .indexTable-body-row-cell-action {
-            @include a11y.mask;
-        }
+			// The focus outline, when needed
+			&::after {
+				inset: calc(var(--components-indexTable-cell-inset-y, 0px) - var(--components-indexTable-outline-offset))
+					calc(var(--components-indexTable-cell-inset-x-right, 0px) - var(--components-indexTable-outline-offset))
+					calc(var(--components-indexTable-cell-inset-y, 0px) - var(--components-indexTable-outline-offset))
+					calc(var(--components-indexTable-cell-inset-x-left, 0px) - var(--components-indexTable-outline-offset));
+				border-radius: var(--components-indexTable-outline-border-radius-left) var(--components-indexTable-outline-border-radius-right)
+					var(--components-indexTable-outline-border-radius-right) var(--components-indexTable-outline-border-radius-left);
+				border-width: var(--components-indexTable-outline-border-width) var(--components-indexTable-outline-border-width-right)
+					var(--components-indexTable-outline-border-width) var(--components-indexTable-outline-border-width-left);
+				border-style: solid;
+				border-color: var(--components-indexTable-outline-color);
+				opacity: var(--components-indexTable-outline-opacity, 0);
+				transition-property: inset;
+			}
 
-        .indexTable-body-row-cellTitle {
-            position: relative;
-            display: flex;
-            align-items: center;
-            gap: var(--pr-t-spacings-100);
-        }
+			// No shadow if the row contain an emptyState
+			&:has(.emptyState) {
+				--components-indexTable-cell-shadow: none;
+			}
+		}
 
-        .indexTable-body-row-cellTitle-button {
-            @include button.text;
-            @include button.S;
-            @include button.onlyIconS;
-            position: static;
-            .lucca-icon {
-                transition: transform var(--commons-animations-durations-fast) ease;
-            }
-            // Extend button reactive zone to his whole parent
-            &::before {
-                content: '';
-                position: absolute;
-                inset: 0;
-            }
-        }
+		.indexTable-body-row-cell-checkbox,
+		.indexTable-head-row-cell-checkbox {
+			display: block;
+			margin: 2px 0 0 var(--pr-t-spacings-50);
+		}
 
-        .indexTable-body-row-cellTitle-title {
-            font-weight: 600;
-        }
+		// Hidden element that take focus when the row is focused
+		.indexTable-body-row-cell-action {
+			@include a11y.mask;
+		}
 
-        .indexTable-foot-row-cell {
-            text-align: right;
-        }
+		.indexTable-body-row-cellTitle {
+			position: relative;
+			display: flex;
+			align-items: center;
+			gap: var(--pr-t-spacings-100);
+		}
 
-        // A wrapper is needed for pagination
-        .indexTableWrapper {
-            @include vars;
-            display: flex;
-            flex-direction: column;
-            padding-bottom: var(--pr-t-spacings-100);
-            border-radius: var(--components-indexTable-border-radius);
-            background-color: var(--components-indexTable-background-color);
-            .indexTable {
-                flex-grow: 1;
-                padding-bottom: 0;
-            }
-            .pagination {
-                align-self: flex-end;
-                padding: var(--pr-t-spacings-50) 0 0 0;
-                margin-right: var(--pr-t-spacings-100);
-            }
-        }
-    }
+		.indexTable-body-row-cellTitle-button {
+			@include button.text;
+			@include button.S;
+			@include button.onlyIconS;
+			position: static;
+			.lucca-icon {
+				transition: transform var(--commons-animations-durations-fast) ease;
+			}
+			// Extend button reactive zone to his whole parent
+			&::before {
+				content: '';
+				position: absolute;
+				inset: 0;
+			}
+		}
+
+		.indexTable-body-row-cellTitle-title {
+			font-weight: 600;
+		}
+
+		.indexTable-foot-row-cell {
+			text-align: right;
+		}
+
+		// A wrapper is needed for pagination
+		.indexTableWrapper {
+			@include vars;
+			display: flex;
+			flex-direction: column;
+			padding-bottom: var(--pr-t-spacings-100);
+			border-radius: var(--components-indexTable-border-radius);
+			background-color: var(--components-indexTable-background-color);
+			.indexTable {
+				flex-grow: 1;
+				padding-bottom: 0;
+			}
+			.pagination {
+				align-self: flex-end;
+				padding: var(--pr-t-spacings-50) 0 0 0;
+				margin-right: var(--pr-t-spacings-100);
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Description

Fix `indexTable` inconsistent cells padding

![image](https://github.com/LuccaSA/lucca-front/assets/65592565/28608a41-8b2c-4a0c-a428-a9dba97c690b)

![image](https://github.com/LuccaSA/lucca-front/assets/65592565/0eeedb37-9ebd-4f96-8fb3-440ad9ab56e0)



-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
