### PR TITLE
refactor(select): do not override overlay container

### DIFF
--- a/packages/ng/core-select/input/select-input.models.ts
+++ b/packages/ng/core-select/input/select-input.models.ts
@@ -1,7 +1,5 @@
-import { Overlay, OverlayContainer } from '@angular/cdk/overlay';
-import { Platform } from '@angular/cdk/platform';
-import { DOCUMENT } from '@angular/common';
-import { ElementRef, Injectable, Provider, inject } from '@angular/core';
+import { OverlayRef } from '@angular/cdk/overlay';
+import { ElementRef, Provider, inject } from '@angular/core';
 import { SELECT_ID, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
 
 let selectId = 0;
@@ -40,28 +38,10 @@ export function provideLuSelectLabelsAndIds(): Provider[] {
 	];
 }
 
-@Injectable()
-class LuSelectOverlayContainer extends OverlayContainer {
-	private selectLabelId = inject(SELECT_LABEL_ID);
-	private selectId = inject(SELECT_ID);
-
-	constructor() {
-		super(inject(DOCUMENT), inject(Platform));
+export function addAttributesOnCdkContainer(overlayRef: OverlayRef, selectLabelId: string, selectId: number) {
+	const potentialCdkOverlayContainer = overlayRef?.overlayElement?.parentElement?.parentElement;
+	if (potentialCdkOverlayContainer && potentialCdkOverlayContainer.className.includes('cdk-overlay-container')) {
+		potentialCdkOverlayContainer.setAttribute('aria-labelledby', selectLabelId);
+		potentialCdkOverlayContainer.id = `lu-select-overlay-container-${selectId}`;
 	}
-
-	protected override _createContainer(): void {
-		super._createContainer();
-		this._containerElement.setAttribute('aria-labelledby', this.selectLabelId);
-		this._containerElement.id = `lu-select-overlay-container-${this.selectId}`;
-	}
-}
-
-export function provideLuSelectOverlayContainer(): Provider[] {
-	return [
-		Overlay,
-		{
-			provide: OverlayContainer,
-			useClass: LuSelectOverlayContainer,
-		},
-	];
 }

--- a/packages/ng/multi-select/input/panel-ref.factory.ts
+++ b/packages/ng/multi-select/input/panel-ref.factory.ts
@@ -6,8 +6,7 @@ import { LuMultiSelectPanelComponent } from '../panel/index';
 import { MULTI_SELECT_INPUT } from '../select.model';
 import { LuMultiSelectPanelRef } from './panel.model';
 import { LuMultiSelectInputComponent } from './select-input.component';
-import { SELECT_ID, SELECT_LABEL_ID } from '../../core-select/select.model';
-import { addAttributesOnCdkContainer } from '../../core-select/input';
+import { addAttributesOnCdkContainer, SELECT_ID, SELECT_LABEL_ID } from '@lucca-front/ng/core-select';
 
 class MultiSelectPanelRef<T> extends LuMultiSelectPanelRef<T> {
 	instance: LuMultiSelectPanelComponent<T>;
@@ -86,7 +85,6 @@ export class LuMultiSelectPanelRefFactory {
 	protected parentInjector = inject(Injector);
 	private selectLabelId = inject(SELECT_LABEL_ID);
 	private selectId = inject(SELECT_ID);
-
 
 	buildPanelRef<T>(selectInput: LuMultiSelectInputComponent<T>, defaultOverlayConfigOverride: OverlayConfig = {}): LuMultiSelectPanelRef<T> {
 		const defaultOverlayConfig = this.buildDefaultOverlayConfig(defaultOverlayConfigOverride);

--- a/packages/ng/multi-select/input/panel-ref.factory.ts
+++ b/packages/ng/multi-select/input/panel-ref.factory.ts
@@ -6,6 +6,8 @@ import { LuMultiSelectPanelComponent } from '../panel/index';
 import { MULTI_SELECT_INPUT } from '../select.model';
 import { LuMultiSelectPanelRef } from './panel.model';
 import { LuMultiSelectInputComponent } from './select-input.component';
+import { SELECT_ID, SELECT_LABEL_ID } from '../../core-select/select.model';
+import { addAttributesOnCdkContainer } from '../../core-select/input';
 
 class MultiSelectPanelRef<T> extends LuMultiSelectPanelRef<T> {
 	instance: LuMultiSelectPanelComponent<T>;
@@ -82,6 +84,9 @@ export class LuMultiSelectPanelRefFactory {
 	protected positionBuilder = inject(OverlayPositionBuilder);
 	protected scrollStrategies = inject(ScrollStrategyOptions);
 	protected parentInjector = inject(Injector);
+	private selectLabelId = inject(SELECT_LABEL_ID);
+	private selectId = inject(SELECT_ID);
+
 
 	buildPanelRef<T>(selectInput: LuMultiSelectInputComponent<T>, defaultOverlayConfigOverride: OverlayConfig = {}): LuMultiSelectPanelRef<T> {
 		const defaultOverlayConfig = this.buildDefaultOverlayConfig(defaultOverlayConfigOverride);
@@ -90,6 +95,8 @@ export class LuMultiSelectPanelRefFactory {
 
 		overlayRef.hostElement.style.transitionProperty = 'height';
 		overlayRef.hostElement.style.transitionDuration = 'var(--commons-animations-durations-standard)';
+
+		addAttributesOnCdkContainer(overlayRef, this.selectLabelId, this.selectId);
 
 		return new MultiSelectPanelRef(overlayRef, this.parentInjector, selectInput, defaultOverlayConfig.positionStrategy);
 	}

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -2,8 +2,7 @@ import { CommonModule } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, Input, model, numberAttribute, OnDestroy, OnInit, TemplateRef, Type, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getIntl } from '@lucca-front/ng/core';
-import { ALuSelectInputComponent, LuOptionContext, provideLuSelectLabelsAndIds, provideLuSelectOverlayContainer, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
-import { IconComponent } from '@lucca-front/ng/icon';
+import { ALuSelectInputComponent, LuOptionContext, provideLuSelectLabelsAndIds } from '@lucca-front/ng/core-select';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { Subject } from 'rxjs';
 import { LuMultiSelectDefaultDisplayerComponent } from '../displayer/index';
@@ -14,7 +13,7 @@ import { LuMultiSelectPanelRef } from './panel.model';
 @Component({
 	selector: 'lu-multi-select',
 	standalone: true,
-	imports: [CommonModule, LuTooltipModule, ɵLuOptionOutletDirective, IconComponent],
+	imports: [CommonModule, LuTooltipModule],
 	templateUrl: './select-input.component.html',
 	styleUrls: ['./select-input.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,
@@ -28,7 +27,6 @@ import { LuMultiSelectPanelRef } from './panel.model';
 			provide: ALuSelectInputComponent,
 			useExisting: forwardRef(() => LuMultiSelectInputComponent),
 		},
-		provideLuSelectOverlayContainer(),
 		provideLuSelectLabelsAndIds(),
 		LuMultiSelectPanelRefFactory,
 	],

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -2,18 +2,19 @@ import { CommonModule } from '@angular/common';
 import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, Input, model, numberAttribute, OnDestroy, OnInit, TemplateRef, Type, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getIntl } from '@lucca-front/ng/core';
-import { ALuSelectInputComponent, LuOptionContext, provideLuSelectLabelsAndIds } from '@lucca-front/ng/core-select';
+import { ALuSelectInputComponent, LuOptionContext, provideLuSelectLabelsAndIds, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { Subject } from 'rxjs';
 import { LuMultiSelectDefaultDisplayerComponent } from '../displayer/index';
 import { LU_MULTI_SELECT_TRANSLATIONS } from '../select.translate';
 import { LuMultiSelectPanelRefFactory } from './panel-ref.factory';
 import { LuMultiSelectPanelRef } from './panel.model';
+import { IconComponent } from '@lucca-front/ng/icon';
 
 @Component({
 	selector: 'lu-multi-select',
 	standalone: true,
-	imports: [CommonModule, LuTooltipModule],
+	imports: [CommonModule, LuTooltipModule, ɵLuOptionOutletDirective, IconComponent],
 	templateUrl: './select-input.component.html',
 	styleUrls: ['./select-input.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -1,7 +1,7 @@
 import { Overlay, OverlayConfig, OverlayPositionBuilder, OverlayRef, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef, ElementRef, Injectable, Injector, inject } from '@angular/core';
-import { LuSelectPanelRef } from '@lucca-front/ng/core-select';
+import { addAttributesOnCdkContainer, LuSelectPanelRef, SELECT_ID, SELECT_LABEL_ID } from '@lucca-front/ng/core-select';
 import { takeUntil } from 'rxjs';
 import { LuSelectPanelComponent } from '../panel';
 import { SIMPLE_SELECT_INPUT } from '../select.model';
@@ -71,10 +71,14 @@ export class LuSimpleSelectPanelRefFactory {
 	protected positionBuilder = inject(OverlayPositionBuilder);
 	protected scrollStrategies = inject(ScrollStrategyOptions);
 	protected parentInjector = inject(Injector);
+	private selectLabelId = inject(SELECT_LABEL_ID);
+	private selectId = inject(SELECT_ID);
 
 	buildPanelRef<T>(selectInput: LuSimpleSelectInputComponent<T>, overlayConfigOverride: OverlayConfig = {}): LuSelectPanelRef<T, T> {
 		const overlayConfig = this.buildOverlayConfig(overlayConfigOverride);
 		const overlayRef = this.overlay.create(overlayConfig);
+
+		addAttributesOnCdkContainer(overlayRef, this.selectLabelId, this.selectId);
 
 		return new SelectPanelRef(overlayRef, this.parentInjector, selectInput);
 	}

--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -3,7 +3,7 @@ import { AsyncPipe, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, forwardRef, inject } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { getIntl } from '@lucca-front/ng/core';
-import { ALuSelectInputComponent, LuSelectPanelRef, provideLuSelectLabelsAndIds, provideLuSelectOverlayContainer, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
+import { ALuSelectInputComponent, LuSelectPanelRef, provideLuSelectLabelsAndIds, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LU_SIMPLE_SELECT_TRANSLATIONS } from '../select.translate';
@@ -27,7 +27,6 @@ import { LuSimpleSelectPanelRefFactory } from './panel-ref.factory';
 			useExisting: forwardRef(() => LuSimpleSelectInputComponent),
 		},
 		LuSimpleSelectPanelRefFactory,
-		provideLuSelectOverlayContainer(),
 		provideLuSelectLabelsAndIds(),
 	],
 	encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
WebComponents cannot used selects due to the overlay container override. 
We use the child to update overlay container properties and not the override.

## Description

Delete provideLuSelectOverlayContainer() and add attributes aria-labelledby & lu-select-overlay-container in the panel factory


-----

