### PR TITLE
fix(popover2): fixed popover2 not being properly destroyed after closing

### DIFF
--- a/packages/ng/popover2/content/popover-content/popover-content.component.ts
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.ts
@@ -80,6 +80,6 @@ export class PopoverContentComponent implements AfterViewInit {
 		this.mouseEnter$.complete();
 		this.mouseLeave$.complete();
 		// Detach overlay
-		this.#config.ref.detach();
+		this.#config.ref.dispose();
 	}
 }

--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -2,7 +2,7 @@
 	container: comment / inline-size;
 	display: flex;
 	flex-direction: column;
-	gap: var(--pr-t-spacings-100);
+	gap: var(--pr-t-spacings-50);
 	max-width: 40rem;
 
 	@at-root ($atRoot) {
@@ -17,9 +17,9 @@
 		.comment-infos-content {
 			flex-direction: column;
 			display: var(--components-comment-info-content-display);
-			font-size: var(--components-comment-info-fontSize);
-			line-height: var(--components-comment-info-lineHeight);
-			margin-top: var(--components-comment-info-content-marginTop);
+			font-size: var(--sizes-S-fontSize);
+			line-height: var(--sizes-S-lineHeight);
+			margin-block: var(--pr-t-spacings-25);
 		}
 
 		.comment-infos-date {

--- a/packages/scss/src/components/comment/mods.scss
+++ b/packages/scss/src/components/comment/mods.scss
@@ -3,9 +3,6 @@
 @mixin S {
 	--components-comment-text-fontSize: var(--sizes-S-fontSize);
 	--components-comment-text-lineHeight: var(--sizes-S-lineHeight);
-	--components-comment-info-fontSize: var(--sizes-XS-fontSize);
-	--components-comment-info-lineHeight: var(--sizes-XS-lineHeight);
-	--components-comment-info-content-marginTop: var(--pr-t-spacings-50);
 }
 
 @mixin noAvatar {

--- a/packages/scss/src/components/comment/vars.scss
+++ b/packages/scss/src/components/comment/vars.scss
@@ -1,10 +1,7 @@
 @mixin vars {
 	--components-comment-text-fontSize: var(--sizes-M-fontSize);
 	--components-comment-text-lineHeight: var(--sizes-M-lineHeight);
-	--components-comment-info-fontSize: var(--sizes-S-fontSize);
-	--components-comment-info-lineHeight: var(--sizes-S-lineHeight);
 	--components-comment-content-margin: calc(1.5rem + var(--pr-t-spacings-100)); // 1.5rem for the width of the avatar and 0.5rem for the gap
 	--components-comment-info-separator: '•';
 	--components-comment-info-content-display: block;
-	--components-comment-info-content-marginTop: var(--pr-t-spacings-25);
 }


### PR DESCRIPTION
## Description

Fixed popover2 not being properly destroyed after closing

-----

Detaching the overlay content does not destroy it, so all overlay logic and events were still active after close
![chrome_FVwZzDZXwu](https://github.com/user-attachments/assets/2d8c22d8-2068-42c9-b724-eb6124b43f67)

-----
