### PR TITLE
feat(user): allow string union type for luUserInput format

### DIFF
--- a/packages/ng/core/type/enum.ts
+++ b/packages/ng/core/type/enum.ts
@@ -1,0 +1,14 @@
+/**
+ * Extracts the values of an enum as a union type.
+ *
+ * @example
+ * ```ts
+ * enum ExampleEnum {
+ *    A = 'a',
+ *    B = 'b',
+ * }
+ *
+ * type ExampleEnumValue = EnumValue<ExampleEnum>; // Same as 'a' | 'b'
+ * ```
+ */
+export type EnumValue<T> = `${T[keyof T] & string}`;

--- a/packages/ng/core/type/index.ts
+++ b/packages/ng/core/type/index.ts
@@ -1,1 +1,2 @@
+export * from './enum';
 export * from './style';

--- a/packages/ng/user/display/display-format.model.ts
+++ b/packages/ng/user/display/display-format.model.ts
@@ -1,4 +1,5 @@
 import { InjectionToken } from '@angular/core';
+import { EnumValue } from '@lucca-front/ng/core';
 
 export enum LuDisplayFullname {
 	firstlast = 'fl',
@@ -21,7 +22,7 @@ export enum LuDisplayHybrid {
 	lastFullfirstI = 'lF',
 }
 
-export type LuDisplayFormat = LuDisplayFullname | LuDisplayInitials | LuDisplayHybrid;
+export type LuDisplayFormat = EnumValue<typeof LuDisplayFullname> | EnumValue<typeof LuDisplayInitials> | EnumValue<typeof LuDisplayHybrid>;
 
 /** Injection token that can be used to change the default displayed user format. */
 export const LU_DEFAULT_DISPLAY_POLICY = new InjectionToken<LuDisplayFormat>('LuDisplayFormat', { factory: () => LuDisplayFullname.lastfirst });


### PR DESCRIPTION
## Description

It is annoying to expose enum in templates, in addition to pass an enum value, we can now pass a string:

```html
<!-- New syntax -->
{{ user | luUserDisplay:'fl' }}

<!-- Previous but still working syntax -->
{{ user | luUserDisplay:LuDisplayFullname.firstlast }}
```

-----

