### PR TITLE
fix(number-input): default placeholder should be '' not `undefined`

### DIFF
--- a/packages/ng/forms/number-input/number-input.component.ts
+++ b/packages/ng/forms/number-input/number-input.component.ts
@@ -21,7 +21,7 @@ export class NumberInputComponent {
 	ngControl = injectNgControl();
 
 	@Input()
-	placeholder: string;
+	placeholder: string = '';
 
 	@Input({ transform: numberAttribute })
 	step: number = 1;


### PR DESCRIPTION
## Description

Placeholder was `undefined` by default, showing it as string in inputs, which isn't ideal.

This PR fixes that by making it an empty string by default instead.

-----


-----
