### PR TITLE
Fix for border on checkbox and revert with only one pseudo-element

### DIFF
--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -16,42 +16,37 @@
 			vertical-align: top;
 
 			&::before {
-				content: '';
+				@include icon.generate('sign_confirm');
+
 				background-color: var(--colors-white-color);
 				width: var(--components-checkbox-input-size);
 				height: var(--components-checkbox-input-size);
 				border-radius: 6px;
 				transition-duration: var(--commons-animations-durations-fast);
-				transition-property: border-color, color, background-color;
+				transition-property: box-shadow, color, background-color;
+				box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-700);
+				line-height: var(--components-checkbox-input-size);
+				font-size: var(--components-checkbox-input-size);
 				flex-grow: 0;
 				flex-shrink: 0;
 				flex-basis: auto;
-				display: block;
-				margin-right: var(--pr-t-spacings-100);
-				margin-top: 2px;
-				border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-700);
-			}
-
-			&::after {
-				@include icon.generate('sign_confirm');
-
-				line-height: var(--components-checkbox-input-size);
-				font-size: var(--components-checkbox-input-size);
 				color: transparent;
+				display: block;
 				text-align: center;
-				position: absolute;
 				margin-top: 2px;
+				margin-right: var(--pr-t-spacings-100);
+				transform: translate3d(0, 0, 0); // Fix box-shadow artifacts
 			}
 
 			&:hover {
 				&::before {
-					border-color: var(--palettes-neutral-600);
+					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-600);
 				}
 			}
 
 			&:active {
 				&::before {
-					border-color: var(--palettes-neutral-800);
+					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-800);
 				}
 			}
 		}
@@ -67,12 +62,9 @@
 
 			&:checked ~ .checkbox-label {
 				&::before {
-					background-color: var(--palettes-700, var(--palettes-product-700));
-					border-color: var(--palettes-700, var(--palettes-product-700));
-				}
-
-				&::after {
 					color: var(--colors-white-color);
+					background-color: var(--palettes-700, var(--palettes-product-700));
+					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-700, var(--palettes-product-700));
 				}
 			}
 
@@ -80,14 +72,14 @@
 				&:hover {
 					&::before {
 						background-color: var(--palettes-600, var(--palettes-product-600));
-						border-color: var(--palettes-600, var(--palettes-product-600));
+						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-600, var(--palettes-product-600));
 					}
 				}
 
 				&:active {
 					&::before {
 						background-color: var(--palettes-800, var(--palettes-product-800));
-						border-color: var(--palettes-800, var(--palettes-product-800));
+						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-800, var(--palettes-product-800));
 					}
 				}
 			}

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -23,9 +23,9 @@
 				height: var(--components-checkbox-input-size);
 				border-radius: 6px;
 				transition-duration: var(--commons-animations-durations-fast);
-				transition-property: box-shadow, color, background-color;
-				box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-700);
-				line-height: var(--components-checkbox-input-size);
+				transition-property: border-color, color, background-color;
+				border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-700);
+				line-height: calc(var(--components-checkbox-input-size) - var(--components-checkbox-input-border-width) * 2);
 				font-size: var(--components-checkbox-input-size);
 				flex-grow: 0;
 				flex-shrink: 0;
@@ -36,17 +36,18 @@
 				margin-top: 2px;
 				margin-right: var(--pr-t-spacings-100);
 				transform: translate3d(0, 0, 0); // Fix box-shadow artifacts
+				text-indent: calc(var(--components-checkbox-input-border-width) * -1);
 			}
 
 			&:hover {
 				&::before {
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-600);
+					border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-600);
 				}
 			}
 
 			&:active {
 				&::before {
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-800);
+					border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-800);
 				}
 			}
 		}
@@ -64,7 +65,7 @@
 				&::before {
 					color: var(--colors-white-color);
 					background-color: var(--palettes-700, var(--palettes-product-700));
-					box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-700, var(--palettes-product-700));
+					border: var(--components-checkbox-input-border-width) solid var(--palettes-700, var(--palettes-product-700));
 				}
 			}
 
@@ -72,14 +73,14 @@
 				&:hover {
 					&::before {
 						background-color: var(--palettes-600, var(--palettes-product-600));
-						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-600, var(--palettes-product-600));
+						border: var(--components-checkbox-input-border-width) solid var(--palettes-600, var(--palettes-product-600));
 					}
 				}
 
 				&:active {
 					&::before {
 						background-color: var(--palettes-800, var(--palettes-product-800));
-						box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-800, var(--palettes-product-800));
+						border: var(--components-checkbox-input-border-width) solid var(--palettes-800, var(--palettes-product-800));
 					}
 				}
 			}

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -41,13 +41,13 @@
 
 			&:hover {
 				&::before {
-					border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-600);
+					border-color: var(--palettes-neutral-600);
 				}
 			}
 
 			&:active {
 				&::before {
-					border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-800);
+					border-color: var(--palettes-neutral-800);
 				}
 			}
 		}
@@ -65,7 +65,7 @@
 				&::before {
 					color: var(--colors-white-color);
 					background-color: var(--palettes-700, var(--palettes-product-700));
-					border: var(--components-checkbox-input-border-width) solid var(--palettes-700, var(--palettes-product-700));
+					border-color: var(--palettes-700, var(--palettes-product-700));
 				}
 			}
 
@@ -73,14 +73,14 @@
 				&:hover {
 					&::before {
 						background-color: var(--palettes-600, var(--palettes-product-600));
-						border: var(--components-checkbox-input-border-width) solid var(--palettes-600, var(--palettes-product-600));
+						border-color: var(--palettes-600, var(--palettes-product-600));
 					}
 				}
 
 				&:active {
 					&::before {
 						background-color: var(--palettes-800, var(--palettes-product-800));
-						border: var(--components-checkbox-input-border-width) solid var(--palettes-800, var(--palettes-product-800));
+						border-color: var(--palettes-800, var(--palettes-product-800));
 					}
 				}
 			}

--- a/packages/scss/src/components/checkbox/states.scss
+++ b/packages/scss/src/components/checkbox/states.scss
@@ -7,7 +7,7 @@
 		cursor: default;
 
 		&::before {
-			border-color: var(--palettes-neutral-500);
+			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-500);
 		}
 
 		.checkbox-label-helper {
@@ -17,12 +17,9 @@
 
 	&:checked ~ .checkbox-label {
 		&::before {
-			background-color: var(--palettes-neutral-100);
-			border-color: var(--palettes-neutral-100);
-		}
-
-		&::after {
 			color: var(--palettes-neutral-500);
+			background-color: var(--palettes-neutral-100);
+			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-100);
 		}
 	}
 }
@@ -30,7 +27,7 @@
 @mixin incomplete {
 	~ .checkbox-mixed ~ .checkbox-label,
 	~ .checkbox-label {
-		&::after {
+		&::before {
 			@include icon.generate('maths_minus');
 		}
 	}

--- a/packages/scss/src/components/checkbox/states.scss
+++ b/packages/scss/src/components/checkbox/states.scss
@@ -7,7 +7,7 @@
 		cursor: default;
 
 		&::before {
-			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-500);
+			border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-500);
 		}
 
 		.checkbox-label-helper {
@@ -19,7 +19,7 @@
 		&::before {
 			color: var(--palettes-neutral-500);
 			background-color: var(--palettes-neutral-100);
-			box-shadow: inset 0 0 0 var(--components-checkbox-input-border-width) var(--palettes-neutral-100);
+			border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-100);
 		}
 	}
 }

--- a/packages/scss/src/components/checkbox/states.scss
+++ b/packages/scss/src/components/checkbox/states.scss
@@ -7,7 +7,7 @@
 		cursor: default;
 
 		&::before {
-			border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-500);
+			border-color: var(--palettes-neutral-500);
 		}
 
 		.checkbox-label-helper {
@@ -19,7 +19,7 @@
 		&::before {
 			color: var(--palettes-neutral-500);
 			background-color: var(--palettes-neutral-100);
-			border: var(--components-checkbox-input-border-width) solid var(--palettes-neutral-100);
+			border-color: var(--palettes-neutral-100);
 		}
 	}
 }

--- a/stories/qa/forms/checkbox-legacy.stories.html
+++ b/stories/qa/forms/checkbox-legacy.stories.html
@@ -62,6 +62,21 @@
 	</div>
 </section>
 
+<!-- Required -->
+<h2>Required</h2>
+<div class="form">
+	<div class="form-group">
+		<label class="checkbox">
+			<input class="checkbox-input " type="checkbox" aria-required="true" checked />
+			<span class="checkbox-label">Label</span>
+		</label>
+		<label class="checkbox">
+			<input class="checkbox-input" type="checkbox" aria-required="true" />
+			<span class="checkbox-label">Label</span>
+		</label>
+	</div>
+</div>
+
 <!-- Inline checkbox -->
 <section class="contentSection">
 	<h2>mod-inline</h2>


### PR DESCRIPTION
## Description

The border on checkboxes was not correctly displayed on Windows with zoom enabled.
We tried a fix, but it ended up causing too many border effects. So we're going back to the previous version and fix it differently.

(Note we are on the depreciated version of the component checkbox.)

-----
A little background:

- [The bug reported by @MarcFairbrother](https://lucca.slack.com/archives/GSCU69USV/p1707486422351609)
- [The fix](https://codepen.io/vincent-valentin/pen/MWxqLNb/3ea9c87f0ee7c0de19cb8c2509b94742?editors=1100)
- [Installing the patch](https://github.com/LuccaSA/lucca-front/pull/2559)
- [The rest of the patch](https://github.com/LuccaSA/lucca-front/pull/2575)

-----
