### PR TITLE
[emptyState] maxWidth + sticky

### DIFF
--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/components/title/exports' as title;
+@use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
@@ -13,9 +14,21 @@
 			display: flex;
 			flex-grow: 1;
 			justify-content: center;
-			max-width: var(--components-emptyState-max-width);
+			max-width: var(--components-emptyState-container-maxWidth);
 			padding: 0;
 			width: 100%;
+			position: sticky;
+			left: var(--components-emptyState-container-left);
+
+			@include media.max('S') {
+				--components-emptyState-container-maxWidth: calc(100vw - 7rem);
+				--components-emptyState-container-left: 3.5rem;
+			}
+
+			.container & {
+				--components-emptyState-container-maxWidth: none;
+				--components-emptyState-container-left: auto;
+			}
 		}
 
 		.emptyState-content {

--- a/packages/scss/src/components/emptyState/vars.scss
+++ b/packages/scss/src/components/emptyState/vars.scss
@@ -1,10 +1,8 @@
-@use '@lucca-front/scss/src/components/container/exports' as container;
-
 @mixin vars {
-	@include container.vars;
+	--components-emptyState-container-maxWidth: calc(100vw - var(--commons-navSide-width) - 7rem);
+	--components-emptyState-container-left: calc(var(--commons-navSide-width) + 3.5rem);
 
 	--components-emptyState-background-color: var(--pr-t-elevation-surface-default);
-	--components-emptyState-max-width: var(--components-container-max-width);
 	--components-emptyState-illustration-top-right-offset-left: min(calc(100% + 5rem), calc(var(--components-emptyState-max-width) - 8.5rem));
 	--components-emptyState-illustration-top-right-offset-left-S: min(
 		calc(100% + 3.5rem),

--- a/stories/documentation/listings/table/table-empty.stories.ts
+++ b/stories/documentation/listings/table/table-empty.stories.ts
@@ -1,0 +1,72 @@
+import { EmptyStateSectionComponent } from '@lucca-front/ng/empty-state';
+import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+import { ButtonComponent } from 'dist/ng/button';
+
+interface TableBasicStory {
+	withOverflow: boolean;
+}
+
+export default {
+	title: 'Documentation/Listings/Table/Basic',
+	decorators: [
+		moduleMetadata({
+			imports: [EmptyStateSectionComponent, ButtonComponent],
+		}),
+	],
+	argTypes: {
+		withOverflow: {
+			control: {
+				type: 'boolean',
+			},
+		},
+	},
+} as Meta;
+
+function getTemplate(args: TableBasicStory): string {
+	const style = args.withOverflow ? `style="width: 200vw"` : '';
+
+	return `
+		<div class="navSide mod-withBanner"></div>
+		<div class="main-content">
+			<table class="table" role="presentation" ${style}>
+				<thead class="table-head" inert="true">
+					<tr class="table-head-row">
+						<th class="table-head-row-cell">Label</th>
+						<th class="table-head-row-cell">Label</th>
+						<th class="table-head-row-cell">Label</th>
+						<th class="table-head-row-cell">Label</th>
+						<th class="table-head-row-cell">Label</th>
+						<th class="table-head-row-cell">Label</th>
+					</tr>
+				</thead>
+				<tbody class="table-body">
+					<tr class="table-body-row">
+						<td colspan="6" class="table-body-row-cell">
+							<lu-empty-state-section hx="3" icon="https://cdn.lucca.fr/lucca-front/assets/empty-states/icons/iconRocket.svg" heading="Empty state section" description="Description can be a string or a ng-template Description can be a string or a ng-template Description can be a string or a ng-template">
+								<button luButton type="button" palette="product">Button</button>
+							</lu-empty-state-section>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+	`;
+}
+
+const Template: StoryFn<TableBasicStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+	styles: [
+		`
+		:host {
+			margin: -1rem;
+			display: block;
+		}
+		`,
+	],
+});
+
+export const Empty = Template.bind({});
+Empty.args = {
+	withOverflow: false,
+};


### PR DESCRIPTION
## Description

Fixes #3096 

- max container width is now based on viewport width
- the component is set to sticky so that it is always visible if horizontal scrolling is present
- two CSS variables can be used to adjust the maximum size and position to the current context (for example, with a compact navSide)

-----



-----

![2024-10-09 11 37 06](https://github.com/user-attachments/assets/38bcf9f9-6bae-4ac6-9adc-a1bc3a6be406)

