### PR TITLE
[Tabled fixed deprecated] Missing table-layout

### DIFF
--- a/packages/scss/src/components/tableFixedDeprecated/index.scss
+++ b/packages/scss/src/components/tableFixedDeprecated/index.scss
@@ -2,18 +2,24 @@
 @use '@lucca-front/scss/src/commons/utils/media';
 @use 'exports' as *;
 
+.table {
+	&.mod-layoutFixed {
+		@include layoutFixed;
+	}
+}
+
 .table-head-row-cell,
 .table-body-row-cell,
 .table-foot-row-cell {
 	@for $i from 2 through 20 {
 		&.mod-layoutFixed-#{$i} {
-			@include layoutFixed($i);
+			@include layoutFixedCell($i);
 		}
 
 		@each $breakpoint, $value in config.$breakpoints {
 			@include media.min($breakpoint) {
 				&.mod-layoutFixed-#{$i}\@mediaMin#{$breakpoint} {
-					@include layoutFixed($i);
+					@include layoutFixedCell($i);
 				}
 			}
 		}

--- a/packages/scss/src/components/tableFixedDeprecated/mods.scss
+++ b/packages/scss/src/components/tableFixedDeprecated/mods.scss
@@ -1,4 +1,8 @@
-@mixin layoutFixed($i) {
+@mixin layoutFixed {
+	table-layout: fixed;
+}
+
+@mixin layoutFixedCell($i) {
 	min-width: $i * 1rem;
 	max-width: $i * 1rem;
 	width: $i * 1rem;


### PR DESCRIPTION
## Description

`table-layout: fixed` was missing on deprecated fixed layout

-----

`.mod-layoutFixed` was previously imported by table component, then was moved to `tableFixed` subcomponent and we forget to also add it to `tableFixedDeprecated`.

-----
