### PR TITLE
[Textfield] Fix wrapping prefix 

### DIFF
--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -122,6 +122,7 @@
 			font-size: var(--component-textField-fontSize);
 			border-top-left-radius: var(--commons-borderRadius-M);
 			border-bottom-left-radius: var(--commons-borderRadius-M);
+			flex-shrink: 0;
 
 			~ .textField-input {
 				border-top-left-radius: 0;


### PR DESCRIPTION
## Description

Fix wrapping prefix 

-----

Before 
![image](https://github.com/user-attachments/assets/105a52bc-8eaa-4e1e-b8d8-0d20350c7480)

After
![image](https://github.com/user-attachments/assets/11d058d5-fbd2-4e9c-867d-0475e8ff594e)


-----
