### PR TITLE
feat: new DecorativePalette type for when they can be used as palette

### DIFF
--- a/packages/ng/core/type/style.ts
+++ b/packages/ng/core/type/style.ts
@@ -4,3 +4,4 @@
 // primary is deprecated
 // grey is deprecated
 export type Palette = 'success' | 'warning' | 'error' | 'product' | 'neutral' | 'none' | 'primary' | 'grey';
+export type DecorativePalette = 'kiwi' | 'lime' | 'cucumber' | 'mint' | 'glacier' | 'lagoon' | 'blueberry' | 'lavender' | 'grape' | 'watermelon' | 'pumpkin' | 'pineapple';

--- a/packages/ng/tag/tag.component.ts
+++ b/packages/ng/tag/tag.component.ts
@@ -2,7 +2,7 @@ import { NgClass } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { LuccaIcon } from '@lucca-front/icons';
-import { Palette } from '@lucca-front/ng/core';
+import { DecorativePalette, Palette } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 
 @Component({
@@ -29,7 +29,7 @@ export class TagComponent {
 	 * Which palette should be used for the entire callout.
 	 * Defaults to none (inherits parent palette)
 	 */
-	palette: Palette = 'none';
+	palette: Palette | DecorativePalette = 'none';
 
 	@Input({ transform: booleanAttribute })
 	/**


### PR DESCRIPTION
## Description

Add a new type for decorative palette so the components that should handle them can, such as tag.

-----


-----
