### PR TITLE
fix(core-select): missing clue filter in users directive under some conditions

### DIFF
--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -28,6 +28,14 @@ class TestDirective extends ALuCoreSelectApiDirective<TestEntity> {
 	public override getOptions(): Observable<TestEntity[]> {
 		return of([{ id: 1, name: 'test' }]);
 	}
+
+	public setPageSize(size: number) {
+		this.pageSize = size;
+	}
+
+	public override getOptionsPage(params: Record<string, string | number | boolean>, page: number): Observable<{ items: TestEntity[]; isLastPage: boolean }> {
+		return super.getOptionsPage(params, page);
+	}
 }
 
 @Component({
@@ -41,6 +49,7 @@ describe('ALuCoreSelectApiDirective', () => {
 	let spectator: Spectator<HostComponent>;
 	let select: LuSimpleSelectInputComponent<TestEntity>;
 	let testApi: TestDirective;
+	let getOptionsSpy: jest.SpyInstance<Observable<TestEntity[]>, []>;
 
 	const createComponent = createComponentFactory<HostComponent>({
 		component: HostComponent,
@@ -50,7 +59,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		spectator = createComponent({ detectChanges: false });
 		testApi = spectator.query(TestDirective);
 		select = spectator.query<LuSimpleSelectInputComponent<TestEntity>>(LuSimpleSelectInputComponent);
-		jest.spyOn(testApi, 'getOptions');
+		getOptionsSpy = jest.spyOn(testApi, 'getOptions');
 	});
 
 	it('should query options when clicking on the select', fakeAsync(() => {
@@ -96,5 +105,101 @@ describe('ALuCoreSelectApiDirective', () => {
 		expect(testApi.getOptions).toHaveBeenCalledWith({ clue: 'hey' }, 0);
 
 		spectator.tick(); // Avoid "1 periodic timer(s) still in the queue." because of the debounceTime(0) in the ALuCoreSelectApiDirective
+	}));
+
+	it('should call each page will page not full', fakeAsync(() => {
+		// Arrange
+		spectator.tick(); // Component initialization uses a setTimeout :see_no_evil:
+		testApi.setPageSize(2);
+
+		// Act (Page 1)
+		getOptionsSpy.mockReturnValue(
+			of([
+				{ id: 1, name: 'test 1' },
+				{ id: 2, name: 'test 2' },
+			]),
+		);
+
+		select.clueChanged('test');
+		spectator.tick(MAGIC_DEBOUNCE_DURATION);
+		spectator.tick();
+
+		// Act (Page 2)
+		getOptionsSpy.mockReturnValue(
+			of([
+				{ id: 3, name: 'test 3' },
+				{ id: 4, name: 'test 4' },
+			]),
+		);
+		select.nextPage.emit();
+		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+		spectator.tick();
+
+		// // Act (Page 3)
+		getOptionsSpy.mockReturnValue(of([{ id: 5, name: 'test 5' }]));
+		select.nextPage.emit();
+		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+		spectator.tick();
+
+		// Act (do nothing)
+		select.nextPage.emit();
+		select.nextPage.emit();
+
+		// // Assert
+		expect(testApi.getOptions).toHaveBeenCalledTimes(3);
+
+		let options: TestEntity[];
+
+		select.options$.subscribe((o) => (options = o));
+
+		expect(options).toEqual([
+			{ id: 1, name: 'test 1' },
+			{ id: 2, name: 'test 2' },
+			{ id: 3, name: 'test 3' },
+			{ id: 4, name: 'test 4' },
+			{ id: 5, name: 'test 5' },
+		]);
+	}));
+
+	it('should allow multiple emission on same page', fakeAsync(() => {
+		// Arrange
+		spectator.tick(); // Component initialization uses a setTimeout :see_no_evil:
+		testApi.setPageSize(2);
+
+		const getPageSpy = jest.spyOn(testApi, 'getOptionsPage');
+		getPageSpy.mockImplementation((params, page) => {
+			// Emit one list, then the same list with one more item
+			return of(
+				{
+					items: [{ id: page * 2 + 1, name: `test ${page * 2 + 1}` }],
+					isLastPage: false,
+				},
+				{
+					items: [
+						{ id: page * 2 + 1, name: `test ${page * 2 + 1}` },
+						{ id: page * 2 + 2, name: `test ${page * 2 + 2}` },
+					],
+					isLastPage: false,
+				},
+			);
+		});
+
+		// Act (Page 1)
+		select.openPanel();
+		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Act (Page 2)
+		select.nextPage.emit();
+		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Assert
+		let options: TestEntity[];
+		select.options$.subscribe((o) => (options = o));
+		expect(options).toEqual([
+			{ id: 1, name: 'test 1' },
+			{ id: 2, name: 'test 2' },
+			{ id: 3, name: 'test 3' },
+			{ id: 4, name: 'test 4' },
+		]);
 	}));
 });

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -73,18 +73,29 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 			switchMap(([params, isOpened]) =>
 				isOpened
 					? this.page$.pipe(
-							concatMap((page) => {
-								this.select.loading = true;
-								return this.getOptions(params, page).pipe(
-									catchError(() => of([] as TOption[])),
-									tap(() => (this.select.loading = false)),
-								);
-							}),
-							takeWhile((items) => items.length === this.pageSize, true),
-							scan((acc, items) => [...acc, ...items], [] as TOption[]),
+							concatMap((page) => this.getOptionsPage(params, page).pipe(map(({ items, isLastPage }) => ({ items, isLastPage, page })))),
+							takeWhile(({ isLastPage }) => !isLastPage, true),
+							scan(
+								(acc, { items, page }) => {
+									acc[page] = items;
+									return acc;
+								},
+								{} as Record<number, TOption[]>,
+							),
+							map((pages) => Object.values(pages).flat()),
 						)
 					: of([] as TOption[]),
 			),
+		);
+	}
+
+	protected getOptionsPage(params: TParams, page: number): Observable<{ items: TOption[]; isLastPage: boolean }> {
+		this.select.loading = true;
+
+		return this.getOptions(params, page).pipe(
+			catchError(() => of([] as TOption[])),
+			tap(() => (this.select.loading = false)),
+			map((items) => ({ items, isLastPage: items.length < this.pageSize })),
 		);
 	}
 

--- a/packages/ng/core-select/panel/index.ts
+++ b/packages/ng/core-select/panel/index.ts
@@ -1,2 +1,3 @@
+export * from './key-manager';
 export * from './panel.models';
 export { getGroupTemplateLocation as ɵgetGroupTemplateLocation } from './panel.utils';

--- a/packages/ng/core-select/panel/key-manager.spec.ts
+++ b/packages/ng/core-select/panel/key-manager.spec.ts
@@ -1,0 +1,135 @@
+import { EventEmitter, QueryList } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject } from 'rxjs';
+import { ɵLuOptionComponent } from '../option';
+import { CoreSelectKeyManager } from './key-manager';
+
+describe('CoreSelectKeyManager', () => {
+	let queryList: QueryList<ɵLuOptionComponent<string>>;
+	let options$: BehaviorSubject<string[]>;
+	let keyManager: CoreSelectKeyManager<string>;
+
+	const clueChange$ = new EventEmitter<string>();
+	const activeOptionIdChanged$ = new EventEmitter<string>();
+
+	beforeEach(fakeAsync(() => {
+		TestBed.configureTestingModule({
+			providers: [CoreSelectKeyManager],
+		});
+
+		queryList = new QueryList<ɵLuOptionComponent<string>>();
+		options$ = new BehaviorSubject<string[]>([]);
+		keyManager = TestBed.inject(CoreSelectKeyManager);
+
+		keyManager.init({
+			queryList,
+			options$,
+			optionComparer: (a, b) => a === b,
+			activeOptionIdChanged$,
+			clueChange$,
+		});
+		tick();
+	}));
+
+	it('should select first option on clue change', fakeAsync(() => {
+		// Arrange
+		options$.next(['lol 1', 'lol 2', 'lol 3']);
+		queryList.reset(createComponents(options$.value));
+		keyManager.setActiveItem(2);
+		tick();
+
+		// Act
+		clueChange$.emit('test');
+		options$.next(['test 1', 'test 2', 'test 3']);
+		queryList.reset(createComponents(options$.value));
+		tick();
+
+		// Assert
+		expect(keyManager.activeItemIndex).toBe(0);
+	}));
+
+	it('should select first option is list goes empty then filled again', fakeAsync(() => {
+		// Arrange
+		options$.next(['lol 1', 'lol 2', 'lol 3']);
+		queryList.reset(createComponents(options$.value));
+		keyManager.setActiveItem(2);
+		tick();
+
+		// Act
+		options$.next([]);
+		queryList.reset([]);
+		tick();
+
+		expect(keyManager.activeItemIndex).toBe(-1);
+
+		options$.next(['test 1', 'test 2', 'test 3']);
+		queryList.reset(createComponents(options$.value));
+		tick();
+
+		// Assert
+		expect(keyManager.activeItemIndex).toBe(0);
+	}));
+
+	it('should keep selected index while options are loading after clue change', fakeAsync(() => {
+		// Arrange
+		options$.next(['lol 1', 'lol 2', 'lol 3', 'lol 4', 'lol 5']);
+		const components = createComponents(options$.value);
+		queryList.reset(components);
+		keyManager.setActiveItem(2);
+		tick();
+
+		// Act
+		clueChange$.emit('test');
+		tick();
+
+		// Assert
+		expect(keyManager.activeItemIndex).toBe(2);
+	}));
+
+	describe('highlightOption', () => {
+		it('should select option immediatly if already available', fakeAsync(() => {
+			// Arrange
+			options$.next(['lol 1', 'lol 2', 'lol 3']);
+			queryList.reset(createComponents(options$.value));
+			tick();
+
+			// Act
+			keyManager.highlightOption('lol 2');
+			tick();
+
+			// Assert
+			expect(keyManager.activeItemIndex).toBe(1);
+		}));
+
+		it('should select option when available', fakeAsync(() => {
+			// Act
+			keyManager.highlightOption('lol 2');
+			tick();
+
+			expect(keyManager.activeItemIndex).toBe(-1);
+
+			tick(1000); // Wait some time
+
+			options$.next(['lol 1', 'lol 2', 'lol 3']);
+			tick();
+
+			// Assert
+			expect(keyManager.activeItemIndex).toBe(1);
+		}));
+	});
+});
+
+let id = 0;
+
+function createComponents(options: string[]): ɵLuOptionComponent<string>[] {
+	return options.map(createComponent);
+}
+
+function createComponent(option: string): ɵLuOptionComponent<string> {
+	const component = {} as ɵLuOptionComponent<string>;
+	component.option = option;
+	component.setActiveStyles = () => {};
+	component.setInactiveStyles = () => {};
+	(component as any).id = String(id++);
+	return component;
+}

--- a/packages/ng/core-select/panel/key-manager.spec.ts
+++ b/packages/ng/core-select/panel/key-manager.spec.ts
@@ -19,7 +19,7 @@ describe('CoreSelectKeyManager', () => {
 
 		queryList = new QueryList<ɵLuOptionComponent<string>>();
 		options$ = new BehaviorSubject<string[]>([]);
-		keyManager = TestBed.inject(CoreSelectKeyManager);
+		keyManager = TestBed.inject<CoreSelectKeyManager<string>>(CoreSelectKeyManager);
 
 		keyManager.init({
 			queryList,
@@ -130,6 +130,6 @@ function createComponent(option: string): ɵLuOptionComponent<string> {
 	component.option = option;
 	component.setActiveStyles = () => {};
 	component.setInactiveStyles = () => {};
-	(component as any).id = String(id++);
+	Object.defineProperty(component, 'id', { get: () => String(id++) });
 	return component;
 }

--- a/packages/ng/core-select/panel/key-manager.ts
+++ b/packages/ng/core-select/panel/key-manager.ts
@@ -40,6 +40,10 @@ export class CoreSelectKeyManager<T> {
 		return this.#cdkKeyManager?.activeItemIndex ?? -1;
 	}
 
+	setActiveItem(index: number): void {
+		this.#cdkKeyManager?.setActiveItem(index);
+	}
+
 	highlightOption(option: T): void {
 		if (!this.#options) {
 			return;
@@ -56,10 +60,6 @@ export class CoreSelectKeyManager<T> {
 				takeUntilDestroyed(this.#destroyRef),
 			)
 			.subscribe((selectedIndex) => this.setActiveItem(selectedIndex));
-	}
-
-	setActiveItem(index: number): void {
-		this.#cdkKeyManager?.setActiveItem(index);
 	}
 
 	#bindClueChange(clueChange$: Observable<string>): void {

--- a/packages/ng/core-select/panel/key-manager.ts
+++ b/packages/ng/core-select/panel/key-manager.ts
@@ -1,0 +1,103 @@
+import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
+import { DestroyRef, EventEmitter, Injectable, QueryList, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Observable, asyncScheduler, debounceTime, filter, map, observeOn, take } from 'rxjs';
+import { ɵLuOptionComponent } from '../option';
+
+interface CoreSelectKeyManagerOptions<T> {
+	queryList: QueryList<ɵLuOptionComponent<T>>;
+	options$: Observable<T[]>;
+	optionComparer: (a: T, b: T) => boolean;
+	activeOptionIdChanged$: EventEmitter<string>;
+	clueChange$: Observable<string>;
+}
+
+@Injectable()
+export class CoreSelectKeyManager<T> {
+	#destroyRef = inject(DestroyRef);
+	#cdkKeyManager?: ActiveDescendantKeyManager<ɵLuOptionComponent<T>>;
+	#hasSearchChanged = false;
+	#options?: CoreSelectKeyManagerOptions<T>;
+
+	init(options: CoreSelectKeyManagerOptions<T>): void {
+		this.#options = options;
+		this.#cdkKeyManager = new ActiveDescendantKeyManager(options.queryList).withHomeAndEnd();
+		this.#bindClueChange(options.clueChange$);
+		this.#bindOptionsChange(options);
+		this.#bindActiveOptionIdChanged(options.activeOptionIdChanged$);
+		this.#cdkKeyManager.setFirstItemActive();
+	}
+
+	onKeydown(event: KeyboardEvent): void {
+		this.#cdkKeyManager?.onKeydown(event);
+	}
+
+	get activeItem(): ɵLuOptionComponent<T> | undefined {
+		return this.#cdkKeyManager?.activeItem;
+	}
+
+	get activeItemIndex(): number {
+		return this.#cdkKeyManager?.activeItemIndex ?? -1;
+	}
+
+	highlightOption(option: T): void {
+		if (!this.#options) {
+			return;
+		}
+
+		const { options$, optionComparer } = this.#options;
+
+		options$
+			.pipe(
+				observeOn(asyncScheduler),
+				map((options) => options.findIndex((o) => optionComparer(o, option))),
+				filter((index) => index !== -1),
+				take(1),
+				takeUntilDestroyed(this.#destroyRef),
+			)
+			.subscribe((selectedIndex) => this.setActiveItem(selectedIndex));
+	}
+
+	setActiveItem(index: number): void {
+		this.#cdkKeyManager?.setActiveItem(index);
+	}
+
+	#bindClueChange(clueChange$: Observable<string>): void {
+		clueChange$.pipe(takeUntilDestroyed(this.#destroyRef)).subscribe(() => {
+			this.#hasSearchChanged = true;
+		});
+	}
+
+	#bindActiveOptionIdChanged(activeOptionIdChanged$: EventEmitter<string>): void {
+		this.#cdkKeyManager.change
+			.pipe(
+				map(() => this.#cdkKeyManager.activeItem?.id),
+				takeUntilDestroyed(this.#destroyRef),
+			)
+			.subscribe((activeDescendant) => activeOptionIdChanged$.emit(activeDescendant));
+	}
+
+	/**
+	 * Ensure always have the correct highlighted item:
+	 * 	- reset to null if no options
+	 * 	- set to first item if search has changed
+	 * 	- set to first item if no active item
+	 */
+	#bindOptionsChange({ options$, queryList }: CoreSelectKeyManagerOptions<T>): void {
+		options$
+			.pipe(
+				debounceTime(0), // Wait until QueryList is updated
+				takeUntilDestroyed(this.#destroyRef),
+			)
+			.subscribe(() => {
+				if (queryList.length === 0) {
+					this.#cdkKeyManager.setActiveItem(-1);
+				} else if (this.#hasSearchChanged) {
+					this.#hasSearchChanged = false;
+					this.#cdkKeyManager.setFirstItemActive();
+				} else if (!this.#cdkKeyManager.activeItem) {
+					this.#cdkKeyManager.setFirstItemActive();
+				}
+			});
+	}
+}

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -1,0 +1,167 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component, Directive, forwardRef, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { MAGIC_DEBOUNCE_DURATION } from '../api/api.directive';
+import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
+import { provideCoreSelectCurrentUserId } from './me.provider';
+import { LuCoreSelectUser } from './user-option.model';
+import { LuCoreSelectUsersDirective } from './users.directive';
+
+@Directive({
+	selector: '[luTestUsers]',
+	standalone: true,
+	providers: [
+		{
+			provide: LuCoreSelectUsersDirective,
+			useExisting: forwardRef(() => TestUsersDirective),
+		},
+	],
+})
+class TestUsersDirective extends LuCoreSelectUsersDirective {
+	public setPageSize(size: number) {
+		this.pageSize = size;
+	}
+}
+
+@Component({
+	selector: 'lu-users-directive-host',
+	standalone: true,
+	imports: [LuSimpleSelectInputComponent, TestUsersDirective],
+	template: `<lu-simple-select luTestUsers />`,
+})
+class LuUsersDirectiveHostComponent {
+	simpleSelect = viewChild.required<LuSimpleSelectInputComponent<LuCoreSelectUser>>(LuSimpleSelectInputComponent);
+	usersDirective = viewChild.required<TestUsersDirective>(TestUsersDirective);
+}
+
+const CURRENT_USER_ID = 12;
+const fields = 'id,firstName,lastName,picture.href';
+
+describe('LuCoreSelectUsersDirective', () => {
+	let httpTestingController: HttpTestingController;
+	let fixture: ComponentFixture<LuUsersDirectiveHostComponent>;
+	let simpleSelect: LuSimpleSelectInputComponent<LuCoreSelectUser>;
+	let usersDirective: TestUsersDirective;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [LuUsersDirectiveHostComponent],
+			providers: [provideHttpClient(), provideHttpClientTesting(), provideCoreSelectCurrentUserId(() => CURRENT_USER_ID)],
+		});
+
+		httpTestingController = TestBed.inject(HttpTestingController);
+		fixture = TestBed.createComponent(LuUsersDirectiveHostComponent);
+		simpleSelect = fixture.componentInstance.simpleSelect();
+		usersDirective = fixture.componentInstance.usersDirective();
+	});
+
+	it('should not make any call on init', fakeAsync(() => {
+		// Act
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Assert
+		httpTestingController.verify();
+	}));
+
+	it('should call initial list on open', fakeAsync(() => {
+		// Act
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Assert (Me + Initial list)
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,20`);
+		httpTestingController.verify();
+	}));
+
+	it('should call search with clue when panel is opened', fakeAsync(() => {
+		// Arrange
+		const clue = 'test';
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION);
+
+		// Act
+		simpleSelect.clueChanged(clue);
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION);
+
+		// Assert (Me + Initial list + Search with clue)
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,20`);
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&clue=${clue}&paging=0,20`);
+		httpTestingController.verify();
+	}));
+
+	it('should not call "me" and call initial filtered list when panel is closed', fakeAsync(() => {
+		// Arrange
+		const clue = 'test';
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION);
+
+		// Act
+		simpleSelect.clueChanged(clue);
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION);
+
+		// Assert (Initial filtered list)
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&clue=${clue}&paging=0,20`);
+		httpTestingController.verify();
+	}));
+
+	it('should return "me" on the first page only if clue is empty', fakeAsync(() => {
+		// Arrange
+		usersDirective.setPageSize(3);
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+
+		const meUser = createUser(CURRENT_USER_ID);
+		const page1 = [createUser(1), createUser(2), createUser(3)];
+		const page2 = [createUser(4), meUser, createUser(6)];
+
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Act (Page 1)
+		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		meReq.flush(usersResponse([meUser]));
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		const page1Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,3`);
+		page1Req.flush(usersResponse(page1));
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Assert (Page 1)
+		let options: LuCoreSelectUser[];
+		simpleSelect.options$.subscribe((o) => (options = o));
+
+		expect(options).toEqual([meUser, ...page1]);
+
+		// Act (Page 2)
+		simpleSelect.nextPage.emit();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		const page2Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=3,3`);
+		page2Req.flush(usersResponse(page2));
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Assert (Page 2)
+		expect(options).toEqual([meUser, ...page1, ...page2.filter((u) => u.id !== CURRENT_USER_ID)]);
+		httpTestingController.verify();
+	}));
+});
+
+function createUser(id: number): LuCoreSelectUser {
+	return { id, firstName: 'test ' + id, lastName: 'test' + id, picture: null };
+}
+
+function usersResponse(users: LuCoreSelectUser[]) {
+	return { data: { items: users.map((u) => ({ item: u })) } };
+}

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -128,7 +128,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		}),
 		map((res) => res.data.items.map(({ item }) => item)[0] ?? null),
 		takeUntilDestroyed(),
-		shareReplay(),
+		shareReplay(1),
 	);
 
 	protected getMe(): Observable<T | null> {

--- a/packages/ng/multi-select/input/panel-ref.factory.ts
+++ b/packages/ng/multi-select/input/panel-ref.factory.ts
@@ -67,7 +67,7 @@ class MultiSelectPanelRef<T> extends LuMultiSelectPanelRef<T> {
 	}
 
 	selectCurrentlyHighlightedValue(): void {
-		if (this.instance.keyManager?.activeItem) {
+		if (this.instance.keyManager.activeItem) {
 			this.instance.toggleOption(this.instance.keyManager.activeItem.option);
 		}
 	}

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,11 +1,10 @@
-import { A11yModule, ActiveDescendantKeyManager } from '@angular/cdk/a11y';
+import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, QueryList, TrackByFunction, ViewChildren, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective, getIntl } from '@lucca-front/ng/core';
-import { LuOptionGroup, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
-import { asyncScheduler, filter, map, observeOn, take, takeUntil } from 'rxjs';
-import { debounceTime, switchMap } from 'rxjs/operators';
+import { CoreSelectKeyManager, LuOptionGroup, SELECT_ID, ɵLuOptionComponent, ɵLuOptionGroupPipe, ɵLuOptionOutletDirective, ɵgetGroupTemplateLocation } from '@lucca-front/ng/core-select';
+import { EMPTY } from 'rxjs';
 import { LuMultiSelectInputComponent } from '../input';
 import { LuMultiSelectPanelRef } from '../input/panel.model';
 import { MULTI_SELECT_INPUT } from '../select.model';
@@ -35,6 +34,7 @@ import { ɵLuMultiSelectSelectedChipDirective } from './selected-chip.directive'
 		PortalDirective,
 		LuNotSelectedOptionsPipe,
 	],
+	providers: [CoreSelectKeyManager],
 })
 export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 	protected selectInput = inject<LuMultiSelectInputComponent<T>>(MULTI_SELECT_INPUT);
@@ -55,11 +55,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 	optionTpl = this.selectInput.optionTpl;
 
 	@ViewChildren(ɵLuOptionComponent) optionsQL: QueryList<ɵLuOptionComponent<T>>;
-	private _keyManager: ActiveDescendantKeyManager<ɵLuOptionComponent<T>>;
-
-	public get keyManager(): ActiveDescendantKeyManager<ɵLuOptionComponent<T>> {
-		return this._keyManager;
-	}
+	keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 
 	public clueChange$ = this.selectInput.clue$;
 	public shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
@@ -94,7 +90,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 		this.selectedOptions = matchingOption ? this.selectedOptions.filter((o) => o !== matchingOption) : [...this.selectedOptions, option];
 		this.panelRef.emitValue(this.selectedOptions);
 		setTimeout(() => this.panelRef.updatePosition());
-		this._keyManager?.setActiveItem(this.optionsQL.toArray().findIndex((o) => o.option === option));
+		this.keyManager.setActiveItem(this.optionsQL.toArray().findIndex((o) => o.option === option));
 	}
 
 	toggleOptions(notSelectedOptions: T[], groupOptions: T[]): void {
@@ -111,40 +107,16 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit {
 	}
 
 	protected initKeyManager(): void {
-		this._keyManager = new ActiveDescendantKeyManager(this.optionsQL).withHomeAndEnd();
+		this.keyManager.init({
+			queryList: this.optionsQL,
+			options$: this.options$,
+			optionComparer: this.optionComparer,
+			activeOptionIdChanged$: this.panelRef.activeOptionIdChanged,
+			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange : EMPTY,
+		});
 
-		if (this.selectedOptions) {
-			this.options$
-				?.pipe(
-					observeOn(asyncScheduler),
-					map((options) => (this.selectedOptions.length ? options.findIndex((o) => this.optionComparer(o, this.selectedOptions[0])) : -1)),
-					filter((index) => index !== -1),
-					take(1),
-					takeUntil(this.panelRef.closed),
-				)
-				.subscribe((selectedIndex) => this._keyManager.setActiveItem(selectedIndex));
+		if (this.selectedOptions?.length) {
+			this.keyManager.highlightOption(this.selectedOptions[0]);
 		}
-
-		this._keyManager.change
-			.pipe(
-				map(() => this._keyManager.activeItem?.id),
-				takeUntil(this.panelRef.closed),
-			)
-			.subscribe((activeDescendant) => this.panelRef.activeOptionIdChanged.emit(activeDescendant));
-
-		/**
-		 * On new options, we want to select the first element with key manager
-		 */
-		if (this.selectInput.searchable) {
-			this.selectInput.clueChange
-				.pipe(
-					switchMap(() => this.optionsQL.changes.pipe(take(1))),
-					debounceTime(0),
-					takeUntil(this.panelRef.closed),
-				)
-				.subscribe(() => (this.optionsQL.length ? this.keyManager.setFirstItemActive() : this.keyManager.setActiveItem(-1)));
-		}
-
-		this.keyManager.setFirstItemActive();
 	}
 }


### PR DESCRIPTION
## Description

- Extracted `CoreSelectKeyManager` to avoid duplication is simple/multi select panels. It makes Highlight logic more testable
- Fix issue in homonyms cache
- Fix highlight issue when using `LuCoreSelectUsersDirective`
- Fix missing clue when typing the first search when using `LuCoreSelectUsersDirective`

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
