### PR TITLE
fix(users): no highlighted item after clue change

### DIFF
--- a/packages/ng/core-select/api/api-v3.directive.ts
+++ b/packages/ng/core-select/api/api-v3.directive.ts
@@ -63,4 +63,5 @@ export class LuCoreSelectApiV3Directive<T extends ILuApiItem> extends ALuCoreSel
 	}
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
+	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -57,4 +57,5 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 	}
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
+	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -31,12 +31,22 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	protected abstract optionComparer: (a: TOption, b: TOption) => boolean;
 
 	/**
+	 * Return a key to identify the option in for-of loops
+	 */
+	protected optionKey?: (option: TOption) => unknown;
+
+	/**
 	 * Return the options for the given params and page
 	 */
 	protected abstract getOptions(params: TParams, page: number): Observable<TOption[]>;
 
 	public ngOnInit(): void {
 		this.select.optionComparer = this.optionComparer;
+
+		if (this.optionKey) {
+			this.select.optionKey = this.optionKey;
+		}
+
 		this.buildOptions()
 			.pipe(takeUntil(this.destroy$))
 			.subscribe((options) => (this.select.options = options));

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -90,4 +90,5 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 	);
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
+	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -111,6 +111,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	}
 
 	@Input() optionComparer: (option1: TOption, option2: TOption) => boolean = (option1, option2) => JSON.stringify(option1) === JSON.stringify(option2);
+	@Input() optionKey: (option: TOption) => unknown = (option) => option;
 	@Input() optionTpl?: TemplateRef<LuOptionContext<TOption>> | Type<unknown> = LuSimpleSelectDefaultOptionComponent;
 	@Input() valueTpl?: TemplateRef<LuOptionContext<TOption>> | Type<unknown>;
 	grouping?: LuOptionGrouping<TOption, unknown>;

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -58,4 +58,5 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 	);
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
+	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/user/user-homonym.service.ts
+++ b/packages/ng/core-select/user/user-homonym.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { ILuApiCollectionResponse } from '@lucca-front/ng/api';
 import { LuDisplayFormat, luUserDisplay } from '@lucca-front/ng/user';
-import { Observable, map, of, startWith, tap } from 'rxjs';
+import { Observable, map, of, tap } from 'rxjs';
 import { LuCoreSelectUser } from './user-option.model';
 
 @Injectable({ providedIn: 'root' })
@@ -45,7 +45,6 @@ export class LuCoreSelectUserHomonymsService {
 					return user;
 				});
 			}),
-			startWith(users),
 		);
 	}
 

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -4,7 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { ILuApiCollectionResponse } from '@lucca-front/ng/api';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { LuDisplayFormat, LuDisplayFullname } from '@lucca-front/ng/user';
-import { EMPTY, Observable, combineLatest, distinctUntilChanged, filter, map, of, shareReplay, switchMap, take } from 'rxjs';
+import { EMPTY, Observable, combineLatest, distinctUntilChanged, filter, map, shareReplay, switchMap, take } from 'rxjs';
 import { LU_CORE_SELECT_CURRENT_USER_ID } from './me.provider';
 import { LuUserDisplayerComponent } from './user-displayer.component';
 import { LuCoreSelectUserHomonymsService } from './user-homonym.service';
@@ -161,11 +161,12 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		const options$ = super.buildOptions();
 
 		return displayMe$.pipe(
-			switchMap((displayMe) => (displayMe ? combineLatest([options$, me$]) : options$.pipe(map((options) => [options, null] as const)))),
+			switchMap((displayMe) => (displayMe ? combineLatest([options$, me$]) : options$.pipe(map((options) => [options, null as T | null] as const)))),
 			map(([options, meFilter]) => (meFilter ? [meFilter, ...(options ?? []).filter((o) => o.id !== meFilter.id)] : options)),
 			switchMap((users) => this.#userHomonymsService.handleHomonyms(users, this.displayFormat)),
 		);
 	}
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;
+	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -158,9 +158,10 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			shareReplay({ bufferSize: 1, refCount: true }),
 		);
 
-		const meFilter$ = displayMe$.pipe(switchMap((displayMe) => (displayMe ? me$ : of(null))));
+		const options$ = super.buildOptions();
 
-		return combineLatest([super.buildOptions(), meFilter$]).pipe(
+		return displayMe$.pipe(
+			switchMap((displayMe) => (displayMe ? combineLatest([options$, me$]) : options$.pipe(map((options) => [options, null] as const)))),
 			map(([options, meFilter]) => (meFilter ? [meFilter, ...(options ?? []).filter((o) => o.id !== meFilter.id)] : options)),
 			switchMap((users) => this.#userHomonymsService.handleHomonyms(users, this.displayFormat)),
 		);

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -19,7 +19,7 @@
 		<div class="lu-picker-content-option">
 			<ng-container *ngIf="grouping && ctx.groupTemplateLocation === 'group-header'">
 				<div
-					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"
+					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector; trackBy: trackGroupsBy"
 					class="lu-picker-content-group"
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
@@ -45,7 +45,7 @@
 
 			<ng-template #optionsList let-options>
 				<lu-select-option
-					*ngFor="let option of options; let index = index"
+					*ngFor="let option of options; let index = index; trackBy: trackOptionsBy"
 					[option]="option"
 					[optionTpl]="optionTpl"
 					[optionIndex]="index"

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,9 +1,9 @@
 import { A11yModule, ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, ViewChildren, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, TrackByFunction, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
+import { LuOptionGroup, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
 import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { LuMultiSelectInputComponent } from '../input';
@@ -46,6 +46,11 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 	grouping = this.selectInput.grouping;
 	loading$ = this.selectInput.loading$;
 	optionComparer = this.selectInput.optionComparer;
+	optionKey = this.selectInput.optionKey;
+
+	trackOptionsBy: TrackByFunction<T> = (_, option) => this.optionKey(option);
+	trackGroupsBy: TrackByFunction<LuOptionGroup<T, unknown>> = (_, group) => group.key;
+
 	selectedOptions: T[] = this.selectInput.value || [];
 	optionTpl = this.selectInput.optionTpl;
 

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -12,7 +12,7 @@
 		<div role="listbox">
 			<ng-container *ngIf="grouping && ctx.groupTemplateLocation === 'group-header'">
 				<div
-					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector"
+					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector; trackBy: trackGroupsBy"
 					class="lu-picker-content-option-group"
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
@@ -29,7 +29,7 @@
 
 			<ng-template #optionsList let-options>
 				<lu-select-option
-					*ngFor="let option of options; let index = index"
+					*ngFor="let option of options; let index = index; trackBy: trackOptionsBy"
 					[option]="option"
 					[optionTpl]="optionTpl"
 					[optionIndex]="index"

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -1,9 +1,9 @@
 import { A11yModule, ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, ViewChildren, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, TrackByFunction, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { LuSelectPanelRef, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
+import { LuOptionGroup, LuSelectPanelRef, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
 import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { LuSimpleSelectInputComponent } from '../input/select-input.component';
@@ -29,6 +29,11 @@ export class LuSelectPanelComponent<T> implements AfterViewInit {
 	grouping = this.selectInput.grouping;
 	loading$ = this.selectInput.loading$;
 	optionComparer = this.selectInput.optionComparer;
+	optionKey = this.selectInput.optionKey;
+
+	trackOptionsBy: TrackByFunction<T> = (_, option) => this.optionKey(option);
+	trackGroupsBy: TrackByFunction<LuOptionGroup<T, unknown>> = (_, group) => group.key;
+
 	initialValue: T | undefined = this.selectInput.value;
 	optionTpl = this.selectInput.optionTpl;
 


### PR DESCRIPTION
## Description

- Avoid highlight issue by limiting the number of time usersDirective emits options. 
- Avoid blinking by adding a trackBy function on select panels (in a non-breaking way).

-----

Fix #2936

I will add a PR on RC to force user to add a `optionKey` on `ALuCoreSelectApiDirective` children.

-----
