### PR TITLE
[Grid] Revert grid width management

### DIFF
--- a/packages/scss/src/components/grid/component.scss
+++ b/packages/scss/src/components/grid/component.scss
@@ -12,7 +12,8 @@
 
 	// workaround for Angular replacing CamelCase by kebab-case
 	// max-width: var(--grid-max-width, var(--grid-maxWidth));
-	max-width: var(--grid-max-width, var(--grid-maxWidth));
+	width: var(--grid-max-width, var(--grid-maxWidth));
+	max-width: 100%;
 
 	@at-root ($atRoot) {
 		.grid-containerWrapper {


### PR DESCRIPTION
## Description

We need to revert grid width management as it breaks UI on some grid/flex contexts (like horizontal fieldset).

-----

@fbasmaison-lucca We could reconsider this fix after the release

-----