### PR TITLE
fix(option-picker): overlayRef may be null

### DIFF
--- a/packages/ng/option/picker/option-picker.component.ts
+++ b/packages/ng/option/picker/option-picker.component.ts
@@ -82,7 +82,7 @@ export abstract class ALuOptionPickerComponent<T, O extends import('../item/opti
 	@ContentChildren(ALuOptionItem, { descendants: true }) set optionsQL(ql: QueryList<O>) {
 		this._optionsQL = ql;
 		ql.changes.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
-			this.overlayRef.updatePosition();
+			this.overlayRef?.updatePosition();
 		});
 	}
 


### PR DESCRIPTION
## Description

The `overlayRef` may be null before changes appear. If so, just ignore the `updatePosition()` because there is no position to update.

-----

Currently throws an error in the console but does not impact the navigation flow.

-----

Please backport this fix on a 18.0 lts release so that Cleemy Expenses may be updated! 