### PR TITLE
[Dialog] Size as select control & show mod-neutralBackground version

### DIFF
--- a/stories/documentation/overlays/dialog/dialog-basic.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-basic.stories.ts
@@ -63,6 +63,7 @@ export default {
 			control: {
 				type: 'boolean',
 			},
+			description: '[v18.3]',
 		},
 	},
 } as Meta;

--- a/stories/documentation/overlays/dialog/dialog.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog.stories.ts
@@ -84,6 +84,9 @@ export default {
 				type: 'select',
 			},
 		},
+		panelClasses: {
+			description: '[v18.3] mod-neutralBackground',
+		},
 	},
 } as Meta;
 

--- a/stories/documentation/overlays/dialog/dialog.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog.stories.ts
@@ -78,6 +78,12 @@ export default {
 				type: 'select',
 			},
 		},
+		size: {
+			options: ['fitContent', 'XS', 'S', '', 'L', 'XL', 'maxContent', 'fullScreen'],
+			control: {
+				type: 'select',
+			},
+		},
 	},
 } as Meta;
 


### PR DESCRIPTION
## Description

Size as select control & show mod-neutralBackground version

-----

![image](https://github.com/user-attachments/assets/b6c817b2-ed8c-4dbf-b32d-b2b8a83ee56d)
![image](https://github.com/user-attachments/assets/61af92f9-6668-41f7-a483-7fb979fa9016)


-----
