### PR TITLE
fix(date-input): validators logic fixes

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.html
+++ b/packages/ng/date2/date-input/date-input.component.html
@@ -14,7 +14,7 @@
 			aria-haspopup="true"
 			role="combobox"
 			(click)="popoverRef.openPopover(true, true)"
-			(keyup.arrowDown)="popoverRef.opened() ? popoverRef.focusBackToContent($event) : openPopover(popoverRef)"
+			(keyup.arrowDown)="arrowDown(popoverRef)"
 			(keyup.space)=" popoverRef.opened() ? popoverRef.focusBackToContent($event) : openPopover(popoverRef)"
 			(keyup.escape)="popoverRef.close()"
 			[disabled]="disabled"

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -175,7 +175,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 	validate(control: AbstractControl<Date, Date>): ValidationErrors {
 		// null is not an error but means we'll skip everything else, we'll let the presence of a
 		// Validators.required (or not) decide if it's an error.
-		if ([null, undefined].includes(control.value)) {
+		if (control.value === null || control.value === undefined) {
 			return null;
 		}
 		// try to parse the display value cause formControl.value is undefined if date is not parsable

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -175,7 +175,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 	validate(control: AbstractControl<Date, Date>): ValidationErrors {
 		// null is not an error but means we'll skip everything else, we'll let the presence of a
 		// Validators.required (or not) decide if it's an error.
-		if ([null, undefined, ''].includes(control.value)) {
+		if ([null, undefined].includes(control.value)) {
 			return null;
 		}
 		// try to parse the display value cause formControl.value is undefined if date is not parsable

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -174,8 +174,8 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 
 	validate(control: AbstractControl<Date, Date>): ValidationErrors {
 		// null with a formControl required
-		if (!control.value && control.hasValidator(Validators.required)) {
-			return { date: true };
+		if (!control.value) {
+			return null;
 		}
 		// try to parse the display value cause formControl.value is undefined if date is not parsable
 		try {

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -44,7 +44,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 	#intlDateTimeFormatYear = new Intl.DateTimeFormat(this.#locale, { year: 'numeric' });
 
 	// Contains the current date format (like dd/mm/yy etc) based on current locale
-	#dateFormat = getDateFormat(this.#locale).toUpperCase();
+	#dateFormat = getDateFormat(this.#locale);
 
 	intl = getIntl(LU_DATE2_TRANSLATIONS);
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -175,7 +175,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 	validate(control: AbstractControl<Date, Date>): ValidationErrors {
 		// null is not an error but means we'll skip everything else, we'll let the presence of a
 		// Validators.required (or not) decide if it's an error.
-		if (!control.value) {
+		if ([null, undefined, ''].includes(control.value)) {
 			return null;
 		}
 		// try to parse the display value cause formControl.value is undefined if date is not parsable

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -157,6 +157,7 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 					if (parsed instanceof Date && parsed.getFullYear() > 999) {
 						this.selectedDate.set(startOfDay(parsed));
 						this.currentDate.set(startOfDay(parsed));
+						this.tabbableDate.set(startOfDay(parsed));
 					} else {
 						this.selectedDate.set(parsed);
 					}
@@ -194,6 +195,14 @@ export class DateInputComponent implements ControlValueAccessor, Validator {
 		setTimeout(() => {
 			this.calendar()?.focusTabbableDate();
 		});
+	}
+
+	arrowDown(popoverRef: PopoverDirective) {
+		if (popoverRef.opened()) {
+			this.calendar()?.focusTabbableDate();
+		} else {
+			this.openPopover(popoverRef);
+		}
 	}
 
 	validate(control: AbstractControl<Date, Date>): ValidationErrors {

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -27,6 +27,7 @@ import { LuTooltipPanelComponent } from '../panel';
 import { EllipsisRuler } from './ellipsis.ruler';
 
 let nextId = 0;
+
 @Directive({
 	selector: '[luTooltip]',
 	exportAs: 'luTooltip',
@@ -127,7 +128,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 
 	@HostBinding('attr.aria-describedby')
 	get ariaDescribedBy() {
-		if (this.luTooltipDisabled() || this.luTooltipWhenEllipsis || this.luTooltipOnlyForDisplay) {
+		if (this.luTooltipDisabled() || this.luTooltipWhenEllipsis() || this.luTooltipOnlyForDisplay) {
 			return null;
 		}
 		return `${this.#generatedId}-panel`;
@@ -208,8 +209,10 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 			});
 		if (this.luTooltip()) {
 			ref.instance.content = this.luTooltip;
-		} else if (this.luTooltipWhenEllipsis) {
+		} else if (this.luTooltipWhenEllipsis()) {
 			ref.instance.content = signal(this.#host.nativeElement.innerText);
+		} else {
+			ref.instance.content = signal('');
 		}
 		ref.instance.id = this.ariaDescribedBy;
 		// On tooltip leave => trigger close


### PR DESCRIPTION
## Description

- Date input no longer considers `null` as invalid as far as Validation goes
- Date input now handles validation errors for `min` and `max` too
-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
