### PR TITLE
[Radio] Fix input size in Safari

### DIFF
--- a/packages/scss/src/components/radioField/component.scss
+++ b/packages/scss/src/components/radioField/component.scss
@@ -63,7 +63,7 @@
 
 		.radioField-input {
 			z-index: 1;
-			opacity: 0;
+			opacity: 0.0001;
 			cursor: pointer;
 			grid-area: radio;
 			width: 100%;

--- a/packages/scss/src/components/radioField/component.scss
+++ b/packages/scss/src/components/radioField/component.scss
@@ -66,6 +66,8 @@
 			opacity: 0;
 			cursor: pointer;
 			grid-area: radio;
+			width: 100%;
+			height: 100%;
 		}
 	}
 }

--- a/packages/scss/src/components/switchField/component.scss
+++ b/packages/scss/src/components/switchField/component.scss
@@ -67,7 +67,7 @@
 			z-index: 1;
 			width: var(--component-switchField-label-input-width);
 			height: var(--component-switchField-label-input-height);
-			opacity: 0;
+			opacity: 0.0001;
 			cursor: pointer;
 
 			&:hover {


### PR DESCRIPTION
## Description
![radio-safari](https://github.com/user-attachments/assets/7f22cecb-fce2-4278-8522-79fcdad28d76)

For reasons I couldn't explain, the radio input doesn't take up the whole space of the `radio` grid area in Safari, making it hard to click.

This PR fixes it by forcing the width and height attributes of the input to 100% of the container.

-----
