### PR TITLE
feat(schematics): add empty-state-heading migration

### DIFF
--- a/packages/ng/schematics/empty-state-title/index.ts
+++ b/packages/ng/schematics/empty-state-title/index.ts
@@ -1,0 +1,41 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
+import { replaceComponentInputName, updateAngularTemplate } from '../lib/angular-template';
+import { migrateFile } from '../lib/schematics';
+
+export default (options?: { skipInstallation?: boolean }): Rule => {
+	const skipInstallation = options?.skipInstallation ?? false;
+
+	return async (tree, context) => {
+		if (!skipInstallation) {
+			context.logger.info('Installing dependencies...');
+
+			try {
+				spawnSync('npm', ['ci'], {
+					cwd: path.join(__dirname, '../lib/local-deps'),
+				});
+				context.logger.info('Installing dependencies... Done!');
+			} catch (e) {
+				// eslint-disable-next-line
+				context.logger.error('Failed to install dependencies', (e as any).toString());
+			}
+		}
+
+		const angularCompiler = await import('@angular/compiler');
+
+		tree.visit((path, entry) => {
+			if (path.includes('node_modules') || !entry) {
+				return;
+			}
+
+			migrateFile(path, entry, tree, (content) =>
+				updateAngularTemplate(path, content, (template) => {
+					template = replaceComponentInputName('lu-empty-state-page', 'title', 'heading', template, angularCompiler);
+					template = replaceComponentInputName('lu-empty-state-section', 'title', 'heading', template, angularCompiler);
+					return template;
+				}),
+			);
+		});
+	};
+};

--- a/packages/ng/schematics/empty-state-title/migration.spec.ts
+++ b/packages/ng/schematics/empty-state-title/migration.spec.ts
@@ -1,0 +1,26 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { createTreeFromFiles, expectTree, runSchematic } from '../lib/migration-test.js';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'migrations.json'));
+const testsRoot = path.join(__dirname, 'tests');
+const files = fs.readdirSync(testsRoot);
+
+describe('Empty state title migration', () => {
+	it('should update files', async () => {
+		// Arrange
+		const tree = createTreeFromFiles(testsRoot, files, '.input.');
+		const expectedTree = createTreeFromFiles(testsRoot, files, '.output.');
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'empty-state-heading', { skipInstallation: true }, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+});

--- a/packages/ng/schematics/empty-state-title/schema.json
+++ b/packages/ng/schematics/empty-state-title/schema.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"$id": "LuccaFrontTokensSpacing",
+	"title": "Lucca Front Tokens Spacing Schema",
+	"type": "object",
+	"properties": {}
+}

--- a/packages/ng/schematics/empty-state-title/tests/template.input.html
+++ b/packages/ng/schematics/empty-state-title/tests/template.input.html
@@ -1,0 +1,19 @@
+<lu-empty-state-page title="Some title" description="Some description">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-page>
+
+<lu-empty-state-page [title]="'TITLE' | transloco" [description]="'DESCRIPTION' | transloco">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-page>
+
+<lu-empty-state-section title="Some title" description="Some description">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-section>
+
+<lu-empty-state-section [title]="'TITLE' | transloco" [description]="'DESCRIPTION' | transloco">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-section>

--- a/packages/ng/schematics/empty-state-title/tests/template.output.html
+++ b/packages/ng/schematics/empty-state-title/tests/template.output.html
@@ -1,0 +1,19 @@
+<lu-empty-state-page heading="Some title" description="Some description">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-page>
+
+<lu-empty-state-page [heading]="'TITLE' | transloco" [description]="'DESCRIPTION' | transloco">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-page>
+
+<lu-empty-state-section heading="Some title" description="Some description">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-section>
+
+<lu-empty-state-section [heading]="'TITLE' | transloco" [description]="'DESCRIPTION' | transloco">
+	<button luButton type="button" palette="product">Button</button>
+	<button luButton="outlined" type="button" palette="product">Button</button>
+</lu-empty-state-section>

--- a/packages/ng/schematics/lib/angular-template.ts
+++ b/packages/ng/schematics/lib/angular-template.ts
@@ -95,7 +95,7 @@ export function replaceComponentInput(componentName: string, inputName: string, 
 				}
 			});
 
-			elAst.visitBoundAttribute('icon', (attr) => {
+			elAst.visitBoundAttribute(inputName, (attr) => {
 				if (attr.valueSpan && attr.value instanceof angularCompiler.ASTWithSource) {
 					const attrValue = attr.value.source || '';
 					const sourcefile = createSourceFile('', attrValue, ScriptTarget.ESNext);

--- a/packages/ng/schematics/migrations.json
+++ b/packages/ng/schematics/migrations.json
@@ -1,4 +1,10 @@
 {
-	"$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
-	"schematics": {}
+  "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
+  "schematics": {
+    "empty-state-heading": {
+      "version": "18.2.0-alpha",
+      "description": "Change title input to heading input in empty state component.",
+      "factory": "./empty-state-title/index"
+    }
+  }
 }

--- a/packages/ng/schematics/new-icons/index.ts
+++ b/packages/ng/schematics/new-icons/index.ts
@@ -24,7 +24,6 @@ export default (options?: { skipInstallation?: boolean }): Rule => {
 
 		const postCssScss = await import('../lib/local-deps/postcss-scss.js');
 		const angularCompiler = await import('@angular/compiler');
-		const { postcssValueParser } = await import('../lib/local-deps/postcss-value-parser.js');
 		const { postcssSelectorParser } = await import('../lib/local-deps/postcss-selector-parser.js');
 
 		tree.visit((path, entry) => {
@@ -32,7 +31,7 @@ export default (options?: { skipInstallation?: boolean }): Rule => {
 				return;
 			}
 			if (path.endsWith('.scss')) {
-				migrateFile(path, entry, tree, (content) => migrateScssFile(content, postCssScss, postcssValueParser, postcssSelectorParser));
+				migrateFile(path, entry, tree, (content) => migrateScssFile(content, postCssScss, postcssSelectorParser));
 			}
 			if (path.endsWith('.html')) {
 				migrateFile(path, entry, tree, (content) => migrateHTMLFile(content, angularCompiler));

--- a/packages/ng/schematics/new-icons/migration.ts
+++ b/packages/ng/schematics/new-icons/migration.ts
@@ -1,4 +1,3 @@
-import { ValueParser } from 'postcss-value-parser';
 import { ScriptTarget, createSourceFile } from 'typescript';
 import { extractNgTemplates, replaceComponentInput } from '../lib/angular-template.js';
 import { updateContent } from '../lib/file-update.js';
@@ -8,7 +7,7 @@ import { PostCssScssLib, updateCSSClassNamesInRules } from '../lib/scss-ast.js';
 import { replaceStringLiterals } from '../lib/typescript-ast.js';
 import { oldIconClassToNewIconClass, oldIconToNewIcon, oldIcons } from './mapping.js';
 
-export function migrateScssFile(content: string, postCssScss: PostCssScssLib, postcssValueParser: ValueParser, postcssSelectorParser: PostCssSelectorParserLib): string {
+export function migrateScssFile(content: string, postCssScss: PostCssScssLib, postcssSelectorParser: PostCssSelectorParserLib): string {
 	const root = postCssScss.parse(content);
 
 	updateCSSClassNamesInRules(root, oldIconClassToNewIconClass, postcssSelectorParser);


### PR DESCRIPTION
## Description

Automatically replace all `title` inputs of empty-states to `heading` input.

-----

Migration has been tested on PEO ([commit](https://github.com/LuccaSA/Poplee.Talent/commit/a873b56bd486bb6756b8b54df03bae1ab9c77a55))

-----
