### PR TITLE
chore(lu-portal): add error message for when Angular fails to create component

### DIFF
--- a/packages/ng/core/portal/portal.directive.ts
+++ b/packages/ng/core/portal/portal.directive.ts
@@ -44,8 +44,12 @@ export class PortalDirective<T = unknown> implements OnChanges, OnDestroy {
 				parent: this.injector,
 				providers: [{ provide: PORTAL_CONTEXT, useValue: this.luPortalContext }],
 			});
-			this.componentRef = this.viewContainerRef.createComponent(this.luPortal, { injector });
-			this.componentRef.changeDetectorRef.detectChanges();
+			try {
+				this.componentRef = this.viewContainerRef.createComponent(this.luPortal, { injector });
+				this.componentRef.changeDetectorRef.detectChanges();
+			} catch (e) {
+				throw new Error('[LuPortal] Angular failed to create component, make sure you are not giving LuPortal an Object that is not a Type<>');
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

When `luPortal` is called with a non-component object as parameter, such as the output of a `| translate` when `count` parameter is `null`, making the pipe lie to us as it no longer returns a `string` but will instead return an `object`, the following error message appears (courtesy of @ArthurVinbeau for the screenshot):
![image](https://github.com/user-attachments/assets/10a7e621-7d5d-4190-b54b-60425608df81)

It's really not meaningful and it takes quite some time to dig through the code and realize that Angular detects a random object as `ComponentFactory` and thus thinks we're calling it with the wrong parameters for the signature we're supposed to be using.

But in reality, the issue is just that we're passing it an object.

This PR adds a better error message for this case because it's impossible to use `luPortal` with a `ComponentFactory` anyways.

-----


-----
