### PR TITLE
Fix footer on dialogs with Safari

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -39,6 +39,25 @@
 
 	.dialog-inside-footer {
 		@include footer.sticky;
+
+		@supports (background-image: -webkit-named-image(test)) {
+			@keyframes footerVisibility {
+				from {
+					visibility: visible;
+					opacity: 0;
+				}
+				to {
+					visibility: visible;
+					opacity: 1;
+				}
+			}
+
+			visibility: hidden;
+			animation-delay: var(--commons-animations-durations-standard);
+			animation-name: footerVisibility;
+			animation-duration: var(--commons-animations-durations-standard);
+			animation-fill-mode: both;
+		}
 	}
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -40,6 +40,7 @@
 	.dialog-inside-footer {
 		@include footer.sticky;
 
+		// Safari fix to avoid footer to clip while loading
 		@supports (background-image: -webkit-named-image(test)) {
 			@keyframes footerVisibility {
 				from {


### PR DESCRIPTION
## Description

The positioning of a sticky element seems to take place in Safari at the end of the animation.

So that the footer doesn't interfere with the display during loading, I suggest displaying it later on this browser.

Fix #2599 

-----


-----

Before: 
![2024-07-11 14 18 34](https://github.com/LuccaSA/lucca-front/assets/64789527/841e2d38-8184-45d7-b083-eca9265b208a)

After: 
![2024-07-11 14 18 53](https://github.com/LuccaSA/lucca-front/assets/64789527/9911d54c-083a-463c-9dd0-fefa4fff5f0a)

