### PR TITLE
Fixes : textarea + typo + calendar

### DIFF
--- a/packages/ng/date2/calendar2/calendar2.component.html
+++ b/packages/ng/date2/calendar2/calendar2.component.html
@@ -25,7 +25,7 @@
 					[class.is-daysOff]="day.isWeekend"
 					[class.is-overflow]="day.isOverflow"
 					[class.is-current]="day.isCurrent"
-					[attr.aria-selected]="day.status.selected || day.rangeInfo?.range!== undefined"
+					[attr.aria-selected]="day.status.selected || !!day.rangeInfo?.range"
 					[class.is-start]="day.rangeInfo?.isStart || day.status.selected"
 					[class.is-end]="day.rangeInfo?.isEnd || day.status.selected"
 					[class.is-selected]="day.rangeInfo?.range || day.status.selected"

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -67,11 +67,13 @@
 				var(--component-textField-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
-			border-radius: var(--commons-borderRadius-M);
-			max-height: var(--component-textField-maxHeight);
 
-			@supports not (height: 1dvh) {
-				--component-textField-maxHeight: var(--component-textField-maxHeightFallback);
+			&:is(textarea, div) {
+				max-height: var(--component-textField-maxHeight);
+
+				@supports not (height: 1dvh) {
+					--component-textField-maxHeight: var(--component-textField-maxHeightFallback);
+				}
 			}
 
 			&::placeholder {

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -1,6 +1,6 @@
 @mixin vars {
-	--component-textField-lineHeight: var(--size-M-lightHeight);
-	--component-textField-fontSize: var(--size-M-fontSize);
+	--component-textField-lineHeight: var(--sizes-M-lineHeight);
+	--component-textField-fontSize: var(--sizes-M-fontSize);
 	--component-textField-placeholder: var(--palettes-neutral-400);
 	--component-textField-background: var(--palettes-neutral-0);
 	--component-textField-border: var(--palettes-neutral-300);
@@ -10,6 +10,6 @@
 	--component-textField-affix-padding: var(--component-textField-padding);
 	--component-textField-affix-size: 1.75rem;
 	--component-textField-scrollMargin: 88rem; // un nombre arbitraire suffit pour scrollIntoView
-	--component-textField-maxHeight: calc(100dvh - 10rem);
-	--component-textField-maxHeightFallback: calc(100vh - 10rem);
+	--component-textField-maxHeight: 90dvh;
+	--component-textField-maxHeightFallback: 90vh;
 }


### PR DESCRIPTION
## Description

1. aria-selected was miscalculated in case of null.
2. max height is reserved for textarea and calculated differently
3. typo on textfield vars

-----



-----
