### PR TITLE
[Form label] Default weight

### DIFF
--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -2,6 +2,7 @@
 	color: var(--components-formLabel-color);
 	display: flex;
 	font-size: var(--components-formLabel-fontSize);
+	font-weight: 400;
 	line-height: var(--components-formLabel-lineHeight);
 	width: var(--components-formLabel-width);
 	align-items: flex-end;


### PR DESCRIPTION
## Description

Set default weight to avoid Form label's parent to override it (e.g. table head)

-----