### PR TITLE
[Secondary nav] Fix inverted deprecated  alert color when item is active

### DIFF
--- a/packages/scss/src/components/navside/states.scss
+++ b/packages/scss/src/components/navside/states.scss
@@ -5,8 +5,8 @@
 
 	.navSide-item-alert {
 		// deprecated
-		background-color: var(--components-navSide-fullwidth-palette-selected-alert-text);
-		color: var(--components-navSide-fullwidth-palette-selected-alert-color);
+		background-color: var(--components-navSide-fullwidth-palette-selected-alert-color);
+		color: var(--components-navSide-fullwidth-palette-selected-alert-text);
 	}
 }
 


### PR DESCRIPTION
## Description

Fix inverted deprecated  alert color when item is active

-----