### PR TITLE
Empty state titles

### DIFF
--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
@@ -10,7 +10,7 @@
 		<div class="emptyState-content">
 			<div *ngIf="icon" class="emptyState-content-icon" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
 			<div class="emptyState-content-text">
-				<h1 class="emptyState-content-heading">{{ title }}</h1>
+				<div role="heading" [attr.aria-level]="hx" class="emptyState-content-heading">{{ title }}</div>
 				<p>
 					<ng-container *luPortal="description"></ng-container>
 				</p>

--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
@@ -62,4 +62,7 @@ export class EmptyStatePageComponent {
 		required: true,
 	})
 	description: PortalContent;
+
+	@Input()
+	hx: number = 1;
 }

--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
@@ -64,5 +64,5 @@ export class EmptyStatePageComponent {
 	description: PortalContent;
 
 	@Input()
-	hx: number = 1;
+	hx: 1 | 2 | 3 | 4 | 5 | 6 = 1;
 }

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.html
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.html
@@ -3,7 +3,7 @@
 		<div class="emptyState-content">
 			<div *ngIf="icon" class="emptyState-content-icon palette-{{palette}}" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
 			<div class="emptyState-content-text">
-				<h3 class="emptyState-content-heading">{{ title }}</h3>
+				<div role="heading" [attr.aria-level]="hx" class="emptyState-content-heading">{{ title }}</div>
 				<p>
 					<ng-container *luPortal="description"></ng-container>
 				</p>

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -1,7 +1,7 @@
+import { NgIf } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
-import { NgIf } from '@angular/common';
 
 @Component({
 	selector: 'lu-empty-state-section',
@@ -36,4 +36,7 @@ export class EmptyStateSectionComponent {
 		required: true,
 	})
 	description: PortalContent;
+
+	@Input()
+	hx: number = 3;
 }

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -38,5 +38,5 @@ export class EmptyStateSectionComponent {
 	description: PortalContent;
 
 	@Input()
-	hx: number = 3;
+	hx: 1 | 2 | 3 | 4 | 5 | 6 = 3;
 }

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/components/title/exports' as title;
+
 @mixin component($atRoot: 'without: rule') {
 	display: flex;
 	flex-direction: column;
@@ -32,6 +34,9 @@
 		}
 
 		.emptyState-content-heading {
+			@include title.component;
+			@include title.h3;
+
 			margin-bottom: 0;
 		}
 

--- a/packages/scss/src/components/emptyState/mods.scss
+++ b/packages/scss/src/components/emptyState/mods.scss
@@ -21,6 +21,8 @@
 	}
 
 	.emptyState-content-heading {
+		@include title.h1;
+
 		@include media.max('XXS') {
 			@include title.h2;
 		}

--- a/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
@@ -12,7 +12,7 @@ export default {
 		}),
 	],
 	render: (args: EmptyStatePageComponent) => {
-		const { title, description, icon, topRightBackground, topRightForeground, bottomLeftBackground, bottomLeftForeground, contentBackgroundColor } = args;
+		const { title, description, icon, topRightBackground, topRightForeground, bottomLeftBackground, bottomLeftForeground, contentBackgroundColor, hx } = args;
 		const paramIcon = args.icon === '' ? '' : 'icon="' + args.icon + '"';
 
 		return {
@@ -34,6 +34,7 @@ export default {
 	bottomLeftBackground="${bottomLeftBackground}"
 	bottomLeftForeground="${bottomLeftForeground}"
 	contentBackgroundColor="${contentBackgroundColor}"
+	hx="${hx}"
 >
 	<button luButton type="button" palette="product">Button</button>
 	<button luButton="outlined" type="button" palette="product">Button</button>
@@ -133,6 +134,13 @@ export default {
 				type: 'text',
 			},
 		},
+		hx: {
+			control: {
+				type: 'number',
+				min: 1,
+				max: 6,
+			},
+		},
 	},
 } as Meta;
 
@@ -146,5 +154,6 @@ export const Page: StoryObj<EmptyStatePageComponent> = {
 		bottomLeftBackground: 'https://cdn.lucca.fr/lucca-front/assets/empty-states/poplee/bubbles-bottom-left-01.svg',
 		bottomLeftForeground: 'https://cdn.lucca.fr/lucca-front/assets/empty-states/poplee/core-hr-01.svg',
 		contentBackgroundColor: 'var(--pr-t-elevation-surface-default)',
+		hx: 1,
 	},
 };

--- a/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
@@ -13,10 +13,10 @@ export default {
 		}),
 	],
 	render: (args: EmptyStateSectionComponent) => {
-		const { title, description, center, palette, icon } = args;
+		const { title, description, center, palette, hx, icon } = args;
 		const paramIcon = args.icon === '' ? '' : 'icon="' + args.icon + '"';
 		return {
-template: `<lu-empty-state-section ${paramIcon} title="${title}" description="${description}" palette="${palette}" ${center ? ' center' : ''}>
+			template: `<lu-empty-state-section hx="${hx}" ${paramIcon} title="${title}" description="${description}" palette="${palette}" ${center ? ' center' : ''}>
 	<button luButton type="button" palette="product">Button</button>
 	<button luButton="outlined" type="button" palette="product">Button</button>
 </lu-empty-state-section>`,
@@ -24,6 +24,13 @@ template: `<lu-empty-state-section ${paramIcon} title="${title}" description="${
 	},
 	argTypes: {
 		palette: PaletteArgType,
+		hx: {
+			control: {
+				type: 'number',
+				min: 1,
+				max: 6,
+			},
+		},
 		icon: {
 			options: [
 				'https://cdn.lucca.fr/lucca-front/assets/empty-states/icons/iconBanknote.svg',
@@ -91,5 +98,6 @@ export const Section: StoryObj<EmptyStateSectionComponent> = {
 		description: 'Description can be a string or a ng-template',
 		center: false,
 		palette: 'none',
+		hx: 3,
 	},
 };

--- a/stories/documentation/feedback/empty-state/html&css/empty-state-section.stories.ts
+++ b/stories/documentation/feedback/empty-state/html&css/empty-state-section.stories.ts
@@ -1,9 +1,8 @@
-import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+import { HttpClientModule } from '@angular/common/http';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
-import { HttpClientModule } from "@angular/common/http";
+import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
 
-interface EmptyStateSectionBasicStory {
-}
+interface EmptyStateSectionBasicStory {}
 
 export default {
 	title: 'Documentation/Feedback/Empty State/HTML&CSS/Section',
@@ -12,8 +11,7 @@ export default {
 			imports: [LuSafeExternalSvgPipe, HttpClientModule],
 		}),
 	],
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: EmptyStateSectionBasicStory): string {
@@ -44,4 +42,4 @@ const Template: StoryFn<EmptyStateSectionBasicStory> = (args: EmptyStateSectionB
 });
 
 export const Section = Template.bind({});
-Section.args = { };
+Section.args = {};


### PR DESCRIPTION
## Description

Fix #2780 

- [x] The style of empty state titles no longer depends on their semantic level.
- [x] A parameter is added to Angular components to make this title level configurable.

-----



-----

![Capture d’écran 2024-05-23 à 17 11 57](https://github.com/LuccaSA/lucca-front/assets/64789527/a20bdec6-43ee-4d27-b187-c6dfb227b90c)

