### PR TITLE
Responsive : add shortcut for queries + add outside option

### DIFF
--- a/packages/scss/src/commons/utils/container.scss
+++ b/packages/scss/src/commons/utils/container.scss
@@ -16,7 +16,7 @@
 	}
 }
 
-// les raccourcis pour min/max/between
+// les raccourcis pour min/max/inside/outside
 
 @mixin min($breakpoint, $property: 'width', $name: '') {
 	@include media.query($breakpoint: $breakpoint, $property: $property, $at: 'container', $name: $name) {
@@ -30,7 +30,7 @@
 	}
 }
 
-@mixin between($breakpoint1, $breakpoint2, $property: 'width', $name: '') {
+@mixin inside($breakpoint1, $breakpoint2, $property: 'width', $name: '') {
 	@include media.queries($breakpoint1, $breakpoint2, $property: $property, $at: 'container', $name: $name) {
 		@content;
 	}
@@ -42,7 +42,7 @@
 	}
 }
 
-// les raccourcis pour minWidth/maxWidth/betweenWidths
+// les raccourcis pour minWidth/maxWidth/insideWidths/outsideWidths
 
 @mixin minWidth($breakpoint, $name: '') {
 	@include media.query($breakpoint, $at: 'container', $name: $name) {
@@ -56,7 +56,7 @@
 	}
 }
 
-@mixin betweenWidths($breakpoint1, $breakpoint2, $name: '') {
+@mixin insideWidths($breakpoint1, $breakpoint2, $name: '') {
 	@include media.queries($breakpoint1, $breakpoint2, $at: 'container', $name: $name) {
 		@content;
 	}
@@ -68,7 +68,7 @@
 	}
 }
 
-// les raccourcis pour minHeight/maxHeight/betweenHeights
+// les raccourcis pour minHeight/maxHeight/insideHeights/outsideHeights
 
 @mixin minHeight($breakpoint, $name: '') {
 	@include media.query($breakpoint, $property: 'height', $at: 'container', $name: $name) {
@@ -82,7 +82,7 @@
 	}
 }
 
-@mixin betweenHeights($breakpoint1, $breakpoint2, $name: '') {
+@mixin insideHeights($breakpoint1, $breakpoint2, $name: '') {
 	@include media.queries($breakpoint1, $breakpoint2, $property: 'height', $at: 'container', $name: $name) {
 		@content;
 	}

--- a/packages/scss/src/commons/utils/container.scss
+++ b/packages/scss/src/commons/utils/container.scss
@@ -36,6 +36,12 @@
 	}
 }
 
+@mixin outside($breakpoint1, $breakpoint2, $property: 'width', $name: '', $inverted: true) {
+	@include media.queries($breakpoint1, $breakpoint2, $property: $property, $at: 'container', $name: $name) {
+		@content;
+	}
+}
+
 // les raccourcis pour minWidth/maxWidth/betweenWidths
 
 @mixin minWidth($breakpoint, $name: '') {
@@ -56,6 +62,12 @@
 	}
 }
 
+@mixin outsideWidths($breakpoint1, $breakpoint2, $name: '') {
+	@include media.queries($breakpoint1, $breakpoint2, $at: 'container', $name: $name, $inverted: true) {
+		@content;
+	}
+}
+
 // les raccourcis pour minHeight/maxHeight/betweenHeights
 
 @mixin minHeight($breakpoint, $name: '') {
@@ -72,6 +84,12 @@
 
 @mixin betweenHeights($breakpoint1, $breakpoint2, $name: '') {
 	@include media.queries($breakpoint1, $breakpoint2, $property: 'height', $at: 'container', $name: $name) {
+		@content;
+	}
+}
+
+@mixin outsideHeights($breakpoint1, $breakpoint2, $name: '') {
+	@include media.queries($breakpoint1, $breakpoint2, $property: 'height', $at: 'container', $name: $name, $inverted: true) {
 		@content;
 	}
 }

--- a/packages/scss/src/commons/utils/container.scss
+++ b/packages/scss/src/commons/utils/container.scss
@@ -4,8 +4,8 @@
 
 // les raccourcis des requêtes simples et multiples
 
-@mixin query($breakpoint, $property: 'width', $max: false, $name: '') {
-	@include media.query($breakpoint: $breakpoint, $property: $property, $max: $max, $at: 'container', $name: $name) {
+@mixin query($breakpoint, $property: 'width', $inverted: false, $name: '') {
+	@include media.query($breakpoint: $breakpoint, $property: $property, $inverted: $inverted, $at: 'container', $name: $name) {
 		@content;
 	}
 }
@@ -25,7 +25,7 @@
 }
 
 @mixin max($breakpoint, $property: 'width', $name: '') {
-	@include media.query($breakpoint, $property: $property, $max: true, $at: 'container', $name: $name) {
+	@include media.query($breakpoint, $property: $property, $inverted: true, $at: 'container', $name: $name) {
 		@content;
 	}
 }
@@ -45,7 +45,7 @@
 }
 
 @mixin maxWidth($breakpoint, $name: '') {
-	@include media.query($breakpoint, $max: true, $at: 'container', $name: $name) {
+	@include media.query($breakpoint, $inverted: true, $at: 'container', $name: $name) {
 		@content;
 	}
 }
@@ -65,7 +65,7 @@
 }
 
 @mixin maxHeight($breakpoint, $name: '') {
-	@include media.query($breakpoint, $max: true, $property: 'height', $at: 'container', $name: $name) {
+	@include media.query($breakpoint, $inverted: true, $property: 'height', $at: 'container', $name: $name) {
 		@content;
 	}
 }

--- a/packages/scss/src/commons/utils/media.scss
+++ b/packages/scss/src/commons/utils/media.scss
@@ -13,27 +13,41 @@
 
 // les requêtes simples et multiples
 
-@mixin query($breakpoint, $property: 'width', $max: false, $at: 'media', $name: '') {
-	$reversed: '';
-
-	@if $max {
-		$reversed: 'not all and';
-
-		@if $at == 'container' {
-			$reversed: 'not';
+@mixin query($breakpoint, $property: 'width', $inverted: false, $at: 'media', $name: '', $breakpoint2: null) {
+	// si on breakpoint supplémentaire est passé, c’est queries qu’il faut appeler
+	@if $breakpoint2 != null {
+		@include queries(
+			$breakpoint1: $breakpoint,
+			$breakpoint2: $breakpoint2,
+			$property: $property,
+			$at: $at,
+			$name: $name,
+			$inverted: $inverted
+		) {
+			@content;
 		}
-	}
+	} @else {
+		$reversed: '';
 
-	@if map.get(config.$breakpoints, $breakpoint) {
-		$breakpoint: pxToEm(map.get(config.$breakpoints, $breakpoint));
-	}
+		@if $inverted {
+			$reversed: 'not all and';
 
-	@#{$at} #{$name} #{$reversed} (min-#{$property}: #{$breakpoint}) {
-		@content;
+			@if $at == 'container' {
+				$reversed: 'not';
+			}
+		}
+
+		@if map.get(config.$breakpoints, $breakpoint) {
+			$breakpoint: pxToEm(map.get(config.$breakpoints, $breakpoint));
+		}
+
+		@#{$at} #{$name} #{$reversed} (min-#{$property}: #{$breakpoint}) {
+			@content;
+		}
 	}
 }
 
-@mixin queries($breakpoint1, $breakpoint2, $property: 'width', $at: 'media', $name: '') {
+@mixin queries($breakpoint1, $breakpoint2, $property: 'width', $at: 'media', $name: '', $inverted: false) {
 	$reversed: 'not all and';
 
 	@if $at == 'container' {
@@ -55,9 +69,18 @@
 		$breakpoint1: $breakpointTmp;
 	}
 
-	@#{$at} #{$name} (min-#{$property}: #{$breakpoint1}) {
-		@#{$at} #{$name} #{$reversed} (min-#{$property}: #{$breakpoint2}) {
+	// si on souhaite inverser, ce sont deux queries combinées (or)
+	@if $inverted == true {
+		@#{$at} #{$name} #{$reversed} (min-#{$property}: #{$breakpoint1}), (min-#{$property}: #{$breakpoint2}) {
 			@content;
+		}
+	}
+	// sinon, ce sont deux queries imbriquées (and)
+	@else {
+		@#{$at} #{$name} (min-#{$property}: #{$breakpoint1}) {
+			@#{$at} #{$name} #{$reversed} (min-#{$property}: #{$breakpoint2}) {
+				@content;
+			}
 		}
 	}
 }
@@ -71,7 +94,7 @@
 }
 
 @mixin max($breakpoint, $property: 'width', $at: 'media') {
-	@include query($breakpoint, $property: $property, $max: true, $at: $at) {
+	@include query($breakpoint, $property: $property, $inverted: true, $at: $at) {
 		@content;
 	}
 }
@@ -91,15 +114,15 @@
 }
 
 @mixin maxWidth($breakpoint, $at: 'media') {
-	@include query($breakpoint, $max: true, $at: $at) {
+	@include query($breakpoint, $inverted: true, $at: $at) {
 		@content;
 	}
 }
 
 @mixin betweenWidths($breakpoint1, $breakpoint2, $at: 'media') {
-    @include queries($breakpoint1, $breakpoint2, $at: $at) {
-        @content;
-    }
+	@include queries($breakpoint1, $breakpoint2, $at: $at) {
+		@content;
+	}
 }
 
 // les raccourcis vers les requêtes pour minHeight/maxHeight/betweenHeights
@@ -111,15 +134,15 @@
 }
 
 @mixin maxHeight($breakpoint, $at: 'media') {
-	@include query($breakpoint, $max: true, $property: 'height', $at: $at) {
+	@include query($breakpoint, $inverted: true, $property: 'height', $at: $at) {
 		@content;
 	}
 }
 
 @mixin betweenHeights($breakpoint1, $breakpoint2, $at: 'media') {
-    @include queries($breakpoint1, $breakpoint2, $property: 'height', $at: $at) {
-        @content;
-    }
+	@include queries($breakpoint1, $breakpoint2, $property: 'height', $at: $at) {
+		@content;
+	}
 }
 
 // Touch detection

--- a/packages/scss/src/commons/utils/media.scss
+++ b/packages/scss/src/commons/utils/media.scss
@@ -105,6 +105,12 @@
 	}
 }
 
+@mixin outside($breakpoint1, $breakpoint2, $property: 'width', $at: 'media') {
+	@include queries($breakpoint1, $breakpoint2, $property: $property, $at: $at, $inverted: true) {
+		@content;
+	}
+}
+
 // les raccourcis vers les requêtes pour minWidth/maxWidth/betweenWidths
 
 @mixin minWidth($breakpoint, $at: 'media') {
@@ -120,6 +126,12 @@
 }
 
 @mixin betweenWidths($breakpoint1, $breakpoint2, $at: 'media') {
+	@include queries($breakpoint1, $breakpoint2, $at: $at) {
+		@content;
+	}
+}
+
+@mixin outsideWidths($breakpoint1, $breakpoint2, $at: 'media', $inverted: true) {
 	@include queries($breakpoint1, $breakpoint2, $at: $at) {
 		@content;
 	}
@@ -141,6 +153,12 @@
 
 @mixin betweenHeights($breakpoint1, $breakpoint2, $at: 'media') {
 	@include queries($breakpoint1, $breakpoint2, $property: 'height', $at: $at) {
+		@content;
+	}
+}
+
+@mixin outsideHeights($breakpoint1, $breakpoint2, $at: 'media') {
+	@include queries($breakpoint1, $breakpoint2, $property: 'height', $at: $at, $inverted: true) {
 		@content;
 	}
 }

--- a/packages/scss/src/commons/utils/media.scss
+++ b/packages/scss/src/commons/utils/media.scss
@@ -85,7 +85,7 @@
 	}
 }
 
-// les raccourcis vers les requêtes pour min/max/between
+// les raccourcis vers les requêtes pour min/max/inside/outside
 
 @mixin min($breakpoint, $property: 'width', $at: 'media') {
 	@include query($breakpoint, $property: $property, $at: $at) {
@@ -99,7 +99,7 @@
 	}
 }
 
-@mixin between($breakpoint1, $breakpoint2, $property: 'width', $at: 'media') {
+@mixin inside($breakpoint1, $breakpoint2, $property: 'width', $at: 'media') {
 	@include queries($breakpoint1, $breakpoint2, $property: $property, $at: $at) {
 		@content;
 	}
@@ -111,7 +111,7 @@
 	}
 }
 
-// les raccourcis vers les requêtes pour minWidth/maxWidth/betweenWidths
+// les raccourcis vers les requêtes pour minWidth/maxWidth/insideWidths
 
 @mixin minWidth($breakpoint, $at: 'media') {
 	@include query($breakpoint, $at: $at) {
@@ -125,7 +125,7 @@
 	}
 }
 
-@mixin betweenWidths($breakpoint1, $breakpoint2, $at: 'media') {
+@mixin insideWidths($breakpoint1, $breakpoint2, $at: 'media') {
 	@include queries($breakpoint1, $breakpoint2, $at: $at) {
 		@content;
 	}
@@ -137,7 +137,7 @@
 	}
 }
 
-// les raccourcis vers les requêtes pour minHeight/maxHeight/betweenHeights
+// les raccourcis vers les requêtes pour minHeight/maxHeight/insideHeights
 
 @mixin minHeight($breakpoint, $at: 'media') {
 	@include query($breakpoint, 'height', $at: $at) {
@@ -151,7 +151,7 @@
 	}
 }
 
-@mixin betweenHeights($breakpoint1, $breakpoint2, $at: 'media') {
+@mixin insideHeights($breakpoint1, $breakpoint2, $at: 'media') {
 	@include queries($breakpoint1, $breakpoint2, $property: 'height', $at: $at) {
 		@content;
 	}


### PR DESCRIPTION
## Description

A few improvements for responsive requests.

-----

`$max` is replaced by `$inverted`, which makes more sense for requests with two breakpoints. (No breaking.)
`$between` is replaced by `$inside`, which makes more sense with outside. (Only one breaking.)

An additional parameter is added to the mixin that handles one breakpoint: if it is used, the mixin that handles two breakpoints is called. This makes it possible to centralize all requests on the same mixin.

We can now reverse the between query and you can call this configuration with mixins prefixed with outside.

-----

![Capture d’écran 2024-06-14 à 10 09 30 copie](https://github.com/LuccaSA/lucca-front/assets/64789527/07ebe42d-8d4b-48ab-afda-5f46a2bfa9cb)

![Capture d’écran 2024-06-14 à 10 09 30 copie 2](https://github.com/LuccaSA/lucca-front/assets/64789527/70075c7c-5f58-448e-91c7-5bcd5f3aa560)

![339696345-0e506e21-61cc-4c96-92ee-162f6c85f9d8](https://github.com/LuccaSA/lucca-front/assets/64789527/b8e5584e-adbe-4b69-bed8-19b6211740f9)

![Capture d’écran 2024-06-14 à 10 09 30](https://github.com/LuccaSA/lucca-front/assets/64789527/f0f1323a-a225-4900-b165-c81243131f36)



