### PR TITLE
fix(callout): default callout size

### DIFF
--- a/packages/ng/callout/callout/callout.component.ts
+++ b/packages/ng/callout/callout/callout.component.ts
@@ -32,7 +32,7 @@ export class CalloutComponent {
 	/**
 	 * Which size should the callout be? Defaults to medium
 	 */
-	size: 'M' | 'S';
+	size: 'M' | 'S' = 'M';
 
 	@Input({ transform: booleanAttribute })
 	/**


### PR DESCRIPTION
## Description

Callout says it defaults to `'M'` but it doesn't.

-----


