### PR TITLE
fix(multi-select): wrong selection/unselection when manually selectin…

### DIFF
--- a/packages/ng/core-select/establishment/establishment-grouping.component.ts
+++ b/packages/ng/core-select/establishment/establishment-grouping.component.ts
@@ -1,4 +1,3 @@
-import { AsyncPipe } from '@angular/common';
 import { Component, inject } from '@angular/core';
 import { PORTAL_CONTEXT } from '@lucca-front/ng/core';
 import { LuOptionGroupByContext } from '@lucca-front/ng/core-select';
@@ -7,7 +6,6 @@ import { LuCoreSelectEstablishment } from './models';
 @Component({
 	selector: 'lu-establishment-grouping',
 	standalone: true,
-	imports: [AsyncPipe],
 	template: `{{ group.options[0].legalUnit.name }}`,
 })
 export class LuEstablishmentGroupingComponent {

--- a/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
+++ b/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
@@ -105,6 +105,11 @@ export class LuMultiSelectWithSelectAllDirective<TValue> extends ɵIsSelectedStr
 			const oldMode = this.#mode();
 			this.#mode.set(this.#getNextMode(oldMode, values));
 			this.#onChange?.(this.#selectAllValue());
+
+			// When all values are selected/unselected one by one, we should reset internal select value to avoid weird behavior when selecting/unselecting after that
+			if (values.length && (this.#mode() === 'all' || this.#mode() === 'none')) {
+				this.#selectWriteValue([]);
+			}
 		});
 	}
 

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -9,12 +9,11 @@ import { LuMultiSelectDefaultDisplayerComponent } from '../displayer/index';
 import { LU_MULTI_SELECT_TRANSLATIONS } from '../select.translate';
 import { LuMultiSelectPanelRefFactory } from './panel-ref.factory';
 import { LuMultiSelectPanelRef } from './panel.model';
-import { IconComponent } from '@lucca-front/ng/icon';
 
 @Component({
 	selector: 'lu-multi-select',
 	standalone: true,
-	imports: [CommonModule, LuTooltipModule, ɵLuOptionOutletDirective, IconComponent],
+	imports: [CommonModule, LuTooltipModule, ɵLuOptionOutletDirective],
 	templateUrl: './select-input.component.html',
 	styleUrls: ['./select-input.component.scss'],
 	changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Description

When manually selecting all options, the select internally store a list with all options instead of relying on selectAll flag. Hence, when unchecking one option, it would keep only this option instead of unchecking it.

Fix #3352

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
