### PR TITLE
fix(select): strange selection behavior on empty search result

### DIFF
--- a/packages/ng/multi-select/input/panel-ref.factory.ts
+++ b/packages/ng/multi-select/input/panel-ref.factory.ts
@@ -62,7 +62,9 @@ class MultiSelectPanelRef<T> extends LuMultiSelectPanelRef<T> {
 	}
 
 	selectCurrentlyHighlightedValue(): void {
-		this.instance.toggleOption(this.instance.keyManager?.activeItem?.option);
+		if (this.instance.keyManager?.activeItem) {
+			this.instance.toggleOption(this.instance.keyManager.activeItem.option);
+		}
 	}
 }
 

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -137,7 +137,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 					debounceTime(0),
 					takeUntil(this.panelRef.closed),
 				)
-				.subscribe(() => this.keyManager.setFirstItemActive());
+				.subscribe(() => (this.optionsQL.length ? this.keyManager.setFirstItemActive() : this.keyManager.setActiveItem(-1)));
 		}
 
 		this.keyManager.setFirstItemActive();

--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -49,7 +49,9 @@ class SelectPanelRef<T> extends LuSelectPanelRef<T, T> {
 	}
 
 	selectCurrentlyHighlightedValue(): void {
-		this.emitValue(this.instance.keyManager.activeItem?.option);
+		if (this.instance.keyManager.activeItem) {
+			this.emitValue(this.instance.keyManager.activeItem.option);
+		}
 		this.close();
 	}
 

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -100,7 +100,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit {
 					debounceTime(0),
 					takeUntil(this.panelRef.closed),
 				)
-				.subscribe(() => this.keyManager.setFirstItemActive());
+				.subscribe(() => (this.optionsQL.length ? this.keyManager.setFirstItemActive() : this.keyManager.setActiveItem(-1)));
 		}
 	}
 }


### PR DESCRIPTION
## Description

Pressing "Enter" when making a search without result was selecting either `null` or the last active item. This PR resets the active item when no options are displayed and stop sending `null` as a value.

-----

