### PR TITLE
Remove scroll block for popover2

### DIFF
--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -148,7 +148,6 @@ export class PopoverDirective {
 						.position()
 						.flexibleConnectedTo(this.#elementRef)
 						.withPositions(this.customPositions || this.#buildPositions()),
-					scrollStrategy: this.#overlay.scrollStrategies.block(),
 					hasBackdrop: this.luPopoverTrigger() === 'click',
 					backdropClass: '',
 					disposeOnNavigation: true,

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -148,6 +148,7 @@ export class PopoverDirective {
 						.position()
 						.flexibleConnectedTo(this.#elementRef)
 						.withPositions(this.customPositions || this.#buildPositions()),
+					scrollStrategy: this.#overlay.scrollStrategies.reposition(),
 					hasBackdrop: this.luPopoverTrigger() === 'click',
 					backdropClass: '',
 					disposeOnNavigation: true,


### PR DESCRIPTION
## Description

Blocking the background scroll causes the scrollbar to disappear and triggers an unwanted shift + reflow.

-----



-----
Before: 
![2024-07-16 10 16 47](https://github.com/user-attachments/assets/a53b53c9-06e8-46a5-b994-be9d1c73c7a7)

After: 
![2024-07-16 10 16 24](https://github.com/user-attachments/assets/b6312fbd-2e3c-447c-8f68-70ed78e259a0)

