### PR TITLE
fix(core-select): remove double URI encoding in API directives

### DIFF
--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -81,7 +81,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 			...filters,
 			...(clue
 				? // When the clue is not empty, sort establishments by name
-					{ search: sanitizeClueFilter(clue), sort: 'name' }
+					{ search: clue, sort: 'name' }
 				: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
 					{ sort: 'legalunit.name,name' }),
 			...(operationIds ? { operations: operationIds.join(',') } : {}),
@@ -90,8 +90,4 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 	);
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
-}
-
-function sanitizeClueFilter(clue: string) {
-	return clue.split(' ').join(',');
 }

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -93,8 +93,5 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 }
 
 function sanitizeClueFilter(clue: string) {
-	return clue
-		.split(' ')
-		.map((c: string) => encodeURIComponent(c))
-		.join(',');
+	return clue.split(' ').join(',');
 }

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -53,13 +53,9 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 	protected override params$: Observable<Record<string, string | number | boolean>> = combineLatest([toObservable(this._filters), this.clue$]).pipe(
 		map(([filters, clue]) => ({
 			...filters,
-			...(clue ? { search: sanitizeClueFilter(clue), sort: 'name' } : { sort: 'job.name,level.position' }),
+			...(clue ? { search: clue, sort: 'name' } : { sort: 'job.name,level.position' }),
 		})),
 	);
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
-}
-
-function sanitizeClueFilter(clue: string) {
-	return clue.split(' ').join(',');
 }

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -61,8 +61,5 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 }
 
 function sanitizeClueFilter(clue: string) {
-	return clue
-		.split(' ')
-		.map((c: string) => encodeURIComponent(c))
-		.join(',');
+	return clue.split(' ').join(',');
 }

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -170,8 +170,5 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 }
 
 function sanitizeClueFilter(clue: string) {
-	return clue
-		.split(' ')
-		.map((c: string) => encodeURIComponent(c))
-		.join(',');
+	return clue.split(' ').join(',');
 }

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -104,7 +104,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			fields: this.#userFields,
 			...filters,
 			...(orderBy ? { orderBy } : {}),
-			...(clue ? { clue: sanitizeClueFilter(clue) } : {}),
+			...(clue ? { clue: clue } : {}),
 			...(operationIds ? { operations: operationIds.join(',') } : {}),
 			...(appInstanceId ? { appInstanceId } : {}),
 			...(enableFormerEmployees ? { formerEmployee: enableFormerEmployees } : {}),
@@ -167,8 +167,4 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	}
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
-}
-
-function sanitizeClueFilter(clue: string) {
-	return clue.split(' ').join(',');
 }


### PR DESCRIPTION
## Description

We were encoding clue for search query twice in the APi directives, I removed that and the `split(' ').join(',')` behavior.

-----

closes #2903

-----
