### PR TITLE
feat(dialog): allow canDeactivate guards in dialogRoutingConfig

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
@@ -1,14 +1,15 @@
 import { DIALOG_DATA } from '@angular/cdk/dialog';
 import { NgComponentOutlet, NgTemplateOutlet } from '@angular/common';
-import { Component, computed, DestroyRef, inject, Injector, OnInit, runInInjectionContext, TemplateRef, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, inject, Injector, OnInit, runInInjectionContext, signal, TemplateRef, viewChild } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router } from '@angular/router';
-import { from } from 'rxjs';
+import { ActivatedRoute, CanDeactivateFn, GuardResult, Router } from '@angular/router';
+import { combineLatest, concat, from, map, Observable } from 'rxjs';
 import { provideLuDialog } from '../dialog.providers';
 import { LuDialogService } from '../dialog.service';
-import { LuDialogRef } from '../model';
+import { LuDialogConfig, LuDialogRef } from '../model';
 import { DialogRouteConfig } from './dialog-routing.models';
-import { deferrableToPromise, DIALOG_ROUTE_CONFIG } from './dialog-routing.utils';
+import { deferrableToObservable, deferrableToPromise, DIALOG_ROUTE_CONFIG } from './dialog-routing.utils';
+import { OutletComponentInstanceDirective } from './outlet-component-instance.directive';
 
 export const defaultOnClosedFn = <C>(router = inject(Router), route = inject(ActivatedRoute), config = inject<DialogRouteConfig<C>>(DIALOG_ROUTE_CONFIG)): void =>
 	void router.navigate(
@@ -29,7 +30,7 @@ export const defaultOnClosedFn = <C>(router = inject(Router), route = inject(Act
 	template: `
 		<ng-template>
 			@if (dialogComponentContent(); as componentType) {
-				<ng-container [ngComponentOutlet]="componentType" [ngComponentOutletInjector]="customInjector" />
+				<ng-container luOutletComponentInstance [ngComponentOutlet]="componentType" [ngComponentOutletInjector]="customInjector" (instanceCreated)="componentInstance.set($event)" />
 			}
 			@if (dialogTemplateContent(); as templateRef) {
 				<ng-container [ngTemplateOutlet]="templateRef" [ngTemplateOutletInjector]="customInjector" />
@@ -37,7 +38,7 @@ export const defaultOnClosedFn = <C>(router = inject(Router), route = inject(Act
 		</ng-template>
 	`,
 	standalone: true,
-	imports: [NgComponentOutlet, NgTemplateOutlet],
+	imports: [NgComponentOutlet, NgTemplateOutlet, OutletComponentInstanceDirective],
 	styles: [
 		`
 			:host {
@@ -48,6 +49,8 @@ export const defaultOnClosedFn = <C>(router = inject(Router), route = inject(Act
 	providers: [provideLuDialog()],
 })
 export class DialogRoutingComponent<C> implements OnInit {
+	readonly #route = inject(ActivatedRoute);
+	readonly #router = inject(Router);
 	readonly #destroyRef = inject(DestroyRef);
 	readonly #dialog = inject(LuDialogService);
 	readonly injector = inject(Injector);
@@ -85,6 +88,8 @@ export class DialogRoutingComponent<C> implements OnInit {
 		],
 	});
 
+	readonly componentInstance = signal<C | null>(null);
+
 	#ref?: LuDialogRef<C>;
 
 	ngOnInit(): void {
@@ -96,7 +101,9 @@ export class DialogRoutingComponent<C> implements OnInit {
 		this.#ref = this.#dialog.open<C>({
 			...dialogConfig,
 			content: this.dialogTemplate(),
+			canClose: this.#getCanCloseFn(dialogConfig),
 		});
+
 		this.#ref.result$.pipe(takeUntilDestroyed(this.#destroyRef)).subscribe((result) =>
 			runInInjectionContext(this.injector, () => {
 				if (this.#config.onClosed) {
@@ -110,5 +117,41 @@ export class DialogRoutingComponent<C> implements OnInit {
 		this.#ref.dismissed$
 			.pipe(takeUntilDestroyed(this.#destroyRef))
 			.subscribe(() => runInInjectionContext(this.injector, () => (this.#config.onDismissed ? this.#config.onDismissed() : defaultOnClosedFn())));
+	}
+
+	#getCanCloseFn(config: LuDialogConfig<C>): ((c: C) => Observable<boolean>) | undefined {
+		const canCloseFns: ((c: C) => Observable<boolean>)[] = [];
+
+		if (config.canClose) {
+			canCloseFns.push((c: C) => deferrableToObservable(config.canClose(c)));
+		}
+
+		if (this.#config.canDeactivate) {
+			canCloseFns.push(this.#getCanCloseFromGuardDialogFn(this.#config.canDeactivate));
+		}
+
+		return canCloseFns.length ? (c: C) => combineLatest(canCloseFns.map((fn) => fn(c))).pipe(map((results) => results.every((r) => r))) : undefined;
+	}
+
+	#getCanCloseFromGuardDialogFn(canDeactivate: CanDeactivateFn<C>[]): () => Observable<boolean> {
+		return () => {
+			const results$ = canDeactivate.map((cD) => this.#callCanDeactivateFn(cD));
+
+			return concat(...results$).pipe(
+				map((guardResult) => {
+					if (typeof guardResult === 'boolean') {
+						return guardResult;
+					}
+					void this.#router.navigate([guardResult]);
+					return true;
+				}),
+			);
+		};
+	}
+
+	#callCanDeactivateFn(canDeactivateFn: CanDeactivateFn<C>): Observable<GuardResult> {
+		const args = [this.componentInstance(), this.#route.snapshot, this.#router.routerState.snapshot, this.#router.routerState.snapshot] as const;
+		const maybeAsyncResult = runInInjectionContext(this.injector, () => canDeactivateFn(...args));
+		return deferrableToObservable(maybeAsyncResult);
 	}
 }

--- a/packages/ng/dialog/dialog-routing/dialog-routing.models.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.models.ts
@@ -1,4 +1,4 @@
-import { Route } from '@angular/router';
+import { CanDeactivateFn, Route } from '@angular/router';
 import { LuDialogConfig, LuDialogResult } from '../model';
 import { Deferrable } from './dialog-routing.utils';
 
@@ -14,4 +14,9 @@ export type DialogRouteConfig<C> = {
 	 * This callback is called within injection context, so you can inject services in it.
 	 */
 	onDismissed?: () => unknown;
-} & Omit<Route, 'component'>;
+
+	/**
+	 * Override canDeactivate to have a stricter type
+	 */
+	canDeactivate?: CanDeactivateFn<C>[];
+} & Omit<Route, 'component' | 'canDeactivate'>;

--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
@@ -1,7 +1,7 @@
 import { ComponentType } from '@angular/cdk/portal';
 import { InjectionToken } from '@angular/core';
 import { Route } from '@angular/router';
-import { Observable, firstValueFrom, isObservable } from 'rxjs';
+import { Observable, firstValueFrom, from, isObservable, of } from 'rxjs';
 import { LuDialogConfig, LuDialogData } from '../model';
 import { DialogRoutingComponent } from './dialog-routing.component';
 import { DialogRouteConfig } from './dialog-routing.models';
@@ -12,11 +12,17 @@ export async function deferrableToPromise<T>(deferrable: Promise<T> | Observable
 	return isObservable(deferrable) ? firstValueFrom(deferrable) : deferrable;
 }
 
+export function deferrableToObservable<T>(deferrable: Promise<T> | Observable<T> | T): Observable<T> {
+	return isObservable(deferrable) ? deferrable : deferrable instanceof Promise ? from(deferrable) : of(deferrable);
+}
+
 export const DIALOG_ROUTE_CONFIG = new InjectionToken<DialogRouteConfig<unknown>>('DIALOG_ROUTE_CONFIG');
 
 export function createDialogRoute<C>(config: DialogRouteConfig<C>): Route {
+	// Remove `canDeactivate` from the route config and handle it in the dialog component
+	const { canDeactivate, ...rest } = config;
 	return {
-		...config,
+		...rest,
 		component: DialogRoutingComponent,
 		providers: [{ provide: DIALOG_ROUTE_CONFIG, useValue: config }, ...[config.providers ?? []]],
 	};

--- a/packages/ng/dialog/dialog-routing/outlet-component-instance.directive.ts
+++ b/packages/ng/dialog/dialog-routing/outlet-component-instance.directive.ts
@@ -1,0 +1,23 @@
+import { NgComponentOutlet } from '@angular/common';
+import { Directive, OnInit, inject, output } from '@angular/core';
+
+@Directive({
+	selector: '[luOutletComponentInstance]',
+	standalone: true,
+})
+export class OutletComponentInstanceDirective<C> implements OnInit {
+	// TODO add a generic type to NgComponentOutlet<C> when Angular 19.0 support is dropped
+	#outlet = inject<NgComponentOutlet>(NgComponentOutlet);
+
+	instanceCreated = output<C>();
+
+	ngOnInit(): void {
+		// TODO use this.#outlet.componentInstance when Angular 19.0 support is dropped
+		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any
+		const instance = (this.#outlet as any)._componentRef?.instance ?? null;
+
+		if (instance) {
+			this.instanceCreated.emit(instance as C); // TODO remove cast when Angular 19.0 support is dropped
+		}
+	}
+}


### PR DESCRIPTION
## Description

In order to allow developper to open a confirm dialog like "You have unsaved data, are you sure you want to close this dialog?", we can now add `canDeactivate` guards in dialogRoutingConfig

-----

https://github.com/user-attachments/assets/182da645-3d2c-4e82-90e3-7346710a218a

-----
