### PR TITLE
feat(front) : [Comment] add chatbox layout

### DIFF
--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -5,7 +5,7 @@
 	display: flex;
 	flex-direction: column;
 	gap: var(--pr-t-spacings-50);
-	max-width: 40rem;
+	max-width: var(--components-comment-max-width);
 
 	@at-root ($atRoot) {
 		.comment-infos {
@@ -45,7 +45,7 @@
 		}
 
 		.comment-content {
-			background: var(--palettes-neutral-50);
+			background: var(--components-comment-background-color, var(--palettes-neutral-50));
 			border-radius: var(--commons-borderRadius-M) var(--commons-borderRadius-L) var(--commons-borderRadius-L);
 			display: flex;
 			flex-direction: column;

--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -57,6 +57,7 @@
 
 		.comment-content-text {
 			margin-bottom: 0;
+			overflow-wrap: break-word;
 		}
 
 		.comment-content-textContainer {

--- a/packages/scss/src/components/comment/index.scss
+++ b/packages/scss/src/components/comment/index.scss
@@ -14,6 +14,10 @@
 		@include noAvatar;
 	}
 
+	&.mod-answer {
+		@include answer;
+	}
+
 	@include container.max(25rem, $name: 'comment') {
 		@include narrow;
 	}
@@ -24,5 +28,9 @@
 
 	&.mod-compact {
 		@include wrapperCompact;
+	}
+
+	&.mod-chatbox {
+		@include chatBox;
 	}
 }

--- a/packages/scss/src/components/comment/mods.scss
+++ b/packages/scss/src/components/comment/mods.scss
@@ -33,3 +33,23 @@
 		}
 	}
 }
+
+@mixin answer {
+	--components-comment-background-color: var(--palettes-product-100);
+	margin-left: auto;
+	align-items: end;
+}
+
+@mixin chatBox {
+	--components-comment-background-color: var(--colors-white-color);
+	gap: var(--pr-t-spacings-200);
+
+	.commentWrapper-item {
+		display: flex;
+	}
+
+	.comment {
+		container-type: normal;
+		max-width: min(var(--components-comment-max-width), 90%);
+	}
+}

--- a/packages/scss/src/components/comment/vars.scss
+++ b/packages/scss/src/components/comment/vars.scss
@@ -1,4 +1,5 @@
 @mixin vars {
+	--components-comment-max-width: 40rem;;
 	--components-comment-text-fontSize: var(--sizes-M-fontSize);
 	--components-comment-text-lineHeight: var(--sizes-M-lineHeight);
 	--components-comment-content-margin: calc(1.5rem + var(--pr-t-spacings-100)); // 1.5rem for the width of the avatar and 0.5rem for the gap

--- a/stories/documentation/texts/comment/chatbox.stories.ts
+++ b/stories/documentation/texts/comment/chatbox.stories.ts
@@ -1,0 +1,109 @@
+import { Meta, StoryFn } from '@storybook/angular';
+
+interface CommentChatboxStory {}
+
+export default {
+	title: 'Documentation/Texts/Comment/HTML&CSS/Chatbox',
+	argTypes: {},
+} as Meta;
+
+function getTemplate(args: CommentChatboxStory): string {
+	return `<ol class="commentWrapper mod-chatbox">
+	<li class="commentWrapper-item">
+		<div class="comment">
+			<div class="comment-infos">
+				<div class="avatar"></div>
+				<div class="comment-infos-content">
+					<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
+					<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+				</div>
+			</div>
+			<blockquote class="comment-content">
+				<p class="comment-content-text">
+					Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
+					nulla iste neque ex ?
+				</p>
+			</blockquote>
+		</div>
+	</li>
+	<li class="commentWrapper-item">
+		<div class="comment mod-answer">
+			<div class="comment-infos">
+				<div class="avatar"></div>
+				<div class="comment-infos-content">
+					<span class="comment-infos-name">Daniel Hernandez</span>&ngsp;
+					<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+				</div>
+			</div>
+			<blockquote class="comment-content">
+				<p class="comment-content-text">Temporibus a veniam necessitatibus aut facilis repellendus provident
+				nulla iste neque ex. Lorem ipsum dolor sit amet, consectetur adipisicing elit. </p>
+			</blockquote>
+		</div>
+	</li>
+	<li class="commentWrapper-item">
+		<div class="comment">
+			<div class="comment-infos">
+				<div class="avatar"></div>
+				<div class="comment-infos-content">
+					<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
+					<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+				</div>
+			</div>
+			<blockquote class="comment-content">
+				<p class="comment-content-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+			</blockquote>
+		</div>
+	</li>
+	<li class="commentWrapper-item">
+		<div class="comment mod-answer">
+			<div class="comment-infos">
+				<div class="avatar"></div>
+				<div class="comment-infos-content">
+					<span class="comment-infos-name">Daniel Hernandez</span>&ngsp;
+					<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+				</div>
+			</div>
+			<blockquote class="comment-content">
+				<p class="comment-content-text">Lorem ipsum dolor sit amet,</p>
+			</blockquote>
+		</div>
+	</li>
+	<li class="commentWrapper-item">
+		<div class="comment mod-answer">
+			<div class="comment-infos">
+				<div class="avatar"></div>
+				<div class="comment-infos-content">
+					<span class="comment-infos-name">Daniel Hernandez</span>&ngsp;
+					<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+				</div>
+			</div>
+			<blockquote class="comment-content">
+				<p class="comment-content-text">Lorem</p>
+			</blockquote>
+		</div>
+	</li>
+</ol>`;
+}
+
+const Template: StoryFn<CommentChatboxStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+	styles: [
+		`.avatar {
+			width: 1.5rem;
+			height: 1.5rem;
+			border-radius: 50%;
+			background: var(--palettes-neutral-100) url("https://cdn.lucca.fr/lucca-front/avatars/finn.png") center;
+			background-size: cover;
+			flex-shrink: 0;
+		}
+		.mod-answer .avatar {
+			background-image: url("https://cdn.lucca.fr/lucca-front/avatars/bob.jpg");
+		}
+		`,
+	],
+});
+
+export const Chatbox = Template.bind({});
+Chatbox.args = {};


### PR DESCRIPTION
## Description

Add chatbox layout for the Comment component

![image](https://github.com/LuccaSA/lucca-front/assets/65592565/ae600f33-ceef-4d2c-83f2-a15ab54a5049)


[Figma](https://www.figma.com/design/CVCTTj29ofwdSwIyHE9CnS/Ligne-directe-(PEng)?node-id=701-80&t=nNXPzA4tju0lf0sS-0)
![image](https://github.com/LuccaSA/lucca-front/assets/65592565/d84b6cbf-42c7-44a0-8011-dbd107ec8a29)

closes #2923 

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
