### PR TITLE
fix(core-select): wrong naming for if-clue-empty startegy

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -22,7 +22,7 @@ import { PortalContent, getIntl } from '@lucca-front/ng/core';
 import { BehaviorSubject, Observable, ReplaySubject, Subject, defer, map, of, startWith, switchMap, take } from 'rxjs';
 import { LuOptionGrouping, LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
-import { LuOptionContext, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
+import { CoreSelectAddOptionStrategy, LuOptionContext, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
 import { LU_CORE_SELECT_TRANSLATIONS } from '../select.translate';
 
 @Directive()
@@ -59,7 +59,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	addOptionLabel: PortalContent = this.coreIntl.addOption;
 
 	@Input()
-	set addOptionStrategy(strategy: 'never' | 'always' | 'if-empty-clue') {
+	set addOptionStrategy(strategy: CoreSelectAddOptionStrategy) {
 		this.addOptionStrategy$.next(strategy);
 	}
 
@@ -153,7 +153,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	lastEmittedClue: string = '';
 	clue$ = defer(() => this.clueChange.pipe(startWith(this.clue)));
 
-	addOptionStrategy$ = new BehaviorSubject<'never' | 'always' | 'if-empty-clue'>('never');
+	addOptionStrategy$ = new BehaviorSubject<CoreSelectAddOptionStrategy>('never');
 	shouldDisplayAddOption$ = this.addOptionStrategy$.pipe(
 		switchMap((strategy) => {
 			switch (strategy) {
@@ -162,6 +162,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 				case 'never':
 					return of(false);
 				case 'if-empty-clue':
+					return this.clue$.pipe(map((clue) => !clue));
+				case 'if-not-empty-clue':
 					return this.clue$.pipe(map((clue) => !!clue));
 			}
 		}),

--- a/packages/ng/core-select/select.model.ts
+++ b/packages/ng/core-select/select.model.ts
@@ -13,6 +13,8 @@ export interface LuOptionGroup<T, TGroup> {
 	options: T[];
 }
 
+export type CoreSelectAddOptionStrategy = 'never' | 'always' | 'if-empty-clue' | 'if-not-empty-clue';
+
 export const SELECT_ID = new InjectionToken<number>('LuSelectPanelData');
 export const SELECT_LABEL = new InjectionToken<HTMLLabelElement | undefined>('LuSelectLabel');
 export const SELECT_LABEL_ID = new InjectionToken<string>('LuSelectLabelId');

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -338,7 +338,7 @@ export const AddOption = generateStory({
 	storyPartial: {
 		argTypes: {
 			addOptionLabel: { control: { type: 'text' } },
-			addOptionStrategy: { control: { type: 'select', options: ['never', 'always', 'if-empty-clue'] } },
+			addOptionStrategy: { control: { type: 'select', options: ['never', 'always', 'if-empty-clue', 'if-not-empty-clue'] } },
 		},
 		args: {
 			addOptionLabel: 'Ajouter un légume',

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -390,7 +390,7 @@ export const AddOption = generateStory({
 	storyPartial: {
 		argTypes: {
 			addOptionLabel: { control: { type: 'text' } },
-			addOptionStrategy: { control: { type: 'radio', options: ['never', 'always', 'if-empty-clue'] } },
+			addOptionStrategy: { control: { type: 'radio', options: ['never', 'always', 'if-empty-clue', 'if-not-empty-clue'] } },
 		},
 		args: {
 			addOptionLabel: 'Ajouter un légume',


### PR DESCRIPTION
## Description

* The condition was the opposite of what the old naming said
* Added a new strategy with the previous behavior

-----

Even if it is a breaking change, nobody uses it at the moment.

-----
