### PR TITLE
feat(date): allow string union type for `lu-date-select`,`lu-date-picker`,`luDateInput` and `lu-calendar`

### DIFF
--- a/packages/ng/core/date/date-adapter.class.ts
+++ b/packages/ng/core/date/date-adapter.class.ts
@@ -1,12 +1,12 @@
 import { ILuDateAdapter } from './date-adapter.interface';
-import { ELuDateGranularity } from './date-granularity.enum';
+import { ELuDateGranularity, LuDateGranularity } from './date-granularity.enum';
 
 export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 	abstract forge(year: number, month: number, date: number): D;
 	abstract forgeToday(): D;
 	abstract forgeInvalid(): D;
 	abstract isValid(d: D): boolean;
-	compare(a: D, b: D, granularity: ELuDateGranularity): number {
+	compare(a: D, b: D, granularity: LuDateGranularity): number {
 		if (!a || !b || !this.isValid(a) || !this.isValid(b)) {
 			throw new Error('you must provide valid and not null dates to be compared');
 		}
@@ -60,8 +60,8 @@ export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 
 		return 0;
 	}
-	abstract isParsable(text: string, granularity?: ELuDateGranularity): boolean;
-	abstract parse(text: string, granularity?: ELuDateGranularity): D;
+	abstract isParsable(text: string, granularity?: LuDateGranularity): boolean;
+	abstract parse(text: string, granularity?: LuDateGranularity): D;
 	abstract format(d: D, format: string): string;
 	abstract clone(d: D): D;
 
@@ -70,5 +70,5 @@ export abstract class ALuDateAdapter<D> implements ILuDateAdapter<D> {
 	abstract getDate(d: D): number;
 	abstract getDay(d: D): number;
 
-	abstract add(d: D, count: number, granularity: ELuDateGranularity): D;
+	abstract add(d: D, count: number, granularity: LuDateGranularity): D;
 }

--- a/packages/ng/core/date/date-adapter.interface.ts
+++ b/packages/ng/core/date/date-adapter.interface.ts
@@ -1,13 +1,13 @@
-import { ELuDateGranularity } from './date-granularity.enum';
+import { LuDateGranularity } from './date-granularity.enum';
 
 export interface ILuDateAdapter<D> {
 	forge(year: number, month: number, date: number): D;
 	forgeToday(): D;
 	forgeInvalid(): D;
 	isValid(d: D): boolean;
-	compare(a: D, b: D, granularity: ELuDateGranularity): number;
-	isParsable(text: string, granularity?: ELuDateGranularity): boolean;
-	parse(text: string, granularity?: ELuDateGranularity): D;
+	compare(a: D, b: D, granularity: LuDateGranularity): number;
+	isParsable(text: string, granularity?: LuDateGranularity): boolean;
+	parse(text: string, granularity?: LuDateGranularity): D;
 	format(d: D, format: string): string;
 	clone(d: D): D;
 
@@ -16,5 +16,5 @@ export interface ILuDateAdapter<D> {
 	getDate(d: D): number;
 	getDay(d: D): number;
 
-	add(d: D, count: number, granularity: ELuDateGranularity): D;
+	add(d: D, count: number, granularity: LuDateGranularity): D;
 }

--- a/packages/ng/core/date/date-granularity.enum.ts
+++ b/packages/ng/core/date/date-granularity.enum.ts
@@ -1,6 +1,10 @@
+import { EnumValue } from '../type';
+
 export enum ELuDateGranularity {
 	day = 'day',
 	month = 'month',
 	year = 'year',
 	decade = 'decade',
 }
+
+export type LuDateGranularity = EnumValue<ELuDateGranularity>;

--- a/packages/ng/core/date/native/native-date.adapter.ts
+++ b/packages/ng/core/date/native/native-date.adapter.ts
@@ -2,8 +2,8 @@ import { formatDate, FormatWidth, getLocaleDateFormat } from '@angular/common';
 import { Inject, Injectable, LOCALE_ID, Optional } from '@angular/core';
 import { ALuDateAdapter } from '../date-adapter.class';
 import { ILuDateAdapter } from '../date-adapter.interface';
-import { ELuDateGranularity } from '../date-granularity.enum';
-import { ILuNativeDateAdapterOptions, luDefaultNativeDateAdapterOptions, LU_NATIVE_DATE_ADAPTER_OPTIONS } from './native-date.option';
+import { ELuDateGranularity, LuDateGranularity } from '../date-granularity.enum';
+import { ILuNativeDateAdapterOptions, LU_NATIVE_DATE_ADAPTER_OPTIONS, luDefaultNativeDateAdapterOptions } from './native-date.option';
 
 @Injectable()
 export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDateAdapter<Date> {
@@ -38,7 +38,7 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 			}
 		});
 	}
-	private extract(text: string, granularity: ELuDateGranularity = ELuDateGranularity.day): { date: number; month: number; year: number } {
+	private extract(text: string, granularity: LuDateGranularity = ELuDateGranularity.day): { date: number; month: number; year: number } {
 		const groups = text.split(this._regex);
 		let date = 1,
 			month = 1,
@@ -59,7 +59,7 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 		}
 		return { date, month, year };
 	}
-	isParsable(text: string, granularity = ELuDateGranularity.day): boolean {
+	isParsable(text: string, granularity: LuDateGranularity = ELuDateGranularity.day): boolean {
 		if (!text) {
 			return false;
 		}
@@ -123,7 +123,7 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 			return false;
 		}
 	}
-	parse(text: string, granularity = ELuDateGranularity.day): Date {
+	parse(text: string, granularity: LuDateGranularity = ELuDateGranularity.day): Date {
 		if (!text) {
 			return undefined;
 		}
@@ -205,7 +205,7 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 		}
 	}
 
-	add(d: Date, count: number, granularity: ELuDateGranularity): Date {
+	add(d: Date, count: number, granularity: LuDateGranularity): Date {
 		let year = this.getYear(d);
 		let month = this.getMonth(d);
 		let date = this.getDate(d);

--- a/packages/ng/core/date/string/string-date.adapter.ts
+++ b/packages/ng/core/date/string/string-date.adapter.ts
@@ -1,8 +1,8 @@
-import { Injectable, Inject, LOCALE_ID } from '@angular/core';
-import { LuNativeDateAdapter } from '../native/index';
+import { Inject, Injectable, LOCALE_ID } from '@angular/core';
 import { ALuDateAdapter } from '../date-adapter.class';
-import { ELuDateGranularity } from '../date-granularity.enum';
 import { ILuDateAdapter } from '../date-adapter.interface';
+import { LuDateGranularity } from '../date-granularity.enum';
+import { LuNativeDateAdapter } from '../native/index';
 
 /** bind to a string with iso 26001 format YYYY-MM-DD */
 @Injectable()
@@ -35,7 +35,7 @@ export class LuStringDateAdapter extends ALuDateAdapter<string> implements ILuDa
 		return this._nativeAdapter.isValid(this.stringToDate(d));
 	}
 
-	override compare(a: string, b: string, granularity: ELuDateGranularity): number {
+	override compare(a: string, b: string, granularity: LuDateGranularity): number {
 		const da = this.stringToDate(a);
 		const db = this.stringToDate(b);
 
@@ -46,7 +46,7 @@ export class LuStringDateAdapter extends ALuDateAdapter<string> implements ILuDa
 		return this._nativeAdapter.isParsable(text);
 	}
 
-	parse(text: string, granularity: ELuDateGranularity): string {
+	parse(text: string, granularity: LuDateGranularity): string {
 		return this.dateToString(this._nativeAdapter.parse(text, granularity));
 	}
 
@@ -74,7 +74,7 @@ export class LuStringDateAdapter extends ALuDateAdapter<string> implements ILuDa
 		return this._nativeAdapter.getDay(this.stringToDate(d));
 	}
 
-	add(d: string, count: number, granularity: ELuDateGranularity): string {
+	add(d: string, count: number, granularity: LuDateGranularity): string {
 		return this.dateToString(this._nativeAdapter.add(this.stringToDate(d), count, granularity));
 	}
 

--- a/packages/ng/date/calendar/calendar-input.component.ts
+++ b/packages/ng/date/calendar/calendar-input.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule, FormStyle, getLocaleDayNames, getLocaleFirstDayOfWeek, TranslationWidth } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, Inject, Input, LOCALE_ID, OnInit, Renderer2 } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
-import { ALuDateAdapter, ELuDateGranularity } from '@lucca-front/ng/core';
+import { ALuDateAdapter, ELuDateGranularity, LuDateGranularity } from '@lucca-front/ng/core';
 import { ALuInput } from '@lucca-front/ng/input';
 import { LuCalendarItemFactory } from './calendar-item.factory';
 import { ICalendarItem } from './calendar-item.interface';
@@ -30,10 +30,10 @@ import { ICalendarItem } from './calendar-item.interface';
 export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlValueAccessor, OnInit, Validator {
 	@Input() min?: D;
 	@Input() max?: D;
-	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+	@Input() granularity: LuDateGranularity = ELuDateGranularity.day;
 	@Input() startOn: D = this._adapter.forgeToday();
 
-	viewGranularity: ELuDateGranularity;
+	viewGranularity: LuDateGranularity;
 	header: ICalendarItem<D>;
 	items: ICalendarItem<D>[] = [];
 	get mod() {

--- a/packages/ng/date/calendar/calendar-item.class.ts
+++ b/packages/ng/date/calendar/calendar-item.class.ts
@@ -1,4 +1,4 @@
-import { ELuDateGranularity } from '@lucca-front/ng/core';
+import { ELuDateGranularity, LuDateGranularity } from '@lucca-front/ng/core';
 import { ICalendarItem } from './calendar-item.interface';
 
 export abstract class ACalendarItem<D> implements ICalendarItem<D> {
@@ -9,7 +9,7 @@ export abstract class ACalendarItem<D> implements ICalendarItem<D> {
 	mods: string[] = [];
 	isDisabled = false;
 	label: string;
-	readonly granularity: ELuDateGranularity;
+	readonly granularity: LuDateGranularity;
 }
 export class DayItem<D> extends ACalendarItem<D> implements ICalendarItem<D> {
 	override readonly granularity = ELuDateGranularity.day;

--- a/packages/ng/date/calendar/calendar-item.interface.ts
+++ b/packages/ng/date/calendar/calendar-item.interface.ts
@@ -1,4 +1,4 @@
-import { ELuDateGranularity } from '@lucca-front/ng/core';
+import { LuDateGranularity } from '@lucca-front/ng/core';
 
 export interface ICalendarItem<D> {
 	id: string;
@@ -6,5 +6,5 @@ export interface ICalendarItem<D> {
 	mods: string[];
 	label: string;
 	isDisabled: boolean;
-	granularity: ELuDateGranularity;
+	granularity: LuDateGranularity;
 }

--- a/packages/ng/date/input/date-input.directive.ts
+++ b/packages/ng/date/input/date-input.directive.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectorRef, Directive, ElementRef, forwardRef, HostListener, Input, OnInit, Renderer2 } from '@angular/core';
 import { AbstractControl, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
-import { ALuDateAdapter, ELuDateGranularity, getIntl } from '@lucca-front/ng/core';
+import { ALuDateAdapter, ELuDateGranularity, getIntl, LuDateGranularity } from '@lucca-front/ng/core';
 import { ALuInput } from '@lucca-front/ng/input';
 import { LU_DATE_INPUT_TRANSLATIONS } from './date-input.translate';
 
@@ -24,7 +24,7 @@ export class LuDateInputDirective<D> extends ALuInput<D, HTMLInputElement> imple
 	private _focused = false;
 	@Input() min?: D;
 	@Input() max?: D;
-	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+	@Input() granularity: LuDateGranularity = ELuDateGranularity.day;
 
 	@Input() override set placeholder(p: string) {
 		this._elementRef.nativeElement.placeholder = p;

--- a/packages/ng/date/picker/date-picker.component.ts
+++ b/packages/ng/date/picker/date-picker.component.ts
@@ -5,7 +5,7 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, EventEmitter, forwardRef, Input, Output, TemplateRef, ViewChild } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ALuDateAdapter, ELuDateGranularity } from '@lucca-front/ng/core';
+import { ALuDateAdapter, ELuDateGranularity, LuDateGranularity } from '@lucca-front/ng/core';
 import { ALuPickerPanel } from '@lucca-front/ng/picker';
 import { luTransformPopover } from '@lucca-front/ng/popover';
 import { LuCalendarInputComponent } from '../calendar';
@@ -31,7 +31,7 @@ export class LuDatePickerComponent<D = Date> extends ALuPickerPanel<D> {
 
 	@Input() min?: D;
 	@Input() max?: D;
-	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+	@Input() granularity: LuDateGranularity = ELuDateGranularity.day;
 	@Input() startOn: D = this._adapter.forgeToday();
 
 	@Output() override close = new EventEmitter<void>();

--- a/packages/ng/date/select/date-select-input.component.ts
+++ b/packages/ng/date/select/date-select-input.component.ts
@@ -1,7 +1,7 @@
 import { Overlay, OverlayModule } from '@angular/cdk/overlay';
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, Input, Renderer2, ViewContainerRef } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
-import { ALuDateAdapter, ELuDateGranularity, getIntl } from '@lucca-front/ng/core';
+import { ALuDateAdapter, ELuDateGranularity, LuDateGranularity, getIntl } from '@lucca-front/ng/core';
 import { LuInputClearerComponent, LuInputDirective, LuInputDisplayerDirective } from '@lucca-front/ng/input';
 import { ILuInputWithPicker } from '@lucca-front/ng/picker';
 import { ALuSelectInputComponent } from '@lucca-front/ng/select';
@@ -32,7 +32,7 @@ import { LU_DATE_SELECT_INPUT_TRANSLATIONS } from './date-select-input.translate
 export class LuDateSelectInputComponent<D> extends ALuSelectInputComponent<D> implements ControlValueAccessor, ILuInputWithPicker<D>, AfterViewInit, Validator {
 	@Input() min?: D;
 	@Input() max?: D;
-	@Input() granularity: ELuDateGranularity = ELuDateGranularity.day;
+	@Input() granularity: LuDateGranularity = ELuDateGranularity.day;
 	@Input('placeholder') override set inputPlaceholder(p: string) {
 		this._placeholder = p;
 	}


### PR DESCRIPTION
## Description

It is annoying to expose enum in templates, in addition to pass an enum value, we can now pass a string:

```html
<!-- New syntax -->
<lu-date-select [granularity]="'month'" />

<!-- Previous but still working syntax -->
<lu-date-select [granularity]="ELuDateGranularity.month" />
```

-----

