### PR TITLE
fix(tooltip): Allow tooltips to break words if they are too long

### DIFF
--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -17,6 +17,7 @@
 	animation-name: scaleIn;
 	animation-duration: var(--commons-animations-durations-fast);
 	animation-iteration-count: 1;
+	word-wrap: break-word;
 
 	@include keyframe.scaleIn;
 


### PR DESCRIPTION
## Description

If a tooltip is made of a word larger than itself, the content of the tooltip won’t be legible.

The scenario is interesting since we use them for truncated text.

This PR allow words to break in a tooltip.

-----

### Before

<img width="263" alt="Long gibberish word is truncated" src="https://github.com/user-attachments/assets/194ab3e2-ae83-4ff7-a89c-f14c46f44e24" />

### After

<img width="263" alt="Long gibberish word is broken into multiple lines" src="https://github.com/user-attachments/assets/20c34c48-ecdb-4dac-84b5-e10796bac2fd" />

-----
