### PR TITLE
Remove titles spacing

### DIFF
--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
@@ -24,7 +24,7 @@
 			</button>
 			<ng-template #popoverMultilanguage>
 				<div class="popover-contentOptional" [style.width.px]="inputElement.clientWidth + 16">
-					<div class="u-displayFlex u-gapXS u-flexDirectionColumn">
+					<div class="u-displayFlex pr-u-gap100 u-flexDirectionColumn">
 						@for (row of panelInputs(); track row.cultureCode) {
 						<lu-form-field [label]="intl.translateTo | intlParams: {lang: getLocaleDisplayName(row.cultureCode)}" hiddenLabel>
 							<lu-text-input

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -55,7 +55,10 @@
 		}
 
 		p {
-			margin: 0 0 var(--pr-t-spacings-200);
+			margin: 0;
+			@if config.$deprecatedParagraphSpacings {
+				margin: 0 0 var(--pr-t-spacings-paragraph);
+			}
 		}
 
 		abbr {

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -57,7 +57,7 @@
 		p {
 			margin: 0;
 			@if config.$deprecatedSpacings {
-				margin-block-end: var(--pr-t-spacings-paragraph);
+				margin-block-end: var(--pr-t-spacings-150);
 			}
 		}
 
@@ -66,7 +66,7 @@
 			margin: 0;
 			padding-inline-start: var(--pr-t-spacings-400);
 			@if config.$deprecatedSpacings {
-				margin-block-end: var(--pr-t-spacings-list);
+				margin-block-end: var(--pr-t-spacings-150);
 			}
 		}
 

--- a/packages/scss/src/commons/base.scss
+++ b/packages/scss/src/commons/base.scss
@@ -56,8 +56,17 @@
 
 		p {
 			margin: 0;
-			@if config.$deprecatedParagraphSpacings {
-				margin: 0 0 var(--pr-t-spacings-paragraph);
+			@if config.$deprecatedSpacings {
+				margin-block-end: var(--pr-t-spacings-paragraph);
+			}
+		}
+
+		ul,
+		ol {
+			margin: 0;
+			padding-inline-start: var(--pr-t-spacings-400);
+			@if config.$deprecatedSpacings {
+				margin-block-end: var(--pr-t-spacings-list);
 			}
 		}
 

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,6 +1,7 @@
 @use 'sass:list';
 
 $isNamespaced: false !default;
+$deprecatedTitleSpacings: false !default;
 
 $fontFamily: 'SourceSans' !default;
 $fontWeights: (

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -2,6 +2,7 @@
 
 $isNamespaced: false !default;
 $deprecatedTitleSpacings: false !default;
+$deprecatedParagraphSpacings: false !default;
 
 $fontFamily: 'SourceSans' !default;
 $fontWeights: (

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,8 +1,7 @@
 @use 'sass:list';
 
 $isNamespaced: false !default;
-$deprecatedTitleSpacings: false !default;
-$deprecatedParagraphSpacings: false !default;
+$deprecatedSpacings: false !default;
 
 $fontFamily: 'SourceSans' !default;
 $fontWeights: (

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -12,8 +12,13 @@
 	}
 
 	@include core.cssvars('pr-t-spacings', config.$spacings);
-	--pr-t-spacings-headings: var(--pr-t-spacings-200);
-	--pr-t-spacings-paragraph: var(--pr-t-spacings-200);
+	--pr-t-spacings-headings: var(--pr-t-spacings-200); // Remove?
+	--pr-t-spacings-h1: var(--pr-t-spacings-300);
+	--pr-t-spacings-h2: var(--pr-t-spacings-300) var(--pr-t-spacings-150);
+	--pr-t-spacings-h3: var(--pr-t-spacings-300) var(--pr-t-spacings-150);
+	--pr-t-spacings-h4: var(--pr-t-spacings-150);
+	--pr-t-spacings-paragraph: var(--pr-t-spacings-150);
+	--pr-t-spacings-list: var(--pr-t-spacings-150);
 	--pr-t-spacings-auto: auto;
 
 	@include core.cssvars('pr-t-color-input', config.$colorInput);

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -13,6 +13,7 @@
 
 	@include core.cssvars('pr-t-spacings', config.$spacings);
 	--pr-t-spacings-headings: var(--pr-t-spacings-200);
+	--pr-t-spacings-paragraph: var(--pr-t-spacings-200);
 	--pr-t-spacings-auto: auto;
 
 	@include core.cssvars('pr-t-color-input', config.$colorInput);

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -12,6 +12,7 @@
 	}
 
 	@include core.cssvars('pr-t-spacings', config.$spacings);
+	--pr-t-spacings-headings: var(--pr-t-spacings-200);
 	--pr-t-spacings-auto: auto;
 
 	@include core.cssvars('pr-t-color-input', config.$colorInput);

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -12,13 +12,6 @@
 	}
 
 	@include core.cssvars('pr-t-spacings', config.$spacings);
-	--pr-t-spacings-headings: var(--pr-t-spacings-200); // Remove?
-	--pr-t-spacings-h1: var(--pr-t-spacings-300);
-	--pr-t-spacings-h2: var(--pr-t-spacings-300) var(--pr-t-spacings-150);
-	--pr-t-spacings-h3: var(--pr-t-spacings-300) var(--pr-t-spacings-150);
-	--pr-t-spacings-h4: var(--pr-t-spacings-150);
-	--pr-t-spacings-paragraph: var(--pr-t-spacings-150);
-	--pr-t-spacings-list: var(--pr-t-spacings-150);
 	--pr-t-spacings-auto: auto;
 
 	@include core.cssvars('pr-t-color-input', config.$colorInput);

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -47,9 +47,9 @@
 			@include title.component;
 			@include title.h3;
 
-			margin-bottom: var(--pr-t-spacings-50);
+			margin-block-end: var(--pr-t-spacings-50);
 			@if config.$deprecatedTitleSpacings {
-				margin-bottom: 0;
+				margin-block-end: 0;
 			}
 		}
 

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -48,7 +48,7 @@
 			@include title.h3;
 
 			margin-block-end: var(--pr-t-spacings-50);
-			@if config.$deprecatedTitleSpacings {
+			@if config.$deprecatedSpacings {
 				margin-block-end: 0;
 			}
 		}

--- a/packages/scss/src/components/emptyState/component.scss
+++ b/packages/scss/src/components/emptyState/component.scss
@@ -1,6 +1,7 @@
-@use '@lucca-front/scss/src/components/title/exports' as title;
+@use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/utils/media';
 @use '@lucca-front/scss/src/commons/utils/namespace';
+@use '@lucca-front/scss/src/components/title/exports' as title;
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
@@ -46,7 +47,10 @@
 			@include title.component;
 			@include title.h3;
 
-			margin-bottom: 0;
+			margin-bottom: var(--pr-t-spacings-50);
+			@if config.$deprecatedTitleSpacings {
+				margin-bottom: 0;
+			}
 		}
 
 		.emptyState-content-description {

--- a/packages/scss/src/components/errorPage/component.scss
+++ b/packages/scss/src/components/errorPage/component.scss
@@ -28,7 +28,7 @@
 	.errorPage-section-info-title {
 		@include title.component;
 		@include title.XXXL;
-		margin-block-end: var(--pr-t-spacings-headings);
+		margin-block-end: var(--pr-t-spacings-50);
 	}
 
 	.errorPage-section-info-text {

--- a/packages/scss/src/components/errorPage/component.scss
+++ b/packages/scss/src/components/errorPage/component.scss
@@ -34,7 +34,7 @@
 	.errorPage-section-info-text {
 		font-size: var(--sizes-L-fontSize);
 		line-height: var(--sizes-L-lineHeight);
-		margin-block-end: var(--pr-t-spacings-paragraph);
+		margin-block-end: var(--pr-t-spacings-150);
 	}
 
 	.errorPage-section-image {

--- a/packages/scss/src/components/errorPage/component.scss
+++ b/packages/scss/src/components/errorPage/component.scss
@@ -28,6 +28,7 @@
 	.errorPage-section-info-title {
 		@include title.component;
 		@include title.XXXL;
+		margin-block-end: var(--pr-t-spacings-headings);
 	}
 
 	.errorPage-section-info-text {

--- a/packages/scss/src/components/errorPage/component.scss
+++ b/packages/scss/src/components/errorPage/component.scss
@@ -34,6 +34,7 @@
 	.errorPage-section-info-text {
 		font-size: var(--sizes-L-fontSize);
 		line-height: var(--sizes-L-lineHeight);
+		margin-block-end: var(--pr-t-spacings-paragraph);
 	}
 
 	.errorPage-section-image {

--- a/packages/scss/src/components/index.scss
+++ b/packages/scss/src/components/index.scss
@@ -92,6 +92,7 @@
 @forward 'dataTable';
 @forward 'dataTableSticked';
 @forward 'dropdown';
+@forward 'textFlow';
 
 // Deprecated CSS components
 // @forward 'tableFixedDeprecated'; // 33 Ko

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -22,11 +22,11 @@
 	}
 
 	ul {
-		margin-block-end: var(--pr-t-spacings-paragraph);
+		margin-block-end: var(--pr-t-spacings-150);
 	}
 
 	li {
-		margin-bottom: 0.25rem;
+		margin-bottom: var(--pr-t-spacings-50);
 	}
 
 	@at-root ($atRoot) {

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -2,23 +2,23 @@
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	h1 {
-		margin-block: var(--pr-t-spacings-h1);
+		margin-block: var(--pr-t-spacings-300);
 	}
 
 	h2 {
-		margin-block: var(--pr-t-spacings-h2);
+		margin-block: var(--pr-t-spacings-300) var(--pr-t-spacings-150);
 	}
 
 	h3 {
-		margin-block: var(--pr-t-spacings-h3);
+		margin-block: var(--pr-t-spacings-300) var(--pr-t-spacings-150);
 	}
 
 	h4 {
-		margin-block: var(--pr-t-spacings-h4);
+		margin-block: var(--pr-t-spacings-150);
 	}
 
 	p {
-		margin-block-end: var(--pr-t-spacings-paragraph);
+		margin-block-end: var(--pr-t-spacings-150);
 	}
 
 	ul {

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -1,0 +1,34 @@
+@use '@lucca-front/scss/src/commons/utils/namespace';
+
+@mixin component($atRoot: namespace.$defaultAtRoot) {
+	h1 {
+		margin-block: var(--pr-t-spacings-h1);
+	}
+
+	h2 {
+		margin-block: var(--pr-t-spacings-h2);
+	}
+
+	h3 {
+		margin-block: var(--pr-t-spacings-h3);
+	}
+
+	h4 {
+		margin-block: var(--pr-t-spacings-h4);
+	}
+
+	p {
+		margin-block-end: var(--pr-t-spacings-paragraph);
+	}
+
+	ul {
+		margin-block-end: var(--pr-t-spacings-paragraph);
+	}
+
+	li {
+		margin-bottom: 0.25rem;
+	}
+
+	@at-root ($atRoot) {
+	}
+}

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -18,17 +18,14 @@
 	}
 
 	p {
-		margin-block-end: var(--pr-t-spacings-150);
+		margin-block: var(--pr-t-spacings-150);
 	}
 
 	ul {
-		margin-block-end: var(--pr-t-spacings-150);
+		margin-block: var(--pr-t-spacings-150);
 	}
 
 	li {
-		margin-bottom: var(--pr-t-spacings-50);
-	}
-
-	@at-root ($atRoot) {
+		margin-block: var(--pr-t-spacings-50);
 	}
 }

--- a/packages/scss/src/components/textFlow/exports.scss
+++ b/packages/scss/src/components/textFlow/exports.scss
@@ -1,0 +1,4 @@
+@forward 'vars';
+@forward 'mods';
+@forward 'states';
+@forward 'component';

--- a/packages/scss/src/components/textFlow/index.scss
+++ b/packages/scss/src/components/textFlow/index.scss
@@ -1,0 +1,6 @@
+@use 'exports' as *;
+
+.textFlow {
+	@include vars;
+	@include component;
+}

--- a/packages/scss/src/components/textFlow/vars.scss
+++ b/packages/scss/src/components/textFlow/vars.scss
@@ -1,0 +1,2 @@
+@mixin vars {
+}

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -12,11 +12,17 @@
 	line-height: var(--sizes-lineHeight) #{$suffix};
 
 	@if config.$deprecatedTitleSpacings {
-		margin-block-end: var(--pr-t-spacings-200);
+		// no suffix here
+		margin-block-end: var(--pr-t-spacings-headings);
+
+		// suffix here
 		padding-block-start: var(--sizes-verticalPadding) #{$suffix};
 		padding-block-end: var(--sizes-verticalPadding) #{$suffix};
 	} @else {
-		padding: 0 #{$suffix};
+		// no suffix here
 		margin-block-end: 0;
+
+		// suffix here
+		padding: 0 #{$suffix};
 	}
 }

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -1,8 +1,8 @@
+@use '@lucca-front/scss/src/commons/config';
 @mixin component($suffix: '') {
 	// no suffix here
 	margin-top: 0;
 	color: var(--palettes-neutral-900);
-	margin-bottom: var(--pr-t-spacings-200);
 	text-rendering: geometricPrecision;
 	text-wrap: pretty;
 
@@ -10,6 +10,13 @@
 	font-weight: var(--components-title-weight, 600) #{$suffix};
 	font-size: var(--sizes-fontSize) #{$suffix};
 	line-height: var(--sizes-lineHeight) #{$suffix};
-	padding-top: var(--sizes-verticalPadding) #{$suffix};
-	padding-bottom: var(--sizes-verticalPadding) #{$suffix};
+
+	@if config.$deprecatedTitleSpacings {
+		margin-bottom: var(--pr-t-spacings-200);
+		padding-top: var(--sizes-verticalPadding) #{$suffix};
+		padding-bottom: var(--sizes-verticalPadding) #{$suffix};
+	} @else {
+		padding: 0 #{$suffix};
+		margin-bottom: 0;
+	}
 }

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -11,7 +11,7 @@
 	font-size: var(--sizes-fontSize) #{$suffix};
 	line-height: var(--sizes-lineHeight) #{$suffix};
 
-	@if config.$deprecatedTitleSpacings {
+	@if config.$deprecatedSpacings {
 		// no suffix here
 		margin-block-end: var(--pr-t-spacings-headings);
 

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -1,7 +1,7 @@
 @use '@lucca-front/scss/src/commons/config';
 @mixin component($suffix: '') {
 	// no suffix here
-	margin-top: 0;
+	margin-block-start: 0;
 	color: var(--palettes-neutral-900);
 	text-rendering: geometricPrecision;
 	text-wrap: pretty;
@@ -12,11 +12,11 @@
 	line-height: var(--sizes-lineHeight) #{$suffix};
 
 	@if config.$deprecatedTitleSpacings {
-		margin-bottom: var(--pr-t-spacings-200);
-		padding-top: var(--sizes-verticalPadding) #{$suffix};
-		padding-bottom: var(--sizes-verticalPadding) #{$suffix};
+		margin-block-end: var(--pr-t-spacings-200);
+		padding-block-start: var(--sizes-verticalPadding) #{$suffix};
+		padding-block-end: var(--sizes-verticalPadding) #{$suffix};
 	} @else {
 		padding: 0 #{$suffix};
-		margin-bottom: 0;
+		margin-block-end: 0;
 	}
 }

--- a/packages/scss/src/components/title/component.scss
+++ b/packages/scss/src/components/title/component.scss
@@ -13,7 +13,7 @@
 
 	@if config.$deprecatedSpacings {
 		// no suffix here
-		margin-block-end: var(--pr-t-spacings-headings);
+		margin-block-end: var(--pr-t-spacings-200);
 
 		// suffix here
 		padding-block-start: var(--sizes-verticalPadding) #{$suffix};

--- a/stories/documentation/texts/text-flow/html&css/basic.stories.ts
+++ b/stories/documentation/texts/text-flow/html&css/basic.stories.ts
@@ -1,0 +1,44 @@
+import { Meta, StoryFn } from '@storybook/angular';
+
+interface TextFlowBasicStory {}
+
+export default {
+	title: 'Documentation/Texts/Text flow/HTML&CSS/Basic',
+	argTypes: {},
+} as Meta;
+
+function getTemplate(args: TextFlowBasicStory): string {
+	return `<div class="textFlow">
+	<h1>Heading 1</h1>
+	<h2>Heading 2</h2>
+	<p>Paragraph</p>
+	<p>Paragraph</p>
+	<h2>Heading 2</h2>
+	<p>Paragraph</p>
+	<ul>
+		<li>List item</li>
+		<li>List item</li>
+		<li>List item</li>
+	</ul>
+	<h3>Heading 3</h3>
+	<p>Paragraph</p>
+	<h4>Heading 4</h4>
+	<ol>
+	<li>List item</li>
+	<li>List item</li>
+	<li>List item</li>
+	</ol>
+</div>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>
+`;
+}
+
+const Template: StoryFn<TextFlowBasicStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+});
+
+export const Basic = Template.bind({});
+Basic.args = {};

--- a/stories/qa/text-flow/text-flow.stories.html
+++ b/stories/qa/text-flow/text-flow.stories.html
@@ -1,0 +1,67 @@
+<div class="textFlow">
+	<h1>Les règles de congés chez Lucca</h1>
+	<h2>Règles générales</h2>
+	<p>Tous les congés doivent être saisis dans Timmi Absences par le collaborateur.</p>
+	<p>Timmi Absences est configuré pour autoriser les congés par anticipation.</p>
+	<p>
+		Les collaborateurs des départements Sales, Consulting, Channels, IT Support et Finance ainsi que ceux disposant de plus de 25 jours de
+		congés payés et RTT au 1er juillet de l'année considérée sont invités à poser au moins 10 jours ouvrés de congés payés (ou RTT) sur la
+		période qui court du 1er juillet au 30 août (hors temps de récupération). Cette règle ne s’applique pas pour les collaborateurs arrivés
+		après le 1er janvier de l'année en cours.
+	</p>
+	<p>Lucca propose le rachat des RTT de l’année en cours et de votre compte de jours de récupération.</p>
+	<h2>Quels sont vos droits à congés ?</h2>
+	<p>
+		Tous les collaborateurs en CDI, CDD, contrat d’apprentissage et contrat de professionnalisation ont le droit à 25 jours ouvrés de Congés
+		Payés par an.
+	</p>
+	<p>
+		Si vous n’avez pas une année complète de présence à la fin de la période ouvrant droit aux congés, vous aurez le droit à un congé
+		calculé prorata temporis sur la base de vingt-cinq jours ouvrés par an.
+	</p>
+	<p>À ceci s’ajoutent des jours de réduction du temps de travail (RTT) dont le nombre varie chaque année.</p>
+	<p>
+		Des autorisations d’absences exceptionnelles non déductibles des congés et n’entraînant pas de perte de rémunération seront accordées
+		pour les événements familiaux suivants :
+	</p>
+	<ul>
+		<li>Mariage/PACS : 4 jours.</li>
+		<li>
+			Naissance ou adoption, pour le père de famille : 3 jours dans une période de quinze jours entourant la date de naissance ou suivant
+		</li>
+		<li>l'arrivée au foyer de l'enfant placé en vue de son adoption.</li>
+		<li>Congés pour stagiaire : 1 jour par mois travaillé (cumulable).</li>
+	</ul>
+	<h3>Congé pour Bénévolat</h3>
+	<p>
+		En plus de ces absences exceptionnelles rémunérées, il est possible de prendre des jours de congés pour bénévolat. Ces congés ne sont
+		pas rémunérés et leur prise doit répondre à certaines conditions :
+	</p>
+	<ul>
+		<li>
+			Le salarié doit être dirigeant statutaire (membre du conseil d'administration, du bureau...) d'une association d'intérêt général (loi
+			1901 ou d'Alsace-Moselle).
+		</li>
+		<li>Ou responsable encadrant d’autres bénévoles d’une association d’intérêt général (loi 1901 ou d’Alsace-Moselle.</li>
+	</ul>
+	<h4>Comment s’appliquent ces congés ?</h4>
+	<ul>
+		<li>Les congés pour Bénévolat ne peuvent dépasser les 6 jours par an (calendaire).</li>
+		<li>Ces congés sont fractionnables.</li>
+		<li>
+			Le manager doit être prévenu 30 jours à l’avance, par mail, avec l’adresse en copie, avec un justificatif du statut ouvrant le droit à
+			ces congés.
+		</li>
+	</ul>
+	<h2>Ancienneté</h2>
+	<p>Notre convention collective prévoit également des jours de congés payés supplémentaires en fonction de l’ancienneté acquise :</p>
+	<ul>
+		<li>Après une période de cinq années d’ancienneté : un jour ouvré supplémentaire,</li>
+		<li>Après une période de dix années d’ancienneté : deux jours ouvrés supplémentaires,</li>
+		<li>Après une période de quinze années d’ancienneté : trois jours ouvrés supplémentaires,</li>
+		<li>Après une période de vingt années d’ancienneté : quatre jours ouvrés supplémentaires</li>
+	</ul>
+</div>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/text-flow/text-flow.stories.ts
+++ b/stories/qa/text-flow/text-flow.stories.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { Meta, StoryFn } from '@storybook/angular';
+
+@Component({
+	standalone: true,
+	selector: 'text-flow-stories',
+	templateUrl: './text-flow.stories.html',
+})
+class TextFlowStory {}
+
+export default {
+	title: 'QA/TextFlow',
+	component: TextFlowStory,
+} as Meta;
+
+const template: StoryFn<TextFlowStory> = () => ({});
+
+export const basic = template.bind({});


### PR DESCRIPTION
## Description

- Remove titles spacings by default (margin + padding)
- Provide a deprecated flag `$deprecatedTitleSpacings` on `config.scss`
- Override a bunch of component to be iso with or without flag activated

-----