### PR TITLE
[indexTable] adjust paddings

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -63,7 +63,7 @@
 			z-index: 3;
 
 			&:not(:first-child) {
-				padding-right: var(--components-indexTable-cell-padding);
+				padding-right: var(--components-indexTable-cell-paddingInline);
 			}
 		}
 
@@ -71,23 +71,7 @@
 		.indexTable-body-row-cell,
 		.indexTable-foot-row-cell {
 			vertical-align: top;
-
-			// Because outlined cell apparence can be cropped we need a bigger padding-right. To compensate we also need a smaller padding-left
-			padding: var(--components-indexTable-cell-padding);
-			padding-left: var(--components-indexTable-cell-padding-left, var(--components-indexTable-cell-padding));
-			padding-right: var(--components-indexTable-cell-padding-right, var(--components-indexTable-cell-padding));
-
-			--components-indexTable-cell-padding-right: calc(var(--components-indexTable-cell-padding) + 4px);
-
-			~ .indexTable-head-row-cell,
-			~ .indexTable-body-row-cell,
-			~ .indexTable-foot-row-cell {
-				--components-indexTable-cell-padding-left: calc(var(--components-indexTable-cell-padding) - 4px);
-			}
-
-			&:last-child {
-				--components-indexTable-cell-padding-right: var(--components-indexTable-cell-padding);
-			}
+			padding: var(--components-indexTable-cell-paddingBlock) var(--components-indexTable-cell-paddingInline);
 		}
 
 		.indexTable-body-row {

--- a/packages/scss/src/components/indexTable/mods.scss
+++ b/packages/scss/src/components/indexTable/mods.scss
@@ -146,9 +146,10 @@
 
 	// We only need one ::before for the card apparence and one ::after for the possible outline
 	.indexTable-body-row-cell {
+		--components-indexTable-cell-paddingBlock: 0;
+
 		position: static;
 		grid-column-start: 1;
-		padding: 0 var(--components-indexTable-cell-padding);
 
 		&::before {
 			--components-indexTable-cell-border-radius-left: var(--components-indexTable-cell-border-radius);

--- a/packages/scss/src/components/indexTable/vars.scss
+++ b/packages/scss/src/components/indexTable/vars.scss
@@ -6,7 +6,8 @@
 	// on responsive, row spacing is increased
 	--components-indexTable-row-spacing-responsive: 8px;
 
-	--components-indexTable-cell-padding: var(--pr-t-spacings-100);
+	--components-indexTable-cell-paddingInline: var(--pr-t-spacings-150);
+	--components-indexTable-cell-paddingBlock: var(--pr-t-spacings-100);
 	--components-indexTable-cell-border-radius: var(--commons-borderRadius-L);
 	--components-indexTable-cell-background-color-default: var(--palettes-neutral-0);
 	// shadows


### PR DESCRIPTION
## Description

Fixes #3241 

-----

The [padding had been modified on the cells to allow the focus-visible to overflow](https://lucca.slack.com/archives/C03GH0104NB/p1712147102570079), but now that it's increased, there's no need to worry about this.

NB: the width of the cells changes slightly, which can cause changes in the BUs.

-----

Before:
![Capture d’écran 2024-12-02 à 10 50 36](https://github.com/user-attachments/assets/d1fd0bd7-086b-4345-91a8-7cda400aee07)

After:
![Capture d’écran 2024-12-02 à 10 50 00](https://github.com/user-attachments/assets/108ab8a2-b0f2-4bdd-8cf5-5fe7a9f0c670)


