### PR TITLE
[navside] Add support for ESR

### DIFF
--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -15,6 +15,10 @@
 			&:has(.navSide.mod-compact, .mod-withMenuCompact) {
 				--commons-navSide-width: 7.5rem;
 			}
+
+			@supports not selector(:has(*)) {
+				--commons-navSide-width: 15rem;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Older versions of Firefox ESR do not support `:has`. A fallback is provided for this major component.

-----



-----
