### PR TITLE
Fix word-break

### DIFF
--- a/packages/ng/styles/definitions/user/user-tile.scss
+++ b/packages/ng/styles/definitions/user/user-tile.scss
@@ -27,7 +27,7 @@
 	}
 
 	&.mod-wordBreak {
-		word-break: break-all;
+		overflow-wrap: break-word;
 	}
 
 	&.mod-nameOnly {


### PR DESCRIPTION
## Description

Better hyphenation management :
- line breaks are made naturally if necessary where words are separated;
- and are forced arbitrarily if words are too long.

Fix #1489 

-----



-----
