### PR TITLE
feat(popover2): hover+focus trigger mode

### DIFF
--- a/packages/ng/popover2/content/popover-content/popover-content.component.ts
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.ts
@@ -58,9 +58,7 @@ export class PopoverContentComponent implements AfterViewInit {
 	}
 
 	grabFocus(): void {
-		if (!this.#config.disableFocusManipulation) {
-			this.#focusManager.focusInitialElement();
-		}
+		this.#focusManager.focusInitialElement();
 	}
 
 	@HostListener('window:keydown.escape')

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -23,7 +23,7 @@ import { POPOVER_CONFIG, PopoverConfig } from './popover-tokens';
 import { combineLatest, debounce, filter, map, merge, Subject, switchMap, timer } from 'rxjs';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { LU_POPOVER2_TRANSLATIONS } from './popover2.translate';
-import { getIntl } from '../core/translate';
+import { getIntl } from '@lucca-front/ng/core';
 
 export type PopoverPosition = 'above' | 'below' | 'before' | 'after';
 

--- a/packages/ng/popover2/popover2.translate.ts
+++ b/packages/ng/popover2/popover2.translate.ts
@@ -1,0 +1,25 @@
+import { InjectionToken } from '@angular/core';
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+export const LU_POPOVER2_TRANSLATIONS = new InjectionToken('LuPopover2Translations', {
+	factory: () => luPopover2Translations,
+});
+
+export interface LuCalloutLabel {
+	screenReaderDescription: string;
+}
+
+export const luPopover2Translations: ILuTranslation<LuCalloutLabel> = {
+	en: {
+		screenReaderDescription: '(Tab key to enter panel.)',
+	},
+	fr: {
+		screenReaderDescription: '(Touche de tabulation pour entrer dans le panneau.)',
+	},
+	es: {
+		screenReaderDescription: '(Tabulador para entrar en el panel.)',
+	},
+	de: {
+		screenReaderDescription: '(Tabulatortaste, um in das Panel zu gelangen.)',
+	},
+};

--- a/stories/documentation/overlays/popover2/popover2.stories.ts
+++ b/stories/documentation/overlays/popover2/popover2.stories.ts
@@ -19,7 +19,7 @@ export default {
 		luPopover2: HiddenArgType,
 		luPopoverTrigger: {
 			control: 'select',
-			options: ['click', 'click+hover'],
+			options: ['click', 'click+hover', 'hover+focus'],
 		},
 	},
 } as Meta;


### PR DESCRIPTION
## Description

On Focus, opens popover after the debounce specified by `luPopoverOpenDelay`.

On `Tab` with popover opened, focus on close button then popover's content, then trigger button again.

-----


-----
