### PR TITLE
fix(core-select): do not send empty fields / wrong operation parameter name

### DIFF
--- a/packages/ng/core-select/api/api-v3.directive.ts
+++ b/packages/ng/core-select/api/api-v3.directive.ts
@@ -41,7 +41,7 @@ export class LuCoreSelectApiV3Directive<T extends ILuApiItem> extends ALuCoreSel
 	protected override params$ = combineLatest([this.fields$, this.filters$, this.orderBy$, this.clue$]).pipe(
 		map(([fields, filters, orderBy, clue]) => ({
 			...filters,
-			fields,
+			...(fields ? { fields } : {}),
 			...(orderBy ? { orderBy } : {}),
 			...(clue ? { name: `like,${clue}` } : {}),
 		})),

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -130,7 +130,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		const params = {
 			fields: this.#userFields,
 			...(this._filters() ?? {}),
-			...(this._operationIds() ? { operationIds: this._operationIds().join(',') } : {}),
+			...(this._operationIds() ? { operations: this._operationIds().join(',') } : {}),
 			...(this._appInstanceId() ? { appInstanceId: this._appInstanceId() } : {}),
 			...(this._enableFormerEmployees() ? { enableFormerEmployees: this._enableFormerEmployees() } : {}),
 			id: this.currentUserId,


### PR DESCRIPTION
## Description

* do not send empty fields
* wrong operation parameter name

-----

