### PR TITLE
Rosetta mixin

### DIFF
--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -120,3 +120,20 @@ $overflow: 'hidden', 'auto', 'visible', 'scroll';
 		}
 	}
 }
+
+@mixin rosetta($before, $after, $iterations) {
+    @if type-of($iterations) == map {
+        @each $iterationBefore, $iterationAfter in $iterations {
+			@if type-of($iterationAfter) == string {
+            	#{$before}-#{$iterationBefore}: var(#{$after}-#{$iterationAfter});
+			} @else {
+				#{$before}-#{$iterationBefore}: #{$iterationAfter};
+			}
+        }
+    }
+    @else {
+        @each $iteration in $iterations {
+            #{$before}-#{$iteration}: var(#{$after}-#{$iteration});
+        }
+    }
+}


### PR DESCRIPTION
## Description

A mixin for transposing CSS vars from one syntax to another.

-----

Possible examples of use after importing `@use '@lucca-front/scss/src/commons/core';`.

Generate a fallback for the legacy primary palette:
```sass
@include core.rosetta('--palettes-primary', '--palettes-product', ('text', '50', '100', '200', '300', '400', '500', '600', '700', '800', '900'));
```

Generate a fallback for the product palette:
```sass
@include core.rosetta('--palettes-product', '--palettes-primary', ('text', '50', '100', '200', '300', '400', '500', '600', '700', '800', '900'));
```

Generate a fallback for legacy spacings:
```sass
@include core.rosetta('--spacings', '--pr-t-spacings', ('0': '0', 'XXS': '50', 'XS': '100', 'S': '200', 'M': '300', 'L': '400', 'XL': '600', 'XXL': '800', 'auto': 'auto'));
```

Generate a fallback for token spacings:
```sass
@include core.rosetta('--pr-t-spacings', '--spacings', ('0': '0', '25': 0.125rem, '50': 'XXS', '75': 0.375rem, '100': 'XS', '150': 0.75rem, '200': 'S', '300': 'M', '400': 'L', '500': 2.5rem, '600': 'XL', '700': 3.5rem, '800': 'XXL'));
```
Live code here: https://www.sassmeister.com/gist/dac0932931dc76eb512573c794cfffe5

-----
