### PR TITLE
fix(users-select): remove extra encoding

### DIFF
--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { computed, Directive, forwardRef, inject, input, model } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiItem } from '@lucca-front/ng/api';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { debounceTime, map, Observable, switchMap } from 'rxjs';
 import { ALuCoreSelectApiDirective } from './api.directive';
 
@@ -36,7 +36,7 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 			return {
 				...this.filters(),
 				...(sort ? { sort } : {}),
-				...(clue ? { search: sanitizeClueFilter(clue, searchDelimiter) } : {}),
+				...(clue ? { search: applySearchDelimiter(clue, searchDelimiter) } : {}),
 			};
 		}),
 	);

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { DestroyRef, Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, debounceTime, filter, map, switchMap } from 'rxjs';
 import { LuEstablishmentGroupingComponent } from './establishment-grouping.component';
@@ -74,7 +74,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 				...this.filters(),
 				...(clue
 					? // When the clue is not empty, sort establishments by name
-						{ search: sanitizeClueFilter(clue, searchDelimiter), sort: 'name' }
+						{ search: applySearchDelimiter(clue, searchDelimiter), sort: 'name' }
 					: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
 						{ sort: 'legalunit.name,name' }),
 				...(operationIds ? { operations: operationIds.join(',') } : {}),

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, debounceTime, map, switchMap } from 'rxjs';
 import { LuJobQualificationGroupingComponent } from './job-qualification-grouping.component';
@@ -61,7 +61,7 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 				...filters,
 				...(clue
 					? {
-							search: sanitizeClueFilter(clue, this.searchDelimiter()),
+							search: applySearchDelimiter(clue, this.searchDelimiter()),
 							sort: 'name',
 						}
 					: { sort: 'job.name,level.position' }),

--- a/packages/ng/core-select/select.utils.ts
+++ b/packages/ng/core-select/select.utils.ts
@@ -1,5 +1,1 @@
-export const sanitizeClueFilter = (clue: string, delimiter: string): string =>
-	clue
-		.split(' ')
-		.map((c: string) => encodeURIComponent(c))
-		.join(delimiter);
+export const applySearchDelimiter = (clue: string, delimiter: string): string => clue.split(' ').join(delimiter);

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Directive, Provider, Type, booleanAttribute, computed, effect, forwardRef, inject, input, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiCollectionResponse } from '@lucca-front/ng/api';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, sanitizeClueFilter } from '@lucca-front/ng/core-select';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { LuDisplayFormat, LuDisplayFullname } from '@lucca-front/ng/user';
 import { EMPTY, Observable, catchError, combineLatest, debounceTime, map, of, shareReplay, switchMap, take, tap } from 'rxjs';
@@ -14,7 +14,13 @@ import { LuUserOptionComponent } from './user-option.component';
 import { LuCoreSelectUser, LuCoreSelectWithAdditionnalInformation } from './user-option.model';
 
 export function provideCoreSelectUsersContext(directiveFn: () => Type<LuCoreSelectUsersDirective>): Provider[] {
-	return [...provideBaseCoreSelectUsersContext(directiveFn), { provide: LuCoreSelectUsersDirective, useExisting: forwardRef(directiveFn) }];
+	return [
+		...provideBaseCoreSelectUsersContext(directiveFn),
+		{
+			provide: LuCoreSelectUsersDirective,
+			useExisting: forwardRef(directiveFn),
+		},
+	];
 }
 
 function provideBaseCoreSelectUsersContext(directiveFn: () => Type<LuCoreSelectUsersDirective>): Provider[] {
@@ -94,7 +100,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 				fields: this.#userFields,
 				...this.filters(),
 				...(orderBy ? { orderBy } : {}),
-				...(clue ? { clue: sanitizeClueFilter(clue, searchDelimiter) } : {}),
+				...(clue ? { clue: applySearchDelimiter(clue, searchDelimiter) } : {}),
 				...(operationIds ? { operations: operationIds.join(',') } : {}),
 				...(appInstanceId ? { appInstanceId } : {}),
 				...(formerEmployees ? { formerEmployees } : {}),
@@ -113,7 +119,15 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	);
 
 	protected me$ = this.meParams$.pipe(
-		switchMap((params) => this.httpClient.get<ILuApiCollectionResponse<{ item: T }>>(this.urlOrDefault(), { params }).pipe(catchError(() => EMPTY))),
+		switchMap((params) =>
+			this.httpClient
+				.get<
+					ILuApiCollectionResponse<{
+						item: T;
+					}>
+				>(this.urlOrDefault(), { params })
+				.pipe(catchError(() => EMPTY)),
+		),
 		map((res) => res.data.items.map(({ item }) => item)[0] ?? null),
 		takeUntilDestroyed(),
 		shareReplay(1),
@@ -147,7 +161,13 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			.pipe(map((res) => res.data.items.map(({ item }) => item)));
 	}
 
-	protected override getOptionsPage(params: Record<string, string | number | boolean>, page: number): Observable<{ items: LuCoreSelectWithAdditionnalInformation<T>[]; isLastPage: boolean }> {
+	protected override getOptionsPage(
+		params: Record<string, string | number | boolean>,
+		page: number,
+	): Observable<{
+		items: LuCoreSelectWithAdditionnalInformation<T>[];
+		isLastPage: boolean;
+	}> {
 		const hasClue = !!params['clue'];
 		const displayMe = this.displayMeOption() && !hasClue;
 		const prependMe = displayMe && page === 0;
@@ -169,7 +189,16 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			}),
 		);
 
-		return page$.pipe(switchMap((page) => this.#userHomonymsService.handleHomonyms(page.items, this.displayFormat()).pipe(map((items) => ({ items, isLastPage: page.isLastPage })))));
+		return page$.pipe(
+			switchMap((page) =>
+				this.#userHomonymsService.handleHomonyms(page.items, this.displayFormat()).pipe(
+					map((items) => ({
+						items,
+						isLastPage: page.isLastPage,
+					})),
+				),
+			),
+		);
 	}
 
 	protected override optionComparer = (a: T, b: T) => a.id === b.id;


### PR DESCRIPTION
## Description

We used to encode search clue but now that we're using `HttpClient`'s `params`, Angular already takes care of the encoding for us.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
