### PR TITLE
feat(tag): Authorize undefined value for icon

### DIFF
--- a/packages/ng/tag/tag.component.ts
+++ b/packages/ng/tag/tag.component.ts
@@ -48,7 +48,7 @@ export class TagComponent {
 	 * Which icon should we display in the callout if any?
 	 * Defaults to no icon.
 	 */
-	icon: LuccaIcon;
+	icon: LuccaIcon | undefined;
 
 	get tagClasses() {
 		return {


### PR DESCRIPTION
## Description

In order to avoid using `@if` / `@else` to manage cases where we don't want icons, I propose to accept `undefined` as value for the icon input.

Simplify this...
```typescript
@if (isExpired()) {
  <lu-tag
    [label]="textKey() | transloco: textParams"
    icon="error"
    palette="error"
  />
} @else {
  <lu-tag
    [label]="textKey() | transloco: textParams"
    palette="product"
    outlined
  />
}
``` 

...with that
```typescript
<lu-tag
  [label]="textKey() | transloco: textParams"
  [icon]="isExpired() ? 'error' : undefined"
  [palette]="isExpired() ? 'error' : 'product'"
  [outlined]="!isExpired()"
/>
``` 

-----

-----
