### PR TITLE
[User tile] Fix component height without user info

### DIFF
--- a/packages/scss/src/components/userTile/component.scss
+++ b/packages/scss/src/components/userTile/component.scss
@@ -10,8 +10,15 @@
 		display: flex;
 		align-self: start;
 		align-items: center;
-		height: calc(var(--components-userTile-title-lineHeight) + var(--components-userTile-info-lineHeight));
 		min-height: var(--components-avatar-size);
+	}
+
+	// .user-tile-label is deprecated
+	&:has(.userTile-content-info, .user-tile-label) {
+		// Apply height to avatar (calculed on title & info height) to avoid img overflow
+		.avatar {
+			height: calc(var(--components-userTile-title-lineHeight) + var(--components-userTile-info-lineHeight));
+		}
 	}
 
 	@at-root ($atRoot) {

--- a/stories/documentation/users/tile/html&css/basic.stories.ts
+++ b/stories/documentation/users/tile/html&css/basic.stories.ts
@@ -9,7 +9,9 @@ export default {
 
 function getTemplate(args: UserTileBasicStory): string {
 	return `<div class="userTile">
-	<div class="avatar"></div>
+	<div class="avatar">
+		<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+	</div>
 	<dl class="userTile-content">
 		<dt class="userTile-content-name">Mertens Finn</dt>
 		<dd class="userTile-content-info">Hero</dd>
@@ -20,18 +22,6 @@ function getTemplate(args: UserTileBasicStory): string {
 const Template: StoryFn<UserTileBasicStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
-	styles: [
-		`
-		.avatar {
-			background: lime;
-			height: var(--components-avatar-size, 2.5rem);
-			width: var(--components-avatar-size, 2.5rem);
-			background: var(--palettes-neutral-100) url("https://cdn.lucca.fr/lucca-front/avatars/finn.png") center;
-			background-size: cover;
-			flex-shrink: 0;
-		}
-	`,
-	],
 });
 
 export const Basic = Template.bind({});

--- a/stories/documentation/users/tile/html&css/sizes.stories.ts
+++ b/stories/documentation/users/tile/html&css/sizes.stories.ts
@@ -1,38 +1,44 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface UserTileBasicStory {
-}
+interface UserTileBasicStory {}
 
 export default {
 	title: 'Documentation/Users/Tile/HTML&CSS/Sizes',
-	argTypes: {
-	},
+	argTypes: {},
 } as Meta;
 
 function getTemplate(args: UserTileBasicStory): string {
 	return `<div class="userTile mod-XS">
-	<div class="avatar"></div>
+	<div class="avatar">
+		<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+	</div>
 	<dl class="userTile-content">
 		<dt class="userTile-content-name">Mertens Finn</dt>
 		<dd class="userTile-content-info">Hero</dd>
 	</dl>
 </div>
 <div class="userTile mod-S">
-	<div class="avatar"></div>
+	<div class="avatar">
+		<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+	</div>
 	<dl class="userTile-content">
 		<dt class="userTile-content-name">Mertens Finn</dt>
 		<dd class="userTile-content-info">Hero</dd>
 	</dl>
 </div>
 <div class="userTile">
-	<div class="avatar"></div>
+	<div class="avatar">
+		<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+	</div>
 	<dl class="userTile-content">
 		<dt class="userTile-content-name">Mertens Finn</dt>
 		<dd class="userTile-content-info">Hero</dd>
 	</dl>
 	</div>
 <div class="userTile mod-L">
-<div class="avatar"></div>
+	<div class="avatar">
+		<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+	</div>
 	<dl class="userTile-content">
 		<dt class="userTile-content-name">Mertens Finn</dt>
 		<dd class="userTile-content-info">Hero</dd>
@@ -43,17 +49,7 @@ function getTemplate(args: UserTileBasicStory): string {
 const Template: StoryFn<UserTileBasicStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
-	styles: [`
-		.avatar {
-			background: lime;
-			height: var(--components-avatar-size, 2.5rem);
-			width: var(--components-avatar-size, 2.5rem);
-			background: var(--palettes-neutral-100) url("https://cdn.lucca.fr/lucca-front/avatars/finn.png") center;
-			background-size: cover;
-			flex-shrink: 0;
-		}
-	`],
 });
 
 export const Basic = Template.bind({});
-Basic.args = { };
+Basic.args = {};

--- a/stories/qa/user-tile/user-tile.stories.html
+++ b/stories/qa/user-tile/user-tile.stories.html
@@ -36,6 +36,39 @@
 			<dd class="userTile-content-info">Hero</dd>
 		</dl>
 	</div>
+	<h2>Without info</h2>
+	<div class="userTile mod-XS">
+		<div class="avatar">
+			<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+		</div>
+		<dl class="userTile-content">
+			<dt class="userTile-content-name">Mertens Finn</dt>
+		</dl>
+	</div>
+	<div class="userTile mod-S">
+		<div class="avatar">
+			<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+		</div>
+		<dl class="userTile-content">
+			<dt class="userTile-content-name">Mertens Finn</dt>
+		</dl>
+	</div>
+	<div class="userTile">
+		<div class="avatar">
+			<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+		</div>
+		<dl class="userTile-content">
+			<dt class="userTile-content-name">Mertens Finn</dt>
+		</dl>
+	</div>
+	<div class="userTile mod-L">
+		<div class="avatar">
+			<img alt="" class="avatar-picture" loading="lazy" src="https://cdn.lucca.fr/lucca-front/avatars/finn.png" />
+		</div>
+		<dl class="userTile-content">
+			<dt class="userTile-content-name">Mertens Finn</dt>
+		</dl>
+	</div>
 	<h2>Deprecated</h2>
 	<div class="userTile mod-XL">
 		<div class="avatar">


### PR DESCRIPTION
## Description

Apply avatar height calculation only if it has user info (to avoid component extra height)

-----

![image](https://github.com/user-attachments/assets/551d860c-b586-4481-8e3b-fbc698d82ec5)


-----
