### PR TITLE
Remove tooltip generated by Safari desktop

### DIFF
--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -23,6 +23,7 @@
 	}
 
 	@at-root ($atRoot) {
+		// Prevent Safari to display a native tooltip
 		[luTooltipWhenEllipsis] {
 			@supports (background-image: -webkit-named-image(i)) {
 				@media (hover: hover) {

--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -21,4 +21,17 @@
 	&:empty {
 		display: none;
 	}
+
+	@at-root ($atRoot) {
+		[luTooltipWhenEllipsis] {
+			@supports (background-image: -webkit-named-image(i)) {
+				@media (hover: hover) {
+					&::after {
+						content: '';
+						display: block;
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Description

Disables the tooltip automatically generated by Safari when it detects truncated text.

-----



-----

Before:
![Capture d’écran 2024-07-16 à 17 33 11](https://github.com/user-attachments/assets/a0c54528-a71b-48e4-9681-750d8df58b97)

