### PR TITLE
[navSide] css vars for width

### DIFF
--- a/packages/scss/src/components/filters/index.scss
+++ b/packages/scss/src/components/filters/index.scss
@@ -15,10 +15,3 @@
 		@include stickyNavSide;
 	}
 }
-
-.navSide.mod-compact ~ .main-content,
-.mod-withMenuCompact .main-content {
-	.filters.mod-sticky {
-		@include stickyNavSideCompact;
-	}
-}

--- a/packages/scss/src/components/filters/mods.scss
+++ b/packages/scss/src/components/filters/mods.scss
@@ -15,7 +15,3 @@
 @mixin stickyNavSide {
 	left: var(--commons-navSide-width);
 }
-
-@mixin stickyNavSideCompact {
-	left: var(--commons-navSide-compact-width);
-}

--- a/packages/scss/src/components/header/index.scss
+++ b/packages/scss/src/components/header/index.scss
@@ -11,11 +11,6 @@
 		.mod-withMenu .main-content & {
 			@include left;
 		}
-
-		.navSide.mod-compact ~ .main-content &,
-		.mod-withMenuCompact .main-content & {
-			@include leftCompact;
-		}
 	}
 
 	&.mod-nav {

--- a/packages/scss/src/components/header/mods.scss
+++ b/packages/scss/src/components/header/mods.scss
@@ -26,9 +26,3 @@
 		top: var(--commons-navSide-mobile-toggle-height);
 	}
 }
-
-@mixin leftCompact {
-	@include left;
-
-	left: var(--commons-navSide-compact-width);
-}

--- a/packages/scss/src/components/layout/component.scss
+++ b/packages/scss/src/components/layout/component.scss
@@ -10,7 +10,7 @@
 	display: grid;
 
 	@include media.min('L') {
-		grid-template-columns: var(--commons-navSide-compact-width) 1fr var(--components-aside-width);
+		grid-template-columns: var(--commons-navSide-width) 1fr var(--components-aside-width);
 		grid-template-rows: var(--commons-banner-height) 1fr;
 		grid-template-areas:
 			'banner banner banner'
@@ -18,7 +18,7 @@
 	}
 
 	@include media.max('L') {
-		grid-template-columns: var(--commons-navSide-compact-width) 1fr;
+		grid-template-columns: var(--commons-navSide-width) 1fr;
 		grid-template-rows: var(--commons-banner-height) 1fr auto;
 		grid-template-areas:
 			'banner banner'

--- a/packages/scss/src/components/layout/mods.scss
+++ b/packages/scss/src/components/layout/mods.scss
@@ -65,7 +65,7 @@
 }
 
 @mixin asideRemoved {
-	grid-template-columns: var(--commons-navSide-compact-width) 1fr;
+	grid-template-columns: var(--commons-navSide-width) 1fr;
 
 	.layout-aside {
 		display: none;

--- a/packages/scss/src/components/main/component.scss
+++ b/packages/scss/src/components/main/component.scss
@@ -1,10 +1,4 @@
-@use '@lucca-front/scss/src/commons/utils/media';
-
 @mixin component {
 	position: relative;
 	scroll-margin-top: var(--commons-banner-height);
-
-	@include media.max('S') {
-		margin-left: 0 !important;
-	}
 }

--- a/packages/scss/src/components/main/index.scss
+++ b/packages/scss/src/components/main/index.scss
@@ -24,9 +24,4 @@
 	.mod-withMenu & {
 		@include menu;
 	}
-
-	.navSide.mod-compact ~ &,
-	.mod-withMenuCompact & {
-		@include menuCompact;
-	}
 }

--- a/packages/scss/src/components/main/mods.scss
+++ b/packages/scss/src/components/main/mods.scss
@@ -4,10 +4,6 @@
 	margin-left: var(--commons-navSide-width);
 }
 
-@mixin menuCompact {
-	margin-left: var(--commons-navSide-compact-width);
-}
-
 @mixin banner {
 	margin-top: var(--commons-banner-height);
 

--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -1,13 +1,23 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/utils/media';
+@use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin compact {
 	background-color: var(--components-navSide-compact-palette-bg-color);
-	width: var(--commons-navSide-compact-width);
 	text-align: center;
+
+	@at-root {
+		@include namespace.appendRootVars {
+			// .mod-withMenuCompact is deprecated
+			&:has(.navSide.mod-compact, .mod-withMenuCompact) {
+				--commons-navSide-width: 7.5rem;
+			}
+		}
+	}
 
 	.navSide-mainSection,
 	.navSide-scrollWrapper {
-		width: var(--commons-navSide-compact-width);
+		width: var(--commons-navSide-width);
 	}
 
 	.navSide-item-link {
@@ -31,7 +41,8 @@
 		margin-left: inherit;
 	}
 
-	.numericBadge, .newBadge {
+	.numericBadge,
+	.newBadge {
 		margin-left: inherit;
 	}
 
@@ -51,7 +62,7 @@
 	}
 
 	.navSide-bottomSection {
-		width: var(--commons-navSide-compact-width);
+		width: var(--commons-navSide-width);
 
 		.navSide-item-link {
 			background-color: var(--components-navSide-bottom-section-palette-bg-color);
@@ -90,6 +101,12 @@
 }
 
 @mixin mobile {
+	@at-root {
+		@include namespace.appendRootVars {
+			--commons-navSide-width: 0;
+		}
+	}
+
 	padding-top: var(--commons-navSide-mobile-toggle-height);
 	width: 100%;
 	bottom: auto;

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -1,10 +1,12 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
+@use '@lucca-front/scss/src/commons/utils/media';
 
-@mixin vars($atRoot: namespace.$defaultAtRoot) {
-	@at-root ($atRoot) {
-		:root {
+@mixin vars {
+	@at-root {
+		@include namespace.appendRootVars {
+			// --commons-navSide-compact-width is deprecated
 			--commons-navSide-width: 15rem;
-			--commons-navSide-compact-width: 7.5rem;
+			--commons-navSide-compact-width: var(--commons-navSide-width);
 			--commons-navSide-mobile-toggle-height: 3.5rem;
 		}
 	}

--- a/stories/qa/secondary-nav/secondary-nav-compact.stories.html
+++ b/stories/qa/secondary-nav/secondary-nav-compact.stories.html
@@ -1,0 +1,37 @@
+<h1>Secondary nav</h1>
+<section class="contentSection">
+	<h2>Mode compact</h2>
+	<aside class="navSide mod-compact u-positionStatic">
+		<div class="navSide-mainSection">
+			<nav class="navSide-scrollWrapper">
+				<div class="navSide-item is-active">
+					<a href="#" class="navSide-item-link is-active">
+						<span aria-hidden="true" class="lucca-icon icon-heart"></span>
+						<span class="navSide-item-link-title">Section 1</span>
+					</a>
+				</div>
+				<div class="navSide-item">
+					<a href="#" class="navSide-item-link">
+						<span aria-hidden="true" class="lucca-icon icon-peoplePerson"></span>
+						<span class="navSide-item-link-title">Section 2</span>
+					</a>
+				</div>
+				<div class="navSide-item">
+					<a href="#" class="navSide-item-link">
+						<span aria-hidden="true" class="lucca-icon icon-settingsGear"></span>
+						<span class="navSide-item-link-title">Section 3</span>
+					</a>
+				</div>
+				<div class="navSide-item">
+					<a href="#" class="navSide-item-link">
+						<span aria-hidden="true" class="lucca-icon icon-settingsEqualizer"></span>
+						<span class="navSide-item-link-title">Section 4</span>
+					</a>
+				</div>
+			</nav>
+		</div>
+	</aside>
+</section>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/secondary-nav/secondary-nav-compact.stories.ts
+++ b/stories/qa/secondary-nav/secondary-nav-compact.stories.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { Meta, StoryFn } from '@storybook/angular';
+
+@Component({
+	standalone: true,
+	selector: 'secondary-nav-compact-stories',
+	templateUrl: './secondary-nav-compact.stories.html',
+})
+class SecondaryNavCompactStory {}
+
+export default {
+	title: 'QA/Secondary Nav',
+	component: SecondaryNavCompactStory,
+} as Meta;
+
+const template: StoryFn<SecondaryNavCompactStory> = () => ({});
+
+export const compact = template.bind({});

--- a/stories/qa/secondary-nav/secondary-nav.stories.html
+++ b/stories/qa/secondary-nav/secondary-nav.stories.html
@@ -1,6 +1,4 @@
 <h1>Secondary nav</h1>
-<!-- Basics -->
-<!-- Basics -->
 <section class="contentSection">
 	<h2>Basique</h2>
 	<aside class="navSide u-positionStatic">
@@ -51,38 +49,6 @@
 						<a href="#" class="navSide-item-subMenu-link">Subsection #4.1</a>
 						<a href="#" class="navSide-item-subMenu-link">Subsection #4.2</a>
 					</nav>
-				</div>
-			</nav>
-		</div>
-	</aside>
-
-	<h2>Mode compact</h2>
-	<aside class="navSide mod-compact u-positionStatic">
-		<div class="navSide-mainSection">
-			<nav class="navSide-scrollWrapper">
-				<div class="navSide-item is-active">
-					<a href="#" class="navSide-item-link is-active">
-						<span aria-hidden="true" class="lucca-icon icon-heart"></span>
-						<span class="navSide-item-link-title">Section 1</span>
-					</a>
-				</div>
-				<div class="navSide-item">
-					<a href="#" class="navSide-item-link">
-						<span aria-hidden="true" class="lucca-icon icon-peoplePerson"></span>
-						<span class="navSide-item-link-title">Section 2</span>
-					</a>
-				</div>
-				<div class="navSide-item">
-					<a href="#" class="navSide-item-link">
-						<span aria-hidden="true" class="lucca-icon icon-settingsGear"></span>
-						<span class="navSide-item-link-title">Section 3</span>
-					</a>
-				</div>
-				<div class="navSide-item">
-					<a href="#" class="navSide-item-link">
-						<span aria-hidden="true" class="lucca-icon icon-settingsEqualizer"></span>
-						<span class="navSide-item-link-title">Section 4</span>
-					</a>
 				</div>
 			</nav>
 		</div>


### PR DESCRIPTION
## Description

Switch to a single CSS var to manage the `.navSide.mod-compact`.

This will greatly simplify the use of the variable, which ends up being :
 - for screen widths below `S` to `0`;
 - for screen widths above `S` :
   - to `15rem` if navSide has no mod-compact;
   - to `7.5rem` if navSide has mod-compact.

`--commons-navSide-compact-width` is deprecated, but a fallback is provided.

-----

Thanks to @nsarradin  and the other workshop members for their joint reflections.

-----
