### PR TITLE
fix(core-select): fix former employees param for users core select

### DIFF
--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -107,7 +107,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			...(clue ? { clue: clue } : {}),
 			...(operationIds ? { operations: operationIds.join(',') } : {}),
 			...(appInstanceId ? { appInstanceId } : {}),
-			...(enableFormerEmployees ? { formerEmployee: enableFormerEmployees } : {}),
+			...(enableFormerEmployees ? { formerEmployees: enableFormerEmployees } : {}),
 		})),
 	);
 


### PR DESCRIPTION
## Description

- On users core-select directive, former employees query param was not the one expected by `api/v3/users/search` (`formerEmployee != formerEmployees`)

-----
