### PR TITLE
Fix tooltip + popover

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -101,7 +101,9 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 
 	@HostListener('focus')
 	onFocus() {
-		this.open$.next();
+		if (this.#host.nativeElement.getAttribute('aria-expanded') !== 'true') {
+			this.open$.next();
+		}
 	}
 
 	@HostListener('blur')


### PR DESCRIPTION
## Description

Focus on popover closure triggers tooltips when buttons combine both behaviors. This has now been corrected.

-----



-----

Before: 
![2024-09-03 11 29 48](https://github.com/user-attachments/assets/abcdb344-bc9c-4c1d-b402-077ea86fd98d)

After: 
![2024-09-03 11 29 00](https://github.com/user-attachments/assets/9415dee4-bf4e-4a6e-aa79-5c5772c1b307)

