### PR TITLE
fix(withSelectAll): exported type in error

### DIFF
--- a/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
+++ b/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
@@ -110,7 +110,7 @@ export class LuMultiSelectWithSelectAllDirective<TValue> extends ɵIsSelectedStr
 
 	writeValue(value: TValue[] | LuMultiSelection<TValue>): void {
 		if (Array.isArray(value)) {
-			throw new Error('MultiSelectWithSelectAllDirective does not support array values. Pass a LuMultiSelectWithSelectAllValue<TValue>.');
+			throw new Error('MultiSelectWithSelectAllDirective does not support array values. The form value or ngModel must be a LuMultiSelection<TValue>.');
 		}
 
 		let mode: LuMultiSelectionMode;

--- a/packages/ng/multi-select/input/select-input.component.spec.ts
+++ b/packages/ng/multi-select/input/select-input.component.spec.ts
@@ -283,7 +283,7 @@ describe('LuMultiSelectInputComponent', () => {
 				const act = () => componentInstance.writeValue([options[0]]);
 
 				// Assert
-				expect(act).toThrow('MultiSelectWithSelectAllDirective does not support array values. Pass a LuMultiSelectWithSelectAllValue<TValue>.');
+				expect(act).toThrow('MultiSelectWithSelectAllDirective does not support array values. The form value or ngModel must be a LuMultiSelection<TValue>.');
 			});
 
 			it('should work with not empty initial value', () => {


### PR DESCRIPTION
## Description

The error thrown when an array value is passed to a `<lu-multi-select withSelectAll />` is imprecise. It refers to a non-exported type which is misleading.

This PR fixes that and refers to the exported type used by this directive.

-----
