### PR TITLE
[dialog] close + popover

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.html
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.html
@@ -1,6 +1,5 @@
-<button class="dialog-inside-header-button button" type="button" luButton (click)="close()" *ngIf="dismissible">
-	<lu-icon icon="signClose"></lu-icon>
-	<span class="u-mask">{{ intl.close }}</span>
+<button class="dialog-inside-header-button button" type="button" (click)="close()" *ngIf="dismissible">
+	<lu-icon icon="signClose" [alt]="intl.close"></lu-icon>
 </button>
 
 <div class="dialog-inside-header-container">


### PR DESCRIPTION
## Description

When opening a popover, the `mod-onlyIcon` loaded in the popover CSS would overwrite the mixin `onlyIconS`. By deleting the `luButton`, the class is no longer generated and the bug no longer occurs.

-----

https://lucca.slack.com/archives/C3W78FWUU/p1733828859780829

-----

Before:
![2024-12-13 18 02 11](https://github.com/user-attachments/assets/9267b47c-17af-4f77-885d-800e7896a671)


After:
![2024-12-13 18 01 30](https://github.com/user-attachments/assets/02264a28-b993-461a-af85-c86546eb0a0e)
