### PR TITLE
Fix spacing for links

### DIFF
--- a/packages/scss/src/components/link/mods.scss
+++ b/packages/scss/src/components/link/mods.scss
@@ -3,11 +3,17 @@
 		text-decoration: none;
 	}
 
+	&:not(:has(.link-icon)) {
+		.lucca-icon {
+			margin-left: 0.2em;
+		}
+	}
+
 	.lucca-icon {
 		text-decoration: none;
-		font-size: var(--sizes-M-fontSize);
-		line-height: var(--sizes-XS-lineHeight);
-		margin-left: var(--pr-t-spacings-50);
+		font-size: 1em;
+		line-height: 1lh;
+		vertical-align: bottom;
 	}
 
 	@at-root ($atRoot) {
@@ -26,10 +32,23 @@
 }
 
 @mixin decorationHover {
-	text-decoration: none;
+	&,
+	.link-text {
+		text-decoration: none;
+	}
 
-	&:hover {
-		text-decoration: underline;
+	&:not(:has(.link-text)) {
+		&:hover {
+			text-decoration: underline;
+		}
+	}
+
+	&:has(.link-text) {
+		&:hover {
+			.link-text {
+				text-decoration: underline;
+			}
+		}
 	}
 }
 

--- a/stories/documentation/actions/links/link-basic.stories.ts
+++ b/stories/documentation/actions/links/link-basic.stories.ts
@@ -1,17 +1,16 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface LinkBasicStory {
-}
+interface LinkBasicStory {}
 
 export default {
 	title: 'Documentation/Actions/Link/Basic',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: LinkBasicStory): string {
 	return `<a href="#" class="link">Lien</a>
-<a class="link mod-icon" href="#" target="_blank">Lien externe <span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span></a>`;
+<a class="link mod-icon" href="#" target="_blank">Lien externe<!-- no text node here --><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span></a>
+`;
 }
 
 const Template: StoryFn<LinkBasicStory> = (args) => ({
@@ -20,10 +19,8 @@ const Template: StoryFn<LinkBasicStory> = (args) => ({
 	styles: [
 		`
 		:host {
-			display: block;
-		}
-		a {
-			margin-right: 1rem;
+			display: flex;
+			gap: var(--pr-t-spacings-200);
 		}
 		`,
 	],

--- a/stories/documentation/actions/links/link-disabled.stories.ts
+++ b/stories/documentation/actions/links/link-disabled.stories.ts
@@ -1,17 +1,15 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface LinkDisabledStory {
-}
+interface LinkDisabledStory {}
 
 export default {
 	title: 'Documentation/Actions/Link/Disabled',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: LinkDisabledStory): string {
 	return `<span class="link is-disabled">Lien</span>
-<span class="link is-disabled mod-icon">Lien externe <span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span>`;
+<span class="link is-disabled mod-icon">Lien externe<!-- no text node here --><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span>`;
 }
 
 const Template: StoryFn<LinkDisabledStory> = (args) => ({
@@ -20,10 +18,8 @@ const Template: StoryFn<LinkDisabledStory> = (args) => ({
 	styles: [
 		`
 		:host {
-			display: block;
-		}
-		span {
-			margin-right: 1rem;
+			display: flex;
+			gap: var(--pr-t-spacings-200);
 		}
 		`,
 	],

--- a/stories/documentation/actions/links/link-hover.stories.ts
+++ b/stories/documentation/actions/links/link-hover.stories.ts
@@ -1,17 +1,15 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface LinkDecorationHoverStory {
-}
+interface LinkDecorationHoverStory {}
 
 export default {
 	title: 'Documentation/Actions/Link/DecorationHover',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: LinkDecorationHoverStory): string {
 	return `<a href="#" class="link mod-decorationHover">Lien</a>
-<a class="link mod-decorationHover mod-icon" href="#" target="_blank">Lien externe <span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span></a>`;
+<a class="link mod-decorationHover mod-icon" href="#" target="_blank">Lien externe<!-- no text node here --><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span></a>`;
 }
 
 const Template: StoryFn<LinkDecorationHoverStory> = (args) => ({
@@ -20,10 +18,8 @@ const Template: StoryFn<LinkDecorationHoverStory> = (args) => ({
 	styles: [
 		`
 		:host {
-			display: block;
-		}
-		a {
-			margin-right: 1rem;
+			display: flex;
+			gap: var(--pr-t-spacings-200);
 		}
 		`,
 	],

--- a/stories/documentation/actions/links/link-nowrap.stories.ts
+++ b/stories/documentation/actions/links/link-nowrap.stories.ts
@@ -1,17 +1,15 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface LinkNoWrapStory {
-}
+interface LinkNoWrapStory {}
 
 export default {
 	title: 'Documentation/Actions/Link/NoWrap',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: LinkNoWrapStory): string {
 	return `<a class="link mod-icon" href="#" target="_blank">
-	Lien externe sans retour à la ligne possible avant l’icône<span class="link-icon"><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span>
+	<span class="link-text">Lien externe sans retour à la ligne possible avant l’icône</span><!-- no text node here --><span class="link-icon"><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span><span class="u-mask">Ouvrir dans une nouvelle fenêtre</span>
 </a>`;
 }
 
@@ -22,9 +20,6 @@ const Template: StoryFn<LinkNoWrapStory> = (args) => ({
 		`
 		:host {
 			display: block;
-		}
-		a {
-			margin-right: 1rem;
 		}
 		`,
 	],

--- a/stories/documentation/feedback/plg-push/angular/plg-push-basic.stories.ts
+++ b/stories/documentation/feedback/plg-push/angular/plg-push-basic.stories.ts
@@ -17,8 +17,7 @@ export default {
 			template: `<lu-plg-push ${generateInputs(inputs, context.argTypes)}>
 	${description}
 	<a class="link mod-icon" href="${linkURL}" target="_blank" rel="noopener noreferrer">
-		<span>${linkLabel}</span>
-		<lu-icon icon="arrowExternal" alt="Ouvrir dans une nouvelle fenêtre"></lu-icon>
+		<span class="link-text">${linkLabel}</span><!-- no text node here --><span class="link-icon"><lu-icon class="u-displayContents" icon="arrowExternal" alt="Ouvrir dans une nouvelle fenêtre"></lu-icon></span>
 	</a>
 </lu-plg-push>`,
 		};

--- a/stories/documentation/feedback/plg-push/html&css/plg-push-basic.stories.ts
+++ b/stories/documentation/feedback/plg-push/html&css/plg-push-basic.stories.ts
@@ -1,7 +1,6 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface PLGPushBasicStory {
-}
+interface PLGPushBasicStory {}
 
 export default {
 	title: 'Documentation/Feedback/PLG Push/HTML & CSS/Basic',
@@ -18,8 +17,7 @@ function getTemplate(args: PLGPushBasicStory): string {
 		<div class="plgPush-content-description">
 			Bénéficiez de toutes les options liées au télétravail avec Timmi Office.
 			<a class="link mod-icon" href="#" target="_blank" rel="noopener noreferrer">
-				<span>Demander un essai gratuit</span>
-				<span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span>
+				<span class="link-text">Demander un essai gratuit</span><!-- no text node here --><span class="link-icon"><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span>
 				<span class="u-mask">Ouvrir dans une nouvelle fenêtre</span>
 			</a>
 		</div>

--- a/stories/documentation/feedback/plg-push/html&css/plg-push-title.stories.ts
+++ b/stories/documentation/feedback/plg-push/html&css/plg-push-title.stories.ts
@@ -1,7 +1,6 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface PLGPushTitleStory {
-}
+interface PLGPushTitleStory {}
 
 export default {
 	title: 'Documentation/Feedback/PLG Push/HTML & CSS/Title',
@@ -19,8 +18,7 @@ function getTemplate(args: PLGPushTitleStory): string {
 		<div class="plgPush-content-description">
 			Activez toutes les options liées aux télétravail.
 			<a class="link mod-icon" href="#" target="_blank" rel="noopener noreferrer">
-				<span>Demander un essai gratuit</span>
-				<span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span>
+				<span class="link-text">Demander un essai gratuit</span><!-- no text node here --><span class="link-icon"><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span>
 				<span class="u-mask">Ouvrir dans une nouvelle fenêtre</span>
 			</a>
 		</div>

--- a/stories/qa/plg-push/plg-push.stories.html
+++ b/stories/qa/plg-push/plg-push.stories.html
@@ -13,8 +13,8 @@
 				<div class="plgPush-content-description">
 					Activez toutes les options liées aux télétravail.
 					<a class="link mod-icon" href="https://www.google.com/" target="_blank" rel="noopener noreferrer">
-						<span>Demander un essai gratuit</span>
-						<span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span>
+						<span class="link-text">Demander un essai gratuit</span
+						><!-- no text node here --><span class="link-icon"><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span></span>
 						<span class="u-mask">Ouvrir dans une nouvelle fenêtre</span>
 					</a>
 				</div>


### PR DESCRIPTION
## Description

- [x] deletion of the underlined space at the end of texts
- [x] mod-hover management for the no wrap mod
- [x] icon size adjusted to text size
- [x] icon centered vertically in relation to line height
- [x] adjustment of space between end of text and icon

-----



-----

Before:
![Capture d’écran 2024-09-02 à 18 06 58](https://github.com/user-attachments/assets/a08fa3e1-3fab-44f5-aea7-2c5ce00d9c6a)

After: 
![Capture d’écran 2024-09-02 à 18 08 05](https://github.com/user-attachments/assets/2f93bbec-0ce9-4387-844e-a2fbc9213d12)

