### PR TITLE
Add option luTooltipOnlyForDisplay for tooltips

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -9,11 +9,11 @@ import {
 	HostBinding,
 	HostListener,
 	Input,
+	OnDestroy,
 	Renderer2,
 	booleanAttribute,
 	inject,
 	numberAttribute,
-	OnDestroy,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SafeHtml } from '@angular/platform-browser';
@@ -66,6 +66,9 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 		}
 	}
 
+	@Input({ transform: booleanAttribute })
+	luTooltipOnlyForDisplay = false;
+
 	@Input()
 	luTooltipPosition: LuPopoverPosition = 'above';
 
@@ -113,7 +116,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 
 	@HostBinding('attr.aria-describedby')
 	get ariaDescribedBy() {
-		if (this.#disabled || this.luTooltipWhenEllipsis) {
+		if (this.#disabled || this.luTooltipWhenEllipsis || this.luTooltipOnlyForDisplay) {
 			return null;
 		}
 		return `${this.#generatedId}-panel`;

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -1,4 +1,5 @@
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { IconComponent } from '@lucca-front/ng/icon';
 import { LuTooltipModule, LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { generateInputs } from '../../../helpers/stories';
@@ -41,7 +42,7 @@ export default {
 	decorators: [
 		applicationConfig({ providers: [provideAnimations()] }),
 		moduleMetadata({
-			imports: [LuTooltipModule],
+			imports: [LuTooltipModule, IconComponent],
 		}),
 	],
 	render: (args, { argTypes }) => {
@@ -50,9 +51,7 @@ export default {
 				`
 					h3 {
 						margin: 0;
-					}
-					.button {
-						margin-bottom: var(--pr-t-spacings-200);
+						margin-top: var(--pr-t-spacings-200);
 					}
 					.ellipsis-example {
 						width: 11rem;
@@ -79,7 +78,10 @@ export default {
 	luTooltip="Ce texte est affiché entièrement. Le tooltip n'apparait pas au survol."
 	${generateInputs(args, argTypes)}
 	luTooltipWhenEllipsis
->Ce texte est affiché entièrement. Le tooltip n'apparait pas au survol.</div>`,
+>Ce texte est affiché entièrement. Le tooltip n'apparait pas au survol.</div>
+<h3>Tooltip et icône (avec alternative)</h3>
+<lu-icon icon="star" alt="Favoris" luTooltip="Favoris" luTooltipOnlyForDisplay="true"></lu-icon>
+`,
 		};
 	},
 } as Meta;


### PR DESCRIPTION
## Description

We'd like to be able to deactivate the accessibility of tooltips when they only serve to repeat text that's already there (masked).

-----

This option disables `aria-describedby`.

-----

![Capture d’écran 2024-07-22 à 15 30 32](https://github.com/user-attachments/assets/b840fcd3-8d67-4b1b-9981-90fb8a5ba593)