### PR TITLE
fix(icons): config path

### DIFF
--- a/packages/icons/src/commons/core.scss
+++ b/packages/icons/src/commons/core.scss
@@ -1,7 +1,7 @@
 @use 'sass:string';
 @use 'sass:list';
 
-@use '@lucca-front/scss/src/commons/config';
+@use '@lucca-front/icons/src/commons/config';
 
 @function capitalize($string) {
 	@return string.to-upper-case(string.slice($string, 1, 1)) + string.slice($string, 2);

--- a/packages/icons/src/commons/core.scss
+++ b/packages/icons/src/commons/core.scss
@@ -1,8 +1,6 @@
 @use 'sass:string';
 @use 'sass:list';
 
-@use '@lucca-front/icons/src/commons/config';
-
 @function capitalize($string) {
 	@return string.to-upper-case(string.slice($string, 1, 1)) + string.slice($string, 2);
 }


### PR DESCRIPTION
## Description

In the `icons` package, there is an import from the `scss` package, which is an error and is also unused. The `icons` package must be independent and this bug prevents LF/icons to be used alone.

The import being unnecessary as no `config` sass variables are used in this file, we simply remove it.

-----

I noticed it while upgrading LF on a project which uses only the `icons` package.

