### PR TITLE
feat(multi-select): new counter displayer

### DIFF
--- a/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.scss
+++ b/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.scss
@@ -1,0 +1,4 @@
+:host {
+	display: block;
+	width: 100%;
+}

--- a/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
@@ -1,22 +1,20 @@
 import { AsyncPipe, NgFor, NgIf, NgPlural, NgPluralCase } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, Input, OnInit, ViewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { getIntl } from '@lucca-front/ng/core';
 import { ILuOptionContext, LU_OPTION_CONTEXT, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { map, switchMap } from 'rxjs/operators';
-import { LuMultiSelectInputComponent } from '../input/select-input.component';
-import { LU_MULTI_SELECT_DISPLAYER_TRANSLATIONS } from './default-displayer.translate';
-import { of } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { BehaviorSubject, of } from 'rxjs';
+import { LuMultiSelectInputComponent } from '../../input';
 
 @Component({
-	selector: 'lu-multi-select-default-displayer',
+	selector: 'lu-multi-select-counter-displayer',
 	standalone: true,
 	imports: [AsyncPipe, LuTooltipModule, NgIf, NgFor, NgPlural, NgPluralCase, ɵLuOptionOutletDirective, FormsModule, InputDirective],
 	template: `
-		<div class="multipleSelect-displayer">
+		<div class="multipleSelect-displayer mod-filter" [class.is-filled]="(selectedOptions$ | async)?.length > 0">
 			<input
 				class="multipleSelect-displayer-search"
 				type="text"
@@ -29,26 +27,26 @@ import { of } from 'rxjs';
 				ngModel
 				(ngModelChange)="select.clueChanged($event)"
 				[placeholder]="placeholder$ | async"
-				(keydown.backspace)="inputBackspace()"
 				role="combobox"
 				aria-haspopup="listbox"
 				luInput
 			/>
-			<div *ngFor="let option of displayedOptions$ | async; let index = index" class="multipleSelect-displayer-chip chip" [class.mod-unkillable]="select.disabled$ | async">
-				<span class="multipleSelect-displayer-chip-value"><ng-container *luOptionOutlet="select.valueTpl || select.optionTpl; value: option"></ng-container></span>
-				<button *ngIf="!(select.disabled$ | async)" type="button" class="chip-kill" (click)="unselectOption(option, $event)">
-					<span class="u-mask">{{ intl.removeOption }}</span>
-				</button>
+			<div class="multipleSelect-displayer-filter" *ngIf="selectedOptions$ | async as selectedOptions">
+				<div class="multipleSelect-displayer-chip chip mod-unkillable" *ngIf="selectedOptions?.length === 1">
+					<ng-container *luOptionOutlet="select.valueTpl || select.optionTpl; value: selectedOptions[0]"></ng-container>
+				</div>
+				<ng-container *ngIf="selectedOptions?.length > 1"
+					><span class="multipleSelect-displayer-numericBadge numericBadge">{{ selectedOptions?.length }}</span
+					><span class="multipleSelect-displayer-label">{{ label }}</span></ng-container
+				>
 			</div>
-			<div class="chip" *ngIf="overflowOptions$ | async as overflow">+ {{ overflow }}</div>
 		</div>
 	`,
-	styleUrls: ['./default-displayer.component.scss'],
+	styleUrls: ['./counter-displayer.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
+export class LuMultiSelectCounterDisplayerComponent<T> implements OnInit {
 	select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
-	intl = getIntl(LU_MULTI_SELECT_DISPLAYER_TRANSLATIONS);
 
 	protected destroyRef = inject(DestroyRef);
 
@@ -65,6 +63,13 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 
 	context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
 
+	selectedOptions$ = new BehaviorSubject<T[]>([]);
+
+	@Input()
+	set selected(options: T[]) {
+		this.selectedOptions$.next(options);
+	}
+
 	placeholder$ = this.context.option$.pipe(
 		switchMap((options) => {
 			if ((options || []).length > 0) {
@@ -74,42 +79,8 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 		}),
 	);
 
-	displayedOptions$ = this.context.option$.pipe(
-		map((options) => {
-			if (this.select.maxValuesShown) {
-				return (options || []).slice(0, this.select.maxValuesShown);
-			}
-			return options;
-		}),
-	);
-
-	overflowOptions$ = this.context.option$.pipe(
-		map((options) => {
-			return Math.max(0, (options || []).length - this.select.maxValuesShown);
-		}),
-	);
-
-	unselectOption(option: T, $event?: Event): void {
-		if ($event) {
-			$event.stopPropagation();
-			$event.preventDefault();
-		}
-		this.select.updateValue(
-			this.value.filter((o) => o !== option),
-			true,
-		);
-		setTimeout(() => {
-			this.select.panelRef?.updatePosition();
-			this.inputElementRef.nativeElement.focus();
-		});
-	}
-
-	inputBackspace(): void {
-		if (this.value.length > 0 && this.inputElementRef.nativeElement.value.length === 0) {
-			this.unselectOption(this.value[this.value.length - 1]);
-			this.select.panelRef?.updateSelectedOptions(this.value);
-		}
-	}
+	@Input({ required: true })
+	label: string;
 
 	ngOnInit(): void {
 		this.select.focusInput$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((data?: { keepClue: true }) => {
@@ -119,7 +90,6 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 				this.inputElementRef.nativeElement.value = '';
 				this.select.clueChanged('');
 			}
-
 			this.inputElementRef.nativeElement.focus();
 		});
 		this.select.emptyClue$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {

--- a/packages/ng/multi-select/displayer/index.ts
+++ b/packages/ng/multi-select/displayer/index.ts
@@ -1,3 +1,4 @@
+export * from './counter-displayer/counter-displayer.component';
 export * from './default-displayer.component';
 export * from './displayer.directive';
 export * from './displayer-input.directive';

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -7,7 +7,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
 import { LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
-import { LuMultiDisplayerDirective, LuMultiSelectDisplayerInputDirective, LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { LuMultiDisplayerDirective, LuMultiSelectCounterDisplayerComponent, LuMultiSelectDisplayerInputDirective, LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { Meta, applicationConfig, moduleMetadata } from '@storybook/angular';
 import { interval, map } from 'rxjs';
@@ -76,22 +76,9 @@ export const WithMultiDisplayer = generateStory({
 	placeholder="Placeholder..."
 	[options]="legumes | filterLegumes:clue"
 	(clueChange)="clue = $event"
-	[maxValuesShown]="maxValuesShown"
 >
-	<ng-container *luMultiDisplayer="let legumes; select: selectRef">
-		<div class="multipleSelect-displayer mod-filter" [class.is-filled]="legumes?.length > 0">
-			<input
-				type="text"
-				luInput
-				luMultiSelectDisplayerInput
-				ngModel
-				(ngModelChange)="selectRef.clueChanged($event)"
-			/>
-			<div class="multipleSelect-displayer-filter">
-				<div class="multipleSelect-displayer-chip chip mod-unkillable" *ngIf="legumes?.length === 1">{{legumes[0]?.name}}</div>
-				<ng-container *ngIf="legumes?.length > 1"><span class="multipleSelect-displayer-numericBadge numericBadge">{{ legumes?.length }}</span><span class="multipleSelect-displayer-label">légumes sélectionnés</span></ng-container>
-			</div>
-		</div>
+	<ng-container *luMultiDisplayer="let values; select: selectRef">
+		<lu-multi-select-counter-displayer [selected]="values" label="trucs sélectionnés"></lu-multi-select-counter-displayer>
 	</ng-container>
 </lu-multi-select>`,
 	neededImports: {
@@ -343,7 +330,14 @@ export const AddOption = generateStory({
 		args: {
 			addOptionLabel: 'Ajouter un légume',
 			addOptionStrategy: 'always',
-			addLegume: (name: string, existing: ILegume[]) => [...existing, { name: name || 'Légume sans titre', index: existing.length, color: existing[0].color }],
+			addLegume: (name: string, existing: ILegume[]) => [
+				...existing,
+				{
+					name: name || 'Légume sans titre',
+					index: existing.length,
+					color: existing[0].color,
+				},
+			],
 			selectLegume: (legume: ILegume, legumes: ILegume[]) => [...legumes, legume],
 		},
 	},
@@ -372,6 +366,7 @@ const meta: Meta<LuMultiSelectInputStoryComponent> = {
 				LuCoreSelectJobQualificationsDirective,
 				LuDisabledOptionDirective,
 				LuMultiSelectDisplayerInputDirective,
+				LuMultiSelectCounterDisplayerComponent,
 				CommonModule,
 				AsyncPipe,
 			],


### PR DESCRIPTION
## Description

Reusable counter displayer for multi-select in order to show either the name when a single item is selected or `X selected` when multiple items are selected.

Usage example:

```html
<lu-multi-select
	#selectRef
	class="multiSelect"
	[clearable]="clearable"
	[loading]="loading"
	[(ngModel)]="selectedLegumes"
	placeholder="Placeholder..."
	[options]="legumes | filterLegumes:clue"
	(clueChange)="clue = $event"
	[maxValuesShown]="maxValuesShown"
>
	<ng-container *luMultiDisplayer="let values; select: selectRef">
		<lu-multi-select-counter-displayer [selected]="values" label="things selected"></lu-multi-select-counter-displayer>
	</ng-container>
</lu-multi-select>
```

@jeremie-lucca I think the docs part should be made inside ZH directly as it's where most of it already is, we really just need the above example in it.

-----

This has to be made using *luMultiDisplayer for now but ideally, the displayer should fill itself inside the parent multi-select, not sure we can do it tho.

-----
