### PR TITLE
fix(date-input): properly handle min/max in a month picker configuration

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -200,7 +200,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 					result = result && this.min().getTime() <= date.getTime();
 					break;
 				case 'month':
-					result = result && this.min().getMonth() <= date.getMonth();
+					result = result && startOfMonth(this.min()).getTime() <= startOfMonth(date).getTime();
 					break;
 				case 'year':
 					result = result && this.min().getFullYear() <= date.getFullYear();
@@ -213,7 +213,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 					result = result && this.max().getTime() >= date.getTime();
 					break;
 				case 'month':
-					result = result && this.max().getMonth() >= date.getMonth();
+					result = result && startOfMonth(this.max()).getTime() >= startOfMonth(date).getTime();
 					break;
 				case 'year':
 					result = result && this.max().getFullYear() >= date.getFullYear();


### PR DESCRIPTION
## Description

We used to compare month value, which was bad because months are the same accross years, obviously...

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
