### PR TITLE
ref(core-select)!: optionKey is mandatory on ApiDirectives

### DIFF
--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -25,6 +25,8 @@ class TestDirective extends ALuCoreSelectApiDirective<TestEntity> {
 
 	protected override optionComparer = (a: TestEntity, b: TestEntity) => a.id === b.id;
 
+	protected override optionKey = (option: TestEntity) => option.id;
+
 	public override getOptions(): Observable<TestEntity[]> {
 		return of([{ id: 1, name: 'test' }]);
 	}

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -33,7 +33,7 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	/**
 	 * Return a key to identify the option in for-of loops
 	 */
-	protected optionKey?: (option: TOption) => unknown;
+	protected abstract optionKey: (option: TOption) => unknown;
 
 	/**
 	 * Return the options for the given params and page
@@ -42,10 +42,7 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 
 	public ngOnInit(): void {
 		this.select.optionComparer = this.optionComparer;
-
-		if (this.optionKey) {
-			this.select.optionKey = this.optionKey;
-		}
+		this.select.optionKey = this.optionKey;
 
 		this.buildOptions()
 			.pipe(takeUntil(this.destroy$))


### PR DESCRIPTION
## Description

*  optionKey is mandatory on ApiDirectives

-----

This will need to be rebased on RC once #2949 is merged and rc is up-to-date with master. Only [this commit](https://github.com/LuccaSA/lucca-front/pull/2950/commits/d961ce992234366c917d7550e14e1e3ca13d118c) is relevant.

This is a breaking change. On all classes that extend `ALuCoreSelectApiDirective`, apps have to:

```diff
class MyDirective extends ALuCoreSelectApiDirective {
+	protected override optionKey = (option: T) => option.id;
}
```

-----
