### PR TITLE
Break word for dialog titles

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -81,6 +81,7 @@
 			padding: var(--components-dialog-insideHeaderTitlePadding);
 			text-align: var(--components-dialog-insideHeaderTitleAlign);
 			margin: 0;
+			overflow-wrap: break-word;
 		}
 
 		.dialog_backdrop {


### PR DESCRIPTION
## Description

Fix #2920 

-----



-----

![Capture d’écran 2024-07-12 à 10 25 11](https://github.com/user-attachments/assets/a3140334-9dd4-48ba-ba0f-c0d7aa9bdd15)

