### PR TITLE
Font face cursive (for caveat)

### DIFF
--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -1,6 +1,7 @@
 @use 'sass:map';
 @use 'sass:list';
 
+@use '@lucca-front/scss/src/commons/core';
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/namespace';
@@ -23,46 +24,12 @@
 
 @mixin base($atRoot: namespace.$defaultAtRoot) {
 	@at-root ($atRoot) {
+		@if config.$fontFamilyCursive {
+			@include core.fontFace(config.$fontFamilyCursive, config.$fontWeightsCursive);
+		}
+
 		@if config.$fontFamily != 'Source Sans Pro' {
-			@font-face {
-				font-family: '#{config.$fontFamily}';
-				src:
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/regular.woff2') format('woff2'),
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/regular.woff') format('woff');
-				font-weight: 400;
-				font-style: normal;
-				font-display: swap;
-			}
-
-			@font-face {
-				font-family: '#{config.$fontFamily}';
-				src:
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/semibold.woff2') format('woff2'),
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/semibold.woff') format('woff');
-				font-weight: 600;
-				font-style: normal;
-				font-display: swap;
-			}
-
-			@font-face {
-				font-family: '#{config.$fontFamily}';
-				src:
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/bold.woff2') format('woff2'),
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/bold.woff') format('woff');
-				font-weight: 700;
-				font-style: normal;
-				font-display: swap;
-			}
-
-			@font-face {
-				font-family: '#{config.$fontFamily}';
-				src:
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/black.woff2') format('woff2'),
-					url('//cdn.lucca.fr/fonts/#{config.$fontFamily}/black.woff') format('woff');
-				font-weight: 900;
-				font-style: normal;
-				font-display: swap;
-			}
+			@include core.fontFace(config.$fontFamily, config.$fontWeights);
 		} @else {
 			@font-face {
 				font-family: 'Source Sans Pro';

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -5,6 +5,19 @@ $importDeprecatedSpacings: true !default;
 $isNamespaced: false !default;
 
 $fontFamily: 'Source Sans Pro' !default;
+$fontWeights: (
+	'regular': 400,
+	'semibold': 600,
+	'bold': 700,
+	'extra-black': 900,
+) !default;
+
+$fontFamilyCursive: 'Caveat' !default;
+$fontWeightsCursive: (
+	'regular': 400,
+	'bold': 700,
+) !default;
+
 $product: 'brand' !default;
 $palettesShades: text, 0, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900; // text is deprecated
 $palettesStates: 'critical', 'error', 'warning', 'success';

--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -140,3 +140,17 @@ $overflow: 'hidden', 'auto', 'visible', 'scroll';
 @function pxToRem($value) {
 	@return math.div($value, 16px) * 1rem;
 }
+
+@mixin fontFace($family, $weights, $path: '//cdn.lucca.fr/fonts', $style: normal) {
+	@each $keyword, $number in $weights {
+		@font-face {
+			font-family: '#{$family}';
+			src:
+				url('#{$path}/#{$family}/#{$keyword}.woff2') format('woff2'),
+				url('#{$path}/#{$family}/#{$keyword}.woff') format('woff');
+			font-weight: #{$number};
+			font-style: #{$style};
+			font-display: swap;
+		}
+	}
+}

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -270,12 +270,20 @@
 .u-noSpinButtons {
 	&::-webkit-outer-spin-button,
 	&::-webkit-inner-spin-button {
-		-webkit-appearance: none;
+		-webkit-appearance: none !important;
 	}
 
 	&[type='number'] {
-		-moz-appearance: textfield;
+		-moz-appearance: textfield !important;
 	}
+}
+
+.u-fontFamily {
+	font-family: var(--commons-font-family) !important;
+}
+
+.u-fontFamilyCursive {
+	font-family: var(--commons-font-family-cursive) !important;
 }
 
 @each $elevation in config.$elevations {

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -45,6 +45,7 @@
 
 	--commons-banner-height: 50px;
 	--commons-font-family: '#{config.$fontFamily}', Tahoma, sans-serif;
+	--commons-font-family-cursive: '#{config.$fontFamilyCursive}', cursive;
 	--commons-divider-width: 1px;
 	--commons-divider-style: solid;
 	--commons-divider-border: var(--commons-divider-width) var(--commons-divider-style) var(--commons-divider-color);

--- a/stories/documentation/texts/text/text.stories.ts
+++ b/stories/documentation/texts/text/text.stories.ts
@@ -7,18 +7,19 @@ export default {
 } as Meta;
 
 function getTemplate(args: TextBasicStory): string {
-	return `<h1>Titre 1 : Portez ce vieux whisky au juge blond qui fume</h1>
-<h2>Titre 2 : Portez ce vieux whisky au juge blond qui fume</h2>
-<h3>Titre 3 : Portez ce vieux whisky au juge blond qui fume</h3>
-<h4>Titre 4 : Portez ce vieux whisky au juge blond qui fume</h4>
-<h5>Titre 5 : Portez ce vieux whisky au juge blond qui fume</h5>
-<h6>Titre 6 : Portez ce vieux whisky au juge blond qui fume</h6>
-<p>Body 1 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-textS">Body 2 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-textXS">Body 3 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-fontStyleItalic">Caption 1 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-fontStyleItalic u-textS">Caption 2 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-fontStyleItalic u-textXS">Caption 3 : Portez ce vieux whisky au juge blond qui fume</p>`;
+	return `<h1>Titre 1 : Portez ce vieux whisky au juge blond qui fume</h1>
+<h2>Titre 2 : Portez ce vieux whisky au juge blond qui fume</h2>
+<h3>Titre 3 : Portez ce vieux whisky au juge blond qui fume</h3>
+<h4>Titre 4 : Portez ce vieux whisky au juge blond qui fume</h4>
+<h5>Titre 5 : Portez ce vieux whisky au juge blond qui fume</h5>
+<h6>Titre 6 : Portez ce vieux whisky au juge blond qui fume</h6>
+<p>Body 1 : Portez ce vieux whisky au juge blond qui fume</p>
+<p class="u-textS">Body 2 : Portez ce vieux whisky au juge blond qui fume</p>
+<p class="u-textXS">Body 3 : Portez ce vieux whisky au juge blond qui fume</p>
+<p class="u-fontStyleItalic">Caption 1 : Portez ce vieux whisky au juge blond qui fume</p>
+<p class="u-fontStyleItalic u-textS">Caption 2 : Portez ce vieux whisky au juge blond qui fume</p>
+<p class="u-fontStyleItalic u-textXS">Caption 3 : Portez ce vieux whisky au juge blond qui fume</p>
+<h1 class="u-fontFamilyCursive">Titre 1 : Portez ce vieux whisky au juge blond qui fume</h1>`;
 }
 
 const Template: StoryFn<TextBasicStory> = (args) => ({

--- a/stories/documentation/texts/text/text.stories.ts
+++ b/stories/documentation/texts/text/text.stories.ts
@@ -7,19 +7,20 @@ export default {
 } as Meta;
 
 function getTemplate(args: TextBasicStory): string {
-	return `<h1>Titre 1 : Portez ce vieux whisky au juge blond qui fume</h1>
-<h2>Titre 2 : Portez ce vieux whisky au juge blond qui fume</h2>
-<h3>Titre 3 : Portez ce vieux whisky au juge blond qui fume</h3>
-<h4>Titre 4 : Portez ce vieux whisky au juge blond qui fume</h4>
-<h5>Titre 5 : Portez ce vieux whisky au juge blond qui fume</h5>
-<h6>Titre 6 : Portez ce vieux whisky au juge blond qui fume</h6>
-<p>Body 1 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-textS">Body 2 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-textXS">Body 3 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-fontStyleItalic">Caption 1 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-fontStyleItalic u-textS">Caption 2 : Portez ce vieux whisky au juge blond qui fume</p>
-<p class="u-fontStyleItalic u-textXS">Caption 3 : Portez ce vieux whisky au juge blond qui fume</p>
-<h1 class="u-fontFamilyCursive">Titre 1 : Portez ce vieux whisky au juge blond qui fume</h1>`;
+	return `<h1 class="u-fontFamilyCursive">Cursive : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h1>
+<h1>Titre 1 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h1>
+<h2>Titre 2 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h2>
+<h3>Titre 3 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h3>
+<h4>Titre 4 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h4>
+<h5>Titre 5 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h5>
+<h6>Titre 6 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</h6>
+<p>Body 1 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</p>
+<p class="u-textS">Body 2 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</p>
+<p class="u-textXS">Body 3 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</p>
+<p class="u-fontStyleItalic">Caption 1 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</p>
+<p class="u-fontStyleItalic u-textS">Caption 2 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</p>
+<p class="u-fontStyleItalic u-textXS">Caption 3 : Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce qui lui permet de penser à la cænogénèse de l'être dont il est question dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui, pense-t-il, diminue çà et là la qualité de son œuvre.</p>
+`;
 }
 
 const Template: StoryFn<TextBasicStory> = (args) => ({


### PR DESCRIPTION
## Description

Disable cursive font support:
```scss
@use '@lucca-front/scss/src/commons/config' with (
	$fontFamilyCursive: false,
);
```

Load another font cursive (or rename it to sandbox) + define define its weights:
```scss
@use '@lucca-front/scss/src/commons/config' with (
	$fontFamilyCursive: 'Lorem',
	$fontWeightsCursive: (
		'ultra-light': 100,
		'light': 200,
		'book': 300,
		'regular': 400,
		'medium': 500,
		'semibold': 600,
		'bold': 700,
		'black': 800,
		'extra-black': 900,
	),
);
```

-----



-----
