### PR TITLE
fix(story): dialog story not opening with focus set to first-input

### DIFF
--- a/stories/documentation/overlays/dialog/dialog.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog.stories.ts
@@ -146,7 +146,7 @@ export const WithForm: StoryObj = {
 <!--form = new FormGroup({
 			example: new FormControl('', Validators.required)
 		})-->
-		<form [formControl]="form" class="dialog-formOptionnal">
+		<form [formGroup]="form" class="dialog-formOptionnal">
 			<lu-dialog-header>Template driven header with Form inside</lu-dialog-header>
 
 			<lu-dialog-content>


### PR DESCRIPTION
## Description

Story was using a `formControl` instead of a `formGroup`, stupid mistake from my past self

-----


-----
