### PR TITLE
Fix tag outlined color

### DIFF
--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -22,7 +22,7 @@
 
 	&,
 	&:is(a, button) {
-		color: var(--components-tag-color);
+		color: var(--palettes-800, var(--palettes-neutral-800));
 	}
 
 	.lucca-icon {

--- a/packages/scss/src/components/tag/mods.scss
+++ b/packages/scss/src/components/tag/mods.scss
@@ -31,7 +31,6 @@
 }
 
 @mixin outlined {
-	--components-tag-color: var(--palettes-600, var(--palettes-neutral-600));
 	--components-tag-shadow: var(--palettes-300, var(--palettes-neutral-300));
 	--components-tag-background: transparent;
 }

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -1,5 +1,4 @@
 @mixin vars {
-	--components-tag-color: var(--palettes-800, var(--palettes-neutral-800));
 	--components-tag-background: var(--palettes-100, var(--palettes-neutral-100));
 	--components-tag-shadow: transparent;
 	--components-tag-fontSize: var(--sizes-S-fontSize);


### PR DESCRIPTION
## Description

Color is now always in 800.

-----



-----

Before: 
![Capture d’écran 2024-09-05 à 10 19 56](https://github.com/user-attachments/assets/fa2be17e-9efe-459f-b3f6-116054bf47a6)
![Capture d’écran 2024-09-05 à 10 20 23](https://github.com/user-attachments/assets/7d016914-cbca-4f6c-84a4-261a8a6e3a81)


After: 
![Capture d’écran 2024-09-05 à 10 19 56](https://github.com/user-attachments/assets/fa2be17e-9efe-459f-b3f6-116054bf47a6)
![Capture d’écran 2024-09-05 à 10 19 52](https://github.com/user-attachments/assets/5b0c8528-5a0c-447c-bd6d-ba8e31112461)