### PR TITLE
Popover : close button on left

### DIFF
--- a/packages/scss/src/components/popover/component.scss
+++ b/packages/scss/src/components/popover/component.scss
@@ -29,7 +29,7 @@
 			padding: 0;
 			border-radius: 50%;
 			position: absolute;
-			right: calc(var(--pr-t-spacings-100) * -1);
+			left: calc(var(--pr-t-spacings-100) * -1);
 			top: calc(var(--pr-t-spacings-100) * -1);
 			z-index: 2;
 


### PR DESCRIPTION
## Description

To avoid overlapping with the scrollbar.

-----

![Capture d’écran 2024-06-21 à 10 47 18](https://github.com/LuccaSA/lucca-front/assets/64789527/cf2c5e7e-7dc8-4672-94cd-5e70d7326d80)

