### PR TITLE
fix(lu-select): panel position not updating when options change

### DIFF
--- a/packages/ng/popover/panel/popover-panel.model.ts
+++ b/packages/ng/popover/panel/popover-panel.model.ts
@@ -1,4 +1,4 @@
-import { HorizontalConnectionPos, VerticalConnectionPos } from '@angular/cdk/overlay';
+import { HorizontalConnectionPos, OverlayRef, VerticalConnectionPos } from '@angular/cdk/overlay';
 import { TemplateRef } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
 
@@ -10,6 +10,7 @@ export declare interface ILuPopoverPanel<T = unknown> {
 	panelId?: string;
 	triggerId?: string;
 	templateRef?: TemplateRef<T>;
+	overlayRef: OverlayRef;
 
 	/** will emit when the panel wants to close */
 	close: Observable<void>;
@@ -28,9 +29,11 @@ export declare interface ILuPopoverPanel<T = unknown> {
 
 	/** method called by the trigger when it opens the popover */
 	onOpen(): void;
+
 	/** method called by the trigger when it closes the popover */
 	onClose(): void;
 }
+
 /**
  * abstract class for basic implementation of a popover panel
  */
@@ -47,6 +50,7 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	get closeOnClick() {
 		return this._closeOnClick;
 	}
+
 	set closeOnClick(coc: boolean) {
 		this._closeOnClick = coc;
 	}
@@ -55,6 +59,7 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	get trapFocus() {
 		return this._trapFocus;
 	}
+
 	set trapFocus(tf: boolean) {
 		this._trapFocus = tf;
 	}
@@ -63,6 +68,7 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	get scrollStrategy() {
 		return this._scrollStrategy;
 	}
+
 	set scrollStrategy(ss: LuPopoverScrollStrategy) {
 		this._scrollStrategy = ss;
 	}
@@ -71,6 +77,7 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	get templateRef() {
 		return this._templateRef;
 	}
+
 	set templateRef(tr: TemplateRef<T>) {
 		this._templateRef = tr;
 	}
@@ -80,9 +87,11 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	get panelClasses() {
 		return this._panelClasses;
 	}
+
 	set panelClasses(cl: string) {
 		this._panelClasses = cl;
 	}
+
 	get panelClassesMap(): Record<string, boolean> {
 		const map: Record<string, boolean> = this._panelClasses
 			.split(' ')
@@ -99,9 +108,11 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	get contentClasses() {
 		return this._contentClasses;
 	}
+
 	set contentClasses(cl: string) {
 		this._contentClasses = cl;
 	}
+
 	get contentClassesMap() {
 		return this._contentClasses.split(' ').reduce((obj: Record<string, boolean>, className: string) => {
 			obj[className] = true;
@@ -109,11 +120,14 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 		}, {});
 	}
 
+	public overlayRef: OverlayRef;
+
 	/** Classes to be passed into the popover's overlay */
 	protected _overlayPaneClass: string | string[];
 	public get overlayPaneClass() {
 		return this._overlayPaneClass;
 	}
+
 	public set overlayPaneClass(opc) {
 		this._overlayPaneClass = opc;
 	}
@@ -121,6 +135,7 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	// /** Config object to be passed into the popover's content ngStyle */
 
 	protected _keydownEventsSub: Subscription;
+
 	set keydownEvents$(evt$: Observable<KeyboardEvent>) {
 		if (!this._keydownEventsSub) {
 			this._keydownEventsSub = evt$.subscribe((e) => this._handleKeydown(e));
@@ -130,8 +145,11 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	close: Observable<void>;
 	open: Observable<void>;
 	hovered: Observable<boolean>;
+
 	abstract _emitCloseEvent(): void;
+
 	abstract _emitOpenEvent(): void;
+
 	abstract _emitHoveredEvent(hovered: boolean): void;
 
 	setPositionClasses(posX: HorizontalConnectionPos, posY: VerticalConnectionPos): void {
@@ -150,9 +168,11 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	onOpen() {
 		this._isOpen = true;
 	}
+
 	onClose() {
 		this._isOpen = false;
 	}
+
 	/**
 	 * TODO: Refactor when @angular/cdk includes feature I mentioned on github see link below.
 	 * https://github.com/angular/material2/pull/5493#issuecomment-313085323
@@ -161,10 +181,12 @@ export abstract class ALuPopoverPanel<T = unknown> implements ILuPopoverPanel<T>
 	onMouseOver() {
 		this._emitHoveredEvent(true);
 	}
+
 	/** Enables close of popover when mouse leaving popover element */
 	onMouseLeave() {
 		this._emitHoveredEvent(false);
 	}
+
 	/** does nothing but must be overridable */
 	// eslint-disable-next-line @typescript-eslint/no-empty-function
 	onMouseDown() {}

--- a/packages/ng/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/popover/trigger/popover-trigger.model.ts
@@ -44,8 +44,11 @@ export declare interface ILuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuP
 	onClose: Observable<void>;
 
 	openPopover();
+
 	closePopover();
+
 	togglePopover();
+
 	destroyPopover();
 }
 
@@ -74,6 +77,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 	get panel() {
 		return this._panel;
 	}
+
 	set panel(p: TPanel) {
 		this._panel = p;
 	}
@@ -83,6 +87,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 	get target() {
 		return this._target;
 	}
+
 	set target(t: TTarget) {
 		this._target = t;
 	}
@@ -91,6 +96,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 	get triggerEvent() {
 		return this._triggerEvent;
 	}
+
 	set triggerEvent(te: LuPopoverTriggerEvent) {
 		this._triggerEvent = te;
 		if (te === 'hover' || te === 'focus') {
@@ -105,17 +111,21 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 				.subscribe((h) => (h ? this.openPopover() : this.closePopover()));
 		}
 	}
+
 	protected _enterDelay = 50;
 	get enterDelay() {
 		return this._enterDelay;
 	}
+
 	set enterDelay(d: number) {
 		this._enterDelay = d;
 	}
+
 	protected _leaveDelay = 50;
 	get leaveDelay() {
 		return this._leaveDelay;
 	}
+
 	set leaveDelay(d: number) {
 		this._leaveDelay = d;
 	}
@@ -124,6 +134,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 	get disabled() {
 		return this._disabled;
 	}
+
 	set disabled(d: boolean) {
 		this._disabled = d;
 	}
@@ -132,6 +143,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 	get whenEllipsis() {
 		return this._whenEllipsis;
 	}
+
 	set whenEllipsis(we: boolean) {
 		this._whenEllipsis = we;
 	}
@@ -145,6 +157,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 	abstract onClose: Observable<void>;
 
 	protected abstract _emitOpen(): void;
+
 	protected abstract _emitClose(): void;
 
 	constructor(protected _overlay: Overlay, protected _elementRef: ElementRef<HTMLElement>, protected _viewContainerRef: ViewContainerRef) {
@@ -169,11 +182,13 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 			this._hovered$.next(false);
 		}
 	}
+
 	onFocus() {
 		if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 			this.openPopover();
 		}
 	}
+
 	onBlur() {
 		if (this.triggerEvent === 'hover' || this.triggerEvent === 'focus') {
 			this.closePopover();
@@ -365,6 +380,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
       <button type="button" [luPopover]="popover"></button>`);
 		}
 	}
+
 	protected _checkTarget() {
 		if (!this.target) {
 			throw Error(`lu-popover-trigger: must pass in a popover target instance.`);
@@ -381,6 +397,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 			const config = this._getOverlayConfig();
 			this._subscribeToPositions(config.positionStrategy as FlexibleConnectedPositionStrategy);
 			this._overlayRef = this._overlay.create(config);
+			this._panel.overlayRef = this._overlayRef;
 		}
 
 		return this._overlayRef;

--- a/packages/ng/popup-employee/card/panel/user-popover-panel.component.ts
+++ b/packages/ng/popup-employee/card/panel/user-popover-panel.component.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @angular-eslint/no-input-rename */
 
-import { OverlayModule, OverlayRef } from '@angular/cdk/overlay';
+import { OverlayModule } from '@angular/cdk/overlay';
 import { AsyncPipe, DatePipe, NgClass, NgIf, NgOptimizedImage, NgSwitch, NgSwitchCase, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Inject, Input, OnDestroy, Output, TemplateRef, ViewChild, ViewEncapsulation } from '@angular/core';
 import { RouterLink } from '@angular/router';
@@ -138,8 +138,6 @@ export class LuUserPopoverPanelComponent extends ALuPopoverPanel implements ILuU
 	}
 
 	private _subs = new Subscription();
-
-	public overlayRef: OverlayRef;
 
 	public constructor(private _changeDetectorRef: ChangeDetectorRef, @Inject(LuUserPopoverStore) private _service: ILuUserPopoverStore) {
 		super();

--- a/packages/ng/popup-employee/card/trigger/user-popover-trigger.directive.ts
+++ b/packages/ng/popup-employee/card/trigger/user-popover-trigger.directive.ts
@@ -22,7 +22,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 	exportAs: 'LuUserPopoverDirective',
 })
 export class LuUserPopoverDirective extends ALuPopoverTrigger<LuUserPopoverPanelComponent, LuPopoverTarget> implements AfterViewInit, OnDestroy {
-	@Input('luUserPopover') public set user(c: ILuUser) {
+	@Input('luUserPopover')
+	public set user(c: ILuUser) {
 		if (this.panel) {
 			this.panel.user = c;
 		}
@@ -30,13 +31,17 @@ export class LuUserPopoverDirective extends ALuPopoverTrigger<LuUserPopoverPanel
 	}
 
 	/** when trigger = hover, delay before the popover panel appears, default 300ms */
-	@Input('luUserPopoverEnterDelay') public set inputEnterDelay(d: number) {
+	@Input('luUserPopoverEnterDelay')
+	public set inputEnterDelay(d: number) {
 		this.enterDelay = d;
 	}
+
 	/** when trigger = hover, delay before the popover panel disappears, default 100ms */
-	@Input('luUserPopoverLeaveDelay') public set inputLeaveDelay(d: number) {
+	@Input('luUserPopoverLeaveDelay')
+	public set inputLeaveDelay(d: number) {
 		this.leaveDelay = d;
 	}
+
 	// TODO : put this back when uniform alignment and position
 	// /** how you want to position the panel relative to the target, allowed values: above, below, before, after */
 	// @Input('luEmployeeCardPosition') public set inputPosition(pos: LuPopoverPosition) {
@@ -47,20 +52,26 @@ export class LuUserPopoverDirective extends ALuPopoverTrigger<LuUserPopoverPanel
 	// 	this.target.alignment = al;
 	// }
 	/** disable popover apparition */
-	@Input('luUserPopoverDisabled') public set inputDisabled(d: boolean) {
+	@Input('luUserPopoverDisabled')
+	public set inputDisabled(d: boolean) {
 		this.disabled = d;
 	}
 
 	/** accessibility attribute - dont override */
-	@HostBinding('attr.aria-expanded') public get _attrAriaExpanded() {
+	@HostBinding('attr.aria-expanded')
+	public get _attrAriaExpanded() {
 		return this._popoverOpen;
 	}
+
 	/** accessibility attribute - dont override */
-	@HostBinding('attr.id') public get _attrId() {
+	@HostBinding('attr.id')
+	public get _attrId() {
 		return this._triggerId;
 	}
+
 	/** accessibility attribute - dont override */
-	@HostBinding('attr.aria-controls') public get _attrAriaControls() {
+	@HostBinding('attr.aria-controls')
+	public get _attrAriaControls() {
 		return this._panelId;
 	}
 
@@ -102,21 +113,26 @@ export class LuUserPopoverDirective extends ALuPopoverTrigger<LuUserPopoverPanel
 	public override onMouseEnter() {
 		super.onMouseEnter();
 	}
+
 	@HostListener('mouseleave')
 	public override onMouseLeave() {
 		super.onMouseLeave();
 	}
+
 	@HostListener('focus')
 	public override onFocus() {
 		super.onFocus();
 	}
+
 	@HostListener('blur')
 	public override onBlur() {
 		super.onBlur();
 	}
+
 	public ngAfterViewInit() {
 		this._checkTarget();
 	}
+
 	public ngOnDestroy() {
 		this._cleanUpSubscriptions();
 		if (this._popoverOpen) {
@@ -167,6 +183,8 @@ export class LuUserPopoverDirective extends ALuPopoverTrigger<LuUserPopoverPanel
 	// Mandatory but useless
 	onClose: Observable<void>;
 	onOpen: Observable<void>;
+
 	protected override _emitOpen(): void {}
+
 	protected override _emitClose(): void {}
 }


### PR DESCRIPTION
## Description

`lu-select` wasn't updating when options arrived after the panel has been opened, this PR fixes that issue.

It's also affecting (and fixing) custom selects like `lu-establishment-picker` etc.

-----


-----
