### PR TITLE
feat(multi-select): new keepSearchAfterSelection option to skip clear on value update

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -1,27 +1,27 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
 import { OverlayConfig, OverlayContainer } from '@angular/cdk/overlay';
 import {
+	booleanAttribute,
 	ChangeDetectorRef,
+	computed,
 	Directive,
 	ElementRef,
 	EventEmitter,
 	HostBinding,
 	HostListener,
+	inject,
 	Input,
+	model,
 	OnDestroy,
 	OnInit,
 	Output,
 	TemplateRef,
 	Type,
 	ViewChild,
-	booleanAttribute,
-	computed,
-	inject,
-	model,
 } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
-import { PortalContent, getIntl } from '@lucca-front/ng/core';
-import { BehaviorSubject, Observable, ReplaySubject, Subject, defer, map, of, startWith, switchMap, take } from 'rxjs';
+import { getIntl, PortalContent } from '@lucca-front/ng/core';
+import { BehaviorSubject, defer, map, Observable, of, ReplaySubject, startWith, Subject, switchMap, take } from 'rxjs';
 import { LuOptionGrouping, LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
 import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
@@ -339,10 +339,12 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		this.value = value;
 	}
 
-	public updateValue(value: TValue, skipPanelOpen = false): void {
+	public updateValue(value: TValue, skipPanelOpen = false, noClear = false): void {
 		this.value = value;
-		this.emptyClue();
-		this.clueChanged('', skipPanelOpen);
+		if (!noClear) {
+			this.emptyClue();
+			this.clueChanged('', skipPanelOpen);
+		}
 		this.onChange?.(value);
 		this.onTouched?.();
 	}

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, forwardRef, inject, Input, model, numberAttribute, OnDestroy, OnInit, TemplateRef, Type, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, Input, model, numberAttribute, OnDestroy, OnInit, TemplateRef, Type, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getIntl } from '@lucca-front/ng/core';
 import { ALuSelectInputComponent, LuOptionContext, provideLuSelectLabelsAndIds, provideLuSelectOverlayContainer, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
@@ -45,6 +45,9 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 	@Input({ transform: numberAttribute })
 	maxValuesShown = 500;
 
+	@Input({ transform: booleanAttribute })
+	keepSearchAfterSelection = false;
+
 	override _value: T[] = [];
 
 	public override get panelRef(): LuMultiSelectPanelRef<T> | undefined {
@@ -78,7 +81,7 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 	}
 
 	public override updateValue(value: T[], skipFocus = false): void {
-		super.updateValue(value, skipFocus);
+		super.updateValue(value, skipFocus, this.keepSearchAfterSelection);
 		if (!skipFocus) {
 			this.focusInput();
 		}

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -22,13 +22,13 @@ import {
 	LuMultiSelectWithSelectAllDirective,
 } from '@lucca-front/ng/multi-select';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { Meta, applicationConfig, moduleMetadata } from '@storybook/angular';
+import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { LuMultiSelection } from 'packages/ng/multi-select/select.model';
 import { interval, map } from 'rxjs';
 import { startWith } from 'rxjs/operators';
 import { HiddenArgType } from 'stories/helpers/common-arg-types';
 import { getStoryGenerator } from 'stories/helpers/stories';
-import { FilterLegumesPipe, ILegume, LuCoreSelectInputStoryComponent, SortLegumesPipe, allLegumes, colorNameByColor, coreSelectStory } from './select.utils';
+import { allLegumes, colorNameByColor, coreSelectStory, FilterLegumesPipe, ILegume, LuCoreSelectInputStoryComponent, SortLegumesPipe } from './select.utils';
 
 type LuMultiSelectInputStoryComponent = LuCoreSelectInputStoryComponent & {
 	selectedLegumes: ILegume[] | LuMultiSelection<ILegume>;
@@ -43,9 +43,6 @@ const generateStory = getStoryGenerator<LuMultiSelectInputStoryComponent>({
 	...coreSelectStory,
 	argTypes: {
 		...coreSelectStory.argTypes,
-		keepSearchAfterSelection: {
-			type: 'boolean',
-		},
 		selectedLegumes: HiddenArgType,
 		valuesTpl: HiddenArgType,
 		panelHeaderTpl: HiddenArgType,
@@ -67,6 +64,7 @@ export const SelectAll = generateStory({
 	[loading]="loading"
 	[(ngModel)]="legumeSelection"
 	[options]="legumes | filterLegumes:clue"
+	[keepSearchAfterSelection]="keepSearchAfterSelection"
 	(clueChange)="clue = $event"
 />
 {{ legumeSelection | json }}`,
@@ -77,6 +75,7 @@ export const SelectAll = generateStory({
 	storyPartial: {
 		args: {
 			legumeSelection: { mode: 'none' },
+			keepSearchAfterSelection: false,
 		},
 	},
 });
@@ -89,6 +88,7 @@ export const Basic = generateStory({
 	[placeholder]="placeholder"
 	[clearable]="clearable"
 	[loading]="loading"
+	[keepSearchAfterSelection]="keepSearchAfterSelection"
 	[(ngModel)]="selectedLegumes"
 	[options]="legumes | filterLegumes:clue"
 	(clueChange)="clue = $event"
@@ -101,6 +101,7 @@ export const Basic = generateStory({
 	storyPartial: {
 		args: {
 			selectedLegumes: allLegumes.slice(0, 15),
+			keepSearchAfterSelection: false,
 		},
 		argTypes: {
 			clearable: { control: { type: 'boolean' } },
@@ -134,6 +135,7 @@ export const WithMultiDisplayer = generateStory({
 	storyPartial: {
 		args: {
 			selectedLegumes: [],
+			keepSearchAfterSelection: false,
 		},
 	},
 });
@@ -146,6 +148,7 @@ export const WithDisplayer = generateStory({
 	#selectRef
 	[placeholder]="placeholder"
 	[options]="legumes | filterLegumes:clue"
+	[keepSearchAfterSelection]="keepSearchAfterSelection"
 	(clueChange)="clue = $event"
 	[clearable]="clearable"
 	[loading]="loading"
@@ -163,6 +166,7 @@ export const WithDisplayer = generateStory({
 	storyPartial: {
 		args: {
 			selectedLegumes: allLegumes.slice(0, 5),
+			keepSearchAfterSelection: false,
 		},
 	},
 });

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -43,6 +43,9 @@ const generateStory = getStoryGenerator<LuMultiSelectInputStoryComponent>({
 	...coreSelectStory,
 	argTypes: {
 		...coreSelectStory.argTypes,
+		keepSearchAfterSelection: {
+			type: 'boolean',
+		},
 		selectedLegumes: HiddenArgType,
 		valuesTpl: HiddenArgType,
 		panelHeaderTpl: HiddenArgType,
@@ -118,6 +121,7 @@ export const WithMultiDisplayer = generateStory({
 	[(ngModel)]="selectedLegumes"
 	placeholder="Placeholder..."
 	[options]="legumes | filterLegumes:clue"
+	[keepSearchAfterSelection]="keepSearchAfterSelection"
 	(clueChange)="clue = $event"
 >
 	<ng-container *luMultiDisplayer="let values; select: selectRef">
@@ -430,7 +434,12 @@ export const AddOption = generateStory({
 	storyPartial: {
 		argTypes: {
 			addOptionLabel: { control: { type: 'text' } },
-			addOptionStrategy: { control: { type: 'select', options: ['never', 'always', 'if-empty-clue', 'if-not-empty-clue'] } },
+			addOptionStrategy: {
+				control: {
+					type: 'select',
+					options: ['never', 'always', 'if-empty-clue', 'if-not-empty-clue'],
+				},
+			},
 		},
 		args: {
 			addOptionLabel: 'Ajouter un légume',


### PR DESCRIPTION
## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
