### PR TITLE
fix(radio): disabled attribute and autogenerated name

### DIFF
--- a/packages/ng/forms/radio-group-input/radio-group-input.component.ts
+++ b/packages/ng/forms/radio-group-input/radio-group-input.component.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component, forwardRef, inject, Input, ViewEncapsulation } from '@angular/core';
-import { FormFieldComponent } from '@lucca-front/ng/form-field';
-import { FORM_FIELD_INSTANCE } from '@lucca-front/ng/form-field';
+import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
-import { InputDirective } from '@lucca-front/ng/form-field';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RADIO_GROUP_INSTANCE } from './radio-group-token';
+
+let nextId = 0;
 
 @Component({
 	selector: 'lu-radio-group-input',
@@ -30,6 +30,8 @@ export class RadioGroupInputComponent {
 
 	@Input()
 	size: 'S' | 'M';
+
+	name = `radio-group-${nextId++}`;
 
 	constructor() {
 		if (this.formField) {

--- a/packages/ng/forms/radio-group-input/radio/radio.component.html
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.html
@@ -4,10 +4,11 @@
 <span class="radioField">
 	<input
 		[formControl]="formControl"
-		[attr.disabled]="formControl.disabled || disabled"
+		[attr.disabled]="(formControl.disabled || disabled) ? 'disabled' : null"
 		type="radio"
 		class="radioField-input"
-		id="{{id}}-input"
+		id="{{id}}"
+		[name]="name"
 		[value]="value"
 		luInput
 		luInputStandalone

--- a/packages/ng/forms/radio-group-input/radio/radio.component.ts
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.ts
@@ -39,6 +39,10 @@ export class RadioComponent<T = unknown> implements OnChanges {
 		return this.#parentGroup.ngControl.control;
 	}
 
+	public get name() {
+		return this.#parentGroup.name;
+	}
+
 	@HostBinding('id')
 	id = `radio-${++nextId}`;
 


### PR DESCRIPTION
## Description

- `<lu-radio disabled="false">...` is now properly enabled, as we're using the native `disabled` attribute, which evaluates `false` as `true` because it's non-null.
- `name` attribute is now set by the parent group to allow multiple `lu-radio-roup-input` to behave properly in the same page.

-----


-----
