### PR TITLE
[Simple & Multi Select] Expose MAGIC_PAGE_SIZE and update doc.

### DIFF
--- a/docs/core-select-users-directive.md
+++ b/docs/core-select-users-directive.md
@@ -41,13 +41,18 @@ Il est possible de modifier l'affichage d'une option en fournissant un template 
 
 Il est possible de modifier la source de données utilisée par le composant. Pour cela, il faut créer une nouvelle directive qui étend `LuCoreSelectUsersDirective` et qui surcharge la méthode `getOptions`.
 
+> ⚠️ Afin de déclencher le chargement au scroll, vous devez spécifier le paramètre `limit` dans les paramètres de votre requête.
+> Vous pouvez utiliser `MAGIC_PAGE_SIZE`, qui correspond à une taille de page de **20** items, ou toute autre variable de votre choix.
+
 ```ts
 import { Directive, forwardRef, inject } from '@angular/core';
 import { LuCoreSelectUsersDirective } from '@lucca-front/ng/core-select/user';
+import { MAGIC_PAGE_SIZE } from '@lucca-front/ng/core-select/api';
 import { Observable, map } from 'rxjs';
 
 import { Person } from '../models';
 import { PersonService } from '../services';
+
 
 @Directive({
   selector: '[appPersons]',
@@ -64,7 +69,7 @@ export class PersonsDirective extends LuCoreSelectUsersDirective<Person> {
   #personsService = inject(PersonService);
 
   protected override getOptions(params: Record<string, string | number | boolean>, page: number): Observable<Person[]> {
-    return this.#personsService.getPersons({ page: page + 1, ...params }).pipe(map((response) => response.items));
+    return this.#personsService.getPersons({ page: page + 1, limit: MAGIC_PAGE_SIZE, ...params }).pipe(map((response) => response.items));
   }
 }
 ```

--- a/docs/core-select-users-directive.md
+++ b/docs/core-select-users-directive.md
@@ -42,12 +42,12 @@ Il est possible de modifier l'affichage d'une option en fournissant un template 
 Il est possible de modifier la source de données utilisée par le composant. Pour cela, il faut créer une nouvelle directive qui étend `LuCoreSelectUsersDirective` et qui surcharge la méthode `getOptions`.
 
 > ⚠️ Afin de déclencher le chargement au scroll, vous devez spécifier le paramètre `limit` dans les paramètres de votre requête.
-> Vous pouvez utiliser `MAGIC_PAGE_SIZE`, qui correspond à une taille de page de **20** items, ou toute autre variable de votre choix.
+> Vous pouvez utiliser `LU_SELECT_MAGIC_PAGE_SIZE`, qui correspond à une taille de page de **20** items, ou toute autre variable de votre choix.
 
 ```ts
 import { Directive, forwardRef, inject } from '@angular/core';
 import { LuCoreSelectUsersDirective } from '@lucca-front/ng/core-select/user';
-import { MAGIC_PAGE_SIZE } from '@lucca-front/ng/core-select/api';
+import { LU_SELECT_MAGIC_PAGE_SIZE } from '@lucca-front/ng/core-select/api';
 import { Observable, map } from 'rxjs';
 
 import { Person } from '../models';
@@ -69,7 +69,7 @@ export class PersonsDirective extends LuCoreSelectUsersDirective<Person> {
   #personsService = inject(PersonService);
 
   protected override getOptions(params: Record<string, string | number | boolean>, page: number): Observable<Person[]> {
-    return this.#personsService.getPersons({ page: page + 1, limit: MAGIC_PAGE_SIZE, ...params }).pipe(map((response) => response.items));
+    return this.#personsService.getPersons({ page: page + 1, limit: LU_SELECT_MAGIC_PAGE_SIZE, ...params }).pipe(map((response) => response.items));
   }
 }
 ```

--- a/packages/ng/core-select/api/api-v3.directive.spec.ts
+++ b/packages/ng/core-select/api/api-v3.directive.spec.ts
@@ -7,9 +7,9 @@ import { ALuSelectInputComponent } from '@lucca-front/ng/core-select';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { BehaviorSubject, ReplaySubject, first } from 'rxjs';
 import { LuCoreSelectApiV3Directive } from './api-v3.directive';
-import { MAGIC_DEBOUNCE_DURATION, MAGIC_PAGE_SIZE } from './api.directive';
+import { MAGIC_DEBOUNCE_DURATION, LU_SELECT_MAGIC_PAGE_SIZE } from './api.directive';
 
-const itemsMocks = Array.from({ length: MAGIC_PAGE_SIZE * 2 + 5 }, (_, i) => ({ id: i, name: `item ${i}` }));
+const itemsMocks = Array.from({ length: LU_SELECT_MAGIC_PAGE_SIZE * 2 + 5 }, (_, i) => ({ id: i, name: `item ${i}` }));
 
 describe('CoreSelectApiV3Directive', () => {
 	let directive: LuCoreSelectApiV3Directive<ILuApiItem>;
@@ -77,7 +77,7 @@ describe('CoreSelectApiV3Directive', () => {
 		tick();
 
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=0,20').flush({
-			data: { items: itemsMocks.slice(0, MAGIC_PAGE_SIZE) },
+			data: { items: itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE) },
 		});
 		tick();
 
@@ -86,11 +86,11 @@ describe('CoreSelectApiV3Directive', () => {
 
 		// Assert
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
-			data: { items: itemsMocks.slice(MAGIC_PAGE_SIZE, MAGIC_PAGE_SIZE * 2) },
+			data: { items: itemsMocks.slice(LU_SELECT_MAGIC_PAGE_SIZE, LU_SELECT_MAGIC_PAGE_SIZE * 2) },
 		});
 
 		selectMock.options$.pipe(first()).subscribe((options) => {
-			expect(options).toEqual(itemsMocks.slice(0, MAGIC_PAGE_SIZE * 2));
+			expect(options).toEqual(itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE * 2));
 		});
 		tick();
 	}));
@@ -104,13 +104,13 @@ describe('CoreSelectApiV3Directive', () => {
 		tick();
 
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=0,20').flush({
-			data: { items: itemsMocks.slice(0, MAGIC_PAGE_SIZE) },
+			data: { items: itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE) },
 		});
 		tick();
 
 		selectMock.nextPage.emit();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
-			data: { items: itemsMocks.slice(MAGIC_PAGE_SIZE, MAGIC_PAGE_SIZE * 2) },
+			data: { items: itemsMocks.slice(LU_SELECT_MAGIC_PAGE_SIZE, LU_SELECT_MAGIC_PAGE_SIZE * 2) },
 		});
 
 		// Act

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -2,13 +2,13 @@ import { Directive, inject, OnDestroy, OnInit } from '@angular/core';
 import { ALuSelectInputComponent } from '@lucca-front/ng/core-select';
 import { catchError, combineLatest, concatMap, debounceTime, distinctUntilChanged, map, merge, Observable, of, pairwise, scan, startWith, Subject, switchMap, takeUntil, takeWhile, tap } from 'rxjs';
 
-export const MAGIC_PAGE_SIZE = 20;
+export const LU_SELECT_MAGIC_PAGE_SIZE = 20;
 export const MAGIC_DEBOUNCE_DURATION = 250;
 
 @Directive()
 export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string, string | number | boolean>> implements OnDestroy, OnInit {
 	protected destroy$ = new Subject<void>();
-	protected pageSize = MAGIC_PAGE_SIZE;
+	protected pageSize = LU_SELECT_MAGIC_PAGE_SIZE;
 	protected debounceDuration = MAGIC_DEBOUNCE_DURATION;
 
 	public select = inject<ALuSelectInputComponent<TOption, unknown>>(ALuSelectInputComponent);

--- a/packages/ng/core-select/api/public-api.ts
+++ b/packages/ng/core-select/api/public-api.ts
@@ -1,4 +1,3 @@
 export * from './api-v3.directive';
 export * from './api-v4.directive';
 export { ALuCoreSelectApiDirective, MAGIC_PAGE_SIZE } from './api.directive';
-

--- a/packages/ng/core-select/api/public-api.ts
+++ b/packages/ng/core-select/api/public-api.ts
@@ -1,3 +1,3 @@
 export * from './api-v3.directive';
 export * from './api-v4.directive';
-export { ALuCoreSelectApiDirective, MAGIC_PAGE_SIZE } from './api.directive';
+export { ALuCoreSelectApiDirective, LU_SELECT_MAGIC_PAGE_SIZE } from './api.directive';

--- a/packages/ng/core-select/api/public-api.ts
+++ b/packages/ng/core-select/api/public-api.ts
@@ -1,3 +1,4 @@
 export * from './api-v3.directive';
 export * from './api-v4.directive';
-export { ALuCoreSelectApiDirective } from './api.directive';
+export { ALuCoreSelectApiDirective, MAGIC_PAGE_SIZE } from './api.directive';
+


### PR DESCRIPTION
## Description

Doc on how to override the user directive has been written in https://github.com/LuccaSA/lucca-front/pull/2748.
However, some explanation was missing, especially regarding the limit parameter which must be provided in the request, in order to trigger the page change on scroll.

This PR is meant to update the doc, as well as exposing the `MAGIC_PAGE_SIZE` const (and renaming it), which is a good default value if you don't want to provide a custom limit.

-----

-----
