### PR TITLE
Focus visible for tooltip informations in labels

### DIFF
--- a/packages/ng/form-field/form-field.component.html
+++ b/packages/ng/form-field/form-field.component.html
@@ -3,7 +3,14 @@
 		<ng-container *luPortal="label"></ng-container
 		><!--
 	--><sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
-		<lu-icon icon="signHelp" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+		<lu-icon
+			class="formLabel-info"
+			icon="signHelp"
+			[alt]="'?'"
+			*ngIf="tooltip"
+			[luTooltip]="tooltip"
+			[color]="invalid ? 'error' : 'inherit'"
+		></lu-icon>
 	</legend>
 	<ng-container *ngTemplateOutlet="projectionTpl"></ng-container>
 	<lu-inline-message
@@ -28,7 +35,14 @@
 		><!--
 	--><sup class="formLabel-required" aria-hidden="true" *ngIf="required">*</sup>
 
-		<lu-icon icon="signHelp" alt="" *ngIf="tooltip" [luTooltip]="tooltip" [color]="invalid ? 'error' : 'inherit'"></lu-icon>
+		<lu-icon
+			class="formLabel-info"
+			icon="signHelp"
+			[alt]="'?'"
+			*ngIf="tooltip"
+			[luTooltip]="tooltip"
+			[color]="invalid ? 'error' : 'inherit'"
+		></lu-icon>
 		<span
 			*ngIf="counter > 0"
 			class="formLabel-counter"

--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/utils/a11y';
+
 @mixin component($atRoot: 'without: rule') {
 	color: var(--components-formLabel-color);
 	display: flex;
@@ -24,6 +26,20 @@
 			text-rendering: geometricPrecision;
 			margin-left: var(--pr-t-spacings-25);
 			top: 0;
+		}
+
+		.formLabel-info {
+			&:focus-visible {
+				outline: none;
+
+				.lucca-icon {
+					&::before {
+						border-radius: 50%;
+
+						@include a11y.focusVisible($offset: 0);
+					}
+				}
+			}
 		}
 
 		.formLabel-counter {

--- a/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
+++ b/stories/documentation/forms/checkbox/checkbox-basic.stories.ts
@@ -92,7 +92,7 @@ function getTemplate(args: CheckboxBasicStory): string {
 
 	return `<div class="form-field${s} pr-u-marginBottom200">
 	<label class="formLabel" for="${id}">
-		Label<sup class="formLabel-required" *ngIf="required" aria-hidden="true">*</sup><span *ngIf="help" aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+		Label<sup class="formLabel-required" *ngIf="required" aria-hidden="true">*</sup><span *ngIf="help" class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 	</label>
 	<span class="checkboxField">
 		<input type="checkbox" class="checkboxField-input" id="${id}" aria-labelledby="${id}label" aria-describedby="${id}message"${checked}${mixed}${disabled}${required}${invalid} />

--- a/stories/documentation/forms/fields/number/angular/numberfield.stories.ts
+++ b/stories/documentation/forms/fields/number/angular/numberfield.stories.ts
@@ -1,9 +1,9 @@
-import { NumberInputComponent } from '@lucca-front/ng/forms';
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { NumberInputComponent } from '@lucca-front/ng/forms';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 
 export default {
 	title: 'Documentation/Forms/Fields/NumberField/Angular',
@@ -70,7 +70,7 @@ export const Basic: StoryObj<NumberInputComponent & { disabled: boolean } & Form
 		inlineMessageState: 'default',
 		size: 'M',
 		placeholder: 'Placeholder',
-		tooltip: "Je suis un message d'aide",
+		tooltip: 'Je suis un message d’aide',
 		step: 1,
 		min: 0,
 		max: 999,

--- a/stories/documentation/forms/fields/text/angular/textfield.stories.ts
+++ b/stories/documentation/forms/fields/text/angular/textfield.stories.ts
@@ -2,7 +2,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TextInputComponent } from '@lucca-front/ng/forms';
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
 import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 
 export default {
@@ -84,7 +84,7 @@ export const Basic: StoryObj<TextInputComponent & { disabled: boolean } & FormFi
 		size: 'M',
 		type: 'text',
 		placeholder: 'Placeholder',
-		tooltip: "Je suis un message d'aide",
+		tooltip: 'Je suis un message d’aide',
 		counter: 0,
 	},
 };
@@ -132,7 +132,7 @@ export const PasswordVisiblity: StoryObj<TextInputComponent & { disabled: boolea
 		inlineMessageState: 'default',
 		size: 'M',
 		placeholder: 'Placeholder',
-		tooltip: "Je suis un message d'aide",
+		tooltip: 'Je suis un message d’aide',
 		counter: 0,
 	},
 };

--- a/stories/documentation/forms/fields/text/html&css/textfield-info.stories.ts
+++ b/stories/documentation/forms/fields/text/html&css/textfield-info.stories.ts
@@ -10,7 +10,7 @@ export default {
 function getTemplate(args: TextfieldInfoStory): string {
 	return `<div class="form-field">
 	<label class="formLabel" id="IDlabel" for="ID">
-		Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+		Label<span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 	</label>
 	<div class="textField">
 		<div class="textField-input">

--- a/stories/documentation/forms/fields/textarea/angular/textarea.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textarea.stories.ts
@@ -76,7 +76,7 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 		inlineMessageState: 'default',
 		size: 'M',
 		placeholder: 'Placeholder',
-		tooltip: "Je suis un message d'aide",
+		tooltip: 'Je suis un message d’aide',
 		counter: 0,
 		rows: 3,
 	},

--- a/stories/documentation/forms/form-label/form-label-basic.stories.ts
+++ b/stories/documentation/forms/form-label/form-label-basic.stories.ts
@@ -1,16 +1,14 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface FormLabelBasicStory {
-}
+interface FormLabelBasicStory {}
 
 export default {
 	title: 'Documentation/Forms/Form Label Basic',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: FormLabelBasicStory): string {
-	return `<label class="formLabel">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>`;
+	return `<label class="formLabel">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span></label>`;
 }
 
 const Template: StoryFn<FormLabelBasicStory> = (args) => ({

--- a/stories/documentation/forms/form-label/form-label-counter.stories.ts
+++ b/stories/documentation/forms/form-label/form-label-counter.stories.ts
@@ -1,17 +1,15 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface FormLabelCounterStory {
-}
+interface FormLabelCounterStory {}
 
 export default {
 	title: 'Documentation/Forms/Form Label Counter',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: FormLabelCounterStory): string {
 	return `<label class="formLabel mod-counter" id="IDlabel" for="ID">
-	Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+	Label<sup class="formLabel-required" aria-hidden="true">*</sup><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 	<span class="formLabel-counter" id="IDcounter" aria-live="polite">
 		<span aria-hidden="true">7/77</span>
 		<span class="u-mask">

--- a/stories/documentation/forms/form-label/form-label-error.stories.ts
+++ b/stories/documentation/forms/form-label/form-label-error.stories.ts
@@ -7,12 +7,11 @@ interface FormLabelErrorStory {
 
 export default {
 	title: 'Documentation/Forms/Form Label Error',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: FormLabelErrorStory): string {
-	return `<label class="formLabel is-error">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>`;
+	return `<label class="formLabel is-error">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span></label>`;
 }
 
 const Template: StoryFn<FormLabelErrorStory> = (args) => ({

--- a/stories/documentation/forms/form-label/form-label-size.stories.ts
+++ b/stories/documentation/forms/form-label/form-label-size.stories.ts
@@ -1,17 +1,15 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface FormLabelSizeStory {
-}
+interface FormLabelSizeStory {}
 
 export default {
 	title: 'Documentation/Forms/Form Label Size',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: FormLabelSizeStory): string {
-	return `<label class="formLabel mod-S">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
-<label class="formLabel mod-XS">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>`;
+	return `<label class="formLabel mod-S">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span></label>
+<label class="formLabel mod-XS">Label<sup class="formLabel-required" aria-hidden="true">*</sup><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span></label>`;
 }
 
 const Template: StoryFn<FormLabelSizeStory> = (args) => ({

--- a/stories/documentation/forms/switch/switch-basic.stories.ts
+++ b/stories/documentation/forms/switch/switch-basic.stories.ts
@@ -78,7 +78,7 @@ function getTemplate(args: SwitchBasicStory): string {
 
 	return `<div class="form-field${s}">
 	<label class="formLabel" for="${id}">
-		Label<span aria-hidden="true" class="lucca-icon icon-signHelp" *ngIf="help"></span>
+		Label<span *ngIf="help" class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 	</label>
 	<span class="switchField">
 		<input type="checkbox" class="switchField-input" id="${id}" aria-describedby="${id}message"${checked}${disabled}${invalid} />

--- a/stories/documentation/integration/utilities/help.stories.ts
+++ b/stories/documentation/integration/utilities/help.stories.ts
@@ -7,7 +7,7 @@ export default {
 } as Meta;
 
 function getTemplate(args: HelpStory): string {
-	return `<p>J'ai besoin d'aide <span aria-hidden="true" class="lucca-icon icon-signHelp u-help"></span><span class="u-mask">Infos supplémentaires</span></p>`;
+	return `<p>J’ai besoin d'aide <span aria-hidden="true" class="lucca-icon icon-signHelp u-help"></span><span class="u-mask">?</span></p>`;
 }
 
 const Template: StoryFn<HelpStory> = (args) => ({

--- a/stories/qa/form-label/form-label.stories.html
+++ b/stories/qa/form-label/form-label.stories.html
@@ -2,12 +2,42 @@
 
 <!-- Basics -->
 <section class="contentSection">
-	<label class="formLabel">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
-	<label class="formLabel is-error">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
-	<label class="formLabel mod-S">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
-	<label class="formLabel mod-S is-error">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
-	<label class="formLabel mod-XS">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
-	<label class="formLabel mod-XS is-error">Text<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span></label>
+	<label class="formLabel"
+		>Text<sup class="formLabel-required" aria-hidden="true">*</sup
+		><span class="formLabel-info"
+			><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+		></label
+	>
+	<label class="formLabel is-error"
+		>Text<sup class="formLabel-required" aria-hidden="true">*</sup
+		><span class="formLabel-info"
+			><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+		></label
+	>
+	<label class="formLabel mod-S"
+		>Text<sup class="formLabel-required" aria-hidden="true">*</sup
+		><span class="formLabel-info"
+			><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+		></label
+	>
+	<label class="formLabel mod-S is-error"
+		>Text<sup class="formLabel-required" aria-hidden="true">*</sup
+		><span class="formLabel-info"
+			><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+		></label
+	>
+	<label class="formLabel mod-XS"
+		>Text<sup class="formLabel-required" aria-hidden="true">*</sup
+		><span class="formLabel-info"
+			><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+		></label
+	>
+	<label class="formLabel mod-XS is-error"
+		>Text<sup class="formLabel-required" aria-hidden="true">*</sup
+		><span class="formLabel-info"
+			><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+		></label
+	>
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/forms/checkbox.stories.html
+++ b/stories/qa/forms/checkbox.stories.html
@@ -1,6 +1,6 @@
 <section class="contentSection">
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CB">
+		<label class="formLabel" for="CB" id="CB-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -19,7 +19,7 @@
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBchecked">
+		<label class="formLabel" for="CBchecked" id="CBchecked-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -39,7 +39,7 @@
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBmixed">
+		<label class="formLabel" for="CBmixed" id="CBmixed-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -62,7 +62,7 @@
 	<h2>Small</h2>
 
 	<div class="form-field mod-S pr-u-marginBottom100">
-		<label class="formLabel" for="CBS">
+		<label class="formLabel" for="CBS" id="CBS-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -80,7 +80,7 @@
 		<div class="inlineMessage" id="CBS-message">Helper text</div>
 	</div>
 	<div class="form-field mod-S pr-u-marginBottom100">
-		<label class="formLabel" for="CBSchecked">
+		<label class="formLabel" for="CBSchecked" id="CBSchecked-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -102,7 +102,7 @@
 	<h2>Disabled</h2>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBdisabled">
+		<label class="formLabel" for="CBdisabled" id="CBdisabled-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -122,7 +122,7 @@
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBdisabledchecked">
+		<label class="formLabel" for="CBdisabledchecked" id="CBdisabledchecked-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -143,7 +143,7 @@
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBmixeddisabled">
+		<label class="formLabel" for="CBmixeddisabled" id="CBmixeddisabled-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -166,7 +166,7 @@
 
 	<h2>Invlid</h2>
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBinvlid">
+		<label class="formLabel" for="CBinvlid" id="CBinvlid-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
@@ -186,7 +186,7 @@
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="CBinvlidchecked">
+		<label class="formLabel" for="CBinvlidchecked" id="CBinvlidchecked-label">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
 			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>

--- a/stories/qa/forms/checkbox.stories.html
+++ b/stories/qa/forms/checkbox.stories.html
@@ -1,11 +1,18 @@
 <section class="contentSection">
-
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CB">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CB" aria-labelledby="CB-label" aria-describedby="CB-message" aria-required="true" />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CB"
+				aria-labelledby="CB-label"
+				aria-describedby="CB-message"
+				aria-required="true"
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CB-message">Helper text</div>
@@ -13,10 +20,19 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBchecked">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBchecked" aria-labelledby="CBchecked-label" aria-describedby="CBchecked-message" aria-required="true" checked />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBchecked"
+				aria-labelledby="CBchecked-label"
+				aria-describedby="CBchecked-message"
+				aria-required="true"
+				checked
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBchecked-message">Helper text</div>
@@ -24,10 +40,20 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBmixed">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBmixed" aria-labelledby="CBmixed-label" aria-describedby="CBmixed-message" aria-required="true" aria-checked="mixed" checked />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBmixed"
+				aria-labelledby="CBmixed-label"
+				aria-describedby="CBmixed-message"
+				aria-required="true"
+				aria-checked="mixed"
+				checked
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBmixed-message">Helper text</div>
@@ -37,20 +63,37 @@
 
 	<div class="form-field mod-S pr-u-marginBottom100">
 		<label class="formLabel" for="CBS">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBS" aria-labelledby="CBS-label" aria-describedby="CBS-message" aria-required="true" />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBS"
+				aria-labelledby="CBS-label"
+				aria-describedby="CBS-message"
+				aria-required="true"
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBS-message">Helper text</div>
 	</div>
 	<div class="form-field mod-S pr-u-marginBottom100">
 		<label class="formLabel" for="CBSchecked">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBSchecked" aria-labelledby="CBSchecked-label" aria-describedby="CBSchecked-message" aria-required="true" checked />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBSchecked"
+				aria-labelledby="CBSchecked-label"
+				aria-describedby="CBSchecked-message"
+				aria-required="true"
+				checked
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBSchecked-message">Helper text</div>
@@ -60,10 +103,19 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBdisabled">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBdisabled" aria-labelledby="CBdisabled-label" aria-describedby="CBdisabled-message" aria-required="true" disabled />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBdisabled"
+				aria-labelledby="CBdisabled-label"
+				aria-describedby="CBdisabled-message"
+				aria-required="true"
+				disabled
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBdisabled-message">Helper text</div>
@@ -71,10 +123,20 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBdisabledchecked">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBdisabledchecked" aria-labelledby="CBdisabledchecked-label" aria-describedby="CBdisabledchecked-message" aria-required="true" disabled checked />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBdisabledchecked"
+				aria-labelledby="CBdisabledchecked-label"
+				aria-describedby="CBdisabledchecked-message"
+				aria-required="true"
+				disabled
+				checked
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBdisabledchecked-message">Helper text</div>
@@ -82,10 +144,21 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBmixeddisabled">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBmixeddisabled" aria-labelledby="CBmixeddisabled-label" aria-describedby="CBmixeddisabled-message" aria-required="true" aria-checked="mixed" checked disabled />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBmixeddisabled"
+				aria-labelledby="CBmixeddisabled-label"
+				aria-describedby="CBmixeddisabled-message"
+				aria-required="true"
+				aria-checked="mixed"
+				checked
+				disabled
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBmixeddisabled-message">Helper text</div>
@@ -94,10 +167,19 @@
 	<h2>Invlid</h2>
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBinvlid">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBinvlid" aria-labelledby="CBinvlid-label" aria-describedby="CBinvlid-message" aria-required="true" aria-invalid="true" />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBinvlid"
+				aria-labelledby="CBinvlid-label"
+				aria-describedby="CBinvlid-message"
+				aria-required="true"
+				aria-invalid="true"
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBinvlid-message">Helper text</div>
@@ -105,15 +187,24 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" for="CBinvlidchecked">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<span class="checkboxField">
-			<input type="checkbox" class="checkboxField-input" id="CBinvlidchecked" aria-labelledby="CBinvlidchecked-label" aria-describedby="CBinvlidchecked-message" aria-required="true" aria-invalid="true" checked />
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBinvlidchecked"
+				aria-labelledby="CBinvlidchecked-label"
+				aria-describedby="CBinvlidchecked-message"
+				aria-required="true"
+				aria-invalid="true"
+				checked
+			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBinvlidchecked-message">Helper text</div>
 	</div>
-
 </section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/forms/switch.stories.html
+++ b/stories/qa/forms/switch.stories.html
@@ -1,9 +1,10 @@
 <section class="contentSection">
-
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="switch">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switch"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
 			<input type="checkbox" class="switchField-input" id="switch" aria-labelledby="switch-label" aria-describedby="switch-message" />
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
@@ -12,11 +13,20 @@
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="switchCheck">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchCheck"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
-			<input type="checkbox" class="switchField-input" id="switchCheck" aria-labelledby="switch-label" aria-describedby="switchCheck-message" checked />
+			<input
+				type="checkbox"
+				class="switchField-input"
+				id="switchCheck"
+				aria-labelledby="switch-label"
+				aria-describedby="switchCheck-message"
+				checked
+			/>
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="switchCheck-message">Helper text</div>
@@ -25,9 +35,11 @@
 	<h2>Sizes</h2>
 
 	<div class="form-field mod-S pr-u-marginBottom100">
-		<label class="formLabel" for="switchS">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchS"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
 			<input type="checkbox" class="switchField-input" id="switchS" aria-labelledby="switch-label" aria-describedby="switchS-message" />
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
@@ -36,11 +48,20 @@
 	</div>
 
 	<div class="form-field mod-S pr-u-marginBottom100">
-		<label class="formLabel" for="switchSCheck">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchSCheck"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
-			<input type="checkbox" class="switchField-input" id="switchSCheck" aria-labelledby="switch-label" aria-describedby="switchSCheck-message" checked />
+			<input
+				type="checkbox"
+				class="switchField-input"
+				id="switchSCheck"
+				aria-labelledby="switch-label"
+				aria-describedby="switchSCheck-message"
+				checked
+			/>
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="switchSCheck-message">Helper text</div>
@@ -49,22 +70,41 @@
 	<h2>Disabled</h2>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="switchDisabled">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchDisabled"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
-			<input type="checkbox" class="switchField-input" id="switchDisabled" aria-labelledby="switch-label" aria-describedby="switchDisabled-message" disabled />
+			<input
+				type="checkbox"
+				class="switchField-input"
+				id="switchDisabled"
+				aria-labelledby="switch-label"
+				aria-describedby="switchDisabled-message"
+				disabled
+			/>
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="switchDisabled-message">Helper text</div>
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="switchDisabledCheck">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchDisabledCheck"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
-			<input type="checkbox" class="switchField-input" id="switchDisabledCheck" aria-labelledby="switch-label" aria-describedby="switchDisabledCheck-message" disabled checked />
+			<input
+				type="checkbox"
+				class="switchField-input"
+				id="switchDisabledCheck"
+				aria-labelledby="switch-label"
+				aria-describedby="switchDisabledCheck-message"
+				disabled
+				checked
+			/>
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="switchDisabledCheck-message">Helper text</div>
@@ -73,22 +113,41 @@
 	<h2>Invalid</h2>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="switchInvalid">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchInvalid"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
-			<input type="checkbox" class="switchField-input" id="switchInvalid" aria-labelledby="switch-label" aria-describedby="switchInvalid-message" aria-invalid="true" />
+			<input
+				type="checkbox"
+				class="switchField-input"
+				id="switchInvalid"
+				aria-labelledby="switch-label"
+				aria-describedby="switchInvalid-message"
+				aria-invalid="true"
+			/>
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="switchInvalid-message">Helper text</div>
 	</div>
 
 	<div class="form-field pr-u-marginBottom100">
-		<label class="formLabel" for="switchInvalidCheck">
-			Label<span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
-		</label>
+		<label class="formLabel" for="switchInvalidCheck"
+			>Label<span class="formLabel-info"
+				><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+			></label
+		>
 		<span class="switchField">
-			<input type="checkbox" class="switchField-input" id="switchInvalidCheck" aria-labelledby="switch-label" aria-describedby="switchInvalidCheck-message" aria-invalid="true" checked />
+			<input
+				type="checkbox"
+				class="switchField-input"
+				id="switchInvalidCheck"
+				aria-labelledby="switch-label"
+				aria-describedby="switchInvalidCheck-message"
+				aria-invalid="true"
+				checked
+			/>
 			<span class="switchField-icon" aria-hidden="true"><span class="switchField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="switchInvalidCheck-message">Helper text</div>

--- a/stories/qa/forms/textfield.stories.html
+++ b/stories/qa/forms/textfield.stories.html
@@ -3,7 +3,11 @@
 
 	<div class="form-field pr-u-marginBottom100">
 		<label class="formLabel" id="fieldSizlabel" for="fieldSiz">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"
+				><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span
+				><span class="u-mask">?</span></span
+			>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -23,7 +27,8 @@
 
 	<div class="form-field mod-S pr-u-marginBottom100">
 		<label class="formLabel" id="fieldSlabel" for="fieldS">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -43,7 +48,8 @@
 
 	<div class="form-field mod-XS pr-u-marginBottom100">
 		<label class="formLabel" id="fieldXSlabel" for="fieldXS">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -66,7 +72,7 @@
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldSearchlabel" for="fieldSearch">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
-			><span aria-hidden="true" class="lucca-icon icon-signHelp" title="yoiejuf"></span>
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -93,7 +99,7 @@
 	<div class="form-field mod-S pr-u-marginBottom300">
 		<label class="formLabel" id="fieldSearchXSlabel" for="fieldSearchXS">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
-			><span aria-hidden="true" class="lucca-icon icon-signHelp" title="yoiejuf"></span>
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -120,7 +126,7 @@
 	<div class="form-field mod-XS pr-u-marginBottom300">
 		<label class="formLabel" id="fieldSearchXSlabel" for="fieldSearchXS">
 			Label<sup class="formLabel-required" aria-hidden="true">*</sup
-			><span aria-hidden="true" class="lucca-icon icon-signHelp" title="yoiejuf"></span>
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -148,7 +154,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldClearlabel" for="fieldClear">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -173,7 +180,8 @@
 
 	<div class="form-field mod-S pr-u-marginBottom300">
 		<label class="formLabel" id="fieldClearSlabel" for="fieldClearS">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -198,7 +206,8 @@
 
 	<div class="form-field mod-XS pr-u-marginBottom300">
 		<label class="formLabel" id="fieldClearXSlabel" for="fieldClear">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -225,7 +234,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldPrefixSlabel" for="fieldPrefixS">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<span class="textField-prefix" id="fieldPrefixSprefix">
@@ -251,7 +261,8 @@
 
 	<div class="form-field mod-S pr-u-marginBottom300">
 		<label class="formLabel" id="fieldPrefixXSlabel" for="fieldPrefixXS">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<span class="textField-prefix" id="fieldPrefixXSprefix">
@@ -277,7 +288,8 @@
 
 	<div class="form-field mod-XS pr-u-marginBottom300">
 		<label class="formLabel" id="fieldPrefixlabel" for="fieldPrefix">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<span class="textField-prefix" id="fieldPrefixprefix">
@@ -305,7 +317,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldErrorEmptylabel" for="fieldErrorEmpty">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -325,7 +338,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldErrorFilledlabel" for="fieldErrorFilled">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<span class="textField-prefix" id="fieldErrorFilledprefix">
@@ -357,7 +371,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldDisabledEmptylabel" for="fieldDisabledEmpty">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<div class="textField-input">
@@ -378,7 +393,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldDisabledFilledlabel" for="fieldDisabledFilled">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<span class="textField-prefix" id="fieldDisabledFilledprefix">
@@ -408,7 +424,8 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldAlllabel" for="fieldAll">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
 		</label>
 		<div class="textField">
 			<span class="textField-prefix" id="fieldAllprefix">


### PR DESCRIPTION
## Description

Before:
![Capture d’écran 2024-05-21 à 14 32 31](https://github.com/LuccaSA/lucca-front/assets/64789527/2f250707-579e-448c-9b17-371d11d72875)

After: 
![Capture d’écran 2024-05-21 à 14 32 10](https://github.com/LuccaSA/lucca-front/assets/64789527/fd93de8d-a020-4b73-a136-f3f9ca2bfa3d)

-----

I'm also adding an alternative text to the icon, but until I can add a translation mechanism, I'm sticking with a very generic text « ? » for « help ».

-----
