### PR TITLE
[Textarea] Add autoResize and scrollIntoView options

### DIFF
--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -1,7 +1,7 @@
 <div class="textField" [class.mod-autoResize]="autoResize">
-	<div class="textField-input">
+	<div class="textField-input" #parent>
 		@if (autoResize) {
-		<div #clone class="textField-input-valueClone" aria-hidden="true" [attr.data-content-before]="cloneValue"></div>
+		<div class="textField-input-valueClone" aria-hidden="true" [attr.data-content-before]="cloneValue"></div>
 		}
 		<textarea
 			luInput

--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -1,7 +1,7 @@
 <div class="textField" [class.mod-autoResize]="autoResize">
 	<div class="textField-input">
 		@if (autoResize) {
-		<div class="textField-input-valueClone" aria-hidden="true" [attr.data-content-before]="ngControl.control.value"></div>
+		<div #clone class="textField-input-valueClone" aria-hidden="true" [attr.data-content-before]="cloneValue"></div>
 		}
 		<textarea
 			luInput
@@ -9,7 +9,7 @@
 			[formControl]="ngControl.control"
 			[attr.placeholder]="placeholder"
 			[attr.rows]="rows"
-			(input)="updateScroll()"
+			(input)="updateScroll(textarea.value)"
 			#textarea
 		></textarea>
 	</div>

--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -1,11 +1,16 @@
-<div class="textField">
+<div class="textField" [class.mod-autoResize]="autoResize">
 	<div class="textField-input">
+		@if (autoResize) {
+		<div class="textField-input-valueClone" aria-hidden="true" [attr.data-content-before]="ngControl.control.value"></div>
+		}
 		<textarea
 			luInput
 			class="textField-input-value"
 			[formControl]="ngControl.control"
 			[attr.placeholder]="placeholder"
 			[attr.rows]="rows"
+			(input)="updateScroll()"
+			#textarea
 		></textarea>
 	</div>
 </div>

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -41,7 +41,7 @@ export class TextareaInputComponent {
 
 	updateScroll(value: string) {
 		this.cloneValue = value;
-		this.#cdr.detectChanges();
+		this.#cdr.detectChanges(); // Needed to apply cloneValue to autoresize HTML clone
 
 		if (this.autoResizeScrollIntoView && this.parent) {
 			this.parent.nativeElement.scrollIntoView({

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { injectNgControl } from '../inject-ng-control';
@@ -14,6 +14,9 @@ import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextareaInputComponent {
+	@ViewChild('textarea', { read: ElementRef, static: true })
+	textarea: ElementRef<HTMLTextAreaElement>;
+
 	ngControl = injectNgControl();
 
 	@Input()
@@ -21,4 +24,20 @@ export class TextareaInputComponent {
 
 	@Input()
 	rows?: number;
+
+	@Input({
+		transform: booleanAttribute,
+	})
+	autoResize = false;
+
+	@Input({
+		transform: booleanAttribute,
+	})
+	scrollIntoViewOnAutoResizing = false;
+
+	updateScroll() {
+		if (this.scrollIntoViewOnAutoResizing) {
+			this.textarea.nativeElement.scrollIntoView();
+		}
+	}
 }

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, Input, ViewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, Input, ViewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { injectNgControl } from '../inject-ng-control';
@@ -14,10 +14,12 @@ import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextareaInputComponent {
-	@ViewChild('textarea', { read: ElementRef, static: true })
-	textarea: ElementRef<HTMLTextAreaElement>;
+	@ViewChild('clone')
+	clone?: ElementRef<HTMLElement>;
 
 	ngControl = injectNgControl();
+
+	#cdr = inject(ChangeDetectorRef);
 
 	@Input()
 	placeholder: string = '';
@@ -35,9 +37,14 @@ export class TextareaInputComponent {
 	})
 	scrollIntoViewOnAutoResizing = false;
 
-	updateScroll() {
-		if (this.scrollIntoViewOnAutoResizing) {
-			this.textarea.nativeElement.scrollIntoView({
+	cloneValue = '';
+
+	updateScroll(value: string) {
+		this.cloneValue = value;
+		this.#cdr.detectChanges();
+
+		if (this.scrollIntoViewOnAutoResizing && this.clone) {
+			this.clone.nativeElement.scrollIntoView({
 				behavior: 'instant',
 				block: 'end',
 			});

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -35,7 +35,7 @@ export class TextareaInputComponent {
 	@Input({
 		transform: booleanAttribute,
 	})
-	scrollIntoViewOnAutoResizing = false;
+	autoResizeScrollIntoView = false;
 
 	cloneValue = '';
 
@@ -43,7 +43,7 @@ export class TextareaInputComponent {
 		this.cloneValue = value;
 		this.#cdr.detectChanges();
 
-		if (this.scrollIntoViewOnAutoResizing && this.parent) {
+		if (this.autoResizeScrollIntoView && this.parent) {
 			this.parent.nativeElement.scrollIntoView({
 				behavior: 'instant',
 				block: 'end',

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -14,8 +14,8 @@ import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextareaInputComponent {
-	@ViewChild('clone')
-	clone?: ElementRef<HTMLElement>;
+	@ViewChild('parent')
+	parent?: ElementRef<HTMLElement>;
 
 	ngControl = injectNgControl();
 
@@ -43,8 +43,8 @@ export class TextareaInputComponent {
 		this.cloneValue = value;
 		this.#cdr.detectChanges();
 
-		if (this.scrollIntoViewOnAutoResizing && this.clone) {
-			this.clone.nativeElement.scrollIntoView({
+		if (this.scrollIntoViewOnAutoResizing && this.parent) {
+			this.parent.nativeElement.scrollIntoView({
 				behavior: 'instant',
 				block: 'end',
 			});

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -37,7 +37,10 @@ export class TextareaInputComponent {
 
 	updateScroll() {
 		if (this.scrollIntoViewOnAutoResizing) {
-			this.textarea.nativeElement.scrollIntoView();
+			this.textarea.nativeElement.scrollIntoView({
+				behavior: 'instant',
+				block: 'end',
+			});
 		}
 	}
 }

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -66,11 +66,6 @@
 				var(--component-textField-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
-			max-height: var(--component-textField-maxHeight);
-
-			@supports not (height: 1dvh) {
-				--component-textField-maxHeight: var(--component-textField-maxHeightFallback);
-			}
 
 			&::placeholder {
 				color: var(--component-textField-placeholder);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -66,6 +66,7 @@
 				var(--component-textField-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
+			max-height: 80vh;
 
 			&::placeholder {
 				color: var(--component-textField-placeholder);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -66,7 +66,11 @@
 				var(--component-textField-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
-			max-height: 80vh;
+			max-height: var(--component-textField-maxHeight);
+
+			@supports not (height: 1dvh) {
+				--component-textField-maxHeight: var(--component-textField-maxHeightFallback);
+			}
 
 			&::placeholder {
 				color: var(--component-textField-placeholder);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -66,6 +66,11 @@
 				var(--component-textField-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
+			max-height: var(--component-textField-maxHeight);
+
+			@supports not (height: 1dvh) {
+				--component-textField-maxHeight: var(--component-textField-maxHeightFallback);
+			}
 
 			&::placeholder {
 				color: var(--component-textField-placeholder);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -55,6 +55,7 @@
 			}
 		}
 
+		.textField-input-valueClone,
 		.textField-input-value {
 			border: 0;
 			outline: 0;

--- a/packages/scss/src/components/textField/index.scss
+++ b/packages/scss/src/components/textField/index.scss
@@ -25,4 +25,8 @@
 	&:has(.textField-input-value:disabled) {
 		@include disabled;
 	}
+
+	&.mod-autoResize {
+		@include autoResize;
+	}
 }

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -60,14 +60,10 @@
 		grid-area: 1 / 1 / 2 / 2;
 		resize: none;
 		min-width: 0;
-		overflow: auto;
 	}
 
 	.textField-input-valueClone {
-		scroll-margin-bottom: var(--component-textField-clone-scrollMagin);
-	}
-
-	.textField-input-valueClone {
+		scroll-margin-bottom: var(--component-textField-clone-scrollMargin);
 		visibility: hidden;
 
 		&::after {

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -64,7 +64,7 @@
 	}
 
 	.textField-input-valueClone {
-		scroll-margin-bottom: 88rem; // un nombre arbitraire suffit pour scrollIntoView
+		scroll-margin-bottom: var(--component-textField-clone-scrollMagin);
 	}
 
 	.textField-input-valueClone {

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -45,6 +45,7 @@
 	}
 }
 
+// on place le textarea et son clone dans une même grille : la hauteur du clone dimentionnera le textarea
 @mixin autoResize {
 	.textField-input {
 		display: grid;
@@ -59,6 +60,11 @@
 		grid-area: 1 / 1 / 2 / 2;
 		resize: none;
 		min-width: 0;
+		overflow: auto;
+	}
+
+	.textField-input-valueClone {
+		scroll-margin-bottom: 88rem; // un nombre arbitraire suffit pour scrollIntoView
 	}
 
 	.textField-input-valueClone {

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -44,3 +44,28 @@
 		text-align: right;
 	}
 }
+
+@mixin autoResize {
+	.textField-input {
+		display: grid;
+		align-items: normal;
+		min-width: 0;
+	}
+
+	.textField-input-valueClone,
+	.textField-input-value {
+		white-space: pre-wrap;
+		overflow-wrap: break-word;
+		grid-area: 1 / 1 / 2 / 2;
+		resize: none;
+		min-width: 0;
+	}
+
+	.textField-input-valueClone {
+		visibility: hidden;
+
+		&::after {
+			content: ' ';
+		}
+	}
+}

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -51,6 +51,7 @@
 		display: grid;
 		align-items: normal;
 		min-width: 0;
+		scroll-margin-bottom: var(--component-textField-scrollMargin);
 	}
 
 	.textField-input-valueClone,
@@ -60,10 +61,10 @@
 		grid-area: 1 / 1 / 2 / 2;
 		resize: none;
 		min-width: 0;
+		overflow: auto;
 	}
 
 	.textField-input-valueClone {
-		scroll-margin-bottom: var(--component-textField-clone-scrollMargin);
 		visibility: hidden;
 
 		&::after {

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -9,5 +9,7 @@
 	--component-textField-padding: var(--pr-t-spacings-100);
 	--component-textField-affix-padding: var(--component-textField-padding);
 	--component-textField-affix-size: 1.75rem;
-	--component-textField-clone-scrollMargin: 88rem; // un nombre arbitraire suffit pour scrollIntoView
+	--component-textField-scrollMargin: 88rem; // un nombre arbitraire suffit pour scrollIntoView
+	--component-textField-maxHeight: calc(100dvh - 10rem);
+	--component-textField-maxHeightFallback: calc(100vh - 10rem);
 }

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -9,7 +9,5 @@
 	--component-textField-padding: var(--pr-t-spacings-100);
 	--component-textField-affix-padding: var(--component-textField-padding);
 	--component-textField-affix-size: 1.75rem;
-	--component-textField-clone-scrollMagin: 88rem; // un nombre arbitraire suffit pour scrollIntoView
-	--component-textField-maxHeight: 80dvh;
-	--component-textField-maxHeightFallback: 80vh;
+	--component-textField-clone-scrollMargin: 88rem; // un nombre arbitraire suffit pour scrollIntoView
 }

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -9,4 +9,7 @@
 	--component-textField-padding: var(--pr-t-spacings-100);
 	--component-textField-affix-padding: var(--component-textField-padding);
 	--component-textField-affix-size: 1.75rem;
+	--component-textField-clone-scrollMagin: 88rem; // un nombre arbitraire suffit pour scrollIntoView
+	--component-textField-maxHeight: 80dvh;
+	--component-textField-maxHeightFallback: 80vh;
 }

--- a/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
@@ -69,32 +69,10 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 		[(ngModel)]="example">
 	</lu-textarea-input>
 </lu-form-field>
-<footer class="demoFooter footer mod-sticky">footer</footer>
 `),
 			moduleMetadata: {
 				imports: [TextareaInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
-			styles: [
-				`
-				.form-field {
-					flex-grow: 1;
-					margin-bottom: 1rem;
-				}
-		
-				.demoFooter {
-					margin: 0 -1rem -1rem;
-					bottom: -1rem;
-				}
-					
-				:host {
-					display: flex;
-					flex-direction: column;
-					height: 20rem;
-					overflow: auto;
-					padding: 1rem;
-					margin: -1rem;
-				}`,
-			],
 		};
 	},
 	args: {

--- a/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
@@ -69,10 +69,32 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 		[(ngModel)]="example">
 	</lu-textarea-input>
 </lu-form-field>
+<footer class="demoFooter footer mod-sticky">footer</footer>
 `),
 			moduleMetadata: {
 				imports: [TextareaInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
+			styles: [
+				`
+				.form-field {
+					flex-grow: 1;
+					margin-bottom: 1rem;
+				}
+		
+				.demoFooter {
+					margin: 0 -1rem -1rem;
+					bottom: -1rem;
+				}
+					
+				:host {
+					display: flex;
+					flex-direction: column;
+					height: 20rem;
+					overflow: auto;
+					padding: 1rem;
+					margin: -1rem;
+				}`,
+			],
 		};
 	},
 	args: {

--- a/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
@@ -37,10 +37,12 @@ export default {
 		},
 		autoResize: {
 			type: 'boolean',
+			description: '[v18.3]',
 		},
 		autoResizeScrollIntoView: {
 			type: 'boolean',
 			if: { arg: 'autoResize', truthy: true },
+			description: '[v18.3]',
 		},
 		hiddenLabel: {
 			description: "Masque le label en le conservant dans le DOM pour les lecteurs d'écrans",

--- a/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
@@ -2,7 +2,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TextareaInputComponent } from '@lucca-front/ng/forms';
-import { Meta, StoryObj, moduleMetadata } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 
 export default {
@@ -38,7 +38,7 @@ export default {
 		autoResize: {
 			type: 'boolean',
 		},
-		scrollIntoViewOnAutoResizing: {
+		autoResizeScrollIntoView: {
 			type: 'boolean',
 			if: { arg: 'autoResize', truthy: true },
 		},
@@ -50,7 +50,7 @@ export default {
 
 export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
-		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, counter, autoResize, scrollIntoViewOnAutoResizing, ...inputArgs } = args;
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, counter, autoResize, autoResizeScrollIntoView, ...inputArgs } = args;
 		return {
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
@@ -64,7 +64,7 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 				},
 				argTypes,
 			)}>
-	<lu-textarea-input scrollIntoViewOnAutoResizing="${scrollIntoViewOnAutoResizing}" autoResize="${autoResize}"
+	<lu-textarea-input autoResizeScrollIntoView="${autoResizeScrollIntoView}" autoResize="${autoResize}"
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="example">
 	</lu-textarea-input>
@@ -86,7 +86,7 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 		tooltip: 'Je suis un message d’aide',
 		counter: 0,
 		autoResize: false,
-		scrollIntoViewOnAutoResizing: false,
+		autoResizeScrollIntoView: false,
 		rows: 3,
 	},
 };

--- a/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textareafield.stories.ts
@@ -35,15 +35,22 @@ export default {
 		counter: {
 			description: '[v17.4]',
 		},
+		autoResize: {
+			type: 'boolean',
+		},
+		scrollIntoViewOnAutoResizing: {
+			type: 'boolean',
+			if: { arg: 'autoResize', truthy: true },
+		},
 		hiddenLabel: {
-			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d\'écrans',
+			description: "Masque le label en le conservant dans le DOM pour les lecteurs d'écrans",
 		},
 	},
 } as Meta;
 
 export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
-		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, counter, ...inputArgs } = args;
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, counter, autoResize, scrollIntoViewOnAutoResizing, ...inputArgs } = args;
 		return {
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
@@ -57,15 +64,12 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 				},
 				argTypes,
 			)}>
-
-	<lu-textarea-input
+	<lu-textarea-input scrollIntoViewOnAutoResizing="${scrollIntoViewOnAutoResizing}" autoResize="${autoResize}"
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="example">
 	</lu-textarea-input>
-
 </lu-form-field>
-
-{{example}}`),
+`),
 			moduleMetadata: {
 				imports: [TextareaInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
@@ -81,6 +85,8 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean } & Fo
 		placeholder: 'Placeholder',
 		tooltip: 'Je suis un message d’aide',
 		counter: 0,
+		autoResize: false,
+		scrollIntoViewOnAutoResizing: false,
 		rows: 3,
 	},
 };

--- a/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
@@ -1,24 +1,49 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface TextareaBasicStory {}
+interface TextareaBasicStory {
+	autoResize: boolean;
+	scrollIntoViewOnAutoResizing: boolean;
+}
 
 export default {
 	title: 'Documentation/Forms/Fields/TextAreaField/HTML&CSS',
-	argTypes: {},
+	argTypes: {
+		autoResize: {
+			type: 'boolean',
+		},
+		scrollIntoViewOnAutoResizing: {
+			type: 'boolean',
+			if: { arg: 'autoResize', truthy: true },
+		},
+	},
 } as Meta;
 
 function getTemplate(args: TextareaBasicStory): string {
+	const autoResize = args.autoResize ? 'mod-autoResize' : '';
+	const clone = args.autoResize ? '<div class="textField-input-valueClone" aria-hidden="true"></div>' : '';
+	let input = '';
+	if (args.autoResize) {
+		if (args.scrollIntoViewOnAutoResizing) {
+			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value; this.scrollIntoViewOnAutoResizing"';
+		} else {
+			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value"';
+		}
+	}
+
 	return `<div class="form-field">
 		<label class="formLabel" id="IDlabel" for="ID">Label</label>
-		<div class="textField">
+		<div class="textField ${autoResize}">
 			<div class="textField-input">
-				<textarea rows="3" id="ID" class="textField-input-value" aria-labelledby="IDlabel" aria-describedby="IDmessage" placeholder="Placeholder" aria-invalid="false"></textarea>
+				${clone}
+				<textarea rows="3" id="ID" class="textField-input-value" aria-labelledby="IDlabel"
+					aria-describedby="IDmessage" placeholder="Placeholder" aria-invalid="false"
+					${input}></textarea>
 			</div>
 		</div>
 		<div class="inlineMessage" id="IDmessage">
 			<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
 			<p class="inlineMessage-content">
-				Helper text
+				Helper Text
 			</p>
 		</div>
 	</div>`;
@@ -30,4 +55,7 @@ const Template: StoryFn<TextareaBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = {};
+Basic.args = {
+	autoResize: false,
+	scrollIntoViewOnAutoResizing: false,
+};

--- a/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
@@ -24,7 +24,7 @@ function getTemplate(args: TextareaBasicStory): string {
 	let input = '';
 	if (args.autoResize) {
 		if (args.scrollIntoViewOnAutoResizing) {
-			input = "onInput=\"this.previousElementSibling.dataset.contentBefore = this.value; this.previousElementSibling.scrollIntoView({ behavior: 'instant', block: 'end' })\"";
+			input = "onInput=\"this.previousElementSibling.dataset.contentBefore = this.value; this.parentNode.scrollIntoView({ behavior: 'instant', block: 'end' })\"";
 		} else {
 			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value"';
 		}

--- a/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
@@ -2,7 +2,7 @@ import { Meta, StoryFn } from '@storybook/angular';
 
 interface TextareaBasicStory {
 	autoResize: boolean;
-	scrollIntoViewOnAutoResizing: boolean;
+	autoResizeScrollIntoView: boolean;
 }
 
 export default {
@@ -11,7 +11,7 @@ export default {
 		autoResize: {
 			type: 'boolean',
 		},
-		scrollIntoViewOnAutoResizing: {
+		autoResizeScrollIntoView: {
 			type: 'boolean',
 			if: { arg: 'autoResize', truthy: true },
 		},
@@ -23,7 +23,7 @@ function getTemplate(args: TextareaBasicStory): string {
 	const clone = args.autoResize ? '<div class="textField-input-valueClone" aria-hidden="true"></div>' : '';
 	let input = '';
 	if (args.autoResize) {
-		if (args.scrollIntoViewOnAutoResizing) {
+		if (args.autoResizeScrollIntoView) {
 			input = "onInput=\"this.previousElementSibling.dataset.contentBefore = this.value; this.parentNode.scrollIntoView({ behavior: 'instant', block: 'end' })\"";
 		} else {
 			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value"';
@@ -58,5 +58,5 @@ const Template: StoryFn<TextareaBasicStory> = (args) => ({
 export const Basic = Template.bind({});
 Basic.args = {
 	autoResize: false,
-	scrollIntoViewOnAutoResizing: false,
+	autoResizeScrollIntoView: false,
 };

--- a/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
@@ -24,13 +24,14 @@ function getTemplate(args: TextareaBasicStory): string {
 	let input = '';
 	if (args.autoResize) {
 		if (args.scrollIntoViewOnAutoResizing) {
-			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value; this.scrollIntoViewOnAutoResizing({ behavior: "instant", block: "end" })"';
+			input = "onInput=\"this.previousElementSibling.dataset.contentBefore = this.value; this.previousElementSibling.scrollIntoView({ behavior: 'instant', block: 'end' })\"";
 		} else {
 			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value"';
 		}
 	}
 
-	return `<div class="form-field">
+	return `
+	<div class="form-field">
 		<label class="formLabel" id="IDlabel" for="ID">Label</label>
 		<div class="textField ${autoResize}">
 			<div class="textField-input">
@@ -46,12 +47,34 @@ function getTemplate(args: TextareaBasicStory): string {
 				Helper Text
 			</p>
 		</div>
-	</div>`;
+	</div>
+	<footer class="demoFooter footer mod-sticky">footer</footer>`;
 }
 
 const Template: StoryFn<TextareaBasicStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
+	styles: [
+		`
+		.form-field {
+			flex-grow: 1;
+			margin-bottom: 1rem;
+		}
+
+		.demoFooter {
+			margin: 0 -1rem -1rem;
+			bottom: -1rem;
+		}
+			
+		:host {
+			display: flex;
+			flex-direction: column;
+			height: 20rem;
+			overflow: auto;
+			padding: 1rem;
+			margin: -1rem;
+		}`,
+	],
 });
 
 export const Basic = Template.bind({});

--- a/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
@@ -47,34 +47,12 @@ function getTemplate(args: TextareaBasicStory): string {
 				Helper Text
 			</p>
 		</div>
-	</div>
-	<footer class="demoFooter footer mod-sticky">footer</footer>`;
+	</div>`;
 }
 
 const Template: StoryFn<TextareaBasicStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
-	styles: [
-		`
-		.form-field {
-			flex-grow: 1;
-			margin-bottom: 1rem;
-		}
-
-		.demoFooter {
-			margin: 0 -1rem -1rem;
-			bottom: -1rem;
-		}
-			
-		:host {
-			display: flex;
-			flex-direction: column;
-			height: 20rem;
-			overflow: auto;
-			padding: 1rem;
-			margin: -1rem;
-		}`,
-	],
 });
 
 export const Basic = Template.bind({});

--- a/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
+++ b/stories/documentation/forms/fields/textarea/html&css/textareafield.stories.ts
@@ -24,7 +24,7 @@ function getTemplate(args: TextareaBasicStory): string {
 	let input = '';
 	if (args.autoResize) {
 		if (args.scrollIntoViewOnAutoResizing) {
-			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value; this.scrollIntoViewOnAutoResizing"';
+			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value; this.scrollIntoViewOnAutoResizing({ behavior: "instant", block: "end" })"';
 		} else {
 			input = 'onInput="this.previousElementSibling.dataset.contentBefore = this.value"';
 		}


### PR DESCRIPTION
## Description

New options for textareas:

 - autoResize: disables browser resize and calculates the appropriate height for the current textarea value.
 - scrollIntoView: ensures that a textarea that changes size is always fully visible in the interface.
 - A maximum height of 80% of the viewport height has also been added.
 - The options are added to the Angular component and also to the HTML component via a JS one-liner.

-----

Thanks @Supamiu for the helping hand!

-----

![2024-09-06 11 30 27](https://github.com/user-attachments/assets/deddb07e-54ea-407b-ab3a-6ef17589ff4f)

![2024-09-25 18 38 31](https://github.com/user-attachments/assets/17bf9a1d-39ec-4ff2-8630-812281edcc97)


