### PR TITLE
fix(multi-select): emit mode none when select all then unselect each

### DIFF
--- a/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
+++ b/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
@@ -135,32 +135,26 @@ export class LuMultiSelectWithSelectAllDirective<TValue> extends ɵIsSelectedStr
 	}
 
 	#getNextMode(fromMode: LuMultiSelectionMode, values: TValue[]): LuMultiSelectionMode {
-		// Keep 'none' when no value selected
-		if (fromMode === 'none' && values.length === 0) {
-			return 'none';
+		// When none selected, "include" -> "none" and "exclude" -> "all"
+		if (values.length === 0) {
+			return fromMode === 'include' || fromMode === 'none' ? 'none' : 'all';
 		}
 
 		const allSelected = values.length === this.totalCount();
 
+		// When all selected, "include" -> "all" and "exclude" -> "none"
 		if (allSelected) {
-			return 'all';
+			return fromMode === 'include' || fromMode === 'none' ? 'all' : 'none';
 		}
 
-		const someSelected = values.length > 0;
-
 		// The first value selected will transition from "all" to "exclude"
-		if (fromMode === 'all' && someSelected) {
+		if (fromMode === 'all') {
 			return 'exclude';
 		}
 
 		// The first value selected will transition from "none" to "include"
-		if (fromMode === 'none' && someSelected) {
+		if (fromMode === 'none') {
 			return 'include';
-		}
-
-		// When none selected, "include" -> "none" and "exclude" -> "all"
-		if (values.length === 0) {
-			return fromMode === 'include' ? 'none' : 'all';
 		}
 
 		// No match, keep the same mode

--- a/packages/ng/multi-select/input/select-input.component.spec.ts
+++ b/packages/ng/multi-select/input/select-input.component.spec.ts
@@ -259,6 +259,22 @@ describe('LuMultiSelectInputComponent', () => {
 				expect(emittedSelectValues).toEqual([{ mode: 'all' }, { mode: 'none' }]);
 			});
 
+			it('should emit "none" selection when clicking on select all then unselect each option', () => {
+				// Arrange
+				const { componentInstance } = fixture;
+				componentInstance.openPanel();
+				componentInstance.panelRef.changeDetectorRef.detectChanges();
+
+				// Act
+				selectAllDirective.setSelectAll(true);
+				TestBed.flushEffects();
+				componentInstance.panelRef.emitValue(options);
+				TestBed.flushEffects();
+
+				// Assert
+				expect(emittedSelectValues).toEqual([{ mode: 'all' }, { mode: 'none' }]);
+			});
+
 			it('should not convert array of options to selection', () => {
 				// Arrange
 				const { componentInstance } = fixture;


### PR DESCRIPTION
## Description

Before this fix, mode "all" was emitted.

See https://github.com/LuccaSA/Lucca.Analytics/pull/570#issuecomment-2464221121

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
