### PR TITLE
fix(intl): remove breaking change by accepting legacy type in getIntl

### DIFF
--- a/packages/ng/core/translate/intl.model.ts
+++ b/packages/ng/core/translate/intl.model.ts
@@ -1,7 +1,7 @@
 import { inject, InjectionToken, LOCALE_ID } from '@angular/core';
-import { LuTranslation } from './translation.model';
+import { ILuTranslation, LuTranslation } from './translation.model';
 
-export function getIntl<T>(translationsToken: InjectionToken<LuTranslation<T>>): T {
+export function getIntl<T>(translationsToken: InjectionToken<LuTranslation<T>> | InjectionToken<ILuTranslation<T>>): T {
 	const locale = inject(LOCALE_ID);
 	const translations = inject(translationsToken);
 


### PR DESCRIPTION
## Description

For teams who create/copy components relying on `getIntl`, the update from `ILuTranslation` to `LuTranslation` was breaking.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
