### PR TITLE
[callout] fix disclosure icon

### DIFF
--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.html
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.html
@@ -1,9 +1,7 @@
 <details class="calloutDisclosure" [ngClass]="calloutClasses" [class.mod-iconless]="!icon" [open]="open" (toggle)="onToggle($event)">
 	<summary class="calloutDisclosure-summary">
 		@if (state | luCalloutIcon: icon; as calloutIcon) {
-		<span class="calloutDisclosure-summary-icon">
-			<lu-icon [icon]="calloutIcon"></lu-icon>
-		</span>
+		<lu-icon class="calloutDisclosure-summary-icon" [icon]="calloutIcon"></lu-icon>
 		}
 		<span class="calloutDisclosure-summary-title">
 			<ng-container *luPortal="heading"></ng-container>


### PR DESCRIPTION
## Description

Better icon positioning for callout disclosure.

-----



-----

Before:
![Capture d’écran 2024-11-21 à 17 06 01](https://github.com/user-attachments/assets/0e258c22-a518-4e76-89a9-9d3026ab4d10)


After:
![Capture d’écran 2024-11-21 à 17 06 19](https://github.com/user-attachments/assets/d7596256-a374-48ba-b0b8-335332f38dcc)


