### PR TITLE
columnSticky is deprecated

### DIFF
--- a/packages/scss/src/components/tableStickedDeprecated/mods.scss
+++ b/packages/scss/src/components/tableStickedDeprecated/mods.scss
@@ -62,6 +62,8 @@
 					}
 				}
 
+				// .mod-columnSticky-shadowMask is deprecated
+				&.mod-stickyColumn-shadowMask,
 				&.mod-columnSticky-shadowMask {
 					&::before {
 						width: var(--components-tableFixed-column-sticky-shadow-width);
@@ -75,8 +77,12 @@
 					}
 				}
 
+				// .mod-columnSticky-shadowMask is deprecated
+				&:not(.mod-stickyColumn-shadowMask),
 				&:not(.mod-columnSticky-shadowMask) {
 					&:not(.mod-stickyColumn-shadow) {
+						// .mod-columnSticky-shadowMask is deprecated
+						+ .mod-stickyColumn-shadowMask,
 						+ .mod-columnSticky-shadowMask {
 							&::before {
 								left: auto;

--- a/stories/documentation/listings/table-legacy/table-sticky-columns-breakpoints.stories.ts
+++ b/stories/documentation/listings/table-legacy/table-sticky-columns-breakpoints.stories.ts
@@ -25,7 +25,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<th class=" table-head-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
-					<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+					<th class="table-head-row-cell mod-stickyColumn-shadowMask">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
@@ -34,7 +34,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<th class="table-head-row-cell">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
 					<th class="table-head-row-cell">Head cell</th>
-					<th class="table-head-row-cell mod-columnSticky-shadowMask">Head cell</th>
+					<th class="table-head-row-cell mod-stickyColumn-shadowMask">Head cell</th>
 					<th class=" table-head-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</th>
@@ -62,7 +62,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class=" table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
@@ -71,7 +71,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 					<td class=" table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -92,7 +92,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class=" table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
@@ -101,7 +101,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 					<td class=" table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
@@ -122,7 +122,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class=" table-body-row-cell mod-stickyColumn-leftOffset20 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>
-					<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
@@ -131,7 +131,7 @@ function getTemplate(args: TableStickyColumnsAndHeaderWithBreakpointsStory): str
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
 					<td class="table-body-row-cell">Body cell</td>
-					<td class="table-body-row-cell mod-columnSticky-shadowMask">Body cell</td>
+					<td class="table-body-row-cell mod-stickyColumn-shadowMask">Body cell</td>
 					<td class=" table-body-row-cell mod-stickyColumn-rightOffset5 mod-stickyColumn-shadow " role="presentation" >
 						<div class="stickyColumn-shadow-wrapper"></div>
 					</td>


### PR DESCRIPTION
## Description

`columnSticky` and `stickyColumn` existed. Only `stickyColumn` is retained.

Fix #1974 

-----



-----

![image](https://github.com/LuccaSA/lucca-front/assets/64789527/09f0765d-bb13-4b2d-b0ad-e838830466ac)

![image](https://github.com/LuccaSA/lucca-front/assets/64789527/e11da6dd-e0a5-4cd6-bc39-ec7bf9a1177b)

