### PR TITLE
[Datepicker] Invalid cover

### DIFF
--- a/packages/ng/styles/definitions/select/_select-input.scss
+++ b/packages/ng/styles/definitions/select/_select-input.scss
@@ -301,7 +301,7 @@
 	}
 
 	// Error
-	:host-context(.textfield-input.is-error, .textfield-input.is-invalid) {
+	:host-context(.textfield-input.is-error, .textfield-input.is-invalid, .textfield-input.ng-invalid.ng-touched) {
 		.lu-select-placeholder {
 			color: var(--palettes-error-400);
 		}

--- a/packages/ng/styles/definitions/select/_select-input.scss
+++ b/packages/ng/styles/definitions/select/_select-input.scss
@@ -301,11 +301,7 @@
 	}
 
 	// Error
-	:host-context(.textfield-input.is-error) {
-		&::after {
-			color: var(--palettes-error-700);
-		}
-
+	:host-context(.textfield-input.is-error, .textfield-input.is-invalid) {
 		.lu-select-placeholder {
 			color: var(--palettes-error-400);
 		}


### PR DESCRIPTION
## Description

Fix placeholder color with `.ng-invalid.ng-touched` classes (previously only `.is-error`)
Date icon should stay grey in error/invalid state to fit with our Design System

-----

![image](https://github.com/LuccaSA/lucca-front/assets/25581936/c7f08684-0e5d-4d8d-b65d-1e8be0f22ecd)

-----
