### PR TITLE
feat(core-select): Add custom search delimiter for apiV4

### DIFF
--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { computed, Directive, forwardRef, inject, input } from '@angular/core';
+import { computed, Directive, forwardRef, inject, input, model } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiItem } from '@lucca-front/ng/api';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
@@ -19,7 +19,7 @@ import { ALuCoreSelectApiDirective } from './api.directive';
 	],
 })
 export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSelectApiDirective<T> implements CoreSelectApiTotalCountProvider {
-	apiV4 = input.required<string>();
+	apiV4 = model.required<string>();
 	sort = input<string | null>('+name');
 	filters = input<Record<string, string | number | boolean>>({});
 	searchDelimiter = input<string>(' ');

--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -1,9 +1,9 @@
 import { HttpClient } from '@angular/common/http';
-import { Directive, forwardRef, inject, Input } from '@angular/core';
+import { computed, Directive, forwardRef, inject, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiItem } from '@lucca-front/ng/api';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
-import { BehaviorSubject, combineLatest, debounceTime, map, Observable, ReplaySubject, switchMap, take } from 'rxjs';
-import { sanitizeClueFilter } from '../select.utils';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
+import { debounceTime, map, Observable, switchMap } from 'rxjs';
 import { ALuCoreSelectApiDirective } from './api.directive';
 
 @Directive({
@@ -19,44 +19,34 @@ import { ALuCoreSelectApiDirective } from './api.directive';
 	],
 })
 export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSelectApiDirective<T> implements CoreSelectApiTotalCountProvider {
-	@Input()
-	public set apiV4(value: string) {
-		this.url$.next(value);
-	}
-
-	@Input()
-	public set sort(value: string | null) {
-		this.sort$.next(value);
-	}
-
-	@Input()
-	public set filters(value: Record<string, string | number | boolean>) {
-		this.filters$.next(value);
-	}
-
-	@Input()
-	public searchDelimiter = ' ';
-
-	protected url$ = new ReplaySubject<string>(1);
-	protected sort$ = new BehaviorSubject<string | null>('+name');
-	protected filters$ = new BehaviorSubject<Record<string, string | number | boolean>>({});
+	apiV4 = input.required<string>();
+	sort = input<string | null>('+name');
+	filters = input<Record<string, string | number | boolean>>({});
+	searchDelimiter = input<string>(' ');
 
 	protected httpClient = inject(HttpClient);
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = combineLatest([this.filters$, this.sort$, this.clue$]).pipe(
-		map(([filters, sort, clue]) => ({
-			...filters,
-			...(sort ? { sort } : {}),
-			...(clue ? { search: sanitizeClueFilter(clue, this.searchDelimiter) } : {}),
-		})),
+	protected clue = toSignal(this.clue$);
+
+	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+		computed(() => {
+			const sort = this.sort();
+			const clue = this.clue();
+			const searchDelimiter = this.searchDelimiter();
+			return {
+				...this.filters(),
+				...(sort ? { sort } : {}),
+				...(clue ? { search: sanitizeClueFilter(clue, searchDelimiter) } : {}),
+			};
+		}),
 	);
 
-	public totalCount$ = combineLatest([this.url$, this.filters$]).pipe(
+	public totalCount$ = toObservable(computed(() => ({ url: this.apiV4(), filters: this.filters() }))).pipe(
 		debounceTime(250),
-		switchMap(([url, params]) =>
+		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {
 				params: {
-					...params,
+					...filters,
 					['fields.root']: 'count',
 				},
 			}),
@@ -65,19 +55,15 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 	);
 
 	protected override getOptions(params: Record<string, string | number | boolean>, page: number): Observable<T[]> {
-		return this.url$.pipe(
-			take(1),
-			switchMap((url) =>
-				this.httpClient.get<T[] | { items: T[] }>(url, {
-					params: {
-						...params,
-						page: page + 1,
-						limit: this.pageSize,
-					},
-				}),
-			),
-			map((res) => (Array.isArray(res) ? res : res?.items) ?? []),
-		);
+		return this.httpClient
+			.get<T[] | { items: T[] }>(this.apiV4(), {
+				params: {
+					...params,
+					page: page + 1,
+					limit: this.pageSize,
+				},
+			})
+			.pipe(map((res) => (Array.isArray(res) ? res : res?.items) ?? []));
 	}
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;

--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -3,6 +3,7 @@ import { Directive, forwardRef, inject, Input } from '@angular/core';
 import { ILuApiItem } from '@lucca-front/ng/api';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
 import { BehaviorSubject, combineLatest, debounceTime, map, Observable, ReplaySubject, switchMap, take } from 'rxjs';
+import { sanitizeClueFilter } from '../select.utils';
 import { ALuCoreSelectApiDirective } from './api.directive';
 
 @Directive({
@@ -33,6 +34,9 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 		this.filters$.next(value);
 	}
 
+	@Input()
+	public searchDelimiter = ' ';
+
 	protected url$ = new ReplaySubject<string>(1);
 	protected sort$ = new BehaviorSubject<string | null>('+name');
 	protected filters$ = new BehaviorSubject<Record<string, string | number | boolean>>({});
@@ -43,7 +47,7 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 		map(([filters, sort, clue]) => ({
 			...filters,
 			...(sort ? { sort } : {}),
-			...(clue ? { search: clue } : {}),
+			...(clue ? { search: sanitizeClueFilter(clue, this.searchDelimiter) } : {}),
 		})),
 	);
 

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { DestroyRef, Directive, OnInit, computed, forwardRef, inject, signal, input } from '@angular/core';
+import { DestroyRef, Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -4,6 +4,7 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, combineLatest, debounceTime, filter, map, switchMap } from 'rxjs';
+import { sanitizeClueFilter } from '../select.utils';
 import { LuEstablishmentGroupingComponent } from './establishment-grouping.component';
 import { EstablishmentGroupingService } from './establishment-grouping.service';
 import { LuCoreSelectEstablishment } from './models';
@@ -50,6 +51,17 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		this._appInstanceId.set(id);
 	}
 
+	@Input()
+	public set searchDelimiter(delimiter: string) {
+		this._searchDelimiter = delimiter;
+	}
+
+	private _searchDelimiter: string;
+
+	public get searchDelimiter() {
+		return this._searchDelimiter;
+	}
+
 	protected _url = signal<string>('/organization/structure/api/establishments');
 	protected _filters = signal<Record<string, string | number | boolean> | null>(null);
 	protected _operationIds = signal<number[] | null>(null);
@@ -91,7 +103,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 			...filters,
 			...(clue
 				? // When the clue is not empty, sort establishments by name
-					{ search: clue, sort: 'name' }
+					{ search: sanitizeClueFilter(clue, this.searchDelimiter), sort: 'name' }
 				: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
 					{ sort: 'legalunit.name,name' }),
 			...(operationIds ? { operations: operationIds.join(',') } : {}),

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -1,10 +1,9 @@
 import { HttpClient } from '@angular/common/http';
-import { DestroyRef, Directive, Input, OnInit, computed, forwardRef, inject, signal } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
+import { DestroyRef, Directive, OnInit, computed, forwardRef, inject, signal, input } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, combineLatest, debounceTime, filter, map, switchMap } from 'rxjs';
-import { sanitizeClueFilter } from '../select.utils';
+import { Observable, debounceTime, filter, map, switchMap } from 'rxjs';
 import { LuEstablishmentGroupingComponent } from './establishment-grouping.component';
 import { EstablishmentGroupingService } from './establishment-grouping.service';
 import { LuCoreSelectEstablishment } from './models';
@@ -31,41 +30,13 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 
 	protected httpClient = inject(HttpClient);
 
-	@Input()
-	public set url(url: string | null) {
-		this._url.set(url);
-	}
+	url = input<string>('/organization/structure/api/establishments');
+	filters = input<Record<string, string | number | boolean> | null>(null);
+	operationIds = input<number[] | null>(null);
+	appInstanceId = input<number | null>(null);
+	searchDelimiter = input<string>(' ');
 
-	@Input()
-	public set filters(filters: Record<string, string | number | boolean> | null) {
-		this._filters.set(filters);
-	}
-
-	@Input()
-	public set operationIds(ids: number[] | null) {
-		this._operationIds.set(ids);
-	}
-
-	@Input()
-	public set appInstanceId(id: number | null) {
-		this._appInstanceId.set(id);
-	}
-
-	@Input()
-	public set searchDelimiter(delimiter: string) {
-		this._searchDelimiter = delimiter;
-	}
-
-	private _searchDelimiter: string;
-
-	public get searchDelimiter() {
-		return this._searchDelimiter;
-	}
-
-	protected _url = signal<string>('/organization/structure/api/establishments');
-	protected _filters = signal<Record<string, string | number | boolean> | null>(null);
-	protected _operationIds = signal<number[] | null>(null);
-	protected _appInstanceId = signal<number | null>(null);
+	protected clue = toSignal(this.clue$);
 
 	public override ngOnInit(): void {
 		super.ngOnInit();
@@ -83,7 +54,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
 		return this.httpClient
-			.get<T[] | { items: T[] }>(this._url(), {
+			.get<T[] | { items: T[] }>(this.url(), {
 				params: {
 					...params,
 					page: page + 1,
@@ -93,25 +64,26 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 			.pipe(map((res) => (Array.isArray(res) ? res : res?.items) ?? []));
 	}
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = combineLatest([
-		toObservable(this._filters),
-		this.clue$,
-		toObservable(this._operationIds),
-		toObservable(this._appInstanceId),
-	]).pipe(
-		map(([filters, clue, operationIds, appInstanceId]) => ({
-			...filters,
-			...(clue
-				? // When the clue is not empty, sort establishments by name
-					{ search: sanitizeClueFilter(clue, this.searchDelimiter), sort: 'name' }
-				: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
-					{ sort: 'legalunit.name,name' }),
-			...(operationIds ? { operations: operationIds.join(',') } : {}),
-			...(appInstanceId ? { appInstanceId } : {}),
-		})),
+	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+		computed(() => {
+			const operationIds = this.operationIds();
+			const appInstanceId = this.appInstanceId();
+			const clue = this.clue();
+			const searchDelimiter = this.searchDelimiter();
+			return {
+				...this.filters(),
+				...(clue
+					? // When the clue is not empty, sort establishments by name
+						{ search: sanitizeClueFilter(clue, searchDelimiter), sort: 'name' }
+					: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
+						{ sort: 'legalunit.name,name' }),
+				...(operationIds ? { operations: operationIds.join(',') } : {}),
+				...(appInstanceId ? { appInstanceId } : {}),
+			};
+		}),
 	);
 
-	public totalCount$ = toObservable(computed(() => ({ url: this._url(), filters: this._filters() }))).pipe(
+	public totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -4,6 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, combineLatest, debounceTime, map, switchMap } from 'rxjs';
+import { sanitizeClueFilter } from '../select.utils';
 import { LuJobQualificationGroupingComponent } from './job-qualification-grouping.component';
 import { LuCoreSelectJobQualification } from './models';
 
@@ -36,6 +37,17 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 		this._filters.set(filters);
 	}
 
+	@Input()
+	public set searchDelimiter(delimiter: string) {
+		this._searchDelimiter = delimiter;
+	}
+
+	private _searchDelimiter: string;
+
+	public get searchDelimiter() {
+		return this._searchDelimiter;
+	}
+
 	protected _url = signal<string>('/organization/structure/api/job-qualifications');
 	protected _filters = signal<Record<string, string | number | boolean> | null>(null);
 
@@ -63,7 +75,7 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 	protected override params$: Observable<Record<string, string | number | boolean>> = combineLatest([toObservable(this._filters), this.clue$]).pipe(
 		map(([filters, clue]) => ({
 			...filters,
-			...(clue ? { search: clue, sort: 'name' } : { sort: 'job.name,level.position' }),
+			...(clue ? { search: sanitizeClueFilter(clue, this.searchDelimiter), sort: 'name' } : { sort: 'job.name,level.position' }),
 		})),
 	);
 

--- a/packages/ng/core-select/public-api.ts
+++ b/packages/ng/core-select/public-api.ts
@@ -4,3 +4,4 @@ export * from './option/index';
 export * from './panel/index';
 export * from './select.model';
 export * from './select.translate';
+export * from './select.utils';

--- a/packages/ng/core-select/select.utils.ts
+++ b/packages/ng/core-select/select.utils.ts
@@ -1,0 +1,5 @@
+export const sanitizeClueFilter = (clue: string, delimiter: string): string =>
+	clue
+		.split(' ')
+		.map((c: string) => encodeURIComponent(c))
+		.join(delimiter);

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Directive, Type, booleanAttribute, computed, effect, forwardRef, inject, input, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiCollectionResponse } from '@lucca-front/ng/api';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { LuDisplayFormat, LuDisplayFullname } from '@lucca-front/ng/user';
 import { EMPTY, Observable, catchError, combineLatest, debounceTime, map, of, shareReplay, switchMap, take, tap } from 'rxjs';
@@ -57,8 +57,6 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	includeFormerEmployees = signal(false);
 	searchDelimiter = input<string>(' ');
 
-	protected _url = signal<string | null>(null);
-
 	constructor() {
 		super();
 		this.select.optionTpl.set(LuUserOptionComponent);
@@ -82,13 +80,14 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			const clue = this.clue();
 			const operationIds = this.operationIds();
 			const appInstanceId = this.appInstanceId();
+			const searchDelimiter = this.searchDelimiter();
 			const formerEmployees = this.includeFormerEmployees();
 
 			return {
 				fields: this.#userFields,
 				...this.filters(),
 				...(orderBy ? { orderBy } : {}),
-				...(clue ? { clue } : {}),
+				...(clue ? { clue: sanitizeClueFilter(clue, searchDelimiter) } : {}),
 				...(operationIds ? { operations: operationIds.join(',') } : {}),
 				...(appInstanceId ? { appInstanceId } : {}),
 				...(formerEmployees ? { formerEmployees } : {}),

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -55,6 +55,9 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	displayMeOption = input(true);
 
 	includeFormerEmployees = signal(false);
+	searchDelimiter = input<string>(' ');
+
+	protected _url = signal<string | null>(null);
 
 	constructor() {
 		super();

--- a/stories/documentation/forms/select/custom-api-example.component.ts
+++ b/stories/documentation/forms/select/custom-api-example.component.ts
@@ -1,4 +1,4 @@
-import { Directive } from '@angular/core';
+import { Directive, input } from '@angular/core';
 import { LuCoreSelectApiV4Directive } from '@lucca-front/ng/core-select/api';
 
 export interface Legume {
@@ -15,6 +15,6 @@ export interface Legume {
 export class LuCoreSelectLegumesDirective extends LuCoreSelectApiV4Directive<Legume> {
 	public constructor() {
 		super();
-		this.apiV4 = '/api/legumes';
+		this.apiV4 = input('/api/legumes');
 	}
 }

--- a/stories/documentation/forms/select/custom-api-example.component.ts
+++ b/stories/documentation/forms/select/custom-api-example.component.ts
@@ -15,6 +15,6 @@ export interface Legume {
 export class LuCoreSelectLegumesDirective extends LuCoreSelectApiV4Directive<Legume> {
 	public constructor() {
 		super();
-		this.apiV4 = input('/api/legumes');
+		this.apiV4.set('/api/legumes');
 	}
 }


### PR DESCRIPTION
## Description

Allow to use searchDelimiter input for apiV4 select to search with comma delimiter for example.
By default it's space delimiter

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----