### PR TITLE
[dataTable] fix Chrome with a white shadow

### DIFF
--- a/packages/scss/src/components/dataTableSticked/mods.scss
+++ b/packages/scss/src/components/dataTableSticked/mods.scss
@@ -102,12 +102,12 @@
 		content: none;
 	}
 
-	:is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell) {
+	:is(.dataTable-head-row-cell, .dataTable-body-row-cell, .dataTable-foot-row-cell) {
 		&.mod-stickyColumn {
 			&:has(~ :is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell):not(.mod-stickyColumn)) {
 				transform: translateX(-1px);
 
-				&:not(:has(+ :is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell).mod-stickyColumn)) {
+				&:not(:has(+ :is(.dataTable-head-row-cell, .dataTable-body-row-cell, .dataTable-foot-row-cell).mod-stickyColumn)) {
 					&::after {
 						@extend %addShadow;
 					}
@@ -116,7 +116,7 @@
 		}
 
 		&:not(.mod-stickyColumn) {
-			~ :is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell).mod-stickyColumn {
+			~ :is(.dataTable-head-row-cell, .dataTable-body-row-cell, .dataTable-foot-row-cell).mod-stickyColumn {
 				&::after {
 					@extend %addShadow;
 
@@ -125,7 +125,7 @@
 					transform: scaleX(-1);
 				}
 
-				& ~ :is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell).mod-stickyColumn {
+				& ~ :is(.dataTable-head-row-cell, .dataTable-body-row-cell, .dataTable-foot-row-cell).mod-stickyColumn {
 					&::after {
 						@extend %removeShadow;
 					}
@@ -144,20 +144,26 @@
 
 			&:last-child {
 				right: 0;
+				--components-dataTable-cell-shadow: 0 1px inset var(--commons-border-200), 1px 0 var(--palettes-neutral-0); // white shadow is for Chrome
 			}
 		}
 	}
 }
 
 @mixin stickyColumnBorder {
-	:is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell) {
+	:is(.dataTable-head-row-cell, .dataTable-body-row-cell, .dataTable-foot-row-cell) {
 		&.mod-stickyColumn {
 			&:has(~ :is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell):not(.mod-stickyColumn)) {
 				&:not(:has(+ :is(.dataTable-body-row-cell, .dataTable-head-row-cell, .dataTable-foot-row-cell).mod-stickyColumn)) {
 					&::after {
-						box-shadow: 1px 0 var(--commons-border-200) inset;
+						--components-dataTable-cell-shadow: 1px 0 var(--commons-border-200) inset;
 					}
 				}
+			}
+
+			&:last-child {
+				--components-dataTable-cell-shadow: 0 1px inset var(--commons-border-200), 1px 0 inset var(--commons-border-200),
+					1px 0 var(--palettes-neutral-0); // white shadow is for Chrome
 			}
 		}
 	}


### PR DESCRIPTION
## Description

With Chrome, the sticky cell at the end of the line sometimes revealed a pixel of content below. This has been corrected with the addition of a white shadow.

-----



-----

Before:
![Capture d’écran 2024-12-18 à 11 15 16](https://github.com/user-attachments/assets/ede365e6-f4fc-4bbd-b9d2-3259f2d6778c)

After:
![Capture d’écran 2024-12-18 à 11 15 25](https://github.com/user-attachments/assets/67b4f85e-b272-4de6-9494-f5e56c9341d4)

