### PR TITLE
Small adjustments for table sticky

### DIFF
--- a/packages/scss/src/components/index.scss
+++ b/packages/scss/src/components/index.scss
@@ -81,5 +81,6 @@
 // Deprecated CSS components
 // @forward 'gridLegacy'; // 40 Ko
 // @forward 'emptyStateDeprecated';
-//@forward 'tableFixedLegacy'; // 33 Ko
-//@forward 'tableStickedLegacy'; // 67 Ko
+
+// @forward 'tableFixedLegacy'; // 33 Ko
+// @forward 'tableStickedLegacy'; // 67 Ko

--- a/packages/scss/src/components/tableFixed/mods.scss
+++ b/packages/scss/src/components/tableFixed/mods.scss
@@ -16,16 +16,28 @@
 }
 
 @mixin layoutFixedCells {
-	[class*='row-cell'] {
-		--cell-width: calc(var(--table-layoutFixed-width) * 1rem);
+	.table-head-row-cell,
+	.table-body-row-cell,
+	.table-foot-row-cell {
+		--cell-width: var(--table-layoutFixed-width);
 	}
-	&.mod-layoutFixed [class*='row-cell'] {
-		@include cellFixedWidth;
+
+	&.mod-layoutFixed {
+		.table-head-row-cell,
+		.table-body-row-cell,
+		.table-foot-row-cell {
+			@include cellFixedWidth;
+		}
 	}
+
 	@each $breakpoint, $value in config.$breakpoints {
 		@include media.min($breakpoint) {
-			&.mod-layoutFixedAtMediaMin#{$breakpoint} [class*='row-cell'] {
-				@include cellFixedWidth;
+			&.mod-layoutFixedAtMediaMin#{$breakpoint} {
+				.table-head-row-cell,
+				.table-body-row-cell,
+				.table-foot-row-cell {
+					@include cellFixedWidth;
+				}
 			}
 		}
 	}
@@ -33,6 +45,5 @@
 
 @mixin cellFixedWidth {
 	min-width: var(--cell-width, auto);
-	max-width: var(--cell-width, auto);
 	width: var(--cell-width, auto);
 }

--- a/packages/scss/src/components/tableSticked/mods.scss
+++ b/packages/scss/src/components/tableSticked/mods.scss
@@ -86,8 +86,9 @@
 
 @mixin stickyColumnOffset {
 	[class*='mod-stickyColumn-'] {
+		--components-tableSticked-column-sticky-offset: var(--table-stickyColumn-offset, 0rem);
+
 		position: sticky;
-		--components-tableSticked-column-sticky-offset: calc(var(--table-stickyColumn-offset) * 1rem);
 	}
 	.mod-stickyColumn-shadow {
 		display: table-cell;

--- a/stories/documentation/listings/table/table-sticky-columns-breakpoints.stories.ts
+++ b/stories/documentation/listings/table/table-sticky-columns-breakpoints.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/angular';
+import { Meta, StoryFn } from '@storybook/angular';
 
 interface TableStickyColumnsAndHeaderWithBreakpointsStory {}
 
@@ -8,21 +8,27 @@ export default {
 } as Meta;
 
 function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): string {
-	return `
-	<div class="demo-wrapper">
-		<table class="table mod-layoutFixedAtMediaMinS mod-stickyColumnAtMediaMinS mod-stickyHeader" [attr.style]="'--table-stickyHeader-shadow-offset: 56px'">
+	return `<!-- header height passed with CSS var -->
+		<table class="table mod-layoutFixedAtMediaMinS mod-stickyColumnAtMediaMinS mod-stickyHeader" [attr.style]="'--table-stickyHeader-shadow-offset: 2.25rem'">
 			<thead class="table-head">
 				<tr class="table-head-row">
-					<th class="table-head-row-cell mod-stickyColumn-left" [attr.style]="'--table-layoutFixed-width: 8; --table-stickyColumn-offset: 0'">
+					<!-- col 1 width passed with CSS var -->
+					<th class="table-head-row-cell mod-stickyColumn-left" [attr.style]="'--table-layoutFixed-width: 8rem'">
 						Head cell
 					</th>
-					<th class="table-head-row-cell mod-stickyColumn-left" [attr.style]="'--table-layoutFixed-width: 7; --table-stickyColumn-offset: 8'">
+					<!-- col 2 width passed with CSS var -->
+					<!-- col 2 offset equal to col 1 width -->
+					<th class="table-head-row-cell mod-stickyColumn-left" [attr.style]="'--table-layoutFixed-width: 7rem; --table-stickyColumn-offset: 8rem'">
 						Head cell
 					</th>
-					<th class="table-head-row-cell mod-stickyColumn-left" [attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 15'">
+					<!-- col 3 width passed with CSS var -->
+					<!-- col 3 offset equal to col 1 width + col 2 width -->
+					<th class="table-head-row-cell mod-stickyColumn-left" [attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: calc(8rem + 7rem)'">
 						Head cell
 					</th>
-					<th class="table-head-row-cell mod-stickyColumn-left mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 20'">
+					<!-- col containing the left shadow -->
+					<!-- col 4 offset equal to col 1 width + col 2 width + col 3 width -->
+					<th class="table-head-row-cell mod-stickyColumn-left mod-stickyColumn-shadow" [attr.style]="'--table-stickyColumn-offset: calc(8rem + 7rem + 5rem)'" aria-hidden="true">
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
 					<th class="table-head-row-cell">Head cell</th>
@@ -35,31 +41,36 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<th class="table-head-row-cell">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
-					<th class="table-head-row-cell mod-stickyColumn-right mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 5'">
+					<!-- col containing the right shadow -->
+					<!-- col 13 offset equal to col 14 width -->
+					<th class="table-head-row-cell mod-stickyColumn-right mod-stickyColumn-shadow" [attr.style]="'--table-stickyColumn-offset: 5rem'" aria-hidden="true">
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
-					<th class="table-head-row-cell mod-stickyColumn-right" [attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 0'">
+					<!-- col 14 width passed with CSS var -->
+					<th class="table-head-row-cell mod-stickyColumn-right" [attr.style]="'--table-layoutFixed-width: 5rem'">
 						Head cell
 					</th>
 				</tr>
 			</thead>
 			<tbody class="table-body">
-				<tr class="table-body-row mod-stickyHeader-shadow">
-					<td class="table-body-row-cell" colspan="16" role="presentation">
+				<!-- row containing the top shadow -->
+				<tr class="table-body-row mod-stickyHeader-shadow" aria-hidden="true">
+					<td class="table-body-row-cell" colspan="16">
 						<div class="stickyHeader-shadow-wrapper"></div>
 					</td>
 				</tr>
-				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">
+				<tr class="table-body-row" *ngFor="let _ of [].constructor(5)">
+					<td class="table-body-row-cell mod-stickyColumn-left">
 						Body cell
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">
 						Body cell
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: calc(8rem + 7rem)'">
 						Body cell
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 20'">
+					<!-- col containing the left shadow -->
+					<td class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow" [attr.style]="'--table-stickyColumn-offset: calc(8rem + 7rem + 5rem)'" aria-hidden="true">
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
 					<td class="table-body-row-cell">Body cell</td>
@@ -72,83 +83,24 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 5'">
+					<!-- col containing the right shadow -->
+					<td class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow" [attr.style]="'--table-stickyColumn-offset: 5rem'" aria-hidden="true">
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">
-						Body cell
-					</td>
-				</tr>
-				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">
-						Body cell
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">
-						Body cell
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">
-						Body cell
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 20'">
-						<div class="stickyColumn-shadow-wrapper"></div>
-					</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 5'">
-						<div class="stickyColumn-shadow-wrapper"></div>
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">
-						Body cell
-					</td>
-				</tr>
-				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">
-						Body cell
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">
-						Body cell
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">
-						Body cell
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 20'">
-						<div class="stickyColumn-shadow-wrapper"></div>
-					</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow" role="presentation" [attr.style]="'--table-stickyColumn-offset: 5'">
-						<div class="stickyColumn-shadow-wrapper"></div>
-					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">
+					<td class="table-body-row-cell mod-stickyColumn-right">
 						Body cell
 					</td>
 				</tr>
 			</tbody>
 		</table>
-	</div>
+	
 	`;
 }
 
-const Template: Story<TableStickyColumnsAndHeaderWithBreakpointsStory> = (args: TableStickyColumnsAndHeaderWithBreakpointsStory) => ({
+const Template: StoryFn<TableStickyColumnsAndHeaderWithBreakpointsStory> = (args: TableStickyColumnsAndHeaderWithBreakpointsStory) => ({
 	props: args,
 	template: getTemplate(args),
-	styles: [`.demo-wrapper {overflow: auto; height: 10rem;}`],
+	styles: [`:host {display: block; overflow: auto; height: 10rem; white-space: nowrap}`],
 });
 
 export const StickyColumnsAndHeaderWithBreakpoints = Template.bind({});

--- a/stories/documentation/listings/table/table-sticky-header.stories.ts
+++ b/stories/documentation/listings/table/table-sticky-header.stories.ts
@@ -8,9 +8,8 @@ export default {
 } as Meta;
 
 function getTemplate(args: TableStickyHeaderStory): string {
-	return `
-	<div class="demo-wrapper">
-		<table class="table mod-stickyHeader" [attr.style]="'--table-stickyHeader-shadow-offset: 37px'">
+	return `<!-- header height passed with CSS var -->
+		<table class="table mod-stickyHeader" [attr.style]="'--table-stickyHeader-shadow-offset: 2.25rem'">
 			<thead class="table-head">
 				<tr class="table-head-row">
 					<th class="table-head-row-cell">Head cell</th>
@@ -19,8 +18,9 @@ function getTemplate(args: TableStickyHeaderStory): string {
 				</tr>
 			</thead>
 			<tbody class="table-body">
-				<tr class="table-body-row mod-stickyHeader-shadow">
-					<td class="table-body-row-cell" colspan="3" role="presentation">
+				<!-- row containing the top shadow -->
+				<tr class="table-body-row mod-stickyHeader-shadow" aria-hidden="true">
+					<td class="table-body-row-cell" colspan="3">
 						<div class="stickyHeader-shadow-wrapper"></div>
 					</td>
 				</tr>
@@ -51,14 +51,14 @@ function getTemplate(args: TableStickyHeaderStory): string {
 				</tr>
 			</tbody>
 		</table>
-	</div>
+	
 	`;
 }
 
 const Template: StoryFn<TableStickyHeaderStory> = (args: TableStickyHeaderStory) => ({
 	props: args,
 	template: getTemplate(args),
-	styles: [`.demo-wrapper {height: 10rem; overflow: auto;}`],
+	styles: [`:host {display: block; height: 10rem; overflow: auto;}`],
 });
 
 export const StickyHeader = Template.bind({});

--- a/stories/documentation/structure/grids/grids-auto-responsive-container.stories.ts
+++ b/stories/documentation/structure/grids/grids-auto-responsive-container.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/angular';
+import { Meta, StoryFn } from '@storybook/angular';
 
 interface GridsPositionStory {
 	reverse: boolean;
@@ -23,7 +23,7 @@ function getTemplate(args: GridsPositionStory): string {
 </div>`;
 }
 
-const Template: Story<GridsPositionStory> = (args: GridsPositionStory) => ({
+const Template: StoryFn<GridsPositionStory> = (args: GridsPositionStory) => ({
 	props: args,
 	template: getTemplate(args),
 	styles: [

--- a/stories/documentation/structure/grids/grids-auto-responsive.stories.ts
+++ b/stories/documentation/structure/grids/grids-auto-responsive.stories.ts
@@ -1,4 +1,4 @@
-import { Meta, Story } from '@storybook/angular';
+import { Meta, StoryFn } from '@storybook/angular';
 
 interface GridsPositionStory {
 	reverse: boolean;
@@ -21,7 +21,7 @@ function getTemplate(args: GridsPositionStory): string {
 </div>`;
 }
 
-const Template: Story<GridsPositionStory> = (args: GridsPositionStory) => ({
+const Template: StoryFn<GridsPositionStory> = (args: GridsPositionStory) => ({
 	props: args,
 	template: getTemplate(args),
 	styles: [

--- a/stories/qa/table/table.stories.html
+++ b/stories/qa/table/table.stories.html
@@ -669,8 +669,8 @@
 	<table class="table mod-layoutFixed">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 8'">Fixed 8rem column</th>
-				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 12'">Fixed 12rem column</th>
+				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 8rem'">Fixed 8rem column</th>
+				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 12rem'">Fixed 12rem column</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
@@ -692,16 +692,12 @@
 			</tr>
 		</tbody>
 	</table>
-	<em
-		><b>Tip:</b> the numeric value used in the var will be calculated in rem. Ex
-		<code class="code">--table-layoutFixed-width: <strong>8</strong></code> means a cell width of <strong>8</strong> rem</em
-	>
 	<h2 class="u-marginTopM">Fixed layout columns starting at breakpoint S</h2>
 	<table class="table mod-layoutFixedAtMediaMinS">
 		<thead class="table-head">
 			<tr class="table-head-row">
-				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 8'">Fixed 8rem head cell</th>
-				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 12'">Fixed 12rem head cell</th>
+				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 8rem'">Fixed 8rem head cell</th>
+				<th class="table-head-row-cell" [attr.style]="'--table-layoutFixed-width: 12rem'">Fixed 12rem head cell</th>
 				<th class="table-head-row-cell">Head cell</th>
 			</tr>
 		</thead>
@@ -729,19 +725,19 @@
 				<tr class="table-head-row">
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 8; --table-stickyColumn-offset: 0'"
+						[attr.style]="'--table-layoutFixed-width: 8rem; --table-stickyColumn-offset: 0rem'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 7; --table-stickyColumn-offset: 8'"
+						[attr.style]="'--table-layoutFixed-width: 7rem; --table-stickyColumn-offset: 8rem'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 15'"
+						[attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: 15rem'"
 					>
 						Head cell
 					</th>
@@ -757,7 +753,7 @@
 					<th class="table-head-row-cell">Head cell</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-right"
-						[attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 0'"
+						[attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: 0rem'"
 					>
 						Head cell
 					</th>
@@ -765,9 +761,9 @@
 			</thead>
 			<tbody class="table-body">
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
@@ -778,12 +774,12 @@
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
@@ -794,7 +790,7 @@
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 			</tbody>
 		</table>
@@ -820,26 +816,26 @@
 				<tr class="table-head-row">
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 8; --table-stickyColumn-offset: 0'"
+						[attr.style]="'--table-layoutFixed-width: 8rem; --table-stickyColumn-offset: 0rem'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 7; --table-stickyColumn-offset: 8'"
+						[attr.style]="'--table-layoutFixed-width: 7rem; --table-stickyColumn-offset: 8rem'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 15'"
+						[attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: 15rem'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
@@ -856,13 +852,13 @@
 					<th
 						class="table-head-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-right"
-						[attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 0'"
+						[attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: 0rem'"
 					>
 						Head cell
 					</th>
@@ -870,13 +866,13 @@
 			</thead>
 			<tbody class="table-body">
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td
 						class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -893,20 +889,20 @@
 					<td
 						class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td
 						class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -923,20 +919,20 @@
 					<td
 						class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td
 						class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -953,11 +949,11 @@
 					<td
 						class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 			</tbody>
 		</table>
@@ -975,26 +971,26 @@
 				<tr class="table-head-row">
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 8; --table-stickyColumn-offset: 0'"
+						[attr.style]="'--table-layoutFixed-width: 8rem; --table-stickyColumn-offset: 0'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 7; --table-stickyColumn-offset: 8'"
+						[attr.style]="'--table-layoutFixed-width: 7rem; --table-stickyColumn-offset: 8rem'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left"
-						[attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 15'"
+						[attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: 15'"
 					>
 						Head cell
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
@@ -1011,13 +1007,13 @@
 					<th
 						class="table-head-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
 					<th
 						class="table-head-row-cell mod-stickyColumn-right"
-						[attr.style]="'--table-layoutFixed-width: 5; --table-stickyColumn-offset: 0'"
+						[attr.style]="'--table-layoutFixed-width: 5rem; --table-stickyColumn-offset: 0'"
 					>
 						Head cell
 					</th>
@@ -1030,13 +1026,13 @@
 					</td>
 				</tr>
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td
 						class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -1053,20 +1049,20 @@
 					<td
 						class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td
 						class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -1083,20 +1079,20 @@
 					<td
 						class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 				<tr class="table-body-row">
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8'">Body cell</td>
-					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 8rem'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-left" [attr.style]="'--table-stickyColumn-offset: 15rem'">Body cell</td>
 					<td
 						class="table-body-row-cell mod-stickyColumn-left mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 20'"
+						[attr.style]="'--table-stickyColumn-offset: 20rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -1113,11 +1109,11 @@
 					<td
 						class="table-body-row-cell mod-stickyColumn-right mod-stickyColumn-shadow"
 						role="presentation"
-						[attr.style]="'--table-stickyColumn-offset: 5'"
+						[attr.style]="'--table-stickyColumn-offset: 5rem'"
 					>
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0'">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-right" [attr.style]="'--table-stickyColumn-offset: 0rem'">Body cell</td>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
## Description

- [x] `[class*='row-cell']` seems harder to find in the code than `.table-body-row-cell, .table-head-row, cell, .table-foot-row-cell`.
- [x] `cellFixedWidth` apparently doesn't need a `max-width`.
- [x] `--table-stickyColumn-offset` and `--table-layoutFixed-width` will be more flexible if they embed their units.
- [x] `--table-stickyColumn-offset`has now a default value of `0rem`, making its use optional for the first column.
- [x] Some comments in the examples, and values in `rem`.
- [x] `role="presentation"` is replaced by `aria-hidden="true"`, it's the whole element of the table that's hidden from assistive technologies, not just its semantics that's suppressed.

-----



-----
