### PR TITLE
[dialogs] subgrid + overflow

### DIFF
--- a/packages/ng/dialog/dialog/dialog.component.scss
+++ b/packages/ng/dialog/dialog/dialog.component.scss
@@ -1,9 +1,15 @@
 @use '@lucca-front/scss/src/components/dialog';
 
 .dialog .cdk-dialog-container {
-	display: flex;
-	flex-direction: column;
 	width: auto;
 	height: auto;
-	flex-grow: 1;
+	grid-row: 1 / -1;
+	display: grid;
+
+	// todo when the support will be better: subgrid
+	grid-template-areas:
+		'header  '
+		'overflow'
+		'footer  ';
+	grid-template-rows: auto 1fr auto;
 }

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -81,6 +81,7 @@
 			&.footer {
 				background-color: transparent;
 				position: relative;
+				overflow: hidden;
 			}
 		}
 


### PR DESCRIPTION
## Description

- change of flex for grid requires revision of `cdk-dialog-container` code
- as the footer of the dialog may overflow, a hidden is also added to it

-----



-----
