### PR TITLE
fix(dialog-header): _addAriaLabelledBy call is now null-safe

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -45,8 +45,7 @@ export class DialogHeaderComponent implements OnInit {
 				this.#renderer.setAttribute(header, 'id', id);
 				this.#renderer.addClass(header, 'dialog-inside-header-container-title');
 			}
-			// TODO change this to _addAriaLabelledBy once cdk is > 17.1
-			(this.#ref.cdkRef.containerInstance as CdkDialogContainer)._ariaLabelledByQueue.push(id);
+			(this.#ref.cdkRef.containerInstance as CdkDialogContainer)?._addAriaLabelledBy(id);
 		});
 	}
 }


### PR DESCRIPTION
## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
