### PR TITLE
fix(inline-message): properly handle PortalContent

### DIFF
--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -119,13 +119,13 @@ export class FormFieldComponent implements OnChanges, OnDestroy, DoCheck {
 	protected invalidStatus = false;
 
 	@Input()
-	inlineMessage: string;
+	inlineMessage: PortalContent;
 
 	/**
 	 * Inline message for when the control is in error state
 	 */
 	@Input()
-	errorInlineMessage: string;
+	errorInlineMessage: PortalContent;
 
 	/**
 	 * State of the inline message, will be ignored if form state is invalid

--- a/packages/ng/inline-message/inline-message.component.ts
+++ b/packages/ng/inline-message/inline-message.component.ts
@@ -1,13 +1,13 @@
 import { NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject, Input, OnChanges, ViewEncapsulation } from '@angular/core';
-import { LuClass, PortalContent } from '@lucca-front/ng/core';
+import { LuClass, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { InlineMessageState } from './inline-message-state';
 
 @Component({
 	selector: 'lu-inline-message',
 	standalone: true,
-	imports: [NgIf, IconComponent],
+	imports: [NgIf, IconComponent, PortalDirective],
 	providers: [LuClass],
 	templateUrl: './inline-message.component.html',
 	styleUrls: ['./inline-message.component.scss'],


### PR DESCRIPTION
## Description

- Fix support of `PortalContent` in `lu-inline-message`
- Add support for `PortalContent` as input in `lu-form-field`'s `inlineMessage` and `errorInlineMessage` inputs.
-----


-----
