### PR TITLE
Fix selector specificity for nested components

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.html
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.html
@@ -1,4 +1,4 @@
-<button class="dialog-inside-header-button" type="button" luButton (click)="close()" *ngIf="dismissible">
+<button class="dialog-inside-header-button button" type="button" luButton (click)="close()" *ngIf="dismissible">
 	<lu-icon icon="signClose"></lu-icon>
 	<span class="u-mask">{{ intl.close }}</span>
 </button>

--- a/packages/ng/popover2/content/popover-content/popover-content.component.html
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.html
@@ -1,7 +1,7 @@
 <div class="popover" (cdkObserveContent)="contentChanged()" [debounce]="contentChangedDebounceTime">
 	@if (!config.noCloseButton) {
 	<div>
-		<button type="button" luButton class="popover-close" (click)="close()">
+		<button type="button" luButton class="popover-close button" (click)="close()">
 			<lu-icon icon="signClose"></lu-icon>
 			<span class="u-mask">{{ intl.close }}</span>
 		</button>

--- a/packages/ng/toast/toasts.component.html
+++ b/packages/ng/toast/toasts.component.html
@@ -11,7 +11,7 @@
 		</div>
 		<button
 			type="button"
-			class="toasts-item-kill"
+			class="toasts-item-kill button"
 			(click)="removeToast(toast)"
 			(animationend)="(!isOnlyDismissibleManually(toast) && toast.duration > 0) ? removeToast(toast) : null"
 			[style.animation-duration]="(!isOnlyDismissibleManually(toast) && toast.duration > 0) ? toast.duration + 'ms' : null"

--- a/packages/scss/src/components/calloutAccordion/mods.scss
+++ b/packages/scss/src/components/calloutAccordion/mods.scss
@@ -2,28 +2,28 @@
 @use '@lucca-front/scss/src/components/calloutFeedbackList/exports' as calloutFeedbackList;
 
 @mixin S {
-  .calloutAccordion-summary-title {
-    font-size: var(--sizes-S-fontSize);
-    line-height: var(--sizes-S-lineHeight);
-  }
+	.calloutAccordion-summary-title {
+		font-size: var(--sizes-S-fontSize);
+		line-height: var(--sizes-S-lineHeight);
+	}
 
-  .calloutAccordion-details {
-    margin: 0 2.75rem;
-  }
+	.calloutAccordion-details {
+		margin: 0 2.75rem;
+	}
 
-  .calloutAccordion-summary-icon {
-  	@include icon.S;
-  }
+	.calloutAccordion-summary-icon {
+		@include icon.S;
+	}
 
-  .calloutAccordion-summary-chevron {
-  	@include icon.S;
-  }
+	.calloutAccordion-summary-chevron {
+		@include icon.S;
+	}
 
-  .calloutAccordion-details {
-    margin-left: 2.75rem;
-  }
+	.calloutAccordion-details {
+		margin-left: 2.75rem;
+	}
 
-  .calloutFeedbackList {
-    @include calloutFeedbackList.S;
-  }
+	.calloutFeedbackList {
+		@include calloutFeedbackList.S;
+	}
 }

--- a/packages/scss/src/components/calloutDisclosure/mods.scss
+++ b/packages/scss/src/components/calloutDisclosure/mods.scss
@@ -2,34 +2,34 @@
 @use '@lucca-front/scss/src/components/calloutFeedbackList/exports' as calloutFeedbackList;
 
 @mixin S {
-  .calloutDisclosure-summary-title {
-    font-size: var(--sizes-S-fontSize);
-    line-height: var(--sizes-S-lineHeight);
-  }
+	.calloutDisclosure-summary-title {
+		font-size: var(--sizes-S-fontSize);
+		line-height: var(--sizes-S-lineHeight);
+	}
 
-  .calloutDisclosure-summary-icon {
-  	@include icon.S;
-  }
+	.calloutDisclosure-summary-icon {
+		@include icon.S;
+	}
 
-  .calloutDisclosure-summary-chevron {
-  	@include icon.S;
-  }
+	.calloutDisclosure-summary-chevron {
+		@include icon.S;
+	}
 
-  .calloutDisclosure-details {
-    margin-left: calc(var(--components-calloutDisclosure-paddingHorizontal) + 2rem);
-  }
+	.calloutDisclosure-details {
+		margin-left: calc(var(--components-calloutDisclosure-paddingHorizontal) + 2rem);
+	}
 
-  .calloutFeedbackList {
-    @include calloutFeedbackList.S;
-  }
+	.calloutFeedbackList {
+		@include calloutFeedbackList.S;
+	}
 }
 
 @mixin iconless {
-  .calloutDisclosure-summary-icon {
-    display: none;
-  }
+	.calloutDisclosure-summary-icon {
+		display: none;
+	}
 
-  .calloutDisclosure-details {
-    margin-left: var(--components-calloutDisclosure-paddingHorizontal);
-  }
+	.calloutDisclosure-details {
+		margin-left: var(--components-calloutDisclosure-paddingHorizontal);
+	}
 }

--- a/packages/scss/src/components/calloutPopover/mods.scss
+++ b/packages/scss/src/components/calloutPopover/mods.scss
@@ -3,48 +3,48 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
 
 @mixin S {
-  font-size: var(--sizes-S-fontSize);
-  line-height: var(--sizes-S-lineHeight);
-  padding: var(--pr-t-spacings-75);
+	font-size: var(--sizes-S-fontSize);
+	line-height: var(--sizes-S-lineHeight);
+	padding: var(--pr-t-spacings-75);
 
-  .calloutPopover-icon {
-    @include icon.S;
-  }
+	.calloutPopover-icon {
+		@include icon.S;
+	}
 }
 
 @mixin XS {
-  font-size: var(--sizes-XS-fontSize);
-  line-height: var(--sizes-XS-lineHeight);
-  padding: var(--pr-t-spacings-25) var(--pr-t-spacings-50);
-  gap: var(--pr-t-spacings-50);
-  border-radius: var(--commons-borderRadius-M);
+	font-size: var(--sizes-XS-fontSize);
+	line-height: var(--sizes-XS-lineHeight);
+	padding: var(--pr-t-spacings-25) var(--pr-t-spacings-50);
+	gap: var(--pr-t-spacings-50);
+	border-radius: var(--commons-borderRadius-M);
 
-  .calloutPopover-icon {
-    @include icon.XS;
-  }
+	.calloutPopover-icon {
+		@include icon.XS;
+	}
 }
 
 @mixin overlayS {
-  --components-calloutPopover-width: 20rem;
-  --components-calloutPopover-content-margin: 1.75rem;
+	--components-calloutPopover-width: 20rem;
+	--components-calloutPopover-content-margin: 1.75rem;
 
-  .calloutPopover-overlay-head-icon {
-    @include icon.S;
-  }
+	.calloutPopover-overlay-head-icon {
+		@include icon.S;
+	}
 
-  .calloutPopover-overlay-head-title {
-    @include title.h5;
-  }
+	.calloutPopover-overlay-head-title {
+		@include title.h5;
+	}
 
-  .calloutFeedbackList {
-    @include calloutFeedbackList.S;
-  }
+	.calloutFeedbackList {
+		@include calloutFeedbackList.S;
+	}
 }
 
 @mixin overlayIconless {
-  --components-calloutPopover-content-margin: 0;
+	--components-calloutPopover-content-margin: 0;
 
-  .calloutPopover-overlay-head-icon {
-    display: none;
-  }
+	.calloutPopover-overlay-head-icon {
+		display: none;
+	}
 }

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -27,14 +27,19 @@
 	flex-direction: column;
 
 	.dialog-inside-header-button {
-		@include button.text;
-		@include button.S;
-		@include button.onlyIconS;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.button,
+		&:not(.button) {
+			@include button.text;
+			@include button.S;
+			@include button.onlyIconS;
 
-		align-self: start;
-		justify-self: end;
-		grid-area: close;
-		display: var(--components-dialog-insideHeaderButtonDisplay);
+			align-self: start;
+			justify-self: end;
+			grid-area: close;
+			display: var(--components-dialog-insideHeaderButtonDisplay);
+		}
 	}
 
 	.dialog-inside-footer {

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -43,7 +43,12 @@
 	}
 
 	.dialog-inside-footer {
-		@include footer.sticky;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.footer,
+		&:not(.footer) {
+			@include footer.sticky;
+		}
 
 		// Safari fix to avoid footer to clip while loading
 		@supports (background-image: -webkit-named-image(test)) {

--- a/packages/scss/src/components/footer/component.scss
+++ b/packages/scss/src/components/footer/component.scss
@@ -1,5 +1,3 @@
-@use '@lucca-front/scss/src/components/container/exports' as container;
-
 @mixin component($atRoot: 'without: rule') {
 	background-color: var(--pr-t-elevation-surface-raised);
 	padding: var(--pr-t-spacings-200) var(--pr-t-spacings-300);

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -227,21 +227,26 @@
 		}
 
 		.indexTable-body-row-cellTitle-button {
-			@include button.text;
-			@include button.S;
-			@include button.onlyIconS;
+			// :not(.class) is only there to increase specificity when the class isn’t present
+			// but the class should be present, and this code is temporary
+			&.button,
+			&:not(.button) {
+				@include button.text;
+				@include button.S;
+				@include button.onlyIconS;
 
-			position: static;
+				position: static;
 
-			.lucca-icon {
-				transition: transform var(--commons-animations-durations-fast) ease;
-			}
+				.lucca-icon {
+					transition: transform var(--commons-animations-durations-fast) ease;
+				}
 
-			// Extend button reactive zone to his whole parent
-			&::before {
-				content: '';
-				position: absolute;
-				inset: 0;
+				// Extend button reactive zone to his whole parent
+				&::before {
+					content: '';
+					position: absolute;
+					inset: 0;
+				}
 			}
 		}
 

--- a/packages/scss/src/components/multiSelect/mods.scss
+++ b/packages/scss/src/components/multiSelect/mods.scss
@@ -14,15 +14,27 @@
 	}
 
 	.multipleSelect-clear {
-		@include clear.S;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
+			@include clear.S;
+		}
 	}
 
 	.multipleSelect-displayer-chip {
-		@include chip.S;
+		.chip {
+			@include chip.S;
+		}
 	}
 
 	.multipleSelect-displayer-numericBadge {
-		@include numericBadge.S;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.numericBadge,
+		&:not(.numericBadge) {
+			@include numericBadge.S;
+		}
 	}
 }
 

--- a/packages/scss/src/components/multiSelect/mods.scss
+++ b/packages/scss/src/components/multiSelect/mods.scss
@@ -23,7 +23,10 @@
 	}
 
 	.multipleSelect-displayer-chip {
-		.chip {
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.chip,
+		&:not(.chip) {
 			@include chip.S;
 		}
 	}

--- a/packages/scss/src/components/plgPush/component.scss
+++ b/packages/scss/src/components/plgPush/component.scss
@@ -56,6 +56,7 @@
 
 		.link {
 			@include link.brand;
+
 			display: inline-block;
 		}
 	}

--- a/packages/scss/src/components/popover/component.scss
+++ b/packages/scss/src/components/popover/component.scss
@@ -11,27 +11,31 @@
 	min-width: var(--pr-t-spacings-500);
 	animation: popup var(--commons-animations-durations-fast) ease 1 forwards;
 
-	// need of a higher specificity
-	.popover-close {
-		@include button.outlined;
-		@include button.XS;
-		@include button.onlyIconXS;
-
-		--components-button-padding: var(--pr-t-spacings-50);
-
-		padding: 0;
-		border-radius: 50%;
-		position: absolute;
-		left: calc(var(--pr-t-spacings-100) * -1);
-		top: calc(var(--pr-t-spacings-100) * -1);
-		z-index: 2;
-
-		&:not(:focus-visible) {
-			@include a11y.mask;
-		}
-	}
-
 	@at-root {
+		.popover-close {
+			// :not(.class) is only there to increase specificity when the class isn’t present
+			// but the class should be present, and this code is temporary
+			&.button,
+			&:not(.button) {
+				@include button.outlined;
+				@include button.XS;
+				@include button.onlyIconXS;
+
+				--components-button-padding: var(--pr-t-spacings-50);
+
+				padding: 0;
+				border-radius: 50%;
+				position: absolute;
+				left: calc(var(--pr-t-spacings-100) * -1);
+				top: calc(var(--pr-t-spacings-100) * -1);
+				z-index: 2;
+
+				&:not(:focus-visible) {
+					@include a11y.mask;
+				}
+			}
+		}
+
 		.popover-contentOptional {
 			padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);
 		}

--- a/packages/scss/src/components/simpleSelect/mods.scss
+++ b/packages/scss/src/components/simpleSelect/mods.scss
@@ -2,31 +2,41 @@
 @use '@lucca-front/scss/src/components/clear/exports' as clear;
 
 @mixin S {
-  --components-simpleSelect-fontSize: var(--sizes-S-fontSize);
-  --components-simpleSelect-lineHeight: var(--sizes-S-lineHeight);
-  --components-simpleSelect-padding: var(--pr-t-spacings-75);
-  --components-simpleSelect-gap: var(--pr-t-spacings-75);
+	--components-simpleSelect-fontSize: var(--sizes-S-fontSize);
+	--components-simpleSelect-lineHeight: var(--sizes-S-lineHeight);
+	--components-simpleSelect-padding: var(--pr-t-spacings-75);
+	--components-simpleSelect-gap: var(--pr-t-spacings-75);
 
-  .simpleSelect-arrow {
-    @include icon.S;
-  }
+	.simpleSelect-arrow {
+		@include icon.S;
+	}
 
-  .simpleSelect-clear {
-    @include clear.S;
-  }
+	.simpleSelect-clear {
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
+			@include clear.S;
+		}
+	}
 }
 
 @mixin XS {
-  --components-simpleSelect-fontSize: var(--sizes-XS-fontSize);
-  --components-simpleSelect-lineHeight: var(--sizes-XS-lineHeight);
-  --components-simpleSelect-padding: var(--pr-t-spacings-50);
-  --components-simpleSelect-gap: var(--pr-t-spacings-50);
+	--components-simpleSelect-fontSize: var(--sizes-XS-fontSize);
+	--components-simpleSelect-lineHeight: var(--sizes-XS-lineHeight);
+	--components-simpleSelect-padding: var(--pr-t-spacings-50);
+	--components-simpleSelect-gap: var(--pr-t-spacings-50);
 
-  .simpleSelect-arrow {
-    @include icon.XS;
-  }
+	.simpleSelect-arrow {
+		@include icon.XS;
+	}
 
-  .simpleSelect-clear {
-    @include clear.S;
-  }
+	.simpleSelect-clear {
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
+			@include clear.S;
+		}
+	}
 }

--- a/packages/scss/src/components/switchField/component.scss
+++ b/packages/scss/src/components/switchField/component.scss
@@ -1,5 +1,3 @@
-@use '@lucca-front/scss/src/components/formLabel/exports' as formLabel;
-@use '@lucca-front/scss/src/components/box/exports' as box;
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 

--- a/packages/scss/src/components/tableSortable/index.scss
+++ b/packages/scss/src/components/tableSortable/index.scss
@@ -6,6 +6,16 @@
 .table-head-row-cell-sortableButton,
 .indexTable-head-row-cell-sortableButton {
 	@include vars;
+}
+
+// :not(.class) is only there to increase specificity when the class isn’t present
+// but the class should be present, and this code is temporary
+// .table-head-row-cell-sortableButton is deprecated
+// .indexTable-head-row-cell-sortableButton is deprecated
+.tableSortable.button,
+.tableSortable:not(.button),
+.table-head-row-cell-sortableButton,
+.indexTable-head-row-cell-sortableButton {
 	@include component;
 }
 

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -12,7 +12,12 @@
 	}
 
 	.textField-input-affix-clear {
-		@include clear.S;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
+			@include clear.S;
+		}
 	}
 
 	.textField-input-affix-icon {
@@ -35,7 +40,12 @@
 	}
 
 	.textField-input-affix-clear {
-		@include clear.S;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
+			@include clear.S;
+		}
 	}
 }
 

--- a/packages/scss/src/components/textfields/mods.scss
+++ b/packages/scss/src/components/textfields/mods.scss
@@ -221,10 +221,15 @@
 	}
 
 	.textfield-clear {
-		@include clear.S;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
+			@include clear.S;
 
-		right: 2.125rem;
-		bottom: 0.625rem;
+			right: 2.125rem;
+			bottom: 0.625rem;
+		}
 	}
 }
 
@@ -247,10 +252,12 @@
 	}
 
 	.textfield-clear {
-		@include clear.S;
+		&.clear {
+			@include clear.S;
 
-		right: 1.75rem;
-		bottom: var(--pr-t-spacings-75);
+			right: 1.75rem;
+			bottom: var(--pr-t-spacings-75);
+		}
 	}
 }
 

--- a/packages/scss/src/components/textfields/mods.scss
+++ b/packages/scss/src/components/textfields/mods.scss
@@ -252,7 +252,10 @@
 	}
 
 	.textfield-clear {
-		&.clear {
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.clear,
+		&:not(.clear) {
 			@include clear.S;
 
 			right: 1.75rem;

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -12,7 +12,7 @@
 	html:has(.main-content .footer.mod-sticky, .dialog.mod-drawer .dialog-inside-footer) & {
 		// Provide extra bottom spacing when a footer is sticked
 		// Will only work on desktop with standard footer layout
-		// Refactor: Position should be calculated dynamically 
+		// Refactor: Position should be calculated dynamically
 		--components-toasts-bottom: calc(var(--components-toasts-footerHeight) + var(--pr-t-spacings-300));
 	}
 
@@ -66,20 +66,21 @@
 		}
 
 		.toasts-item-kill {
-			// the button class should be added to the component, but in the meantime we initialize the component here
-			@include button.vars;
-			@include button.component;
+			// :not(.class) is only there to increase specificity when the class isn’t present
+			// but the class should be present, and this code is temporary
+			&.button,
+			&:not(.button) {
+				@include button.onlyIcon;
+				@include button.text;
+				@include button.inverted;
 
-			@include button.onlyIcon;
-			@include button.text;
-			@include button.inverted;
+				@keyframes timer {
+				}
 
-			@keyframes timer {
+				align-self: flex-start;
+				border-radius: var(--commons-borderRadius-L);
+				animation-name: timer;
 			}
-
-			align-self: flex-start;
-			border-radius: var(--commons-borderRadius-L);
-			animation-name: timer;
 		}
 	}
 }

--- a/packages/scss/src/components/userPopover/component.scss
+++ b/packages/scss/src/components/userPopover/component.scss
@@ -64,7 +64,13 @@
 	}
 
 	.userPopover-details-avatar {
-		@include avatar.XXXL;
-		margin: var(--pr-t-spacings-50) 0;
+		// :not(.class) is only there to increase specificity when the class isn’t present
+		// but the class should be present, and this code is temporary
+		&.avatar,
+		&:not(.avatar) {
+			@include avatar.XXXL;
+
+			margin: var(--pr-t-spacings-50) 0;
+		}
 	}
 }

--- a/stories/documentation/listings/index-table/index-table-sortable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-sortable.stories.ts
@@ -1,4 +1,5 @@
-import { Meta, StoryFn } from '@storybook/angular';
+import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+import { ButtonComponent } from 'dist/ng/button';
 
 interface IndexTableSortableStory {
 	align: string;
@@ -14,6 +15,11 @@ export default {
 			},
 		},
 	},
+	decorators: [
+		moduleMetadata({
+			imports: [ButtonComponent],
+		}),
+	],
 } as Meta;
 
 function getTemplate(args: IndexTableSortableStory): string {
@@ -79,7 +85,7 @@ function getTemplate(args: IndexTableSortableStory): string {
 			<td class="indexTable-body-row-cell ${args.align}">Content</td>
 		</tr>
 	</tbody>
-</table>`;
+</table><button luButton>test</button>`;
 }
 
 const Template: StoryFn<IndexTableSortableStory> = (args) => ({

--- a/stories/documentation/listings/index-table/index-table-sortable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-sortable.stories.ts
@@ -1,5 +1,4 @@
-import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
-import { ButtonComponent } from 'dist/ng/button';
+import { Meta, StoryFn } from '@storybook/angular';
 
 interface IndexTableSortableStory {
 	align: string;
@@ -15,11 +14,6 @@ export default {
 			},
 		},
 	},
-	decorators: [
-		moduleMetadata({
-			imports: [ButtonComponent],
-		}),
-	],
 } as Meta;
 
 function getTemplate(args: IndexTableSortableStory): string {
@@ -85,7 +79,7 @@ function getTemplate(args: IndexTableSortableStory): string {
 			<td class="indexTable-body-row-cell ${args.align}">Content</td>
 		</tr>
 	</tbody>
-</table><button luButton>test</button>`;
+</table>`;
 }
 
 const Template: StoryFn<IndexTableSortableStory> = (args) => ({


### PR DESCRIPTION
## Description

SCSS components can be loaded via an explicit CSS call, but also via NG components.

As the order in which NG components were called could not be controlled, we ended up with style overloads when components were nested and overloaded within other components.

In this PR, I increase the specificity of selectors when this happens, to ensure that the order in which CSS components are called up no longer interferes. 

-----

-----
