### PR TITLE
[numericBadge] inherit mixin

### DIFF
--- a/packages/scss/src/components/button/component.scss
+++ b/packages/scss/src/components/button/component.scss
@@ -50,7 +50,7 @@
 	// .mod-outline is deprecated
 	&:not(.mod-outlined, .mod-outline) {
 		.numericBadge {
-			@include numericBadge.product;
+			@include numericBadge.inherit;
 		}
 	}
 

--- a/packages/scss/src/components/menu/states.scss
+++ b/packages/scss/src/components/menu/states.scss
@@ -20,7 +20,7 @@
 	}
 
 	.numericBadge {
-		@include numericBadge.product;
+		@include numericBadge.inherit;
 	}
 }
 

--- a/packages/scss/src/components/numericBadge/mods.scss
+++ b/packages/scss/src/components/numericBadge/mods.scss
@@ -14,9 +14,9 @@
 	--components-numericBadge-lineHeight: var(--sizes-XS-lineHeight);
 }
 
-@mixin product {
-	--components-numericBadge-background: var(--palettes-product-200);
-	--components-numericBadge-color: var(--palettes-product-800);
+@mixin inherit {
+	--components-numericBadge-background: var(--palettes-200, var(--palettes-product-200));
+	--components-numericBadge-color: var(--palettes-800, var(--palettes-product-700));
 }
 
 @mixin brand {

--- a/packages/scss/src/components/radioButtons/component.scss
+++ b/packages/scss/src/components/radioButtons/component.scss
@@ -74,7 +74,7 @@
 						color: var(--palettes-product-800);
 
 						.numericBadge {
-							@include numericBadge.product;
+							@include numericBadge.inherit;
 						}
 					}
 				}

--- a/packages/scss/src/components/segmentedControl/states.scss
+++ b/packages/scss/src/components/segmentedControl/states.scss
@@ -9,7 +9,7 @@
 	--components-segmentedControl-zIndex: 1;
 
 	.numericBadge {
-		@include numericBadge.product;
+		@include numericBadge.inherit;
 	}
 }
 

--- a/stories/documentation/actions/button/html&css/button-counter.stories.ts
+++ b/stories/documentation/actions/button/html&css/button-counter.stories.ts
@@ -7,12 +7,24 @@ export default {
 } as Meta;
 
 function getTemplate(args: ButtonCounterStory): string {
-	return `<button type="button" class="button">Button<span class="numericBadge">7</span></button>`;
+	return `
+		<button type="button" class="button">Button<span class="numericBadge">7</span></button>
+		<button type="button" class="button palette-warning">Button<span class="numericBadge">7</span></button>
+		<button type="button" class="button palette-mint">Button<span class="numericBadge">7</span></button>
+	`;
 }
 
 const Template: StoryFn<ButtonCounterStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
+	styles: [
+		`
+		:host {
+			display: flex;
+			gap: 1rem;
+		}
+	`,
+	],
 });
 
 export const CounterButton = Template.bind({});


### PR DESCRIPTION
## Description

Mixin `product` becomes `inherit` and applies not just a product palette but an inherited palette.

-----



-----

Before:
![Capture d’écran 2024-09-25 à 17 04 00](https://github.com/user-attachments/assets/d4004cd3-b315-4161-89f3-bf75b0bb5308)

After: 
![Capture d’écran 2024-09-25 à 17 02 30](https://github.com/user-attachments/assets/76856e2b-baef-4e99-b9f2-4cf4596f236b)


