### PR TITLE
Replace title with heading

### DIFF
--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
@@ -1,6 +1,6 @@
 <section
 	class="emptyState mod-page"
-	[attr.role]="title ? null : 'presentation'"
+	[attr.role]="heading ? null : 'presentation'"
 	[style.--components-emptyState-background-color]="contentBackgroundColor"
 	style.--components-emptyState-illustration-background-bottom-left="url({{bottomLeftBackground}})"
 	style.--components-emptyState-illustration-foreground-bottom-left="url({{bottomLeftForeground}})"
@@ -11,7 +11,7 @@
 		<div class="emptyState-content">
 			<div *ngIf="icon" class="emptyState-content-icon" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
 			<div class="emptyState-content-text">
-				<div role="heading" [attr.aria-level]="hx" class="emptyState-content-heading" *ngIf="title">{{ title }}</div>
+				<div role="heading" [attr.aria-level]="hx" class="emptyState-content-heading" *ngIf="heading">{{ heading }}</div>
 				<p class="emptyState-content-description" *ngIf="description">
 					<ng-container *luPortal="description"></ng-container>
 				</p>

--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
@@ -54,7 +54,7 @@ export class EmptyStatePageComponent {
 	contentBackgroundColor = 'var(--pr-t-elevation-surface-default)';
 
 	@Input()
-	title: string;
+	heading: string;
 
 	@Input()
 	description: PortalContent;

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.html
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.html
@@ -1,9 +1,9 @@
-<section class="emptyState" [class.mod-center]="center" [attr.role]="title ? null : 'presentation'">
+<section class="emptyState" [class.mod-center]="center" [attr.role]="heading ? null : 'presentation'">
 	<div class="emptyState-container">
 		<div class="emptyState-content">
 			<div *ngIf="icon" class="emptyState-content-icon palette-{{palette}}" aria-hidden="true" [innerHtml]="icon | luSafeExternalSvg"></div>
 			<div class="emptyState-content-text">
-				<div role="heading" [attr.aria-level]="hx" class="emptyState-content-heading" *ngIf="title">{{ title }}</div>
+				<div role="heading" [attr.aria-level]="hx" class="emptyState-content-heading" *ngIf="heading">{{ heading }}</div>
 				<p class="emptyState-content-description" *ngIf="description">
 					<ng-container *luPortal="description"></ng-container>
 				</p>

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -28,7 +28,7 @@ export class EmptyStateSectionComponent {
 	center = false;
 
 	@Input()
-	title: string;
+	heading: string;
 
 	@Input()
 	description: PortalContent;

--- a/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
@@ -12,7 +12,7 @@ export default {
 		}),
 	],
 	render: (args: EmptyStatePageComponent) => {
-		const { title, description, icon, topRightBackground, topRightForeground, bottomLeftBackground, bottomLeftForeground, contentBackgroundColor, hx } = args;
+		const { heading, description, icon, topRightBackground, topRightForeground, bottomLeftBackground, bottomLeftForeground, contentBackgroundColor, hx } = args;
 		const paramIcon = args.icon === '' ? '' : 'icon="' + args.icon + '"';
 
 		return {
@@ -26,7 +26,7 @@ export default {
 `,
 			],
 			template: `<lu-empty-state-page
-	title="${title}"
+	heading="${heading}"
 	description="${description}"
 	${paramIcon}
 	topRightBackground="${topRightBackground}"
@@ -153,7 +153,7 @@ export default {
 
 export const Page: StoryObj<EmptyStatePageComponent> = {
 	args: {
-		title: 'Empty state page',
+		heading: 'Empty state page',
 		description: 'Description can be a string or a ng-template',
 		icon: '',
 		topRightBackground: 'https://cdn.lucca.fr/lucca-front/assets/empty-states/poplee/bubbles-top-right-01.svg',

--- a/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
@@ -13,10 +13,10 @@ export default {
 		}),
 	],
 	render: (args: EmptyStateSectionComponent) => {
-		const { title, description, center, palette, hx, icon } = args;
+		const { heading, description, center, palette, hx, icon } = args;
 		const paramIcon = args.icon === '' ? '' : 'icon="' + args.icon + '"';
 		return {
-			template: `<lu-empty-state-section hx="${hx}" ${paramIcon} title="${title}" description="${description}" palette="${palette}" ${center ? ' center' : ''}>
+			template: `<lu-empty-state-section hx="${hx}" ${paramIcon} heading="${heading}" description="${description}" palette="${palette}" ${center ? ' center' : ''}>
 	<button luButton type="button" palette="product">Button</button>
 	<button luButton="outlined" type="button" palette="product">Button</button>
 </lu-empty-state-section>`,
@@ -89,7 +89,7 @@ export default {
 			],
 			control: 'select',
 		},
-		title: {
+		heading: {
 			description: '[v18.1] Optional',
 		},
 		description: {
@@ -101,7 +101,7 @@ export default {
 export const Section: StoryObj<EmptyStateSectionComponent> = {
 	args: {
 		icon: 'https://cdn.lucca.fr/lucca-front/assets/empty-states/icons/iconRocket.svg',
-		title: 'Empty state section',
+		heading: 'Empty state section',
 		description: 'Description can be a string or a ng-template',
 		center: false,
 		palette: 'none',

--- a/stories/qa/forms/textfield.stories.html
+++ b/stories/qa/forms/textfield.stories.html
@@ -354,8 +354,7 @@
 
 	<div class="form-field pr-u-marginBottom300">
 		<label class="formLabel" id="fieldAlignRightAffixlabel" for="fieldAlignRightAffix">
-			Label<sup class="formLabel-required" aria-hidden="true">*</sup
-			><span aria-hidden="true" class="lucca-icon icon-signHelp" title="yoiejuf"></span>
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup><span aria-hidden="true" class="lucca-icon icon-signHelp"></span>
 		</label>
 		<div class="textField mod-valueAlignRight">
 			<div class="textField-input">


### PR DESCRIPTION
## Description

The `title` attribute of the Angular component generates an HTML tooltip, so we change it to `heading`.

-----



-----

Before:
![Capture d’écran 2024-07-15 à 10 40 58](https://github.com/user-attachments/assets/899132c9-cf58-4f06-89ff-9960c4cdd4c5)




