### PR TITLE
Toast position when footer is present

### DIFF
--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -9,6 +9,10 @@
 	z-index: 9999;
 	inset: var(--components-toasts-inset);
 
+	html:has(.main-content .footer.mod-sticky, .dialog.mod-drawer .dialog-inside-footer) & {
+		--components-toasts-bottom: calc(var(--components-toasts-footerHeight) + var(--pr-t-spacings-300));
+	}
+
 	@at-root ($atRoot) {
 		.toasts-item {
 			display: flex;
@@ -30,7 +34,7 @@
 					transform: translateY(var(--pr-t-spacings-200));
 					opacity: 0;
 				}
-		
+
 				100% {
 					opacity: 1;
 				}
@@ -67,7 +71,8 @@
 			@include button.text;
 			@include button.inverted;
 
-			@keyframes timer {}
+			@keyframes timer {
+			}
 
 			align-self: flex-start;
 			border-radius: var(--commons-borderRadius-L);

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -10,6 +10,9 @@
 	inset: var(--components-toasts-inset);
 
 	html:has(.main-content .footer.mod-sticky, .dialog.mod-drawer .dialog-inside-footer) & {
+		// Provide extra bottom spacing when a footer is sticked
+		// Will only work on desktop with standard footer layout
+		// Refactor: Position should be calculated dynamically 
 		--components-toasts-bottom: calc(var(--components-toasts-footerHeight) + var(--pr-t-spacings-300));
 	}
 

--- a/packages/scss/src/components/toast/vars.scss
+++ b/packages/scss/src/components/toast/vars.scss
@@ -7,6 +7,7 @@
 	--components-toasts-margin-bottom: var(--pr-t-spacings-50);
 	--components-toasts-maxwidth: 22.5rem;
 	--components-toasts-inset: var(--components-toasts-top) var(--components-toasts-right) auto auto;
+	--components-toasts-footerHeight: 4.5rem;
 
 	// Deprecated
 	--components-toasts-background: var(--palettes-neutral-800);


### PR DESCRIPTION
## Description

#2131 

⚠️ This shift in the footer when a footer is detected is a test. The size of the footer may be wrong, as may its position.

-----



-----
