### PR TITLE
[dataTable] fix overflow with WebKit

### DIFF
--- a/packages/scss/src/components/dataTable/component.scss
+++ b/packages/scss/src/components/dataTable/component.scss
@@ -21,7 +21,7 @@
 			border: 1px solid var(--commons-border-200);
 			overflow: var(--components-dataTable-overflow);
 			background-color: var(--components-dataTable-cell-background);
-			contain: paint;
+			contain: paint; // Fix overflow on webkit when table has scroll
 
 			&:focus-visible {
 				@include a11y.focusVisible;

--- a/packages/scss/src/components/dataTable/component.scss
+++ b/packages/scss/src/components/dataTable/component.scss
@@ -21,6 +21,7 @@
 			border: 1px solid var(--commons-border-200);
 			overflow: var(--components-dataTable-overflow);
 			background-color: var(--components-dataTable-cell-background);
+			contain: paint;
 
 			&:focus-visible {
 				@include a11y.focusVisible;


### PR DESCRIPTION
## Description

An overflow occurs with webkit in certain (unidentified) contexts, and is fixed with a contain.

-----



-----
