### PR TITLE
ci: strip "v" from env.BRANCH_NAME if it's a release or pre-release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,8 @@ node(label: CI.getSelectedLinuxNode(script:this)) {
 			)
 
 			loggableStage('Publish', isPR) {
-				def version = env.BRANCH_NAME
+				// Strip "v" from env.BRANCH_NAME if it's a release or pre-release (ie 18.2.1 instead of v18.2.1)
+				def version = (isRelease || isPreRelease) ? env.BRANCH_NAME.substring(1) : env.BRANCH_NAME
 
 				def iconsPackageJson = readFile(file: 'dist/icons/package.json');
 				def scssPackageJson = readFile(file: 'dist/scss/package.json');


### PR DESCRIPTION
## Description

When `package.json` are published, there is a `v` in `peerDependencies` which can lead to peer deps issues.

![image](https://github.com/user-attachments/assets/c98d9d9a-d32d-4fdb-94ae-740e1bb6d2d9)


-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
