### PR TITLE
TooltipTriggerDirective: change inputs for models

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -14,7 +14,7 @@ import {
 	computed,
 	effect,
 	inject,
-	input,
+	model,
 	numberAttribute,
 	signal,
 } from '@angular/core';
@@ -43,7 +43,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 
 	#destroyRef = inject(DestroyRef);
 
-	luTooltip = input<string | SafeHtml>();
+	luTooltip = model<string | SafeHtml>();
 
 	#openDelay$ = new BehaviorSubject<number>(300);
 
@@ -59,7 +59,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 		this.#closeDelay$.next(delay);
 	}
 
-	luTooltipDisabled = input(false, { transform: booleanAttribute });
+	luTooltipDisabled = model(false);
 
 	@Input({ transform: booleanAttribute })
 	luTooltipOnlyForDisplay = false;
@@ -67,7 +67,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 	@Input()
 	luTooltipPosition: LuPopoverPosition = 'above';
 
-	luTooltipWhenEllipsis = input(false, { transform: booleanAttribute });
+	luTooltipWhenEllipsis = model(false);
 
 	resize$ = new Observable((observer) => {
 		const resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
## Description

Change `input`s for `model`s to set properties from outside.

-----

Th goal is to be able to set `luTooltip`, `luTooltipDisabled` etc directly within a `.ts` file. E.g. on T.Abs we have a `translateI18n` directive that adds a tooltip on host so we want to set it within `ngOnInit`.

-----
