### PR TITLE
Checkbox unchecked mixed

### DIFF
--- a/packages/scss/src/components/checkboxField/index.scss
+++ b/packages/scss/src/components/checkboxField/index.scss
@@ -11,6 +11,7 @@
 
 .checkboxField-input {
 	&[aria-checked='mixed'] {
+		@include checked;
 		@include mixed;
 	}
 

--- a/stories/qa/forms/checkbox.stories.html
+++ b/stories/qa/forms/checkbox.stories.html
@@ -56,11 +56,33 @@
 				aria-describedby="CBmixed-message"
 				aria-required="true"
 				aria-checked="mixed"
-				checked
+				checked="checked"
 			/>
 			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
 		</span>
 		<div class="inlineMessage" id="CBmixed-message">
+			<p class="inlineMessage-content">Helper text</p>
+		</div>
+	</div>
+
+	<div class="form-field pr-u-marginBottom100">
+		<label class="formLabel" for="CBmixed2" id="CBmixed2-label">
+			Label<sup class="formLabel-required" aria-hidden="true">*</sup
+			><span class="formLabel-info"><span aria-hidden="true" class="lucca-icon icon-signHelp"></span><span class="u-mask">?</span></span>
+		</label>
+		<span class="checkboxField">
+			<input
+				type="checkbox"
+				class="checkboxField-input"
+				id="CBmixed2"
+				aria-labelledby="CBmixed2-label"
+				aria-describedby="CBmixed2-message"
+				aria-required="true"
+				aria-checked="mixed"
+			/>
+			<span class="checkboxField-icon" aria-hidden="true"><span class="checkboxField-icon-check"></span></span>
+		</span>
+		<div class="inlineMessage" id="CBmixed2-message">
 			<p class="inlineMessage-content">Helper text</p>
 		</div>
 	</div>


### PR DESCRIPTION
## Description

Unchecked indeterminate checkboxes were not indicated as indeterminate, wrongly. This has now been corrected.

-----



-----
Before:
![Capture d’écran 2024-08-23 à 10 53 52](https://github.com/user-attachments/assets/ebdd1edd-eaa0-48ab-8554-89287c2998eb)

After:
![Capture d’écran 2024-08-23 à 10 54 02](https://github.com/user-attachments/assets/51c2c569-8712-4aae-8f1c-244c12e5cd46)

