### PR TITLE
chore: remove allowSignalWrites options in effect

### DIFF
--- a/packages/ng/date2/calendar2/calendar2.component.ts
+++ b/packages/ng/date2/calendar2/calendar2.component.ts
@@ -249,14 +249,11 @@ export class Calendar2Component implements OnInit {
 	});
 
 	constructor() {
-		effect(
-			() => {
-				if (this.tabbableDate() === null) {
-					this.tabbableDate.set(this.date());
-				}
-			},
-			{ allowSignalWrites: true },
-		);
+		effect(() => {
+			if (this.tabbableDate() === null) {
+				this.tabbableDate.set(this.date());
+			}
+		});
 	}
 
 	focusTabbableDate(): void {

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -19,7 +19,7 @@ import {
 import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { LuClass, ɵeffectWithDeps } from '@lucca-front/ng/core';
-import { FilterPillDisplayerDirective, FilterPillInputComponent, FILTER_PILL_INPUT_COMPONENT } from '@lucca-front/ng/filter-pills';
+import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
@@ -145,29 +145,26 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 
 	constructor() {
 		super();
-		effect(
-			() => {
-				const inputValue = this.userTextInput();
-				if (inputValue.length > 0) {
-					let parsed: Date;
-					try {
-						parsed = parse(inputValue, this.dateFormat, startOfDay(new Date()));
-					} catch {
-						/* not a correct date */
-					}
-					if (parsed instanceof Date && parsed.getFullYear() > 999) {
-						this.selectedDate.set(startOfDay(parsed));
-						this.currentDate.set(startOfDay(parsed));
-						this.tabbableDate.set(startOfDay(parsed));
-					} else if (!this.isFilterPill) {
-						this.selectedDate.set(parsed);
-					}
-				} else {
-					this.selectedDate.set(null);
+		effect(() => {
+			const inputValue = this.userTextInput();
+			if (inputValue.length > 0) {
+				let parsed: Date;
+				try {
+					parsed = parse(inputValue, this.dateFormat, startOfDay(new Date()));
+				} catch {
+					/* not a correct date */
 				}
-			},
-			{ allowSignalWrites: true },
-		);
+				if (parsed instanceof Date && parsed.getFullYear() > 999) {
+					this.selectedDate.set(startOfDay(parsed));
+					this.currentDate.set(startOfDay(parsed));
+					this.tabbableDate.set(startOfDay(parsed));
+				} else if (!this.isFilterPill) {
+					this.selectedDate.set(parsed);
+				}
+			} else {
+				this.selectedDate.set(null);
+			}
+		});
 
 		effect(() => {
 			if (!this.#safeCompareDate(untracked(this.dateFromWriteValue), this.selectedDate())) {

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -283,42 +283,39 @@ export class DateRangeInputComponent extends AbstractDateComponent implements Co
 	}
 
 	setupInputEffect(inputSignal: Signal<string | null>, rangeProperty: 'start' | 'end'): void {
-		effect(
-			() => {
-				const inputValue = inputSignal();
-				let currentRange: DateRange = untracked(this.selectedRange) || ({} as DateRange);
-				if (inputValue?.length > 0) {
-					const parsed = parse(inputValue, this.dateFormat, startOfDay(new Date()));
-					if (parsed.getFullYear() > 999) {
-						currentRange = {
-							...currentRange,
-							scope: this.mode(),
-							[rangeProperty]: parsed,
-						};
-						this.currentDate.set(startOfDay(parsed));
-						this.tabbableDate.set(startOfDay(parsed));
-					} else if (this.isValidDate(parsed)) {
-						currentRange = {
-							...currentRange,
-							scope: this.mode(),
-							[rangeProperty]: parsed,
-						};
-					}
-				} else if (inputValue !== null) {
+		effect(() => {
+			const inputValue = inputSignal();
+			let currentRange: DateRange = untracked(this.selectedRange) || ({} as DateRange);
+			if (inputValue?.length > 0) {
+				const parsed = parse(inputValue, this.dateFormat, startOfDay(new Date()));
+				if (parsed.getFullYear() > 999) {
 					currentRange = {
 						...currentRange,
 						scope: this.mode(),
-						[rangeProperty]: undefined,
+						[rangeProperty]: parsed,
+					};
+					this.currentDate.set(startOfDay(parsed));
+					this.tabbableDate.set(startOfDay(parsed));
+				} else if (this.isValidDate(parsed)) {
+					currentRange = {
+						...currentRange,
+						scope: this.mode(),
+						[rangeProperty]: parsed,
 					};
 				}
-				if (!currentRange.start && !currentRange.end) {
-					this.selectedRange.set(null);
-				} else {
-					this.selectedRange.set(currentRange);
-				}
-			},
-			{ allowSignalWrites: true },
-		);
+			} else if (inputValue !== null) {
+				currentRange = {
+					...currentRange,
+					scope: this.mode(),
+					[rangeProperty]: undefined,
+				};
+			}
+			if (!currentRange.start && !currentRange.end) {
+				this.selectedRange.set(null);
+			} else {
+				this.selectedRange.set(currentRange);
+			}
+		});
 	}
 
 	inputBlur(): void {


### PR DESCRIPTION
## Description

Remove deprecated allowSignalWrites options
Prevent a warning message in console 

`The 'allowSignalWrites' flag is deprecated and no longer impacts effect() (writes are always allowed)`

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
