### PR TITLE
[segmentedControl] fix hover + focus

### DIFF
--- a/packages/scss/src/components/segmentedControl/component.scss
+++ b/packages/scss/src/components/segmentedControl/component.scss
@@ -84,8 +84,9 @@
 				content: var(--components-segmentedControl-backgroundContent);
 				z-index: -1;
 				position: absolute;
-				inset: var(--pr-t-spacings-50);
-				bottom: calc(var(--pr-t-spacings-50) - var(--commons-divider-width));
+				background-color: var(--palettes-neutral-50);
+				inset: var(--pr-t-spacings-75);
+				bottom: calc(var(--pr-t-spacings-75) - var(--commons-divider-width));
 				border-radius: var(--commons-borderRadius-M);
 				transition-property: scale, opacity;
 				transition-duration: var(--commons-animations-durations-standard);
@@ -95,7 +96,6 @@
 
 			&:hover {
 				&::before {
-					background-color: var(--palettes-neutral-50);
 					opacity: 1;
 					scale: 1;
 				}


### PR DESCRIPTION
## Description

When combining keyboard and mouse navigation, an overlap appeared.

-----



-----

Before:
![Capture d’écran 2024-09-25 à 16 42 21](https://github.com/user-attachments/assets/c385673b-0503-4510-995f-24273ea5ea90)

After: 
![Capture d’écran 2024-09-25 à 17 08 42](https://github.com/user-attachments/assets/bf042fb7-5b02-4592-9816-a6c62b115ed4)
