### PR TITLE
Replace absolute position with grid

### DIFF
--- a/packages/scss/src/components/checkboxField/component.scss
+++ b/packages/scss/src/components/checkboxField/component.scss
@@ -3,23 +3,25 @@
 
 @mixin component($atRoot: 'without: rule') {
 	position: relative;
-	display: block;
 	width: fit-content;
 	height: fit-content;
 
+	display: grid;
+	grid-template-areas: 'checkbox';
+	grid-template-columns: var(--component-checkboxField-size);
+	grid-template-rows: var(--component-checkboxField-size);
+
 	@at-root ($atRoot) {
 		.checkboxField-icon {
-			width: var(--component-checkboxField-size);
-			height: var(--component-checkboxField-size);
 			border: 2px solid var(--palettes-neutral-700);
 			border-radius: var(--component-checkboxField-borderRadius);
-			position: relative;
 			color: var(--palettes-neutral-0);
 			transition-property: color, border-color, background-color;
 			transition-duration: var(--commons-animations-durations-fast);
 			background-color: var(--palettes-neutral-0);
-			display: block;
 			cursor: pointer;
+			grid-area: checkbox;
+			display: flex;
 
 			@media (prefers-reduced-motion: reduce) {
 				transition-property: none;
@@ -28,7 +30,7 @@
 			&::after {
 				content: '';
 				position: absolute;
-				inset: -2px;
+				inset: 0;
 				outline-offset: 2px;
 				border-radius: var(--component-checkboxField-borderRadius);
 			}
@@ -67,12 +69,10 @@
 		}
 
 		.checkboxField-input {
-			position: absolute;
 			z-index: 1;
-			width: var(--component-checkboxField-size);
-			height: var(--component-checkboxField-size);
 			opacity: 0;
 			cursor: pointer;
+			grid-area: checkbox;
 		}
 	}
 }

--- a/packages/scss/src/components/radioField/component.scss
+++ b/packages/scss/src/components/radioField/component.scss
@@ -3,20 +3,24 @@
 
 @mixin component($atRoot: 'without: rule') {
 	position: relative;
+	width: fit-content;
+	height: fit-content;
+	display: grid;
+	grid-template-areas: 'radio';
+	grid-template-columns: var(--component-radioField-size);
+	grid-template-rows: var(--component-radioField-size);
 
 	@at-root ($atRoot) {
 		.radioField-icon {
-			width: var(--component-radioField-size);
-			height: var(--component-radioField-size);
 			border: 2px solid var(--palettes-neutral-700);
 			border-radius: var(--component-radioField-borderRadius);
-			position: relative;
 			color: var(--palettes-neutral-0);
 			transition-property: color, border-color, background-color;
 			transition-duration: var(--commons-animations-durations-fast);
 			background-color: var(--palettes-neutral-0);
-			display: block;
 			cursor: pointer;
+			grid-area: radio;
+			display: flex;
 
 			@media (prefers-reduced-motion: reduce) {
 				transition-property: none;
@@ -25,7 +29,7 @@
 			&::after {
 				content: '';
 				position: absolute;
-				inset: -2px;
+				inset: 0;
 				outline-offset: 2px;
 				border-radius: 6px;
 			}
@@ -57,12 +61,10 @@
 		}
 
 		.radioField-input {
-			position: absolute;
 			z-index: 1;
-			width: var(--component-radioField-size);
-			height: var(--component-radioField-size);
 			opacity: 0;
 			cursor: pointer;
+			grid-area: radio;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Based on an idea by @BertrandPodevin, simplified positioning of radio buttons and checkboxes.

Hopefully, this will also correct the sometimes slightly off-centering under Windows when zoom is applied.

-----



-----

![Capture d’écran 2024-07-12 à 11 07 29](https://github.com/user-attachments/assets/5b70a62d-a042-4384-b7a3-a8d10c862a34)

![Capture d’écran 2024-07-12 à 11 07 22](https://github.com/user-attachments/assets/923ea960-e46a-47e7-bb0a-def65be8e806)

