### PR TITLE
[Form field with arrow] Fix spacing gap jump when box appear/disappear

### DIFF
--- a/packages/scss/src/components/form/mods.scss
+++ b/packages/scss/src/components/form/mods.scss
@@ -101,7 +101,7 @@
 
 @mixin withArrow {
 	padding-bottom: var(--pr-t-spacings-200);
-	margin-block: 0;
+	margin-block-end: 0;
 
 	.form-field-arrow {
 		@include box.arrow;


### PR DESCRIPTION
## Description

Fix spacing gap jump when box appear/disappear

-----

Fixed by keeping the default top margin (even when there is a box)

-----