### PR TITLE
[Datepicker] Invalid cover

### DIFF
--- a/packages/ng/styles/definitions/select/_select-input.scss
+++ b/packages/ng/styles/definitions/select/_select-input.scss
@@ -301,11 +301,7 @@
 	}
 
 	// Error
-	:host-context(.textfield-input.is-error) {
-		&::after {
-			color: var(--palettes-error-700);
-		}
-
+	:host-context(.textfield-input.is-error, .textfield-input.is-invalid) {
 		.lu-select-placeholder {
 			color: var(--palettes-error-400);
 		}


### PR DESCRIPTION
## Description

- Fix placeholder color with `is-invalid` class (previously only `is-error`)
- Date icon should stay grey in error/invalid state to fit with our Design System

-----

![image](https://github.com/LuccaSA/lucca-front/assets/25581936/dbaa73c5-4599-4a5a-8e80-4b09aab341aa)

-----
