### PR TITLE
[Callout] Set callout state input multiple times doesn't work

### DIFF
--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.html
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.html
@@ -1,6 +1,10 @@
 <details class="calloutDisclosure" [ngClass]="calloutClasses" [class.mod-iconless]="!icon" [open]="open" (toggle)="onToggle($event)">
 	<summary class="calloutDisclosure-summary">
-		<lu-icon class="calloutDisclosure-summary-icon" *ngIf="icon" [icon]="icon"></lu-icon>
+		@if (state | luCalloutIcon: icon; as calloutIcon) {
+		<span class="calloutDisclosure-summary-icon">
+			<lu-icon [icon]="calloutIcon"></lu-icon>
+		</span>
+		}
 		<span class="calloutDisclosure-summary-title">
 			<ng-container *luPortal="heading"></ng-container>
 		</span>

--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.ts
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.ts
@@ -3,12 +3,14 @@ import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEn
 import { LuccaIcon } from '@lucca-front/icons';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
-import { CalloutState, CalloutStateMap } from '../callout-state';
+import { CalloutIconPipe } from '../callout-icon.pipe';
+import { CalloutState } from '../callout-state';
+import { getCalloutPalette } from '../callout.utils';
 
 @Component({
 	selector: 'lu-callout-disclosure',
 	standalone: true,
-	imports: [CommonModule, IconComponent, NgClass, PortalDirective],
+	imports: [CommonModule, IconComponent, NgClass, PortalDirective, CalloutIconPipe],
 	templateUrl: './callout-disclosure.component.html',
 	styleUrls: ['./callout-disclosure.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -35,15 +37,7 @@ export class CalloutDisclosureComponent {
 	 * If one of the icon or palette inputs are filled along with the state input, their values will have the priority over
 	 * state (so setting state to success and palette to warning will make the palette warning)
 	 */
-	set state(state: CalloutState) {
-		const { icon, palette } = CalloutStateMap[state];
-		if (this.palette === 'none') {
-			this.palette = palette;
-		}
-		if (!this.icon) {
-			this.icon = icon;
-		}
-	}
+	state: CalloutState;
 
 	@Input({ transform: booleanAttribute }) open = false;
 
@@ -56,9 +50,10 @@ export class CalloutDisclosureComponent {
 	}
 
 	get calloutClasses() {
+		const palette = getCalloutPalette(this.state, this.palette);
 		return {
 			[`mod-${this.size}`]: !!this.size,
-			[`palette-${this.palette}`]: !!this.palette,
+			[`palette-${palette}`]: !!palette,
 		};
 	}
 }

--- a/packages/ng/callout/callout-icon.pipe.ts
+++ b/packages/ng/callout/callout-icon.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { LuccaIcon } from '@lucca-front/icons';
+import { CalloutState } from './callout-state';
+import { getCalloutIcon } from './callout.utils';
+
+/**
+ * Get icon for callout
+ *
+ * If the icon is defined then it takes priority over the callout state icon
+ */
+@Pipe({
+	name: 'luCalloutIcon',
+	standalone: true,
+})
+export class CalloutIconPipe implements PipeTransform {
+	transform(state: CalloutState, icon: LuccaIcon): LuccaIcon | undefined {
+		return getCalloutIcon(state, icon);
+	}
+}

--- a/packages/ng/callout/callout-popover/callout-popover.component.html
+++ b/packages/ng/callout/callout-popover/callout-popover.component.html
@@ -8,8 +8,9 @@
 	(mouseleave)="hideContent($event)"
 	(blur)="hideContent(null)"
 >
-	<lu-icon class="calloutPopover-icon" *ngIf="icon" [icon]="icon"></lu-icon>
-	{{buttonLabel}}
+	@if (state | luCalloutIcon: icon; as calloutIcon) {
+	<lu-icon class="calloutPopover-icon" [icon]="calloutIcon"></lu-icon>
+	} {{buttonLabel}}
 </button>
 <ng-template #overlayContentRef>
 	<div

--- a/packages/ng/callout/callout-popover/callout-popover.component.ts
+++ b/packages/ng/callout/callout-popover/callout-popover.component.ts
@@ -7,12 +7,14 @@ import { LuccaIcon } from '@lucca-front/icons';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
-import { CalloutState, CalloutStateMap } from '../callout-state';
+import { CalloutIconPipe } from '../callout-icon.pipe';
+import { CalloutState } from '../callout-state';
+import { getCalloutPalette } from '../callout.utils';
 
 @Component({
 	selector: 'lu-callout-popover',
 	standalone: true,
-	imports: [CommonModule, IconComponent, ButtonComponent, PortalDirective],
+	imports: [CommonModule, IconComponent, ButtonComponent, PortalDirective, CalloutIconPipe],
 	animations: [
 		trigger('tooltip', [
 			state(
@@ -100,15 +102,7 @@ export class CalloutPopoverComponent implements OnDestroy {
 	 * If one of the icon or palette inputs are filled along with the state input, their values will have the priority over
 	 * state (so setting state to success and palette to warning will make the palette warning)
 	 */
-	set state(state: CalloutState) {
-		const { icon, palette } = CalloutStateMap[state];
-		if (this.palette === 'none') {
-			this.palette = palette;
-		}
-		if (!this.icon) {
-			this.icon = icon;
-		}
-	}
+	state: CalloutState;
 
 	/**
 	 * Heading for the details popover
@@ -124,9 +118,10 @@ export class CalloutPopoverComponent implements OnDestroy {
 	}
 
 	get calloutClasses() {
+		const palette = getCalloutPalette(this.state, this.palette);
 		return {
 			[`mod-${this.size}`]: !!this.size,
-			[`palette-${this.palette}`]: !!this.palette,
+			[`palette-${palette}`]: !!palette,
 		};
 	}
 
@@ -137,8 +132,9 @@ export class CalloutPopoverComponent implements OnDestroy {
 	}
 
 	get calloutOverlayHeadClasses() {
+		const palette = getCalloutPalette(this.state, this.palette);
 		return {
-			[`palette-${this.palette}`]: !!this.palette,
+			[`palette-${palette}`]: !!palette,
 		};
 	}
 

--- a/packages/ng/callout/callout-state.ts
+++ b/packages/ng/callout/callout-state.ts
@@ -1,7 +1,9 @@
-import { Palette } from '@lucca-front/ng/core';
 import { LuccaIcon } from '@lucca-front/icons';
+import { Palette } from '@lucca-front/ng/core';
 
-export type CalloutState = 'success' | 'warning' | 'error';
+export const CalloutStates = ['success', 'warning', 'error'] as const;
+
+export type CalloutState = (typeof CalloutStates)[number];
 
 export const CalloutStateMap: Record<CalloutState, { icon: LuccaIcon; palette: Palette }> = {
 	success: {

--- a/packages/ng/callout/callout.utils.spec.ts
+++ b/packages/ng/callout/callout.utils.spec.ts
@@ -1,0 +1,50 @@
+import { LuccaIcon } from '@lucca-front/icons';
+import { Palette } from '@lucca-front/ng/core';
+import { CalloutStateMap, CalloutStates } from './callout-state';
+import { getCalloutIcon, getCalloutPalette } from './callout.utils';
+
+describe('CalloutUtils', () => {
+	describe(getCalloutIcon.name, () => {
+		it('should be state icon when state is defined and icon is undefined', () => {
+			for (const state of CalloutStates) {
+				expect(getCalloutIcon(state, undefined)).toBe(CalloutStateMap[state].icon);
+			}
+		});
+
+		it('should be icon when state is defined and icon is defined', () => {
+			for (const state of CalloutStates) {
+				expect(getCalloutIcon(state, 'signHelp')).toBe<LuccaIcon>('signHelp');
+			}
+		});
+
+		it('should be icon when state is undefined and icon is defined', () => {
+			expect(getCalloutIcon(undefined, 'adduser')).toBe<LuccaIcon>('adduser');
+		});
+
+		it('should be undefined when state is undefined and icon is undefined', () => {
+			expect(getCalloutIcon(undefined, undefined)).toBeUndefined();
+		});
+	});
+
+	describe(getCalloutPalette.name, () => {
+		it('should be state palette when state is defined and palette is none', () => {
+			for (const state of CalloutStates) {
+				expect(getCalloutPalette(state, 'none')).toBe(CalloutStateMap[state].palette);
+			}
+		});
+
+		it('should be palette when state is defined and palette is defined', () => {
+			for (const state of CalloutStates) {
+				expect(getCalloutPalette(state, 'warning')).toBe('warning');
+			}
+		});
+
+		it('should be palette when state is undefined and palette is defined', () => {
+			expect(getCalloutPalette(undefined, 'warning')).toBe('warning');
+		});
+
+		it('should be none when state is undefined and palette is none', () => {
+			expect(getCalloutPalette(undefined, 'none')).toBe<Palette>('none');
+		});
+	});
+});

--- a/packages/ng/callout/callout.utils.ts
+++ b/packages/ng/callout/callout.utils.ts
@@ -1,0 +1,23 @@
+import { LuccaIcon } from '@lucca-front/icons';
+import { Palette } from '@lucca-front/ng/core';
+import { CalloutState, CalloutStateMap } from './callout-state';
+
+/**
+ * Get icon for callout
+ *
+ * If the icon is defined then it takes priority over the callout state icon
+ */
+export function getCalloutIcon(state: CalloutState | undefined, icon: LuccaIcon | undefined): LuccaIcon | undefined {
+	const stateMap = CalloutStateMap[state] ?? { icon };
+	return icon ?? stateMap.icon;
+}
+
+/**
+ * Get palette for callout
+ *
+ * If the palette is different from "none" then it takes priority over the callout state palette
+ */
+export function getCalloutPalette(state: CalloutState | undefined, palette: Palette): string {
+	const stateMap = CalloutStateMap[state] ?? { palette };
+	return palette !== 'none' ? palette : stateMap.palette;
+}

--- a/packages/ng/callout/callout/callout.component.html
+++ b/packages/ng/callout/callout/callout.component.html
@@ -1,16 +1,24 @@
-<div class="callout" [ngClass]="calloutClasses" *ngIf="!removed">
-	<div class="callout-icon" *ngIf="icon">
-		<span aria-hidden="true" class="lucca-icon icon-{{icon}}"></span>
+@if (!removed) {
+<div class="callout" [ngClass]="calloutClasses">
+	@if (state | luCalloutIcon: icon; as calloutIcon) {
+	<div class="callout-icon">
+		<span aria-hidden="true" class="lucca-icon icon-{{calloutIcon}}"></span>
 	</div>
+	}
 	<div class="callout-content">
-		<strong class="callout-content-title" *ngIf="heading">
+		@if (heading) {
+		<strong class="callout-content-title">
 			<ng-container *luPortal="heading"></ng-container>
 		</strong>
+		}
 		<div class="callout-content-description">
 			<ng-content></ng-content>
 		</div>
 	</div>
-	<button *ngIf="removable" type="button" class="callout-kill" (click)="removed = true; removedChange.emit(true)">
+	@if (removable) {
+	<button type="button" class="callout-kill" (click)="removed = true; removedChange.emit(true)">
 		<span class="u-mask">{{ intl.close }}</span>
 	</button>
+	}
 </div>
+}

--- a/packages/ng/callout/callout/callout.component.ts
+++ b/packages/ng/callout/callout/callout.component.ts
@@ -1,14 +1,16 @@
-import { NgClass, NgIf } from '@angular/common';
+import { NgClass } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, HostBinding, Input, Output, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
 import { getIntl, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
-import { CalloutState, CalloutStateMap } from '../callout-state';
+import { CalloutIconPipe } from '../callout-icon.pipe';
+import { CalloutState } from '../callout-state';
 import { LU_CALLOUT_TRANSLATIONS } from '../callout.translate';
+import { getCalloutPalette } from '../callout.utils';
 
 @Component({
 	selector: 'lu-callout',
 	standalone: true,
-	imports: [NgClass, NgIf, PortalDirective],
+	imports: [NgClass, PortalDirective, CalloutIconPipe],
 	templateUrl: './callout.component.html',
 	styleUrls: ['./callout.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -55,15 +57,7 @@ export class CalloutComponent {
 	 * If one of the icon or palette inputs are filled along with the state input, their values will have the priority over
 	 * state (so setting state to success and palette to warning will make the palette warning)
 	 */
-	set state(state: CalloutState) {
-		const { icon, palette } = CalloutStateMap[state];
-		if (this.palette === 'none') {
-			this.palette = palette;
-		}
-		if (!this.icon) {
-			this.icon = icon;
-		}
-	}
+	state: CalloutState;
 
 	@Input({ transform: booleanAttribute })
 	/**
@@ -82,9 +76,10 @@ export class CalloutComponent {
 	public intl = getIntl(LU_CALLOUT_TRANSLATIONS);
 
 	get calloutClasses() {
+		const palette = getCalloutPalette(this.state, this.palette);
 		return {
 			[`mod-${this.size}`]: !!this.size,
-			[`palette-${this.palette}`]: !!this.palette,
+			[`palette-${palette}`]: !!palette,
 		};
 	}
 }


### PR DESCRIPTION
## Description

When callout state input was updated multiple times without icon and palette inputs then the palette and icon doesn't refresh with state value.

-----

The callout state input setter was modifying other palette and icon inputs instead of just rendering.

### N.B.

This problem would have been detected using signal inputs because it's not writable signals.

-----
