### PR TITLE
fix(callout): #3170 Callout disclosure fixes

### DIFF
--- a/packages/scss/src/components/calloutDisclosure/component.scss
+++ b/packages/scss/src/components/calloutDisclosure/component.scss
@@ -48,6 +48,7 @@
 		}
 
 		.calloutDisclosure-summary-chevron {
+			align-self: start;
 			color: var(--palettes-neutral-700);
 			margin-left: auto;
 			transition: transform var(--commons-animations-durations-standard) ease;

--- a/packages/scss/src/components/calloutDisclosure/component.scss
+++ b/packages/scss/src/components/calloutDisclosure/component.scss
@@ -37,6 +37,10 @@
 					box-shadow: none;
 				}
 			}
+
+			&::-webkit-details-marker {
+				display: none;
+			}
 		}
 
 		.calloutDisclosure-summary-icon {


### PR DESCRIPTION
## Description

- The arrow now correctly rotates around its own axis,
- Safari's custom summary marker has been removed.

https://github.com/user-attachments/assets/90858c6e-ddaa-41ae-9894-db5eb0858980

-----
