### PR TITLE
date pipe custom format options

### DIFF
--- a/packages/ng/date/input/date-input.directive.ts
+++ b/packages/ng/date/input/date-input.directive.ts
@@ -59,10 +59,10 @@ export class LuDateInputDirective<D> extends ALuInput<D, HTMLInputElement> imple
 		let format: string;
 		switch (this.granularity) {
 			case ELuDateGranularity.year:
-				format = 'Y';
+				format = 'y';
 				break;
 			case ELuDateGranularity.month:
-				format = 'MM/Y';
+				format = 'MM/y';
 				break;
 			case ELuDateGranularity.day:
 			default:

--- a/packages/ng/date/select/date-select-input.component.ts
+++ b/packages/ng/date/select/date-select-input.component.ts
@@ -48,9 +48,9 @@ export class LuDateSelectInputComponent<D> extends ALuSelectInputComponent<D> im
 	get format(): string {
 		switch (this.granularity) {
 			case ELuDateGranularity.year:
-				return 'Y';
+				return 'y';
 			case ELuDateGranularity.month:
-				return 'MM/Y';
+				return 'MM/y';
 			case ELuDateGranularity.day:
 			default:
 				return 'shortDate';


### PR DESCRIPTION
## Description

Fix date picker "month" granularity mode.

-----

Change date format to match `datePipe` [custom format option](https://angular.dev/api/common/DatePipe?tab=usage-notes) (use in [formatDate](https://angular.dev/api/common/formatDate))

-----
