### PR TITLE
[dialog] fix grid without header

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -90,6 +90,8 @@
 		}
 
 		.dialog-inside-footer {
+			grid-area: footer;
+
 			&.footer {
 				background-color: transparent;
 				position: relative;
@@ -106,6 +108,7 @@
 			gap: var(--pr-t-spacings-200);
 			position: relative;
 			z-index: 1;
+			grid-area: header;
 		}
 
 		.dialog-inside-content {


### PR DESCRIPTION
## Description

A `grid-area` was missing for cases where all 3 children (header/overflow/footer) in a dialog are not present.

-----



-----

Before:
![Capture d’écran 2024-10-30 à 10 51 41](https://github.com/user-attachments/assets/41a66b89-e451-4a11-a95f-ec8dec706f72)

After: 

![Capture d’écran 2024-10-30 à 10 51 27](https://github.com/user-attachments/assets/a1a4d224-0da4-4ec8-8b7b-b56f46d2c239)

