### PR TITLE
[utils] reset list

### DIFF
--- a/packages/scss/src/commons/utils/reset.scss
+++ b/packages/scss/src/commons/utils/reset.scss
@@ -4,6 +4,18 @@
 	@if $list == 'ul' or $list == 'ol' {
 		padding: 0 #{$suffix};
 		list-style-type: none #{$suffix};
+
+		ul {
+			list-style-type: disc #{$suffix};
+
+			ul {
+				list-style-type: circle #{$suffix};
+
+				ul {
+					list-style-type: square #{$suffix};
+				}
+			}
+		}
 	}
 
 	@if $list == 'dl' {

--- a/stories/documentation/integration/utilities/reset.stories.ts
+++ b/stories/documentation/integration/utilities/reset.stories.ts
@@ -17,7 +17,14 @@ function getTemplate(args: ResetStory): string {
 		<ul class="u-listReset">
 			<li>List item</li>
 			<li>List item</li>
-			<li>List item</li>
+			<li>
+				List item
+				<ul>
+					<li>List item</li>
+					<li>List item</li>
+					<li>List item</li>
+				</ul>
+			</li>
 		</ul>
 	</div>
 	<div class="demo-utility">


### PR DESCRIPTION
## Description

The disc/circle/square styles were not reset.


-----



-----
Before:
<img width="128" alt="Capture d’écran 2024-12-06 à 14 42 55" src="https://github.com/user-attachments/assets/df659f9c-1efd-406d-9ea6-f3ab7b4a285b">

After:
<img width="126" alt="Capture d’écran 2024-12-06 à 14 42 13" src="https://github.com/user-attachments/assets/46b31d1c-736c-4350-8840-91d0cc310bb3">