### PR TITLE
[Form field] Add existing box condition to display arrow style

### DIFF
--- a/packages/scss/src/components/form/index.scss
+++ b/packages/scss/src/components/form/index.scss
@@ -20,6 +20,18 @@
 	&.mod-S {
 		@include S;
 	}
+
+	&:has(~ .box) {
+		.form-field {
+			&.mod-withArrow {
+				@include withArrow;
+
+				&.mod-S {
+					@include withArrowS;
+				}
+			}
+		}
+	}
 }
 
 .form-field {
@@ -29,14 +41,6 @@
 
 	&.mod-XS {
 		@include XS;
-	}
-
-	&.mod-withArrow {
-		@include withArrow;
-
-		&.mod-S {
-			@include withArrowS;
-		}
 	}
 
 	&.mod-checkable,


### PR DESCRIPTION
## Description

Add existing box condition to display arrow style

-----

Note: Arrow will only works within a `.form-fieldset` 
https://github.com/user-attachments/assets/2deeb550-1e8b-4516-bcea-2b9be6ffc4d4

-----
