### PR TITLE
fix(schematics): support nx migration logic

### DIFF
--- a/packages/ng/schematics/action-icon/index.ts
+++ b/packages/ng/schematics/action-icon/index.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 import { migrateFile } from '../lib/schematics';
 import { migrateHTMLFile, migrateScssFile } from './migration';
 
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
 export default (options?: { skipInstallation?: boolean }): Rule => {
 	const skipInstallation = options?.skipInstallation ?? false;
 

--- a/packages/ng/schematics/empty-state-title/index.ts
+++ b/packages/ng/schematics/empty-state-title/index.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 import { replaceComponentInputName, updateAngularTemplate } from '../lib/angular-template';
 import { migrateFile } from '../lib/schematics';
 
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
 export default (options?: { skipInstallation?: boolean }): Rule => {
 	const skipInstallation = options?.skipInstallation ?? false;
 

--- a/packages/ng/schematics/new-icons/index.ts
+++ b/packages/ng/schematics/new-icons/index.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 import { migrateFile } from '../lib/schematics.js';
 import { migrateHTMLFile, migrateScssFile, migrateTsFile } from './migration.js';
 
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
 export default (options?: { skipInstallation?: boolean }): Rule => {
 	const skipInstallation = options?.skipInstallation ?? false;
 

--- a/packages/ng/schematics/palettes/index.ts
+++ b/packages/ng/schematics/palettes/index.ts
@@ -3,6 +3,9 @@ import { spawnSync } from 'child_process';
 import * as path from 'path';
 import { CssMapper } from '../lib/css-mapper';
 
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
 export default (options?: { skipInstallation?: boolean }): Rule => {
 	const skipInstallation = options?.skipInstallation ?? false;
 

--- a/packages/ng/schematics/tokens-spacing/index.ts
+++ b/packages/ng/schematics/tokens-spacing/index.ts
@@ -3,6 +3,9 @@ import { spawnSync } from 'child_process';
 import * as path from 'path';
 import { CssMapper } from '../lib/css-mapper';
 
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
 export default (options?: { skipInstallation?: boolean }): Rule => {
 	const skipInstallation = options?.skipInstallation ?? false;
 


### PR DESCRIPTION
## Description

Because of a strange logic in Nx migration system, LF's scripts were not called as they would be with `@angular/cli`.

The issue seems tracked in https://github.com/nrwl/nx/issues/20282

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
