### PR TITLE
fix(number-format): touched should be triggered even if value has not been changed

### DIFF
--- a/packages/ng/number-format/number-format.directive.ts
+++ b/packages/ng/number-format/number-format.directive.ts
@@ -23,7 +23,6 @@ export class NumberFormatDirective implements ControlValueAccessor {
 	readonly #renderer = inject(Renderer2);
 
 	#value = signal<number | undefined | null>(null);
-	#valueAtFocus: number | undefined | null = null;
 	#isFocused = signal<boolean>(false);
 
 	formatOptions = input.required<NumberFormatOptions>();
@@ -53,7 +52,6 @@ export class NumberFormatDirective implements ControlValueAccessor {
 		this.#renderer.setProperty(this.#inputElement, 'disabled', isDisabled);
 	}
 	@HostListener('focus') focus(): void {
-		this.#valueAtFocus = this.#value();
 		this.#isFocused.set(true);
 		this.#inputElement.value = this.#numberFormat().getFocusFormat(this.#value());
 	}
@@ -61,9 +59,7 @@ export class NumberFormatDirective implements ControlValueAccessor {
 	@HostListener('blur') lostFocus(): void {
 		this.#isFocused.set(false);
 		this.#inputElement.value = this.#numberFormat().getBlurFormat(this.#value());
-		if (this.#valueAtFocus !== this.#value()) {
-			this.onTouched();
-		}
+		this.onTouched();
 	}
 
 	@HostListener('input') input(): void {


### PR DESCRIPTION
## Description

The following condition has been removed :
- if value has not been changed, `blur` event will no trigger `onTouched`

-----

Before fix

https://github.com/user-attachments/assets/64416a2a-532a-407d-8efa-ac835c67fe52


After fix

https://github.com/user-attachments/assets/d1566abf-c00c-438d-b2a3-40f567657257


-----
