### PR TITLE
fix(form-field): get validators from descendants to handle deep inputs

### DIFF
--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -43,12 +43,12 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 
 	#doCheck$ = new Subject<void>();
 
-	@ContentChildren(NG_VALIDATORS)
+	@ContentChildren(NG_VALIDATORS, { descendants: true })
 	public set validators(validators: QueryList<Validator | undefined>) {
 		this.#requiredValidator = validators.toArray()?.find((v): v is RequiredValidator => v instanceof RequiredValidator);
 	}
 
-	@ContentChildren(NgControl)
+	@ContentChildren(NgControl, { descendants: true })
 	set controls(controls: QueryList<NgControl>) {
 		const controls$ = controls.changes.pipe(
 			takeUntilDestroyed(this.#destroyRef),


### PR DESCRIPTION
## Description

Because we were only querying the first layer of content children, we were only fetching controls from it and not descendants, meaning that in cases like this:

```html
<lu-form-field>
  <div class="inputWrapper">
    <lu-text-input type="text"></lu-text-input>
    <button luButton="text" type="button"></button>
  </div>
</lu-form-field>
```

The `lu-text-input` component wasn't behaving properly with `aria-*` flags and the field wasn't detected as required.

-----


-----
