### PR TITLE
Show index table link

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -12,6 +12,7 @@
 	border-radius: var(--components-indexTable-border-radius);
 	background-color: var(--components-indexTable-background-color);
 	color: var(--palettes-neutral-800);
+	contain: paint;
 
 	@at-root ($atRoot) {
 		.indexTable-head {
@@ -39,7 +40,6 @@
 
 		.indexTable-body-row {
 			border-radius: var(--commons-borderRadius-L);
-			cursor: pointer;
 		}
 
 		.indexTable-head-row-transparentCell,
@@ -56,6 +56,9 @@
 		.indexTable-body-row-transparentCell {
 			vertical-align: middle;
 			padding: var(--pr-t-spacings-50) 0;
+			position: relative;
+			z-index: 3;
+
 			&:not(:first-child) {
 				padding-right: var(--components-indexTable-cell-padding);
 			}
@@ -80,6 +83,10 @@
 
 			&:last-child {
 				--components-indexTable-cell-padding-right: var(--components-indexTable-cell-padding);
+			}
+
+			&:not(:has(button, a, input, textarea, select, [tabindex='0'])) {
+				pointer-events: none;
 			}
 		}
 
@@ -183,6 +190,12 @@
 
 		.indexTable-body-row-cell-link {
 			text-decoration: none;
+
+			&::after {
+				content: '';
+				position: absolute;
+				inset: 0 -9999px;
+			}
 
 			&,
 			&:hover {

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -176,9 +176,22 @@
 			margin: 2px 0 0 var(--pr-t-spacings-50);
 		}
 
-		// Hidden element that take focus when the row is focused
+		// indexTable-body-row-cell-action is deprecated
 		.indexTable-body-row-cell-action {
 			@include a11y.mask;
+		}
+
+		.indexTable-body-row-cell-link {
+			text-decoration: none;
+
+			&,
+			&:hover {
+				color: currentColor;
+			}
+
+			&:focus-visible {
+				outline: none;
+			}
 		}
 
 		.indexTable-body-row-cellTitle {

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -27,6 +27,7 @@
 		//There might be more than one footer
 		.indexTable-foot {
 			display: table-row-group;
+
 			&:is(tfoot) {
 				display: table-footer-group;
 			}
@@ -75,6 +76,7 @@
 			padding-right: var(--components-indexTable-cell-padding-right, var(--components-indexTable-cell-padding));
 
 			--components-indexTable-cell-padding-right: calc(var(--components-indexTable-cell-padding) + 4px);
+
 			~ .indexTable-head-row-cell,
 			~ .indexTable-body-row-cell,
 			~ .indexTable-foot-row-cell {
@@ -85,7 +87,7 @@
 				--components-indexTable-cell-padding-right: var(--components-indexTable-cell-padding);
 			}
 
-			&:not(:has(button, a, input, textarea, select, [tabindex='0'])) {
+			&:not(:has(button, a, input, textarea, select, details, [tabindex='0']), .mod-allowTextSelection) {
 				pointer-events: none;
 			}
 		}
@@ -218,10 +220,13 @@
 			@include button.text;
 			@include button.S;
 			@include button.onlyIconS;
+
 			position: static;
+
 			.lucca-icon {
 				transition: transform var(--commons-animations-durations-fast) ease;
 			}
+
 			// Extend button reactive zone to his whole parent
 			&::before {
 				content: '';
@@ -241,15 +246,18 @@
 		// A wrapper is needed for pagination
 		.indexTableWrapper {
 			@include vars;
+
 			display: flex;
 			flex-direction: column;
 			padding-bottom: var(--pr-t-spacings-100);
 			border-radius: var(--components-indexTable-border-radius);
 			background-color: var(--components-indexTable-background-color);
+
 			.indexTable {
 				flex-grow: 1;
 				padding-bottom: 0;
 			}
+
 			.pagination {
 				align-self: flex-end;
 				padding: var(--pr-t-spacings-50) 0 0 0;

--- a/packages/scss/src/components/indexTable/states.scss
+++ b/packages/scss/src/components/indexTable/states.scss
@@ -1,73 +1,77 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
 @mixin openClosedRow {
-    .indexTable-body-row,
-    .indexTable-foot-row {
-        &.is-closed {
-            display: none;
-        }
-    }
-    .indexTable-body-row-cellTitle-button[aria-expanded='false'] .lucca-icon {
-        transform: rotate(180deg);
-    }
-    // subTotal in header are not displayed when the row is open
-    .indexTable-body-row:has(.indexTable-body-row-cellTitle-button[aria-expanded='true']) {
-        .indexTable-body-row-subTotal {
-            display: none;
-        }
-    }
+	.indexTable-body-row,
+	.indexTable-foot-row {
+		&.is-closed {
+			display: none;
+		}
+	}
+	.indexTable-body-row-cellTitle-button[aria-expanded='false'] .lucca-icon {
+		transform: rotate(180deg);
+	}
+	// subTotal in header are not displayed when the row is open
+	.indexTable-body-row:has(.indexTable-body-row-cellTitle-button[aria-expanded='true']) {
+		.indexTable-body-row-subTotal {
+			display: none;
+		}
+	}
 }
 
 @mixin focusedRow {
-    .indexTable-body-row {
-        // We can't use focus-within because it would show actions when focusing checkboxs
-        &:has(.indexTable-body-row-cell-action:focus, .indexTable-body-row-cell.mod-actions:focus-within) {
-            --components-indexTable-cell-subAction-opacity: 1;
-        }
-        &:has(.indexTable-body-row-cell-action:focus) {
-            --components-indexTable-outline-opacity: 1;
-        }
-    }
+	.indexTable-body-row {
+		// We can't use focus-within because it would show actions when focusing checkboxs
+		&:has(
+				.indexTable-body-row-cell-action:focus-visible,
+				.indexTable-body-row-cell-link:focus-visible,
+				.indexTable-body-row-cell.mod-actions:focus-within
+			) {
+			--components-indexTable-cell-subAction-opacity: 1;
+		}
+		&:has(.indexTable-body-row-cell-action:focus-visible, .indexTable-body-row-cell-link:focus-visible) {
+			--components-indexTable-outline-opacity: 1;
+		}
+	}
 }
 
 @mixin hoveredRow {
-    .indexTable-body-row:hover {
-        @include hoveredCells;
-    }
+	.indexTable-body-row:hover {
+		@include hoveredCells;
+	}
 }
 
 // selectable selected rows
 @mixin selectableSelectedRow {
-    .indexTable-body-row:has(.checkbox-input:checked, .checkboxField-input:checked) {
-        @include selectedCells;
-    }
+	.indexTable-body-row:has(.checkbox-input:checked, .checkboxField-input:checked) {
+		@include selectedCells;
+	}
 }
 
 // on selectable indexTable : no hover effect on lines when hovering the checkbox
 @mixin selectableHoveredRow {
-    .indexTable-body-row:hover:has(.indexTable-body-row-transparentCell:hover) {
-        // cancel for all :hover css vars
-        --components-indexTable-cell-shadow: var(--components-indexTable-cell-shadow-default);
-        --components-indexTable-cell-inset-x: 0px;
-        --components-indexTable-cell-inset-y: 0px;
-        --components-indexTable-cell-subAction-opacity: 0;
-    }
+	.indexTable-body-row:hover:has(.indexTable-body-row-transparentCell:hover) {
+		// cancel for all :hover css vars
+		--components-indexTable-cell-shadow: var(--components-indexTable-cell-shadow-default);
+		--components-indexTable-cell-inset-x: 0px;
+		--components-indexTable-cell-inset-y: 0px;
+		--components-indexTable-cell-subAction-opacity: 0;
+	}
 }
 
 // states vars
 @mixin selectedCells {
-    // !important here for overriding a potential overrided non blank row background color
-    --components-indexTable-cell-background-color: var(--components-indexTable-cell-background-color-selected) !important;
-    // !important here if for overriding a potential selectableHoveredRow reset
-    --components-indexTable-cell-shadow: var(--components-indexTable-cell-shadow-selected) !important;
-    // if selected stackable row : we also change the stacks background color
-    --components-indexTable-stack-svg: var(--components-indexTable-stack-svg-selected);
+	// !important here for overriding a potential overrided non blank row background color
+	--components-indexTable-cell-background-color: var(--components-indexTable-cell-background-color-selected) !important;
+	// !important here if for overriding a potential selectableHoveredRow reset
+	--components-indexTable-cell-shadow: var(--components-indexTable-cell-shadow-selected) !important;
+	// if selected stackable row : we also change the stacks background color
+	--components-indexTable-stack-svg: var(--components-indexTable-stack-svg-selected);
 }
 
 @mixin hoveredCells {
-    --components-indexTable-cell-shadow: var(--components-indexTable-cell-shadow-hover);
-    --components-indexTable-cell-inset-x: var(--components-indexTable-hover-offset-x);
-    --components-indexTable-cell-inset-y: var(--components-indexTable-hover-offset-y);
-    --components-indexTable-cell-z-index: 2;
-    --components-indexTable-cell-subAction-opacity: 1;
+	--components-indexTable-cell-shadow: var(--components-indexTable-cell-shadow-hover);
+	--components-indexTable-cell-inset-x: var(--components-indexTable-hover-offset-x);
+	--components-indexTable-cell-inset-y: var(--components-indexTable-hover-offset-y);
+	--components-indexTable-cell-z-index: 2;
+	--components-indexTable-cell-subAction-opacity: 1;
 }

--- a/stories/documentation/listings/index-table/index-table-actions-touch-detection.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-touch-detection.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableActionsTouchDetectionStory {
-
-}
+interface IndexTableActionsTouchDetectionStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Actions touch detection',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableActionsTouchDetectionStory): string {
@@ -26,8 +22,7 @@ function getTemplate(args: IndexTableActionsTouchDetectionStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -60,4 +55,4 @@ const Template: StoryFn<IndexTableActionsTouchDetectionStory> = (args) => ({
 });
 
 export const ActionsTouchDetection = Template.bind({});
-ActionsTouchDetection.args = { };
+ActionsTouchDetection.args = {};

--- a/stories/documentation/listings/index-table/index-table-actions.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableActionsStory {
-
-}
+interface IndexTableActionsStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Actions',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableActionsStory): string {
@@ -26,8 +22,7 @@ function getTemplate(args: IndexTableActionsStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -50,4 +45,4 @@ const Template: StoryFn<IndexTableActionsStory> = (args) => ({
 });
 
 export const Actions = Template.bind({});
-Actions.args = { };
+Actions.args = {};

--- a/stories/documentation/listings/index-table/index-table-basic.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-basic.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableBasicStory {
-
-}
+interface IndexTableBasicStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Basic',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableBasicStory): string {
@@ -23,16 +19,18 @@ function getTemplate(args: IndexTableBasicStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+			</td>
+			<td class="indexTable-body-row-cell">
 				Content
 			</td>
-			<td class="indexTable-body-row-cell">Content</td>
-			<td class="indexTable-body-row-cell">Content</td>
+			<td class="indexTable-body-row-cell">
+				Content
+			</td>
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -47,4 +45,4 @@ const Template: StoryFn<IndexTableBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { };
+Basic.args = {};

--- a/stories/documentation/listings/index-table/index-table-basic.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-basic.stories.ts
@@ -21,8 +21,15 @@ function getTemplate(args: IndexTableBasicStory): string {
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
+			<td class="indexTable-body-row-cell">Content</td>
+			<td class="indexTable-body-row-cell">Content</td>
+		</tr>
+		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+			</td>
+			<td class="indexTable-body-row-cell mod-allowTextSelection">
+				Content selectable
 			</td>
 			<td class="indexTable-body-row-cell">
 				Content
@@ -32,7 +39,7 @@ function getTemplate(args: IndexTableBasicStory): string {
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
-			<td class="indexTable-body-row-cell">Content</td>
+			<td class="indexTable-body-row-cell"><a href="#">Content actionable</a></td>
 			<td class="indexTable-body-row-cell">Content</td>
 		</tr>
 	</tbody>

--- a/stories/documentation/listings/index-table/index-table-footer.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-footer.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableFooterStory {
-
-}
+interface IndexTableFooterStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Footer',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableFooterStory): string {
@@ -23,7 +19,7 @@ function getTemplate(args: IndexTableFooterStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -31,7 +27,7 @@ function getTemplate(args: IndexTableFooterStory): string {
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -57,7 +53,7 @@ function getTemplate(args: IndexTableFooterStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -72,7 +68,7 @@ function getTemplate(args: IndexTableFooterStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -98,4 +94,4 @@ const Template: StoryFn<IndexTableFooterStory> = (args) => ({
 });
 
 export const Footer = Template.bind({});
-Footer.args = { };
+Footer.args = {};

--- a/stories/documentation/listings/index-table/index-table-footer.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-footer.stories.ts
@@ -20,7 +20,6 @@ function getTemplate(args: IndexTableFooterStory): string {
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell u-textRight">100,00 €</td>
@@ -28,7 +27,6 @@ function getTemplate(args: IndexTableFooterStory): string {
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell u-textRight">50,00 €</td>
@@ -54,7 +52,6 @@ function getTemplate(args: IndexTableFooterStory): string {
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell u-textRight">126,00 €</td>
@@ -69,7 +66,6 @@ function getTemplate(args: IndexTableFooterStory): string {
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				Content
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell u-textRight">133,00 €</td>

--- a/stories/documentation/listings/index-table/index-table-interactive-nested-selectable.stories.html
+++ b/stories/documentation/listings/index-table/index-table-interactive-nested-selectable.stories.html
@@ -4,11 +4,16 @@
 			<th class="indexTable-head-row-transparentCell" scope="col">
 				<label class="formLabel u-mask" for="allchbx">Select all items</label>
 				<span class="checkboxField indexTable-head-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="allchbx" checked aria-checked="mixed"
+					<input
+						class="checkboxField-input"
+						type="checkbox"
+						id="allchbx"
+						checked
+						aria-checked="mixed"
 						aria-controls="r0chbx r1chbx r2chbx r3chbx r4chbx r5chbx r6chbx r7chbx r8chbx"
-						(click)="toggleCheckbox($event,'allchbx', '#r0chbx, #r1chbx, #r2chbx, #r3chbx, #r4chbx, #r5chbx, #r6chbx, #r7chbx, #r8chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+						(click)="toggleCheckbox($event,'allchbx', '#r0chbx, #r1chbx, #r2chbx, #r3chbx, #r4chbx, #r5chbx, #r6chbx, #r7chbx, #r8chbx')"
+					/>
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</th>
 			<th class="indexTable-head-row-transparentCell" scope="col"></th>
@@ -20,20 +25,30 @@
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row" id="r0">
 			<th class="indexTable-body-row-transparentCell">
-				<label class=" formLabel u-mask" for="r0chbx">Select all lines for 2021</label>
+				<label class="formLabel u-mask" for="r0chbx">Select all lines for 2021</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" checked aria-checked="mixed" type="checkbox" id="r0chbx"
+					<input
+						class="checkboxField-input"
+						checked
+						aria-checked="mixed"
+						type="checkbox"
+						id="r0chbx"
 						aria-controls="r1chbx r2chbx r3chbx r4chbx r5chbx"
-						(click)="toggleCheckbox($event,'r0chbx', '#r1chbx, #r2chbx, #r3chbx, #r4chbx, #r5chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+						(click)="toggleCheckbox($event,'r0chbx', '#r1chbx, #r2chbx, #r3chbx, #r4chbx, #r5chbx')"
+					/>
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</th>
 			<th class="indexTable-body-row-transparentCell" colspan="4" id="y2021">
 				<div class="indexTable-body-row-cellTitle">
-					<button class="indexTable-body-row-cellTitle-button button" aria-expanded="true"
-						aria-controls="r1 r2 r3 r4 r5" type="button"
-						(click)="toggleRows($event,'r0btn', '#r1, #r2, #r3, #r4, #r5')" id="r0btn">
+					<button
+						class="indexTable-body-row-cellTitle-button button"
+						aria-expanded="true"
+						aria-controls="r1 r2 r3 r4 r5"
+						type="button"
+						(click)="toggleRows($event,'r0btn', '#r1, #r2, #r3, #r4, #r5')"
+						id="r0btn"
+					>
 						<span class="lucca-icon icon-arrowChevronTop" aria-hidden="true"></span>
 						<span class="u-mask">Hide details</span>
 					</button>
@@ -46,16 +61,26 @@
 			<th class="indexTable-body-row-transparentCell" header="y2021" colspan="2">
 				<label class="formLabel u-mask" for="r1chbx">Select all items for september 2021</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r1chbx" aria-controls="r2chbx"
-						(click)="toggleCheckbox($event,'r1chbx', '#r2chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input
+						class="checkboxField-input"
+						type="checkbox"
+						id="r1chbx"
+						aria-controls="r2chbx"
+						(click)="toggleCheckbox($event,'r1chbx', '#r2chbx')"
+					/>
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</th>
 			<th class="indexTable-body-row-transparentCell" colspan="3" id="september" header="y2021">
 				<div class="indexTable-body-row-cellTitle">
-					<button class="indexTable-body-row-cellTitle-button button" aria-expanded="true"
-						aria-controls="r2" type="button" (click)="toggleRows($event,'r1btn', '#r2')" id="r1btn">
+					<button
+						class="indexTable-body-row-cellTitle-button button"
+						aria-expanded="true"
+						aria-controls="r2"
+						type="button"
+						(click)="toggleRows($event,'r1btn', '#r2')"
+						id="r1btn"
+					>
 						<span class="lucca-icon icon-arrowChevronTop" aria-hidden="true"></span>
 						<span class="u-mask">Hide details</span>
 					</button>
@@ -68,15 +93,12 @@
 			<td class="indexTable-body-row-transparentCell" header="y2021 september" colspan="2">
 				<label class="formLabel u-mask" for="r2chbx">Select this item</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r2chbx"
-						(click)="toggleCheckbox($event,'r2chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input class="checkboxField-input" type="checkbox" id="r2chbx" (click)="toggleCheckbox($event,'r2chbx')" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">Content</td>
@@ -85,18 +107,28 @@
 			<th class="indexTable-body-row-transparentCell" header="y2021" colspan="2">
 				<label class="formLabel u-mask" for="r3chbx">Select all items for october 2021</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r3chbx" aria-controls="r4chbx r5chbx"
-						(click)="toggleCheckbox($event,'r3chbx', '#r4chbx, #r5chbx')" checked
-						aria-checked="mixed" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input
+						class="checkboxField-input"
+						type="checkbox"
+						id="r3chbx"
+						aria-controls="r4chbx r5chbx"
+						(click)="toggleCheckbox($event,'r3chbx', '#r4chbx, #r5chbx')"
+						checked
+						aria-checked="mixed"
+					/>
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</th>
 			<th class="indexTable-body-row-transparentCell" colspan="3" id="october" header="y2021">
 				<div class="indexTable-body-row-cellTitle">
-					<button class="indexTable-body-row-cellTitle-button button" aria-expanded="true"
-						aria-controls="r4 r5" type="button" (click)="toggleRows($event,'r3btn', '#r4, #r5')"
-						id="r3btn">
+					<button
+						class="indexTable-body-row-cellTitle-button button"
+						aria-expanded="true"
+						aria-controls="r4 r5"
+						type="button"
+						(click)="toggleRows($event,'r3btn', '#r4, #r5')"
+						id="r3btn"
+					>
 						<span class="lucca-icon icon-arrowChevronTop" aria-hidden="true"></span>
 						<span class="u-mask">Hide details</span>
 					</button>
@@ -109,15 +141,12 @@
 			<td class="indexTable-body-row-transparentCell" header="y2021 october" colspan="2">
 				<label class="formLabel u-mask" for="r4chbx">Select this item</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" checked id="r4chbx"
-						(click)="toggleCheckbox($event,'r4chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input class="checkboxField-input" type="checkbox" checked id="r4chbx" (click)="toggleCheckbox($event,'r4chbx')" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
@@ -126,15 +155,12 @@
 			<td class="indexTable-body-row-transparentCell" header="y2021 october" colspan="2">
 				<label class="formLabel u-mask" for="r5chbx">Select this item</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r5chbx"
-						(click)="toggleCheckbox($event,'r5chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input class="checkboxField-input" type="checkbox" id="r5chbx" (click)="toggleCheckbox($event,'r5chbx')" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
@@ -145,17 +171,26 @@
 			<th class="indexTable-body-row-transparentCell">
 				<label class="formLabel u-mask" for="r6chbx">Select all items for 2022</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r6chbx" aria-controls="r7chbx r8chbx"
-						(click)="toggleCheckbox($event,'r6chbx', '#r7chbx, #r8chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input
+						class="checkboxField-input"
+						type="checkbox"
+						id="r6chbx"
+						aria-controls="r7chbx r8chbx"
+						(click)="toggleCheckbox($event,'r6chbx', '#r7chbx, #r8chbx')"
+					/>
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</th>
 			<th class="indexTable-body-row-transparentCell" colspan="4" id="y2022">
 				<div class="indexTable-body-row-cellTitle">
-					<button class="indexTable-body-row-cellTitle-button button" aria-expanded="true"
-						aria-controls="r7 r8" type="button" (click)="toggleRows($event,'r6btn', '#r7, #r8')"
-						id="r6btn">
+					<button
+						class="indexTable-body-row-cellTitle-button button"
+						aria-expanded="true"
+						aria-controls="r7 r8"
+						type="button"
+						(click)="toggleRows($event,'r6btn', '#r7, #r8')"
+						id="r6btn"
+					>
 						<span class="lucca-icon icon-arrowChevronTop" aria-hidden="true"></span>
 						<span class="u-mask">Hide details</span>
 					</button>
@@ -168,16 +203,26 @@
 			<th class="indexTable-body-row-transparentCell" header="y2022" colspan="2">
 				<label class="formLabel u-mask" for="r7chbx">Select all items for january 2022</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r7chbx" aria-controls="r8chbx"
-						(click)="toggleCheckbox($event,'r7chbx', '#r8chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input
+						class="checkboxField-input"
+						type="checkbox"
+						id="r7chbx"
+						aria-controls="r8chbx"
+						(click)="toggleCheckbox($event,'r7chbx', '#r8chbx')"
+					/>
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</th>
 			<th class="indexTable-body-row-transparentCell" colspan="3" id="january" header="y2022">
 				<div class="indexTable-body-row-cellTitle">
-					<button class="indexTable-body-row-cellTitle-button button" aria-expanded="true"
-						aria-controls="r8" type="button" (click)="toggleRows($event,'r7btn', '#r8')" id="r7btn">
+					<button
+						class="indexTable-body-row-cellTitle-button button"
+						aria-expanded="true"
+						aria-controls="r8"
+						type="button"
+						(click)="toggleRows($event,'r7btn', '#r8')"
+						id="r7btn"
+					>
 						<span class="lucca-icon icon-arrowChevronTop" aria-hidden="true"></span>
 						<span class="u-mask">Hide details</span>
 					</button>
@@ -190,15 +235,12 @@
 			<td class="indexTable-body-row-transparentCell" header="y2022 january" colspan="2">
 				<label class="formLabel u-mask" for="r8chbx">Select this item</label>
 				<span class="checkboxField indexTable-body-row-cell-checkbox">
-					<input class="checkboxField-input" type="checkbox" id="r8chbx"
-						(click)="toggleCheckbox($event,'r8chbx')" />
-					<span class="checkboxField-icon" aria-hidden="true"><span
-							class="checkboxField-icon-check"></span></span>
+					<input class="checkboxField-input" type="checkbox" id="r8chbx" (click)="toggleCheckbox($event,'r8chbx')" />
+					<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">Content</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">Content</td>

--- a/stories/documentation/listings/index-table/index-table-layout-fixed-responsive.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-layout-fixed-responsive.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableLayoutFixedResponsiveStory {
-
-}
+interface IndexTableLayoutFixedResponsiveStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Layout Fixed Responsive',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableLayoutFixedResponsiveStory): string {
@@ -24,8 +20,7 @@ function getTemplate(args: IndexTableLayoutFixedResponsiveStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -33,8 +28,7 @@ function getTemplate(args: IndexTableLayoutFixedResponsiveStory): string {
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -42,8 +36,7 @@ function getTemplate(args: IndexTableLayoutFixedResponsiveStory): string {
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -59,4 +52,4 @@ const Template: StoryFn<IndexTableLayoutFixedResponsiveStory> = (args) => ({
 });
 
 export const LayoutFixedResponsive = Template.bind({});
-LayoutFixedResponsive.args = { };
+LayoutFixedResponsive.args = {};

--- a/stories/documentation/listings/index-table/index-table-layout-fixed.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-layout-fixed.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableLayoutFixedStory {
-
-}
+interface IndexTableLayoutFixedStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Layout Fixed',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableLayoutFixedStory): string {
@@ -24,8 +20,7 @@ function getTemplate(args: IndexTableLayoutFixedStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -33,8 +28,7 @@ function getTemplate(args: IndexTableLayoutFixedStory): string {
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -42,8 +36,7 @@ function getTemplate(args: IndexTableLayoutFixedStory): string {
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -59,4 +52,4 @@ const Template: StoryFn<IndexTableLayoutFixedStory> = (args) => ({
 });
 
 export const LayoutFixed = Template.bind({});
-LayoutFixed.args = { };
+LayoutFixed.args = {};

--- a/stories/documentation/listings/index-table/index-table-mass-selection-and-pagination.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-mass-selection-and-pagination.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableMassSelectionAndPaginationStory {
-
-}
+interface IndexTableMassSelectionAndPaginationStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Mass Selection And Pagination',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableMassSelectionAndPaginationStory): string {
@@ -49,8 +45,7 @@ function getTemplate(args: IndexTableMassSelectionAndPaginationStory): string {
 					</span>
 				</td>
 				<td class="indexTable-body-row-cell">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				</td>
 				<td class="indexTable-body-row-cell">Content</td>
 				<td class="indexTable-body-row-cell">Content</td>
@@ -65,8 +60,7 @@ function getTemplate(args: IndexTableMassSelectionAndPaginationStory): string {
 					</span>
 				</td>
 				<td class="indexTable-body-row-cell">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				</td>
 				<td class="indexTable-body-row-cell">Content</td>
 				<td class="indexTable-body-row-cell">Content</td>
@@ -105,4 +99,4 @@ const Template: StoryFn<IndexTableMassSelectionAndPaginationStory> = (args) => (
 });
 
 export const Pagination = Template.bind({});
-Pagination.args = { };
+Pagination.args = {};

--- a/stories/documentation/listings/index-table/index-table-nested-selectable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-nested-selectable.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableNestedSelectableStory {
-
-}
+interface IndexTableNestedSelectableStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Nested Selectable',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableNestedSelectableStory): string {
@@ -84,8 +80,7 @@ function getTemplate(args: IndexTableNestedSelectableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">Content</td>
@@ -121,8 +116,7 @@ function getTemplate(args: IndexTableNestedSelectableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
@@ -137,8 +131,7 @@ function getTemplate(args: IndexTableNestedSelectableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
@@ -197,8 +190,7 @@ function getTemplate(args: IndexTableNestedSelectableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">Content</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">Content</td>
@@ -214,4 +206,4 @@ const Template: StoryFn<IndexTableNestedSelectableStory> = (args) => ({
 });
 
 export const NestedSelectable = Template.bind({});
-NestedSelectable.args = { };
+NestedSelectable.args = {};

--- a/stories/documentation/listings/index-table/index-table-nested-sub-totals.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-nested-sub-totals.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableNestedSubTotalsStory {
-
-}
+interface IndexTableNestedSubTotalsStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Nested Sub Totals',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableNestedSubTotalsStory): string {
@@ -41,8 +37,8 @@ function getTemplate(args: IndexTableNestedSubTotalsStory): string {
 		</tr>
 		<tr class="indexTable-body-row" id="r1">
 			<td class="indexTable-body-row-cell" header="y2021">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+				
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 			<td class="indexTable-body-row-cell u-textRight" header="y2021">
@@ -51,8 +47,7 @@ function getTemplate(args: IndexTableNestedSubTotalsStory): string {
 		</tr>
 		<tr class="indexTable-body-row" id="r2">
 			<td class="indexTable-body-row-cell" header="y2021">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 			<td class="indexTable-body-row-cell u-textRight" header="y2021">
@@ -61,8 +56,7 @@ function getTemplate(args: IndexTableNestedSubTotalsStory): string {
 		</tr>
 		<tr class="indexTable-body-row" id="r3">
 			<td class="indexTable-body-row-cell" header="y2021">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 			<td class="indexTable-body-row-cell u-textRight" header="y2021">
@@ -97,8 +91,7 @@ function getTemplate(args: IndexTableNestedSubTotalsStory): string {
 		</tr>
 		<tr class="indexTable-body-row" id="r6">
 			<td class="indexTable-body-row-cell" header="y2022">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022">Content</td>
 			<td class="indexTable-body-row-cell u-textRight" header="y2022">
@@ -133,8 +126,7 @@ function getTemplate(args: IndexTableNestedSubTotalsStory): string {
 		</tr>
 		<tr class="indexTable-body-row is-closed" id="r9">
 			<td class="indexTable-body-row-cell" header="y2023">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2023">Content</td>
 			<td class="indexTable-body-row-cell u-textRight" header="y2023">
@@ -165,4 +157,4 @@ const Template: StoryFn<IndexTableNestedSubTotalsStory> = (args) => ({
 });
 
 export const NestedSubTotals = Template.bind({});
-NestedSubTotals.args = { };
+NestedSubTotals.args = {};

--- a/stories/documentation/listings/index-table/index-table-nested.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-nested.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableNestedStory {
-
-}
+interface IndexTableNestedStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Nested',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableNestedStory): string {
@@ -35,24 +31,21 @@ function getTemplate(args: IndexTableNestedStory): string {
 		</tr>
 		<tr class="indexTable-body-row" id="r1">
 			<td class="indexTable-body-row-cell" header="y2021">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 		</tr>
 		<tr class="indexTable-body-row" id="r2">
 			<td class="indexTable-body-row-cell" header="y2021">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 		</tr>
 		<tr class="indexTable-body-row" id="r3">
 			<td class="indexTable-body-row-cell" header="y2021">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021">Content</td>
@@ -73,8 +66,7 @@ function getTemplate(args: IndexTableNestedStory): string {
 		</tr>
 		<tr class="indexTable-body-row" id="r5">
 			<td class="indexTable-body-row-cell" header="y2022">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022">Content</td>
 			<td class="indexTable-body-row-cell" header="y2022">Content</td>
@@ -89,4 +81,4 @@ const Template: StoryFn<IndexTableNestedStory> = (args) => ({
 });
 
 export const Nested = Template.bind({});
-Nested.args = { };
+Nested.args = {};

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list-custom.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list-custom.stories.ts
@@ -36,14 +36,14 @@ function getTemplate(args: IndexTableResponsiveCardListCustomStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">Lorem ipsum dolor</a>
+				<a href="#" class="indexTable-body-row-cell-link">Lorem</a>
 			</td>
 			<td class="indexTable-body-row-cell">Aliquam vestibulum pulvinar luctus</td>
 			<td class="indexTable-body-row-cell"><strong>122,00 €</strong></td>
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">Vivamus a accumsan</a>
+				<a href="#" class="indexTable-body-row-cell-link">Lorem</a>
 			</td>
 			<td class="indexTable-body-row-cell">Phasellus ullamcorper vehicula diam in dignissim. Mauris cursus volutpat leo eu convallis. Sed sed scelerisque libero</td>
 			<td class="indexTable-body-row-cell"><strong>56,50 €</strong></td>

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list-custom.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list-custom.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableResponsiveCardListCustomStory {
-
-}
+interface IndexTableResponsiveCardListCustomStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Responsive Card List Custom',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableResponsiveCardListCustomStory): string {
@@ -40,16 +36,14 @@ function getTemplate(args: IndexTableResponsiveCardListCustomStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Lorem ipsum dolor
+				<a href="#" class="indexTable-body-row-cell-action">Lorem ipsum dolor</a>
 			</td>
 			<td class="indexTable-body-row-cell">Aliquam vestibulum pulvinar luctus</td>
 			<td class="indexTable-body-row-cell"><strong>122,00 €</strong></td>
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Vivamus a accumsan
+				<a href="#" class="indexTable-body-row-cell-action">Vivamus a accumsan</a>
 			</td>
 			<td class="indexTable-body-row-cell">Phasellus ullamcorper vehicula diam in dignissim. Mauris cursus volutpat leo eu convallis. Sed sed scelerisque libero</td>
 			<td class="indexTable-body-row-cell"><strong>56,50 €</strong></td>
@@ -64,4 +58,4 @@ const Template: StoryFn<IndexTableResponsiveCardListCustomStory> = (args) => ({
 });
 
 export const ResponsiveCardListCustom = Template.bind({});
-ResponsiveCardListCustom.args = { };
+ResponsiveCardListCustom.args = {};

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list-label.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list-label.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableResponsiveCardListLabelStory {
-
-}
+interface IndexTableResponsiveCardListLabelStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Responsive Card List Labels',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableResponsiveCardListLabelStory): string {
@@ -24,8 +20,8 @@ function getTemplate(args: IndexTableResponsiveCardListLabelStory): string {
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
 				<div class="indexTable-body-row-cell-content" data-label="Label 1">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
+					
 				</div>
 			</td>
 			<td class="indexTable-body-row-cell">
@@ -42,8 +38,8 @@ function getTemplate(args: IndexTableResponsiveCardListLabelStory): string {
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
 				<div class="indexTable-body-row-cell-content" data-label="Label 1">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
+					
 				</div>
 			</td>
 			<td class="indexTable-body-row-cell">
@@ -58,7 +54,8 @@ function getTemplate(args: IndexTableResponsiveCardListLabelStory): string {
 			</td>
 		</tr>
 	</tbody>
-</table>`;}
+</table>`;
+}
 
 const Template: StoryFn<IndexTableResponsiveCardListLabelStory> = (args) => ({
 	props: args,
@@ -66,4 +63,4 @@ const Template: StoryFn<IndexTableResponsiveCardListLabelStory> = (args) => ({
 });
 
 export const ResponsiveCardListLabel = Template.bind({});
-ResponsiveCardListLabel.args = { };
+ResponsiveCardListLabel.args = {};

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list-label.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list-label.stories.ts
@@ -21,7 +21,6 @@ function getTemplate(args: IndexTableResponsiveCardListLabelStory): string {
 			<td class="indexTable-body-row-cell">
 				<div class="indexTable-body-row-cell-content" data-label="Label 1">
 					<a href="#" class="indexTable-body-row-cell-link">Content</a>
-					
 				</div>
 			</td>
 			<td class="indexTable-body-row-cell">

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list-nested.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list-nested.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableResponsiveCardListNestedStory {
-
-}
+interface IndexTableResponsiveCardListNestedStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Responsive Card List Nested',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableResponsiveCardListNestedStory): string {
@@ -84,8 +80,7 @@ function getTemplate(args: IndexTableResponsiveCardListNestedStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 september">Content</td>
@@ -121,8 +116,8 @@ function getTemplate(args: IndexTableResponsiveCardListNestedStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+				
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
@@ -137,8 +132,7 @@ function getTemplate(args: IndexTableResponsiveCardListNestedStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
@@ -197,8 +191,7 @@ function getTemplate(args: IndexTableResponsiveCardListNestedStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">Content</td>
 			<td class="indexTable-body-row-cell" header="y2022 january">Content</td>
@@ -213,4 +206,4 @@ const Template: StoryFn<IndexTableResponsiveCardListNestedStory> = (args) => ({
 });
 
 export const ResponsiveCardListNested = Template.bind({});
-ResponsiveCardListNested.args = { };
+ResponsiveCardListNested.args = {};

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list-nested.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list-nested.stories.ts
@@ -117,7 +117,6 @@ function getTemplate(args: IndexTableResponsiveCardListNestedStory): string {
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				
 			</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>
 			<td class="indexTable-body-row-cell" header="y2021 october">Content</td>

--- a/stories/documentation/listings/index-table/index-table-responsive-card-list.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-responsive-card-list.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableResponsiveCardListStory {
-
-}
+interface IndexTableResponsiveCardListStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Responsive Card List',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableResponsiveCardListStory): string {
@@ -23,16 +19,14 @@ function getTemplate(args: IndexTableResponsiveCardListStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -47,4 +41,4 @@ const Template: StoryFn<IndexTableResponsiveCardListStory> = (args) => ({
 });
 
 export const ResponsiveCardList = Template.bind({});
-ResponsiveCardList.args = { };
+ResponsiveCardList.args = {};

--- a/stories/documentation/listings/index-table/index-table-selectable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-selectable.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableSelectableStory {
-
-}
+interface IndexTableSelectableStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Selectable',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableSelectableStory): string {
@@ -40,8 +36,7 @@ function getTemplate(args: IndexTableSelectableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -56,8 +51,7 @@ function getTemplate(args: IndexTableSelectableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -72,4 +66,4 @@ const Template: StoryFn<IndexTableSelectableStory> = (args) => ({
 });
 
 export const Selectable = Template.bind({});
-Selectable.args = { };
+Selectable.args = {};

--- a/stories/documentation/listings/index-table/index-table-sorted.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-sorted.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableSortedStory {
-
-}
+interface IndexTableSortedStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Sorted',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableSortedStory): string {
@@ -27,16 +23,14 @@ function getTemplate(args: IndexTableSortedStory): string {
 	<tbody class="indexTable-body">
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
 		</tr>
 		<tr class="indexTable-body-row">
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -51,4 +45,4 @@ const Template: StoryFn<IndexTableSortedStory> = (args) => ({
 });
 
 export const Sorted = Template.bind({});
-Sorted.args = { };
+Sorted.args = {};

--- a/stories/documentation/listings/index-table/index-table-stackable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-stackable.stories.ts
@@ -36,8 +36,7 @@ function getTemplate(args: IndexTableStackableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">Content/a>
-				
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -53,7 +52,6 @@ function getTemplate(args: IndexTableStackableStory): string {
 			</td>
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -69,7 +67,6 @@ function getTemplate(args: IndexTableStackableStory): string {
 			</td>
 			<td class="indexTable-body-row-cell">
 				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-				
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>

--- a/stories/documentation/listings/index-table/index-table-stackable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-stackable.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableStackableStory {
-
-}
+interface IndexTableStackableStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Stackable',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableStackableStory): string {
@@ -40,8 +36,8 @@ function getTemplate(args: IndexTableStackableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-action">Content/a>
+				
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -56,8 +52,8 @@ function getTemplate(args: IndexTableStackableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+				
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -72,8 +68,8 @@ function getTemplate(args: IndexTableStackableStory): string {
 				</span>
 			</td>
 			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">See details</a>
-				Content
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+				
 			</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
@@ -88,4 +84,4 @@ const Template: StoryFn<IndexTableStackableStory> = (args) => ({
 });
 
 export const Stackable = Template.bind({});
-Stackable.args = { };
+Stackable.args = {};

--- a/stories/documentation/listings/index-table/index-table-sticky-header.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-sticky-header.stories.ts
@@ -1,14 +1,10 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableStickyHeaderStory {
-
-}
+interface IndexTableStickyHeaderStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Sticky Header',
-	argTypes: {
-
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: IndexTableStickyHeaderStory): string {
@@ -24,32 +20,28 @@ function getTemplate(args: IndexTableStickyHeaderStory): string {
 		<tbody class="indexTable-body">
 			<tr class="indexTable-body-row">
 				<td class="indexTable-body-row-cell">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				</td>
 				<td class="indexTable-body-row-cell">Content</td>
 				<td class="indexTable-body-row-cell">Content</td>
 			</tr>
 			<tr class="indexTable-body-row">
 				<td class="indexTable-body-row-cell">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				</td>
 				<td class="indexTable-body-row-cell">Content</td>
 				<td class="indexTable-body-row-cell">Content</td>
 			</tr>
 			<tr class="indexTable-body-row">
 				<td class="indexTable-body-row-cell">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				</td>
 				<td class="indexTable-body-row-cell">Content</td>
 				<td class="indexTable-body-row-cell">Content</td>
 			</tr>
 			<tr class="indexTable-body-row">
 				<td class="indexTable-body-row-cell">
-					<a href="#" class="indexTable-body-row-cell-action">See details</a>
-					Content
+					<a href="#" class="indexTable-body-row-cell-link">Content</a>
 				</td>
 				<td class="indexTable-body-row-cell">Content</td>
 				<td class="indexTable-body-row-cell">Content</td>
@@ -66,4 +58,4 @@ const Template: StoryFn<IndexTableStickyHeaderStory> = (args) => ({
 });
 
 export const StickyHeader = Template.bind({});
-StickyHeader.args = { };
+StickyHeader.args = {};


### PR DESCRIPTION
## Description

Users have expressed the need to be able to open links in tables to new tabs  (via the right-click menu, for example).
To do this, these links must not be hidden and must be visible in the interface.

`.indexTable-body-row-cell-action` is therefore deprecated and replaced by `.indexTable-body-row-cell-link`, which is its unmasked equivalent, and following @BertrandPodevin's idea, we extend this link so that it can be operated on the whole line, without requiring an `overflow: hidden`, `z-index`, or superimposing itself on other interactive elements.

-----



-----

![Capture d’écran 2024-06-04 à 12 04 23](https://github.com/LuccaSA/lucca-front/assets/64789527/c6c5d1bd-f140-4799-8f72-be490a049daa)
