### PR TITLE
feat(button): apply default type set to `button` when not present on the button

### DIFF
--- a/packages/ng/button/button.component.ts
+++ b/packages/ng/button/button.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ElementRef, inject, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ContentChild, ElementRef, inject, Input, OnChanges, OnInit, Renderer2, ViewEncapsulation } from '@angular/core';
 import { LuClass, Palette } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 
@@ -15,9 +15,10 @@ import { IconComponent } from '@lucca-front/ng/icon';
 		class: 'button',
 	},
 })
-export class ButtonComponent implements OnChanges {
+export class ButtonComponent implements OnChanges, OnInit {
 	#luClass = inject(LuClass);
 	#elementRef = inject<ElementRef<HTMLButtonElement>>(ElementRef);
+	#renderer = inject(Renderer2);
 
 	@Input()
 	size: 'M' | 'S' | 'XS';
@@ -61,6 +62,12 @@ export class ButtonComponent implements OnChanges {
 
 	ngOnChanges(): void {
 		this.updateClasses();
+	}
+
+	ngOnInit(): void {
+		if (this.#elementRef.nativeElement.tagName.toLowerCase() === 'button' && this.#elementRef.nativeElement.getAttribute('type') === null) {
+			this.#renderer.setAttribute(this.#elementRef.nativeElement, 'type', 'button');
+		}
 	}
 
 	updateClasses(): void {

--- a/stories/documentation/actions/button/angular/button-basic.stories.ts
+++ b/stories/documentation/actions/button/angular/button-basic.stories.ts
@@ -7,7 +7,7 @@ export default {
 	component: ButtonComponent,
 	render: ({ luButton, ...inputs }, { argTypes }) => {
 		return {
-			template: `<button type="button" luButton${luButton !== '' ? `="${luButton}"` : ''}${generateInputs(inputs, argTypes)}
+			template: `<button luButton${luButton !== '' ? `="${luButton}"` : ''}${generateInputs(inputs, argTypes)}
 >Button</button>`,
 		};
 	},


### PR DESCRIPTION
## Description

As described in #2739, this won't override already present type (like `submit` for instance) and won't be applied to `<a luButton>` tags, only `<button luButton>` ones.

-----

closes #2739

-----
