### PR TITLE
ref: handle namespaced at-root and :root selectors

### DIFF
--- a/packages/icons/src/commons/base.scss
+++ b/packages/icons/src/commons/base.scss
@@ -2,21 +2,23 @@
 
 body {
 	-moz-osx-font-smoothing: grayscale;
+}
 
-	@at-root {
-		@font-face {
-			font-family: config.$font-name;
-			font-style: normal;
-			font-weight: 400;
-			src: url('#{config.$font-path}.woff2') format('woff2'), url('#{config.$font-path}.woff') format('woff');
-			letter-spacing: normal;
-			-webkit-font-feature-settings: 'liga';
-			-moz-font-feature-settings: 'liga=1';
-			-moz-font-feature-settings: 'liga';
-			-ms-font-feature-settings: 'liga' 1;
-			font-feature-settings: 'liga';
-			-webkit-font-variant-ligatures: discretionary-ligatures;
-			font-variant-ligatures: discretionary-ligatures;
-		}
+@at-root {
+	@font-face {
+		font-family: config.$font-name;
+		font-style: normal;
+		font-weight: 400;
+		src:
+			url('#{config.$font-path}.woff2') format('woff2'),
+			url('#{config.$font-path}.woff') format('woff');
+		letter-spacing: normal;
+		-webkit-font-feature-settings: 'liga';
+		-moz-font-feature-settings: 'liga=1';
+		-moz-font-feature-settings: 'liga';
+		-ms-font-feature-settings: 'liga' 1;
+		font-feature-settings: 'liga';
+		-webkit-font-variant-ligatures: discretionary-ligatures;
+		font-variant-ligatures: discretionary-ligatures;
 	}
 }

--- a/packages/icons/src/commons/base.scss
+++ b/packages/icons/src/commons/base.scss
@@ -1,7 +1,13 @@
 @use '@lucca-front/icons/src/commons/config';
 
-body {
-	-moz-osx-font-smoothing: grayscale;
+@if config.$isNamespaced {
+	& {
+		-moz-osx-font-smoothing: grayscale;
+	}
+} @else {
+	body {
+		-moz-osx-font-smoothing: grayscale;
+	}
 }
 
 @at-root {

--- a/packages/icons/src/commons/config.scss
+++ b/packages/icons/src/commons/config.scss
@@ -7,6 +7,7 @@
 // $font-path: '../../font/lucca-icons' !default;
 $font-path: '//cdn.lucca.fr/lucca-front/icons/font/lucca-icons' !default;
 $font-name: 'Lucca icons' !default;
+$isNamespaced: false !default;
 
 $icons: (
 	'app': '\e959',

--- a/packages/icons/src/icon/component.scss
+++ b/packages/icons/src/icon/component.scss
@@ -1,7 +1,9 @@
 @use '@lucca-front/icons/src/commons/config';
 @use '@lucca-front/icons/src/commons/core';
 
-@mixin component($atRoot: 'without: rule') {
+$defaultAtRoot: config.$isNamespaced and 'with: rule' or 'without: rule';
+
+@mixin component($atRoot: $defaultAtRoot) {
 	font-weight: 400;
 	font-size: var(--icon-size, var(--icon-sizeDefault));
 	direction: ltr;

--- a/packages/ng/styles/components/_calendar.scss
+++ b/packages/ng/styles/components/_calendar.scss
@@ -1,4 +1,6 @@
-:root {
-  --components-calendar-width: 17.5rem;
-  --components-calendar-day-size: 2.5rem;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@include ns.appendRootVars {
+	--components-calendar-width: 17.5rem;
+	--components-calendar-day-size: 2.5rem;
 }

--- a/packages/ng/styles/components/_calendar.scss
+++ b/packages/ng/styles/components/_calendar.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	--components-calendar-width: 17.5rem;
 	--components-calendar-day-size: 2.5rem;
 }

--- a/packages/ng/styles/components/_dropdown.scss
+++ b/packages/ng/styles/components/_dropdown.scss
@@ -1,6 +1,7 @@
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-:root {
+@include namespace.appendRootVars {
 	--components-dropdown-min-width: 10rem;
 	--components-dropdown-max-width: 30rem;
 	--components-dropdown-max-height: 60vh;

--- a/packages/ng/styles/components/_popup.scss
+++ b/packages/ng/styles/components/_popup.scss
@@ -1,8 +1,8 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/components/title/exports' as title;
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	--components-popup-XS: 25rem;
 	--components-popup-S: 30rem;
 	--components-popup-M: 40rem;

--- a/packages/ng/styles/components/_popup.scss
+++ b/packages/ng/styles/components/_popup.scss
@@ -1,7 +1,8 @@
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/components/title/exports' as title;
 
-:root {
+@include ns.appendRootVars {
 	--components-popup-XS: 25rem;
 	--components-popup-S: 30rem;
 	--components-popup-M: 40rem;

--- a/packages/ng/styles/components/_sidepanel.scss
+++ b/packages/ng/styles/components/_sidepanel.scss
@@ -1,4 +1,6 @@
-:root {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@include ns.appendRootVars {
 	--components-sidepanel-XS: 25rem;
 	--components-sidepanel-S: 30rem;
 	--components-sidepanel-M: 40rem;

--- a/packages/ng/styles/components/_sidepanel.scss
+++ b/packages/ng/styles/components/_sidepanel.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	--components-sidepanel-XS: 25rem;
 	--components-sidepanel-S: 30rem;
 	--components-sidepanel-M: 40rem;

--- a/packages/ng/styles/components/cdk/_overlay.scss
+++ b/packages/ng/styles/components/cdk/_overlay.scss
@@ -1,7 +1,8 @@
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 @use '@lucca-front/scss/src/commons/utils/keyframe';
 @use '@lucca-front/scss/src/commons/utils/color';
 
-:root {
+@include ns.appendRootVars {
 	--components-cdk-backdrop-opacity: 0.4;
 }
 

--- a/packages/ng/styles/components/cdk/_overlay.scss
+++ b/packages/ng/styles/components/cdk/_overlay.scss
@@ -1,8 +1,8 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/commons/utils/keyframe';
 @use '@lucca-front/scss/src/commons/utils/color';
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	--components-cdk-backdrop-opacity: 0.4;
 }
 

--- a/packages/ng/styles/components/cdk/_textarea.scss
+++ b/packages/ng/styles/components/cdk/_textarea.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	--components-cdk-textarea-input-padding-horizontal: var(--pr-t-spacings-100);
 }
 

--- a/packages/ng/styles/components/cdk/_textarea.scss
+++ b/packages/ng/styles/components/cdk/_textarea.scss
@@ -1,4 +1,6 @@
-:root {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@include ns.appendRootVars {
 	--components-cdk-textarea-input-padding-horizontal: var(--pr-t-spacings-100);
 }
 

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -1,8 +1,8 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	--components-options-item-padding-vertical: var(--pr-t-spacings-50);
 	--components-options-item-padding-horizontal: var(--pr-t-spacings-100);
 	--components-options-item-multiple-padding: 2.25rem;

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -1,7 +1,8 @@
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 
-:root {
+@include ns.appendRootVars {
 	--components-options-item-padding-vertical: var(--pr-t-spacings-50);
 	--components-options-item-padding-horizontal: var(--pr-t-spacings-100);
 	--components-options-item-multiple-padding: 2.25rem;

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -3,7 +3,7 @@
 
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin body {
 	background-color: var(--pr-t-elevation-surface-default);
@@ -21,7 +21,7 @@
 	height: -webkit-fill-available;
 }
 
-@mixin base($atRoot: ns.$defaultAtRoot) {
+@mixin base($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		@if config.$fontFamily != 'Source Sans Pro' {
 			@font-face {

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -3,8 +3,25 @@
 
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin base($atRoot: 'without: rule') {
+@mixin body {
+	background-color: var(--pr-t-elevation-surface-default);
+	color: var(--palettes-neutral-800);
+	font-family: var(--commons-font-family);
+	font-size: var(--sizes-M-fontSize);
+	line-height: var(--sizes-M-lineHeight);
+
+	@supports (-webkit-touch-callout: none) {
+		min-height: -webkit-fill-available;
+	}
+}
+
+@mixin html {
+	height: -webkit-fill-available;
+}
+
+@mixin base($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		@if config.$fontFamily != 'Source Sans Pro' {
 			@font-face {
@@ -90,19 +107,18 @@
 			opacity: 1;
 		}
 
-		html {
-			height: -webkit-fill-available;
-		}
+		@if config.$isNamespaced {
+			& {
+				@include body;
+				@include html;
+			}
+		} @else {
+			html {
+				@include html;
+			}
 
-		body {
-			background-color: var(--pr-t-elevation-surface-default);
-			color: var(--palettes-neutral-800);
-			font-family: var(--commons-font-family);
-			font-size: var(--sizes-M-fontSize);
-			line-height: var(--sizes-M-lineHeight);
-
-			@supports (-webkit-touch-callout: none) {
-				min-height: -webkit-fill-available;
+			body {
+				@include body;
 			}
 		}
 

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -2,6 +2,7 @@
 @use '@lucca-front/scss/src/commons/utils/color';
 
 $importDeprecatedSpacings: true !default;
+$isNamespaced: false !default;
 
 $fontFamily: 'Source Sans Pro' !default;
 $product: 'brand' !default;

--- a/packages/scss/src/commons/index.scss
+++ b/packages/scss/src/commons/index.scss
@@ -1,7 +1,7 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use 'exports' as *;
 
-@include ns.appendRootVars {
+@include namespace.appendRootVars {
 	@include vars;
 	@include base;
 }

--- a/packages/scss/src/commons/index.scss
+++ b/packages/scss/src/commons/index.scss
@@ -1,6 +1,7 @@
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 @use 'exports' as *;
 
-:root {
+@include ns.appendRootVars {
 	@include vars;
 	@include base;
 }

--- a/packages/scss/src/commons/utils/namespace.scss
+++ b/packages/scss/src/commons/utils/namespace.scss
@@ -2,7 +2,7 @@
 
 $defaultAtRoot: 'without: rule';
 
-@if ($isNamespaced) {
+@if (config.$isNamespaced) {
 	// When namespaced, we need to keep the surrounding selector
 	$defaultAtRoot: 'with: rule';
 }

--- a/packages/scss/src/commons/utils/namespace.scss
+++ b/packages/scss/src/commons/utils/namespace.scss
@@ -1,8 +1,11 @@
 @use '@lucca-front/scss/src/commons/config';
 
-// default to 'without: rule' is namespace.$isNamespaced is false
-// default to 'with: rule' is namespace.$isNamespaced is true
-$defaultAtRoot: config.$isNamespaced and 'with: rule' or 'without: rule';
+$defaultAtRoot: 'without: rule';
+
+@if ($isNamespaced) {
+	// When namespaced, we need to keep the surrounding selector
+	$defaultAtRoot: 'with: rule';
+}
 
 @mixin appendRootVars {
 	@if config.$isNamespaced {

--- a/packages/scss/src/commons/utils/namespace.scss
+++ b/packages/scss/src/commons/utils/namespace.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/config';
 
-// default to 'without: rule' is ns.$isNamespaced is false
-// default to 'with: rule' is ns.$isNamespaced is true
+// default to 'without: rule' is namespace.$isNamespaced is false
+// default to 'with: rule' is namespace.$isNamespaced is true
 $defaultAtRoot: config.$isNamespaced and 'with: rule' or 'without: rule';
 
 @mixin appendRootVars {

--- a/packages/scss/src/commons/utils/namespace.scss
+++ b/packages/scss/src/commons/utils/namespace.scss
@@ -1,0 +1,17 @@
+@use '@lucca-front/scss/src/commons/config';
+
+// default to 'without: rule' is ns.$isNamespaced is false
+// default to 'with: rule' is ns.$isNamespaced is true
+$defaultAtRoot: config.$isNamespaced and 'with: rule' or 'without: rule';
+
+@mixin appendRootVars {
+	@if config.$isNamespaced {
+		& {
+			@content;
+		}
+	} @else {
+		:root {
+			@content;
+		}
+	}
+}

--- a/packages/scss/src/components/_sample/component.scss
+++ b/packages/scss/src/components/_sample/component.scss
@@ -2,9 +2,9 @@
 // It does not contain its selector, which is present in the index.
 // Any sub-components are placed in the `@at-root`.
 // The `@at-root` eliminates this selector by default, and its parameter can be used to restore it.
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	property: value;
 	property: var(--components-sample-property1);
 

--- a/packages/scss/src/components/_sample/component.scss
+++ b/packages/scss/src/components/_sample/component.scss
@@ -2,8 +2,9 @@
 // It does not contain its selector, which is present in the index.
 // Any sub-components are placed in the `@at-root`.
 // The `@at-root` eliminates this selector by default, and its parameter can be used to restore it.
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	property: value;
 	property: var(--components-sample-property1);
 

--- a/packages/scss/src/components/avatar/component.scss
+++ b/packages/scss/src/components/avatar/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: inline-block;
 	vertical-align: middle;
 	border-radius: var(--commons-borderRadius-full);

--- a/packages/scss/src/components/avatar/component.scss
+++ b/packages/scss/src/components/avatar/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: inline-block;
 	vertical-align: middle;
 	border-radius: var(--commons-borderRadius-full);

--- a/packages/scss/src/components/box/component.scss
+++ b/packages/scss/src/components/box/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	border-radius: var(--components-box-border-radius);
 	margin: var(--components-box-margin);
 	padding: var(--components-box-padding);

--- a/packages/scss/src/components/box/component.scss
+++ b/packages/scss/src/components/box/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	border-radius: var(--components-box-border-radius);
 	margin: var(--components-box-margin);
 	padding: var(--components-box-padding);

--- a/packages/scss/src/components/breadcrumbs/component.scss
+++ b/packages/scss/src/components/breadcrumbs/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.breadcrumbs-list {
 			display: flex;

--- a/packages/scss/src/components/breadcrumbs/component.scss
+++ b/packages/scss/src/components/breadcrumbs/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.breadcrumbs-list {
 			display: flex;

--- a/packages/scss/src/components/callout/component.scss
+++ b/packages/scss/src/components/callout/component.scss
@@ -2,9 +2,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/button/exports' as button;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	align-items: flex-start;
 	position: relative;
 	border-radius: var(--commons-borderRadius-L);

--- a/packages/scss/src/components/callout/component.scss
+++ b/packages/scss/src/components/callout/component.scss
@@ -2,8 +2,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/button/exports' as button;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	align-items: flex-start;
 	position: relative;
 	border-radius: var(--commons-borderRadius-L);

--- a/packages/scss/src/components/calloutAccordion/component.scss
+++ b/packages/scss/src/components/calloutAccordion/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	border-radius: var(--commons-borderRadius-L);
 	background-color: var(--palettes-50, var(--palettes-neutral-50));
 	color: var(--palettes-neutral-800);

--- a/packages/scss/src/components/calloutAccordion/component.scss
+++ b/packages/scss/src/components/calloutAccordion/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	border-radius: var(--commons-borderRadius-L);
 	background-color: var(--palettes-50, var(--palettes-neutral-50));
 	color: var(--palettes-neutral-800);

--- a/packages/scss/src/components/calloutDisclosure/component.scss
+++ b/packages/scss/src/components/calloutDisclosure/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	border-radius: var(--commons-borderRadius-L);
 	background-color: var(--palettes-50, var(--palettes-neutral-50));
 	color: var(--palettes-neutral-800);

--- a/packages/scss/src/components/calloutDisclosure/component.scss
+++ b/packages/scss/src/components/calloutDisclosure/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	border-radius: var(--commons-borderRadius-L);
 	background-color: var(--palettes-50, var(--palettes-neutral-50));
 	color: var(--palettes-neutral-800);

--- a/packages/scss/src/components/calloutFeedbackList/component.scss
+++ b/packages/scss/src/components/calloutFeedbackList/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/components/button/exports' as button;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@include reset.list;
 
 	display: flex;

--- a/packages/scss/src/components/calloutFeedbackList/component.scss
+++ b/packages/scss/src/components/calloutFeedbackList/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/components/button/exports' as button;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@include reset.list;
 
 	display: flex;

--- a/packages/scss/src/components/calloutPopover/component.scss
+++ b/packages/scss/src/components/calloutPopover/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/title/exports' as title;
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: inline-flex;
 	gap: var(--pr-t-spacings-75);
 	align-items: center;

--- a/packages/scss/src/components/calloutPopover/component.scss
+++ b/packages/scss/src/components/calloutPopover/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/title/exports' as title;
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: inline-flex;
 	gap: var(--pr-t-spacings-75);
 	align-items: center;

--- a/packages/scss/src/components/calloutPopover/vars.scss
+++ b/packages/scss/src/components/calloutPopover/vars.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin vars($atRoot: ns.$defaultAtRoot) {
+@mixin vars($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		:root {
 			--components-calloutPopover-width: 30rem;

--- a/packages/scss/src/components/calloutPopover/vars.scss
+++ b/packages/scss/src/components/calloutPopover/vars.scss
@@ -1,8 +1,10 @@
-@mixin vars($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin vars($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		:root {
-			  --components-calloutPopover-width: 30rem;
-			  --components-calloutPopover-content-margin: 2rem;
+			--components-calloutPopover-width: 30rem;
+			--components-calloutPopover-content-margin: 2rem;
 		}
 	}
 }

--- a/packages/scss/src/components/card/component.scss
+++ b/packages/scss/src/components/card/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--components-card-background);
 	border-radius: var(--components-card-border-radius);
 	border-color: var(--components-card-border-color);

--- a/packages/scss/src/components/card/component.scss
+++ b/packages/scss/src/components/card/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--components-card-background);
 	border-radius: var(--components-card-border-radius);
 	border-color: var(--components-card-border-color);

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;
 	position: relative;
 	line-height: var(--sizes-M-lineHeight);

--- a/packages/scss/src/components/checkbox/component.scss
+++ b/packages/scss/src/components/checkbox/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: block;
 	position: relative;
 	line-height: var(--sizes-M-lineHeight);

--- a/packages/scss/src/components/checkboxField/component.scss
+++ b/packages/scss/src/components/checkboxField/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	position: relative;
 	width: fit-content;
 	height: fit-content;

--- a/packages/scss/src/components/checkboxField/component.scss
+++ b/packages/scss/src/components/checkboxField/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	position: relative;
 	width: fit-content;
 	height: fit-content;

--- a/packages/scss/src/components/chip/component.scss
+++ b/packages/scss/src/components/chip/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/reset';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--palettes-700, var(--palettes-neutral-200));
 	border-radius: var(--commons-borderRadius-M);
 	color: var(--palettes-0, var(--palettes-text, var(--palettes-neutral-800)));

--- a/packages/scss/src/components/chip/component.scss
+++ b/packages/scss/src/components/chip/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/reset';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--palettes-700, var(--palettes-neutral-200));
 	border-radius: var(--commons-borderRadius-M);
 	color: var(--palettes-0, var(--palettes-text, var(--palettes-neutral-800)));

--- a/packages/scss/src/components/collapse/component.scss
+++ b/packages/scss/src/components/collapse/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: block;
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/collapse/component.scss
+++ b/packages/scss/src/components/collapse/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	container: comment / inline-size;
 	display: flex;
 	flex-direction: column;

--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	container: comment / inline-size;
 	display: flex;
 	flex-direction: column;

--- a/packages/scss/src/components/comment/mods.scss
+++ b/packages/scss/src/components/comment/mods.scss
@@ -1,5 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin S {
 	--components-comment-text-fontSize: var(--sizes-S-fontSize);
@@ -11,7 +11,7 @@
 }
 
 @mixin narrow {
-	@at-root (ns.$defaultAtRoot) {
+	@at-root (namespace.$defaultAtRoot) {
 		.comment-infos-content {
 			--components-comment-info-content-display: flex;
 		}

--- a/packages/scss/src/components/comment/mods.scss
+++ b/packages/scss/src/components/comment/mods.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
 @mixin S {
 	--components-comment-text-fontSize: var(--sizes-S-fontSize);
@@ -10,7 +11,7 @@
 }
 
 @mixin narrow {
-	@at-root {
+	@at-root (ns.$defaultAtRoot) {
 		.comment-infos-content {
 			--components-comment-info-content-display: flex;
 		}

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -2,8 +2,9 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 @use '@lucca-front/scss/src/components/footer/exports' as footer;
 @use '@lucca-front/scss/src/commons/utils/keyframe';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@include keyframe.scaleIn;
 
 	@supports not (height: 1dvh) {

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -2,9 +2,9 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 @use '@lucca-front/scss/src/components/footer/exports' as footer;
 @use '@lucca-front/scss/src/commons/utils/keyframe';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@include keyframe.scaleIn;
 
 	@supports not (height: 1dvh) {

--- a/packages/scss/src/components/divider/component.scss
+++ b/packages/scss/src/components/divider/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	border: 0;
 
 	&:where(:empty) {

--- a/packages/scss/src/components/divider/component.scss
+++ b/packages/scss/src/components/divider/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	border: 0;
 
 	&:where(:empty) {

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/components/title/exports' as title;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/components/title/exports' as title;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;

--- a/packages/scss/src/components/emptyStateDeprecated/component.scss
+++ b/packages/scss/src/components/emptyStateDeprecated/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	margin: 6rem auto var(--pr-t-spacings-800);
 	text-align: center;
 	max-width: 30rem;

--- a/packages/scss/src/components/emptyStateDeprecated/component.scss
+++ b/packages/scss/src/components/emptyStateDeprecated/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	margin: 6rem auto var(--pr-t-spacings-800);
 	text-align: center;
 	max-width: 30rem;

--- a/packages/scss/src/components/field/component.scss
+++ b/packages/scss/src/components/field/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;

--- a/packages/scss/src/components/field/component.scss
+++ b/packages/scss/src/components/field/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	flex-direction: column;
 	align-items: flex-start;

--- a/packages/scss/src/components/field/index.scss
+++ b/packages/scss/src/components/field/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
 .form.mod-framed {
 	.textfield,
@@ -69,7 +70,7 @@
 			@include fieldFramedState('success');
 		}
 
-		@at-root {
+		@at-root (ns.$defaultAtRoot) {
 			.form.mod-framed {
 				.is-error {
 					@include fieldFramedState('error');

--- a/packages/scss/src/components/field/index.scss
+++ b/packages/scss/src/components/field/index.scss
@@ -1,5 +1,5 @@
 @use 'exports' as *;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
 .form.mod-framed {
 	.textfield,
@@ -70,7 +70,7 @@
 			@include fieldFramedState('success');
 		}
 
-		@at-root (ns.$defaultAtRoot) {
+		@at-root (namespace.$defaultAtRoot) {
 			.form.mod-framed {
 				.is-error {
 					@include fieldFramedState('error');

--- a/packages/scss/src/components/fieldset/component.scss
+++ b/packages/scss/src/components/fieldset/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/components/title/exports' as title;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	border: 0;
 	margin: 0;
 	padding: 0;

--- a/packages/scss/src/components/fieldset/component.scss
+++ b/packages/scss/src/components/fieldset/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/components/title/exports' as title;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	border: 0;
 	margin: 0;
 	padding: 0;

--- a/packages/scss/src/components/filterBar/component.scss
+++ b/packages/scss/src/components/filterBar/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/container';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--components-filterBar-backgroundColor);
 	border-radius: var(--commons-borderRadius-L);
 	border: var(--commons-divider-width) solid var(--commons-border-200);

--- a/packages/scss/src/components/filterBar/component.scss
+++ b/packages/scss/src/components/filterBar/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/container';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--components-filterBar-backgroundColor);
 	border-radius: var(--commons-borderRadius-L);
 	border: var(--commons-divider-width) solid var(--commons-border-200);

--- a/packages/scss/src/components/filters/component.scss
+++ b/packages/scss/src/components/filters/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--components-filters-background);
 	box-shadow: 0 1px 0 0 var(--commons-border-200);
 	min-height: var(--components-filters-height);

--- a/packages/scss/src/components/filters/component.scss
+++ b/packages/scss/src/components/filters/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--components-filters-background);
 	box-shadow: 0 1px 0 0 var(--commons-border-200);
 	min-height: var(--components-filters-height);

--- a/packages/scss/src/components/footer/component.scss
+++ b/packages/scss/src/components/footer/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	padding: var(--pr-t-spacings-200) var(--components-footer-paddingInline);
 	display: flex;

--- a/packages/scss/src/components/footer/component.scss
+++ b/packages/scss/src/components/footer/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	padding: var(--pr-t-spacings-200) var(--components-footer-paddingInline);
 	display: flex;

--- a/packages/scss/src/components/form/component.scss
+++ b/packages/scss/src/components/form/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 @use '@lucca-front/scss/src/components/formLabel/exports' as formLabel;
 @use '@lucca-front/scss/src/components/inlineMessage/exports' as inlineMessage;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.form-fieldset {
 			margin: 0;
@@ -17,7 +17,7 @@
 	}
 }
 
-@mixin componentDeprecated($atRoot: ns.$defaultAtRoot) {
+@mixin componentDeprecated($atRoot: namespace.$defaultAtRoot) {
 	padding: 0;
 	border: 0;
 	margin: 0 0 var(--components-form-group-margin-bottom);

--- a/packages/scss/src/components/form/component.scss
+++ b/packages/scss/src/components/form/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 @use '@lucca-front/scss/src/components/formLabel/exports' as formLabel;
 @use '@lucca-front/scss/src/components/inlineMessage/exports' as inlineMessage;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.form-fieldset {
 			margin: 0;
@@ -16,7 +17,7 @@
 	}
 }
 
-@mixin componentDeprecated($atRoot: 'without: rule') {
+@mixin componentDeprecated($atRoot: ns.$defaultAtRoot) {
 	padding: 0;
 	border: 0;
 	margin: 0 0 var(--components-form-group-margin-bottom);

--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;
 	position: relative;
 	color: var(--components-formLabel-color);

--- a/packages/scss/src/components/formLabel/component.scss
+++ b/packages/scss/src/components/formLabel/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: block;
 	position: relative;
 	color: var(--components-formLabel-color);

--- a/packages/scss/src/components/gauge/component.scss
+++ b/packages/scss/src/components/gauge/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	border-radius: var(--commons-borderRadius-full);
 	height: var(--components-gauge-height);
 	overflow: hidden;

--- a/packages/scss/src/components/gauge/component.scss
+++ b/packages/scss/src/components/gauge/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	border-radius: var(--commons-borderRadius-full);
 	height: var(--components-gauge-height);
 	overflow: hidden;

--- a/packages/scss/src/components/grid/component.scss
+++ b/packages/scss/src/components/grid/component.scss
@@ -3,8 +3,9 @@
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/utils/container';
 @use '@lucca-front/scss/src/commons/config';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: grid;
 	grid-template-columns: var(--grid-template-columns);
 	gap: var(--grid-row-gap) var(--grid-column-gap);

--- a/packages/scss/src/components/grid/component.scss
+++ b/packages/scss/src/components/grid/component.scss
@@ -3,9 +3,9 @@
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/utils/container';
 @use '@lucca-front/scss/src/commons/config';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: grid;
 	grid-template-columns: var(--grid-template-columns);
 	gap: var(--grid-row-gap) var(--grid-column-gap);

--- a/packages/scss/src/components/header/component.scss
+++ b/packages/scss/src/components/header/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	box-shadow: var(--pr-t-elevation-shadow-overflow);
 	background-color: var(--components-header-background);
 	min-height: var(--components-header-height);

--- a/packages/scss/src/components/header/component.scss
+++ b/packages/scss/src/components/header/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	box-shadow: var(--pr-t-elevation-shadow-overflow);
 	background-color: var(--components-header-background);
 	min-height: var(--components-header-height);

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -1,8 +1,9 @@
 @use 'vars' as *;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/button/exports' as button;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	position: relative;
 	display: table;
 	width: 100%;

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -1,9 +1,9 @@
 @use 'vars' as *;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/button/exports' as button;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	position: relative;
 	display: table;
 	width: 100%;

--- a/packages/scss/src/components/inlineMessage/component.scss
+++ b/packages/scss/src/components/inlineMessage/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	gap: var(--components-inlineMessage-gap);
 	grid-column: 2;

--- a/packages/scss/src/components/inlineMessage/component.scss
+++ b/packages/scss/src/components/inlineMessage/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	gap: var(--components-inlineMessage-gap);
 	grid-column: 2;

--- a/packages/scss/src/components/layout/component.scss
+++ b/packages/scss/src/components/layout/component.scss
@@ -3,8 +3,9 @@
 
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/config';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	min-height: 100vh;
 	display: grid;
 

--- a/packages/scss/src/components/layout/component.scss
+++ b/packages/scss/src/components/layout/component.scss
@@ -3,9 +3,9 @@
 
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/config';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	min-height: 100vh;
 	display: grid;
 

--- a/packages/scss/src/components/link/mods.scss
+++ b/packages/scss/src/components/link/mods.scss
@@ -1,4 +1,6 @@
-@mixin icon($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin icon($atRoot: ns.$defaultAtRoot) {
 	&:has(.link-text) {
 		text-decoration: none;
 	}

--- a/packages/scss/src/components/link/mods.scss
+++ b/packages/scss/src/components/link/mods.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin icon($atRoot: ns.$defaultAtRoot) {
+@mixin icon($atRoot: namespace.$defaultAtRoot) {
 	&:has(.link-text) {
 		text-decoration: none;
 	}

--- a/packages/scss/src/components/list/component.scss
+++ b/packages/scss/src/components/list/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	box-shadow: var(--pr-t-elevation-shadow-raised);
 	margin-bottom: var(--components-list-margin-bottom);

--- a/packages/scss/src/components/list/component.scss
+++ b/packages/scss/src/components/list/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	box-shadow: var(--pr-t-elevation-shadow-raised);
 	margin-bottom: var(--components-list-margin-bottom);

--- a/packages/scss/src/components/menu/component.scss
+++ b/packages/scss/src/components/menu/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	position: relative;
 	column-gap: var(--pr-t-spacings-400);
 	align-items: center;

--- a/packages/scss/src/components/menu/component.scss
+++ b/packages/scss/src/components/menu/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	position: relative;
 	column-gap: var(--pr-t-spacings-400);
 	align-items: center;

--- a/packages/scss/src/components/mobileHeader/component.scss
+++ b/packages/scss/src/components/mobileHeader/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	align-items: center;
 	gap: var(--pr-t-spacings-100);

--- a/packages/scss/src/components/mobileHeader/component.scss
+++ b/packages/scss/src/components/mobileHeader/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	align-items: center;
 	gap: var(--pr-t-spacings-100);

--- a/packages/scss/src/components/mobileNavigation/component.scss
+++ b/packages/scss/src/components/mobileNavigation/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	bottom: 0;
 	box-shadow: var(--pr-t-elevation-shadow-overflow);

--- a/packages/scss/src/components/mobileNavigation/component.scss
+++ b/packages/scss/src/components/mobileNavigation/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	bottom: 0;
 	box-shadow: var(--pr-t-elevation-shadow-overflow);

--- a/packages/scss/src/components/multiSelect/component.scss
+++ b/packages/scss/src/components/multiSelect/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	box-shadow: 0 0 0 1px var(--components-multiSelect-border-color);
 	background-color: var(--components-multiSelect-background);

--- a/packages/scss/src/components/multiSelect/component.scss
+++ b/packages/scss/src/components/multiSelect/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	box-shadow: 0 0 0 1px var(--components-multiSelect-border-color);
 	background-color: var(--components-multiSelect-background);

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -3,9 +3,10 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/color';
 @use '@lucca-front/scss/src/commons/utils/keyframe';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	bottom: 0;
 	left: 0;
 	top: 0;

--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -3,10 +3,10 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/color';
 @use '@lucca-front/scss/src/commons/utils/keyframe';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	bottom: 0;
 	left: 0;
 	top: 0;

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -1,4 +1,6 @@
-@mixin vars($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin vars($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		:root {
 			--commons-navSide-width: 15rem;

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin vars($atRoot: ns.$defaultAtRoot) {
+@mixin vars($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		:root {
 			--commons-navSide-width: 15rem;

--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/media';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	padding: var(--components-pageHeader-padding);
 
 	.menu {

--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/media';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	padding: var(--components-pageHeader-padding);
 
 	.menu {

--- a/packages/scss/src/components/pagination/component.scss
+++ b/packages/scss/src/components/pagination/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	flex-wrap: wrap;
 	padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);

--- a/packages/scss/src/components/pagination/component.scss
+++ b/packages/scss/src/components/pagination/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	flex-wrap: wrap;
 	padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);

--- a/packages/scss/src/components/plgPush/component.scss
+++ b/packages/scss/src/components/plgPush/component.scss
@@ -2,9 +2,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/link/exports' as link;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	align-items: flex-start;
 	gap: var(--pr-t-spacings-100);

--- a/packages/scss/src/components/plgPush/component.scss
+++ b/packages/scss/src/components/plgPush/component.scss
@@ -2,8 +2,9 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/components/link/exports' as link;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	align-items: flex-start;
 	gap: var(--pr-t-spacings-100);

--- a/packages/scss/src/components/popover/component.scss
+++ b/packages/scss/src/components/popover/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: block;
 	background-color: var(--pr-t-elevation-surface-raised);
 	box-shadow: var(--pr-t-elevation-shadow-overlay);
@@ -11,31 +12,27 @@
 	min-width: var(--pr-t-spacings-500);
 	animation: popup var(--commons-animations-durations-fast) ease 1 forwards;
 
-	@at-root {
-		.popover-close {
-			// :not(.class) is only there to increase specificity when the class isn’t present
-			// but the class should be present, and this code is temporary
-			&.button,
-			&:not(.button) {
-				@include button.outlined;
-				@include button.XS;
-				@include button.onlyIconXS;
+	// need of a higher specificity
+	.popover-close {
+		@include button.outlined;
+		@include button.XS;
+		@include button.onlyIconXS;
 
-				--components-button-padding: var(--pr-t-spacings-50);
+		--components-button-padding: var(--pr-t-spacings-50);
 
-				padding: 0;
-				border-radius: 50%;
-				position: absolute;
-				left: calc(var(--pr-t-spacings-100) * -1);
-				top: calc(var(--pr-t-spacings-100) * -1);
-				z-index: 2;
+		padding: 0;
+		border-radius: 50%;
+		position: absolute;
+		left: calc(var(--pr-t-spacings-100) * -1);
+		top: calc(var(--pr-t-spacings-100) * -1);
+		z-index: 2;
 
-				&:not(:focus-visible) {
-					@include a11y.mask;
-				}
-			}
+		&:not(:focus-visible) {
+			@include a11y.mask;
 		}
+	}
 
+	@at-root ($atRoot) {
 		.popover-contentOptional {
 			padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);
 		}

--- a/packages/scss/src/components/popover/component.scss
+++ b/packages/scss/src/components/popover/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;
 	background-color: var(--pr-t-elevation-surface-raised);
 	box-shadow: var(--pr-t-elevation-shadow-overlay);

--- a/packages/scss/src/components/progress/component.scss
+++ b/packages/scss/src/components/progress/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/keyframe';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@keyframes progress {
 		0% {
 			transform: scale(0, 1);

--- a/packages/scss/src/components/progress/component.scss
+++ b/packages/scss/src/components/progress/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/keyframe';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@keyframes progress {
 		0% {
 			transform: scale(0, 1);

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 @use '@lucca-front/scss/src/components/numericBadge/exports' as numericBadge;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/radioField/component.scss
+++ b/packages/scss/src/components/radioField/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	position: relative;
 	width: fit-content;
 	height: fit-content;

--- a/packages/scss/src/components/radioField/component.scss
+++ b/packages/scss/src/components/radioField/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	position: relative;
 	width: fit-content;
 	height: fit-content;

--- a/packages/scss/src/components/scrollBox/component.scss
+++ b/packages/scss/src/components/scrollBox/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/color';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--components-scrollBox-backgroundColor);
 	position: relative;
 	display: flex;

--- a/packages/scss/src/components/scrollBox/component.scss
+++ b/packages/scss/src/components/scrollBox/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/color';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--components-scrollBox-backgroundColor);
 	position: relative;
 	display: flex;

--- a/packages/scss/src/components/simpleSelect/component.scss
+++ b/packages/scss/src/components/simpleSelect/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: grid;
 	grid-template-columns: 1fr auto auto;
 	align-items: center;

--- a/packages/scss/src/components/simpleSelect/component.scss
+++ b/packages/scss/src/components/simpleSelect/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: grid;
 	grid-template-columns: 1fr auto auto;
 	align-items: center;

--- a/packages/scss/src/components/skeleton/component.scss
+++ b/packages/scss/src/components/skeleton/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.skeleton-item {
 			animation: skeletonFade var(--commons-animations-durations-fast) ease-in 1 forwards;

--- a/packages/scss/src/components/skeleton/component.scss
+++ b/packages/scss/src/components/skeleton/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.skeleton-item {
 			animation: skeletonFade var(--commons-animations-durations-fast) ease-in 1 forwards;

--- a/packages/scss/src/components/sortableList/component.scss
+++ b/packages/scss/src/components/sortableList/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	border: var(--commons-divider-width) solid var(--commons-divider-color);
 	border-radius: var(--commons-borderRadius-M);

--- a/packages/scss/src/components/sortableList/component.scss
+++ b/packages/scss/src/components/sortableList/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--pr-t-elevation-surface-raised);
 	border: var(--commons-divider-width) solid var(--commons-divider-color);
 	border-radius: var(--commons-borderRadius-M);

--- a/packages/scss/src/components/statusBadge/component.scss
+++ b/packages/scss/src/components/statusBadge/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	align-items: flex-start;
 	background-color: var(--palettes-100, var(--palettes-product-100));
 	border-radius: var(--commons-borderRadius-L);

--- a/packages/scss/src/components/statusBadge/component.scss
+++ b/packages/scss/src/components/statusBadge/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	align-items: flex-start;
 	background-color: var(--palettes-100, var(--palettes-product-100));
 	border-radius: var(--commons-borderRadius-L);

--- a/packages/scss/src/components/switch/component.scss
+++ b/packages/scss/src/components/switch/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/commons/utils/icon';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;
 	position: relative;
 	line-height: var(--components-switch-lineHeight);

--- a/packages/scss/src/components/switch/component.scss
+++ b/packages/scss/src/components/switch/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: block;
 	position: relative;
 	line-height: var(--components-switch-lineHeight);

--- a/packages/scss/src/components/switchField/component.scss
+++ b/packages/scss/src/components/switchField/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	position: relative;
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/switchField/component.scss
+++ b/packages/scss/src/components/switchField/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	position: relative;
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/table/component.scss
+++ b/packages/scss/src/components/table/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	font-size: var(--components-table-font-size);
 	line-height: var(--components-table-line-height);
 	border-spacing: 0;

--- a/packages/scss/src/components/table/component.scss
+++ b/packages/scss/src/components/table/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	font-size: var(--components-table-font-size);
 	line-height: var(--components-table-line-height);
 	border-spacing: 0;

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -1,5 +1,5 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin S {
 	font-size: var(--sizes-S-fontSize);
@@ -208,7 +208,7 @@
 	}
 }
 
-@mixin draggable($atRoot: ns.$defaultAtRoot) {
+@mixin draggable($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.table-body-row-cell-handler,
 		.table-foot-row-cell-handler {
@@ -273,7 +273,7 @@
 	}
 }
 
-@mixin twoLines($atRoot: ns.$defaultAtRoot) {
+@mixin twoLines($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.table-head-row-cell-secondLine {
 			margin-top: var(--pr-t-spacings-50);

--- a/packages/scss/src/components/table/mods.scss
+++ b/packages/scss/src/components/table/mods.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/icons/src/commons/utils/icon';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
 @mixin S {
 	font-size: var(--sizes-S-fontSize);
@@ -207,7 +208,7 @@
 	}
 }
 
-@mixin draggable($atRoot: 'without: rule') {
+@mixin draggable($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.table-body-row-cell-handler,
 		.table-foot-row-cell-handler {
@@ -272,7 +273,7 @@
 	}
 }
 
-@mixin twoLines($atRoot: 'without: rule') {
+@mixin twoLines($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.table-head-row-cell-secondLine {
 			margin-top: var(--pr-t-spacings-50);

--- a/packages/scss/src/components/tableOfContent/component.scss
+++ b/packages/scss/src/components/tableOfContent/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	align-items: flex-start;
 	display: flex;
 	flex-direction: column;

--- a/packages/scss/src/components/tableOfContent/component.scss
+++ b/packages/scss/src/components/tableOfContent/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	align-items: flex-start;
 	display: flex;
 	flex-direction: column;

--- a/packages/scss/src/components/tableSortable/component.scss
+++ b/packages/scss/src/components/tableSortable/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@include button.text;
 	@include button.withIcon;
 

--- a/packages/scss/src/components/tableSortable/component.scss
+++ b/packages/scss/src/components/tableSortable/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@include button.text;
 	@include button.withIcon;
 

--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	background-color: var(--components-tag-background);
 	border-radius: var(--commons-borderRadius-M);
 	font-size: var(--components-tag-fontSize);

--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	background-color: var(--components-tag-background);
 	border-radius: var(--commons-borderRadius-M);
 	font-size: var(--components-tag-fontSize);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -2,8 +2,9 @@
 @use '@lucca-front/scss/src/components/inlineMessage/exports' as inlineMessage;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icon;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	align-items: stretch;
 	border-radius: var(--commons-borderRadius-M);

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -2,9 +2,9 @@
 @use '@lucca-front/scss/src/components/inlineMessage/exports' as inlineMessage;
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icon;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	align-items: stretch;
 	border-radius: var(--commons-borderRadius-M);

--- a/packages/scss/src/components/textfields/component.scss
+++ b/packages/scss/src/components/textfields/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	vertical-align: middle;
 	width: var(--components-textfield-sizes-default);
 

--- a/packages/scss/src/components/textfields/component.scss
+++ b/packages/scss/src/components/textfields/component.scss
@@ -1,4 +1,6 @@
-@mixin component($atRoot: 'without: rule') {
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	vertical-align: middle;
 	width: var(--components-textfield-sizes-default);
 

--- a/packages/scss/src/components/timeline/component.scss
+++ b/packages/scss/src/components/timeline/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	list-style-type: none;
 	padding: 0;
 	margin: var(--pr-t-spacings-200) 0;

--- a/packages/scss/src/components/timeline/component.scss
+++ b/packages/scss/src/components/timeline/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/reset';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	list-style-type: none;
 	padding: 0;
 	margin: var(--pr-t-spacings-200) 0;

--- a/packages/scss/src/components/timepicker/component.scss
+++ b/packages/scss/src/components/timepicker/component.scss
@@ -1,8 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icons;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	padding: var(--components-timepicker-padding);
 	width: fit-content;
 

--- a/packages/scss/src/components/timepicker/component.scss
+++ b/packages/scss/src/components/timepicker/component.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/icons/src/icon/exports' as icons;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	padding: var(--components-timepicker-padding);
 	width: fit-content;
 

--- a/packages/scss/src/components/timepickerDeprecated/component.scss
+++ b/packages/scss/src/components/timepickerDeprecated/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	padding: var(--components-timepicker-padding);
 	border: 0;
 	border-radius: var(--commons-borderRadius-M);

--- a/packages/scss/src/components/timepickerDeprecated/component.scss
+++ b/packages/scss/src/components/timepickerDeprecated/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	padding: var(--components-timepicker-padding);
 	border: 0;
 	border-radius: var(--commons-borderRadius-M);

--- a/packages/scss/src/components/titleSection/component.scss
+++ b/packages/scss/src/components/titleSection/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/config';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	margin-bottom: 1.2rem;
 
 	.titleSection-title,

--- a/packages/scss/src/components/titleSection/component.scss
+++ b/packages/scss/src/components/titleSection/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/config';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	margin-bottom: 1.2rem;
 
 	.titleSection-title,

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	max-width: var(--components-toasts-maxwidth);
 	display: flex;
 	flex-direction: column;

--- a/packages/scss/src/components/toast/component.scss
+++ b/packages/scss/src/components/toast/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/components/button/exports' as button;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	max-width: var(--components-toasts-maxwidth);
 	display: flex;
 	flex-direction: column;

--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/keyframe';
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@include keyframe.scaleIn;
 
 	background-color: var(--components-tooltip-background-color);

--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/utils/keyframe';
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@include keyframe.scaleIn;
 
 	background-color: var(--components-tooltip-background-color);

--- a/packages/scss/src/components/userPopover/component.scss
+++ b/packages/scss/src/components/userPopover/component.scss
@@ -1,6 +1,7 @@
 @use '@lucca-front/scss/src/components/avatar/exports' as avatar;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	width: 23.5rem;
 	max-width: calc(100vw - var(--pr-t-spacings-200) * 2);
 	padding: var(--pr-t-spacings-200);

--- a/packages/scss/src/components/userPopover/component.scss
+++ b/packages/scss/src/components/userPopover/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/components/avatar/exports' as avatar;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	width: 23.5rem;
 	max-width: calc(100vw - var(--pr-t-spacings-200) * 2);
 	padding: var(--pr-t-spacings-200);

--- a/packages/scss/src/components/userTile/component.scss
+++ b/packages/scss/src/components/userTile/component.scss
@@ -1,6 +1,6 @@
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
 	align-items: center;
 	gap: var(--pr-t-spacings-150);

--- a/packages/scss/src/components/userTile/component.scss
+++ b/packages/scss/src/components/userTile/component.scss
@@ -1,5 +1,6 @@
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	display: flex;
 	align-items: center;
 	gap: var(--pr-t-spacings-150);

--- a/packages/scss/src/components/verticalNavigation/component.scss
+++ b/packages/scss/src/components/verticalNavigation/component.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/components/title/exports' as title;
-@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
-@mixin component($atRoot: ns.$defaultAtRoot) {
+@mixin component($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.verticalNavigation-sectionTitle {
 			@include title.h5;

--- a/packages/scss/src/components/verticalNavigation/component.scss
+++ b/packages/scss/src/components/verticalNavigation/component.scss
@@ -1,8 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/components/title/exports' as title;
+@use '@lucca-front/scss/src/commons/utils/namespace' as ns;
 
-@mixin component($atRoot: 'without: rule') {
+@mixin component($atRoot: ns.$defaultAtRoot) {
 	@at-root ($atRoot) {
 		.verticalNavigation-sectionTitle {
 			@include title.h5;


### PR DESCRIPTION
## Description

Icons ans scss can now be imported inside any element without polluting the global style.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
