### PR TITLE
feat(select): add required validator for multiselection control

### DIFF
--- a/packages/ng/multi-select/public-api.ts
+++ b/packages/ng/multi-select/public-api.ts
@@ -1,3 +1,4 @@
 export * from './displayer/index';
 export * from './input/index';
 export * from './select.translate';
+export * from './select.validators';

--- a/packages/ng/multi-select/select.validators.ts
+++ b/packages/ng/multi-select/select.validators.ts
@@ -1,0 +1,13 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+import { LuMultiSelection } from './select.model';
+
+const required = (control: AbstractControl<LuMultiSelection<unknown>>): ValidationErrors | null => {
+	if (!control.value || control.value.mode === 'none') {
+		return { required: true };
+	}
+	return null;
+};
+
+export const LuMultiSelectionValidators = {
+	required,
+};


### PR DESCRIPTION
## Description

Implemented the `required` validator for `LuMultiSelection` controls, which checks if the selection mode is set to 'none' and returns a validation error if true.

-----
