### PR TITLE
Back button for page header

### DIFF
--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -18,7 +18,7 @@
 
 		.pageHeader-content-title {
 			display: flex;
-			column-gap: var(--pr-t-spacings-200);
+			column-gap: var(--pr-t-spacings-100);
 			align-items: center;
 			flex-wrap: wrap;
 		}

--- a/stories/documentation/structure/page-header/page-header-back.stories.ts
+++ b/stories/documentation/structure/page-header/page-header-back.stories.ts
@@ -1,28 +1,26 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface PageHeaderBasicStory {
+interface PageHeaderBackStory {
 	sticky: boolean;
 }
 
 export default {
-	title: 'Documentation/Structure/PageHeader/Basic',
-	argTypes: {
-		sticky: {
-			control: {
-				type: 'boolean',
-			},
-		},
-	},
+	title: 'Documentation/Structure/PageHeader/Back',
+	argTypes: {},
 } as Meta;
 
-function getTemplate(args: PageHeaderBasicStory): string {
-	const sticky = args.sticky ? `mod-sticky` : '';
-
+function getTemplate(args: PageHeaderBackStory): string {
 	return `
-	<header class="pageHeader ${sticky}">
+	<header class="pageHeader">
 		<div class="pageHeader-content">
 			<div class="pageHeader-content-title">
-				<h1 class="pr-u-margin0">H1. Page title</h1>
+				<nav class="pageHeader-content-title-back">
+					<a href="#" class="button mod-onlyIcon mod-text">
+						<span class="lucca-icon icon-arrowLeft" aria-hidden="true"></span>
+						<span class="u-mask">Page parente</span>
+					</a>
+				</nav>
+				<h1 class="pr-u-margin0">Page courante</h1>
 				<div>
 					<button type="button" class="button mod-onlyIcon mod-text" luTooltip="Modifier">
 						<span aria-hidden="true" class="lucca-icon icon-officePen"></span>
@@ -47,25 +45,24 @@ function getTemplate(args: PageHeaderBasicStory): string {
 				<button type="button" class="button mod-outline">Button</button>
 				<button type="button" class="button mod-onlyIcon mod-text">
 					<span aria-hidden="true" class="lucca-icon icon-menuDots"></span>
-					<span class="u-mask">voir plus</span>
+					<span class="u-mask">Voir plus</span>
 				</button>
 			</div>
 		</div>
 		<div class="pageHeader-description">
 			<p class="pr-u-marginBottom0">
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed ac justo scelerisque, blandit nibh quis, imperdiet justo.
-				Nullam condimentum nulla et neque ultricies bibendum
-				<a target="_blank">Lien<span aria-hidden="true" class="lucca-icon icon-arrowExternal mod-XS pr-u-marginLeft50"></span></a>.
+				Nullam condimentum nulla et neque ultricies bibendum.
 			</p>
 		</div>
 	</header>
 	`;
 }
 
-const Template: StoryFn<PageHeaderBasicStory> = (args) => ({
+const Template: StoryFn<PageHeaderBackStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
 });
 
-export const BasicPageHeader = Template.bind({});
-BasicPageHeader.args = { sticky: false };
+export const PageHeaderBackStory = Template.bind({});
+PageHeaderBackStory.args = {};


### PR DESCRIPTION
## Description

Add a link in front of the header title to go back to the parent section.

-----


-----

![Capture d’écran 2024-07-15 à 14 43 59](https://github.com/user-attachments/assets/135406ba-26dd-47a2-bc92-f1c33cf70b26)

![Capture d’écran 2024-07-15 à 14 48 53](https://github.com/user-attachments/assets/2b0907b6-7c22-49ef-aea7-d4415dd7555b)
