### PR TITLE
feat(core-select): add a noClue directive to disable apiV3/V4 search

### DIFF
--- a/packages/ng/core-select/input/select-input.component.spec.ts
+++ b/packages/ng/core-select/input/select-input.component.spec.ts
@@ -40,7 +40,22 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 		expect(component.isPanelOpen).toBe(true);
 	});
 
-	it.each(['a', 'A', 'À'])('should openPanel and emit clueChange when pressing %s', async (key) => {
+	it.each(['a', 'A', 'À'])('should openPanel and emit clueChange when pressing %s and select is searchable', async (key) => {
+		// Arrange
+		const event = new KeyboardEvent('keydown', { key });
+		const clueChangeSpy = jest.spyOn(component.clueChange, 'emit');
+		component.clueChange.subscribe(); // Emulate a `(clueChange)=""` binding
+
+		// Act
+		nativeElement.dispatchEvent(event);
+		await fixture.whenStable();
+
+		// Assert
+		expect(component.isPanelOpen).toBe(true);
+		expect(clueChangeSpy).toHaveBeenCalledWith(key);
+	});
+
+	it.each(['a', 'A', 'À'])('should openPanel and not emit clueChange when pressing %s and select is not searchable', async (key) => {
 		// Arrange
 		const event = new KeyboardEvent('keydown', { key });
 		const clueChangeSpy = jest.spyOn(component.clueChange, 'emit');
@@ -51,7 +66,7 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 
 		// Assert
 		expect(component.isPanelOpen).toBe(true);
-		expect(clueChangeSpy).toHaveBeenCalledWith(key);
+		expect(clueChangeSpy).not.toHaveBeenCalled();
 	});
 
 	it('should openPanel and but not emit clueChange when pressing Space', async () => {

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -292,7 +292,11 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 			}
 
 			this.isPanelOpen$.next(true);
-			this.clueChanged(clue);
+
+			if (this.searchable) {
+				this.clueChanged(clue);
+			}
+
 			this._panelRef = this.buildPanelRef();
 			this.bindInputToPanelRefEvents();
 		});

--- a/packages/ng/core-select/no-clue/index.ts
+++ b/packages/ng/core-select/no-clue/index.ts
@@ -1,0 +1,1 @@
+export * from './no-clue.directive';

--- a/packages/ng/core-select/no-clue/no-clue.directive.spec.ts
+++ b/packages/ng/core-select/no-clue/no-clue.directive.spec.ts
@@ -1,0 +1,58 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component, viewChild } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { LuCoreSelectApiV3Directive } from '../api/api-v3.directive';
+import { LuCoreSelectApiV4Directive } from '../api/api-v4.directive';
+import { LuCoreSelectNoClueDirective } from './no-clue.directive';
+
+@Component({
+	selector: 'lu-test-v3-no-clue',
+	standalone: true,
+	imports: [LuSimpleSelectInputComponent, LuCoreSelectNoClueDirective, LuCoreSelectApiV4Directive],
+	template: `<lu-simple-select noClue apiV4="/some/api" />`,
+})
+class TestV3NoClueComponent {
+	select = viewChild.required(LuSimpleSelectInputComponent);
+}
+
+@Component({
+	selector: 'lu-test-v4-no-clue',
+	standalone: true,
+	imports: [LuSimpleSelectInputComponent, LuCoreSelectNoClueDirective, LuCoreSelectApiV3Directive],
+	template: `<lu-simple-select noClue apiV3="/some/api" />`,
+})
+class TestV4NoClueComponent {
+	select = viewChild.required(LuSimpleSelectInputComponent);
+}
+
+describe('LuCoreSelectNoClueDirective', () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			providers: [provideHttpClient(), provideHttpClientTesting()],
+		});
+	});
+
+	it('should not be searchable when using apiV3 and noClue directives', () => {
+		// Arrange
+		const fixture = TestBed.createComponent(TestV3NoClueComponent);
+
+		// Act
+		const select = fixture.componentInstance.select();
+
+		// Assert
+		expect(select.searchable).toBe(false);
+	});
+
+	it('should not be searchable when using apiV4 and noClue directives', () => {
+		// Arrange
+		const fixture = TestBed.createComponent(TestV4NoClueComponent);
+
+		// Act
+		const select = fixture.componentInstance.select();
+
+		// Assert
+		expect(select.searchable).toBe(false);
+	});
+});

--- a/packages/ng/core-select/no-clue/no-clue.directive.ts
+++ b/packages/ng/core-select/no-clue/no-clue.directive.ts
@@ -1,0 +1,13 @@
+import { Directive, inject } from '@angular/core';
+import { ALuSelectInputComponent } from '../input/index';
+
+@Directive({
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'lu-simple-select[noClue],lu-multi-select[noClue]',
+	standalone: true,
+})
+export class LuCoreSelectNoClueDirective {
+	constructor() {
+		inject(ALuSelectInputComponent).clueChange.complete();
+	}
+}

--- a/packages/ng/core-select/public-api.ts
+++ b/packages/ng/core-select/public-api.ts
@@ -1,5 +1,6 @@
 export * from './displayer/index';
 export * from './input/index';
+export * from './no-clue/index';
 export * from './option/index';
 export * from './panel/index';
 export * from './select.model';

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -1,7 +1,7 @@
 import { I18nPluralPipe, SlicePipe } from '@angular/common';
 import { provideHttpClient } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { LuCoreSelectPanelHeaderDirective, LuDisabledOptionDirective, LuDisplayerDirective, LuOptionDirective, LuOptionGroupDirective } from '@lucca-front/ng/core-select';
+import { LuCoreSelectNoClueDirective, LuCoreSelectPanelHeaderDirective, LuDisabledOptionDirective, LuDisplayerDirective, LuOptionDirective, LuOptionGroupDirective } from '@lucca-front/ng/core-select';
 import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-front/ng/core-select/api';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
@@ -196,6 +196,22 @@ export const ApiV4 = generateStory({
 ></lu-simple-select>`,
 	neededImports: {
 		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
+		'@lucca-front/ng/core-select/api': ['LuCoreSelectApiV4Directive'],
+	},
+});
+
+export const ApiV4NoCLue = generateStory({
+	name: 'Api V4 (no clue)',
+	description: `Il est possible de désactiver la recherche ajoutée par les directives apiV3 et apiV4 en utilisant la directive \`noClue\`.`,
+	template: `<lu-simple-select
+	placeholder="Placeholder..."
+	apiV4="/organization/structure/api/establishments"
+	noClue
+	[(ngModel)]="selectedEstablishment"
+></lu-simple-select>`,
+	neededImports: {
+		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
+		'@lucca-front/ng/core-select': ['LuCoreSelectNoClueDirective'],
 		'@lucca-front/ng/core-select/api': ['LuCoreSelectApiV4Directive'],
 	},
 });
@@ -452,6 +468,7 @@ const meta: Meta<LuSimpleSelectInputStoryComponent> = {
 				SlicePipe,
 				LuCoreSelectApiV3Directive,
 				LuCoreSelectApiV4Directive,
+				LuCoreSelectNoClueDirective,
 				LuCoreSelectEstablishmentsDirective,
 				LuCoreSelectCustomEstablishmentsDirective,
 				LuCoreSelectCustomUsersDirective,


### PR DESCRIPTION
## Description

In some niche cases, we cannot implement a search feature on an API. The `noClue` allows apiV4/apiV3 usage on these APIs.

When testing on a story, I found a bug: when typings a character to open a select, it would update the clue even if the select is not searchable.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
