### PR TITLE
[Toast] Fix misaligned kill button in Safari iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,6 @@ In order to work on Lucca Front, we use Storybook to display components.
 
 - Install [volta.sh](https://docs.volta.sh/guide/getting-started)
 - Install node `volta install node@lts`
-- Build Compodoc to avoid errors (To be fixed) `npm run compodoc`
 - Run storybook `npm start`
 
 ## TODO

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -1,3 +1,4 @@
+@use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/icons/src/commons/utils/icon';
 
 @mixin component($atRoot: 'without: rule') {
@@ -50,6 +51,8 @@
 		}
 
 		.toasts-item-kill {
+			@include reset.button;
+			width: auto;
 			color: var(--colors-white-color);
 			transition-property: opacity;
 			transition-duration: var(--commons-animations-durations-fast);
@@ -60,9 +63,6 @@
 			border: 0;
 			background: transparent;
 			margin-top: 2px;
-
-			// safari iOS fix
-			padding: unset;
 
 			&:hover {
 				opacity: 0.66;

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -61,6 +61,9 @@
 			background: transparent;
 			margin-top: 2px;
 
+			// safari iOS fix
+			padding: unset;
+
 			&:hover {
 				opacity: 0.66;
 			}


### PR DESCRIPTION
## Description

Toast kill button was misaligned only in iOS browsers

-----

iOS sets a default padding on this button, which is not there in other browsers ; unsetting it fixes the issue

Before:
![image](https://github.com/LuccaSA/lucca-front/assets/18215442/ce408e83-71f4-4d6e-bccc-f20d44258487)

After:
![image](https://github.com/LuccaSA/lucca-front/assets/18215442/0f5ed66d-7e75-4852-b9fe-dfaf4539e078)

-----
