### PR TITLE
Fix ellipsis calculation

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -235,8 +235,8 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 	 * We used to do this using scrollWidth but the thing is, it's a rounded value. Sometimes,
 	 * you'd get true while it should be false and vice-versa, because of rounding.
 	 *
-	 * We could also use getBoundingClientRect() but it only considers text content, meaning that if ellipsis is caused by
-	 * any margin or padding, it won't be detected
+	 * So we duplicate the properties we're interested in on the element to be tested to calculate its ideal size,
+	 * which we then compare with its current size.
 	 *
 	 * @private
 	 */
@@ -245,29 +245,44 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 			return false;
 		}
 
-		const mask = this.#renderer.createElement('div') as HTMLDivElement;
-		const clone = this.#host.nativeElement.cloneNode(true) as HTMLElement;
+		const element = this.#host.nativeElement;
+		const elementCloned = this.#renderer.createElement('div') as HTMLDivElement;
+		const parentMasked = this.#renderer.createElement('div') as HTMLDivElement;
+		const elementStyle = window.getComputedStyle(element);
 
-		this.#renderer.setStyle(clone, 'position', 'fixed');
-		this.#renderer.setStyle(clone, 'overflow', 'visible');
-		this.#renderer.setStyle(clone, 'white-space', 'nowrap');
-		this.#renderer.setStyle(clone, 'visibility', 'hidden');
-		this.#renderer.setStyle(clone, 'width', 'fit-content');
+		this.#renderer.addClass(parentMasked, 'u-mask');
+		this.#renderer.setAttribute(parentMasked, 'aria-hidden', 'true');
 
-		this.#renderer.addClass(mask, 'u-mask');
-		this.#renderer.setAttribute(mask, 'aria-hidden', 'true');
-		this.#renderer.appendChild(mask, clone);
+		this.#renderer.setStyle(elementCloned, 'width', 'fit-content');
 
-		this.#renderer.appendChild(this.#host.nativeElement.parentElement, mask);
+		this.#renderer.setStyle(elementCloned, 'padding', elementStyle.padding);
+		this.#renderer.setStyle(elementCloned, 'borderWidth', elementStyle.borderWidth);
+		this.#renderer.setStyle(elementCloned, 'borderStyle', elementStyle.borderStyle);
+		this.#renderer.setStyle(elementCloned, 'boxSizing', elementStyle.boxSizing);
+		this.#renderer.setStyle(elementCloned, 'fontFamily', elementStyle.fontFamily);
+		this.#renderer.setStyle(elementCloned, 'fontWeight', elementStyle.fontWeight);
+		this.#renderer.setStyle(elementCloned, 'fontStyle', elementStyle.fontStyle);
+		this.#renderer.setStyle(elementCloned, 'whiteSpace', 'nowrap');
+		this.#renderer.setStyle(
+			elementCloned,
+			'fontSize',
+			(Number(elementStyle.fontSize.replace('px', '')) / Number(window.getComputedStyle(document.body).fontSize.replace('px', ''))).toString() + 'rem',
+		);
+
+		elementCloned.innerHTML = element.innerHTML;
+
+		this.#renderer.appendChild(parentMasked, elementCloned);
+		this.#renderer.appendChild(document.body, parentMasked);
+
 		try {
-			const fullWidth = clone.getBoundingClientRect().width;
-			const displayWidth = this.#host.nativeElement.getBoundingClientRect().width;
+			const elementClonedWidth = elementCloned.getBoundingClientRect().width;
+			const elementWidth = element.getBoundingClientRect().width;
 
-			return fullWidth > displayWidth;
+			return elementClonedWidth > elementWidth;
 		} catch (e) {
 			return false;
 		} finally {
-			mask.remove();
+			parentMasked.remove();
 		}
 	}
 

--- a/stories/documentation/overlays/tooltip/tooltip-ellipsis.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip-ellipsis.stories.ts
@@ -7,7 +7,7 @@ import { Meta, StoryFn, applicationConfig } from '@storybook/angular';
 	selector: 'tooltip-stories',
 	standalone: true,
 	imports: [LuTooltipModule],
-	template: ` <div class="test width200" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
+	template: `<div class="test width200" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
 		<div class="test ellipsis resize" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
 		<div class="test ellipsis width400" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
 		<div class="test ellipsis width400 fontWeight" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
@@ -78,6 +78,10 @@ import { Meta, StoryFn, applicationConfig } from '@storybook/angular';
 				display: flex;
 				flex-direction: column;
 				justify-content: flex-start;
+			}
+
+			[tabindex='0'] {
+				color: green;
 			}
 		`,
 	],


### PR DESCRIPTION
## Description

Calculation with a clone posed problems because the clone was injected into a `div`, itself injected into the current context, which posed structural problems.

Moving the clone into the body, on the other hand, posed inheritance problems.

So we've changed our approach: we now duplicate the properties rather than the element.

-----



-----
