### PR TITLE
fix(dialog): wrong spread operator

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
@@ -18,7 +18,7 @@ export function createDialogRoute<C>(config: DialogRouteConfig<C>): Route {
 	return {
 		...config,
 		component: DialogRoutingComponent,
-		providers: [{ provide: DIALOG_ROUTE_CONFIG, useValue: config }, ...[config.providers ?? []]],
+		providers: [{ provide: DIALOG_ROUTE_CONFIG, useValue: config }, ...(config.providers ?? [])],
 	};
 }
 


### PR DESCRIPTION
## Description

Dialog routing was not taking providers into account.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----