### PR TITLE
[Notch box] Improve box shadow

### DIFF
--- a/packages/scss/src/components/notchBox/vars.scss
+++ b/packages/scss/src/components/notchBox/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/utils/color';
+
 @mixin vars {
 	/** notch */
 	--component-notchbox-notch-radius: var(--commons-borderRadius-M);
@@ -11,7 +13,7 @@
 	--component-notchbox-box-radius: 16px;
 	--component-notchbox-box-padding: var(--pr-t-spacings-200);
 	--component-notchbox-box-background-color: var(--pr-t-elevation-surface-raised);
-	--component-notchbox-box-shadow: 0 0 4px var(--palettes-neutral-200);
+	--component-notchbox-box-shadow: 0 1px 2px #{color.transparentize(var(--palettes-neutral-400), 0.6)};
 
 	/** badge */
 	--component-notchbox-badge-offset: 17px;


### PR DESCRIPTION
## Description

Improve box shadow

-----

![image (59)](https://github.com/LuccaSA/lucca-front/assets/25581936/887858c3-d86b-4816-86bc-0a36645ec2a6)

We can't apply `--pr-t-elevation-shadow-raised` token as we use a filter `drop-shadow` on this component.
It would be possible to make a combination of 3 different `drop-shadow` but that would lead to a breaking change as some BU override `--component-notchbox-box-shadow` to remove or set a 1px border style shadow on Notch Box, so we decided to apply a single shadow quite close to orginal mockups.

-----
