### PR TITLE
docs(pagination): replace "aria-labelledby" with "aria-label"

### DIFF
--- a/stories/documentation/listings/index-table/index-table-mass-selection-and-pagination.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-mass-selection-and-pagination.stories.ts
@@ -67,8 +67,8 @@ function getTemplate(args: IndexTableMassSelectionAndPaginationStory): string {
 			</tr>
 		</tbody>
 	</table>
-	<nav class="pagination" role="navigation" aria-labelledby="pagination-count">
-		<div id="pagination-count" class="pagination-count">
+	<nav class="pagination" role="navigation" aria-label="Pagination des résultats">
+		<div class="pagination-count">
 			<span class="pagination-count-current">
 				<span class="u-mask">Résultats de </span>
 				1<span aria-hidden="true"> – </span>

--- a/stories/documentation/navigation/pagination/pagination-basic.stories.ts
+++ b/stories/documentation/navigation/pagination/pagination-basic.stories.ts
@@ -9,8 +9,8 @@ export default {
 
 function getTemplate(args: PaginationBasicStory): string {
 	return `
-	<nav class="pagination" role="navigation" aria-labelledby="pagination-count">
-		<div id="pagination-count" class="pagination-count">
+	<nav class="pagination" role="navigation" aria-label="Pagination des résultats">
+		<div class="pagination-count">
 			<span class="pagination-count-current">
 				<span class="u-mask">Résultats de </span>
 				1<span aria-hidden="true"> – </span>

--- a/stories/documentation/navigation/pagination/pagination-compact.stories.ts
+++ b/stories/documentation/navigation/pagination/pagination-compact.stories.ts
@@ -9,7 +9,7 @@ export default {
 
 function getTemplate(args: PaginationCompactStory): string {
 	return `
-	<nav class="pagination mod-compact" role="navigation" aria-labelledby="pagination-count">
+	<nav class="pagination mod-compact" role="navigation" aria-label="Pagination">
 		<div class="pagination-scrolling">
 			<button type="button" class="button mod-onlyIcon mod-text mod-S" disabled>
 				<span aria-hidden="true" class="lucca-icon icon-arrowChevronLeft"></span>

--- a/stories/documentation/navigation/pagination/pagination-pages.stories.ts
+++ b/stories/documentation/navigation/pagination/pagination-pages.stories.ts
@@ -9,8 +9,8 @@ export default {
 
 function getTemplate(args: PaginationPagesStory): string {
 	return `
-	<nav class="pagination" role="navigation" aria-labelledby="pagination-navigation">
-		<ul id="pagination-navigation" class="pagination-navigation">
+	<nav class="pagination" role="navigation" aria-label="Pagination">
+		<ul class="pagination-navigation">
 			<li class="pagination-navigation-item is-active" aria-current="page"><span class="u-mask">Vous êtes sur la page </span>1</li>
 			<li class="pagination-navigation-item"><a href="#">2</a></li>
 			<li class="pagination-navigation-item"><a href="#">3</a></li>

--- a/stories/qa/pagination/pagination.stories.html
+++ b/stories/qa/pagination/pagination.stories.html
@@ -2,8 +2,8 @@
 
 <section class="contentSection">
 	<h2>Pagination</h2>
-	<nav class="pagination" role="navigation" aria-labelledby="pagination-count">
-		<div id="pagination-count" class="pagination-count">
+	<nav class="pagination" role="navigation" aria-label="Results pagination">
+		<div class="pagination-count">
 			<span class="pagination-count-current">
 				<span class="u-mask">Results from </span>
 				1<span aria-hidden="true"> – </span> <span class="u-mask">to </span>10
@@ -26,8 +26,8 @@
 
 <section>
 	<h2>Per page</h2>
-	<nav class="pagination" role="navigation" aria-labelledby="pagination-navigation">
-		<ul id="pagination-navigation" class="pagination-navigation">
+	<nav class="pagination" role="navigation" aria-label="Pagination">
+		<ul class="pagination-navigation">
 			<li class="pagination-navigation-item is-active" aria-current="page"><span class="u-mask">You’re on page </span>1</li>
 			<li class="pagination-navigation-item"><a href="#">2</a></li>
 			<li class="pagination-navigation-item"><a href="#">3</a></li>


### PR DESCRIPTION
## Description

Following the accessibility audit, we were asked to replace the `aria-labelledby` attribute on the `<nav>` element with an `aria-label` attribute. ([See criteria 9.2](https://docs.google.com/spreadsheets/d/1T7LIRH6YSZINQwhJ_tl2pcm0jIRrro98UkLF9xCgjpQ/edit?gid=644615132#gid=644615132))

-----
