### PR TITLE
fix(user-popover): background color not matching user-picture

### DIFF
--- a/packages/ng/popup-employee/card/panel/user-popover-panel.component.ts
+++ b/packages/ng/popup-employee/card/panel/user-popover-panel.component.ts
@@ -89,7 +89,7 @@ export class LuUserPopoverPanelComponent extends ALuPopoverPanel implements ILuU
 
 			return {
 				initials,
-				color: `${employee.firstName}${employee.lastName}`.split('').reduce((sum, a) => sum + a.charCodeAt(0), 0) % 360,
+				color: `${employee.firstName} ${employee.lastName}`.split('').reduce((sum, a) => sum + a.charCodeAt(0), 0) % 360,
 			};
 		}),
 	);


### PR DESCRIPTION
## Description

Color in user picture embed inside the user-popover panel was missmatching the one from "real" `lu-user-picture` due to a missing space in the string used to feed the base value for HSL. This PR just fixes that by adding a space (big PR yeah).

-----

-----
