### PR TITLE
fix(core-select): handle option value falsy not displaying

### DIFF
--- a/packages/ng/core-select/option/option-outlet.directive.ts
+++ b/packages/ng/core-select/option/option-outlet.directive.ts
@@ -25,7 +25,7 @@ export class LuOptionOutletDirective<T> implements OnChanges, OnDestroy {
 
 		const hasRef = this.embeddedViewRef || this.componentRef;
 
-		if (changes['luOptionOutlet'] || (changes['luOptionOutletValue'].currentValue && !hasRef)) {
+		if (changes['luOptionOutlet'] || (changes['luOptionOutletValue'].currentValue !== null && changes['luOptionOutletValue'].currentValue !== undefined && !hasRef)) {
 			const newValue = changes['luOptionOutletValue'].currentValue as T | undefined;
 			if (newValue !== null && newValue !== undefined) {
 				this.createComponent();


### PR DESCRIPTION
## Description

Handle option value falsy not displaying (false boolean or 0 number)

-----
