### PR TITLE
fix(dialog): content is `null` when using `[luDialogConfig]` in a template-driven approach

### DIFF
--- a/packages/ng/dialog/directives/dialog-open.directive.ts
+++ b/packages/ng/dialog/directives/dialog-open.directive.ts
@@ -23,8 +23,8 @@ export class DialogOpenDirective {
 	@HostListener('click')
 	click(): void {
 		this.#dialogService.open({
-			content: this.dialog,
 			...this.luDialogConfig,
+			content: this.dialog,
 		});
 	}
 }


### PR DESCRIPTION
## Description

This was due to config being applied after content, overriding its value.

-----

closes #2999

-----
