### PR TITLE
fix(tooltip): missing tabindex when using without ellipsis logic

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -173,7 +173,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 			});
 
 		effect(() => {
-			if (!this.luTooltipDisabled() && this.#hasEllipsis()) {
+			if (!this.luTooltipDisabled() && (!this.luTooltipWhenEllipsis() || this.#hasEllipsis())) {
 				this.setAccessibilityProperties(0);
 			} else {
 				this.setAccessibilityProperties(null);


### PR DESCRIPTION
## Description

Signal-based logic made tabindex logic go boom.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
