### PR TITLE
fix(dialog): close can be disabled specifically for click on backdrop

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -57,8 +57,9 @@ export class LuDialogService {
 
 		if (!config.alert) {
 			// Setup close listeners on backdrop click and escape key by ourselves so we can hook the `canClose` method to it.
-			merge(cdkRef.backdropClick.pipe(filter(() => config.canCloseWithBackdrop ?? true)), cdkRef.keydownEvents.pipe(filter((e) => e.key === 'Escape' && !e.defaultPrevented)))
+			merge(cdkRef.backdropClick, cdkRef.keydownEvents.pipe(filter((e) => e.key === 'Escape' && !e.defaultPrevented)))
 				.pipe(
+					filter(() => config.canCloseWithBackdrop ?? true),
 					switchMap(() => {
 						const canClose = config.canClose?.(cdkRef.componentInstance) ?? true;
 						const canClose$ = isObservable(canClose) ? canClose : of(canClose);

--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -26,7 +26,7 @@ export class LuDialogService {
 			ariaModal: config.modal ?? true,
 			hasBackdrop: config.modal ?? true,
 			data: 'data' in config ? config.data : null,
-			disableClose: false,
+			disableClose: true,
 			closeOnDestroy: true,
 			role: config.alert ? 'alertdialog' : 'dialog',
 			restoreFocus: true,
@@ -57,7 +57,7 @@ export class LuDialogService {
 
 		if (!config.alert) {
 			// Setup close listeners on backdrop click and escape key by ourselves so we can hook the `canClose` method to it.
-			merge(cdkRef.backdropClick.pipe(filter(() => !config.cdkConfigOverride.disableClose)), cdkRef.keydownEvents.pipe(filter((e) => e.key === 'Escape' && !e.defaultPrevented)))
+			merge(cdkRef.backdropClick.pipe(filter(() => config.canCloseWithBackdrop ?? true)), cdkRef.keydownEvents.pipe(filter((e) => e.key === 'Escape' && !e.defaultPrevented)))
 				.pipe(
 					switchMap(() => {
 						const canClose = config.canClose?.(cdkRef.componentInstance) ?? true;

--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -70,7 +70,7 @@ interface BaseLuDialogConfig<C> {
 	canClose?: (comp: C) => boolean | Observable<boolean>;
 
 	/**
-	 * Determine if the current dialog can be close by a click on backdrop
+	 * Determine if the current dialog can be close by a click on backdrop or escape key
 	 */
 	canCloseWithBackdrop?: boolean;
 

--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -70,6 +70,11 @@ interface BaseLuDialogConfig<C> {
 	canClose?: (comp: C) => boolean | Observable<boolean>;
 
 	/**
+	 * Determine if the current dialog can be close by a click on backdrop
+	 */
+	canCloseWithBackdrop?: boolean;
+
+	/**
 	 * The size of the panel used for the dialog
 	 */
 	size?: 'XS' | 'S' | 'M' | 'L' | 'XL' | 'fitContent' | `maxContent` | 'fullScreen';

--- a/stories/documentation/overlays/dialog/dialog-canClose.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-canClose.stories.ts
@@ -1,0 +1,148 @@
+import { allLegumes } from '@/stories/forms/select/select.utils';
+import { Component, inject, input } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import {
+	DialogComponent,
+	DialogContentComponent,
+	DialogDismissDirective,
+	DialogFooterComponent,
+	DialogHeaderComponent,
+	LuDialogRef,
+	LuDialogService,
+	configureLuDialog,
+	injectDialogData,
+	injectDialogRef,
+	provideLuDialog,
+} from '@lucca-front/ng/dialog';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { Meta, StoryObj, applicationConfig } from '@storybook/angular';
+
+@Component({
+	selector: 'sb-dialog-content',
+	template: `
+		<lu-dialog>
+			<lu-dialog-header>Header</lu-dialog-header>
+
+			<lu-dialog-content>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+				<lu-form-field label="Test">
+					<lu-simple-select ngModel [options]="legumes"></lu-simple-select>
+				</lu-form-field>
+			</lu-dialog-content>
+
+			<lu-dialog-footer>
+				<div class="footer-content">Optional footer text</div>
+				<div class="footer-actions">
+					<button type="button" luButton (click)="close()">Confirm</button>
+					<button type="button" luButton="text" luDialogDismiss>Cancel</button>
+				</div>
+			</lu-dialog-footer>
+		</lu-dialog>
+	`,
+	imports: [
+		DialogFooterComponent,
+		DialogContentComponent,
+		DialogHeaderComponent,
+		DialogComponent,
+		ButtonComponent,
+		DialogDismissDirective,
+		FormFieldComponent,
+		LuSimpleSelectInputComponent,
+		FormsModule,
+	],
+	standalone: true,
+})
+export class DialogContentStoryComponent {
+	ref = injectDialogRef<string>();
+	data = injectDialogData<number>();
+
+	legumes = allLegumes;
+
+	close(): void {
+		this.ref.close(this.data.toString());
+	}
+}
+
+@Component({
+	selector: 'lu-dialog-story',
+	standalone: true,
+	template: ` <button luButton (click)="openDialog()">Open dialog</button>`,
+	imports: [ButtonComponent],
+	providers: [provideLuDialog()],
+})
+export class DialogStory {
+	dialog = inject(LuDialogService);
+
+	canClose = input<boolean>(true);
+	canCloseWithBackdrop = input<boolean>(true);
+
+	openDialog(): void {
+		const ref: LuDialogRef<DialogContentStoryComponent> = this.dialog.open({
+			content: DialogContentStoryComponent,
+			data: 5,
+			canClose: () => this.canClose(),
+			canCloseWithBackdrop: this.canCloseWithBackdrop(),
+		});
+
+		const res = ref.result$;
+	}
+}
+
+export default {
+	title: 'Documentation/Overlays/Dialog/canClose',
+	component: DialogStory,
+	decorators: [
+		applicationConfig({
+			providers: [configureLuDialog()],
+		}),
+	],
+	argTypes: {
+		canClose: {
+			control: {
+				type: 'boolean',
+			},
+		},
+		canCloseWithBackdrop: {
+			control: {
+				type: 'boolean',
+			},
+		},
+	},
+} as Meta;
+
+export const Basic: StoryObj = {
+	args: {
+		canClose: true,
+		canCloseWithBackdrop: true,
+	},
+	parameters: {
+		docs: {
+			source: {
+				language: 'ts',
+				type: 'code',
+				code: `
+canClose = input<boolean>(true);
+canCloseWithBackdrop = input<boolean>(true);
+
+openDialog(): void {
+  const ref: LuDialogRef<DialogContentStoryComponent> = this.dialog.open({
+    content: DialogContentStoryComponent,
+    data: 5,
+    canClose: () => this.canClose(),
+    canCloseWithBackdrop: this.canCloseWithBackdrop(),
+  });
+`,
+			},
+		},
+	},
+};


### PR DESCRIPTION
## Description

Dialog close should not be handled by default by angular/cdk
Close can be disabled for click on backdrop

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
