### PR TITLE
fix(callout-disclosure): use icon based on state for iconless mod

### DIFF
--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.html
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.html
@@ -1,7 +1,8 @@
-<details class="calloutDisclosure" [ngClass]="calloutClasses" [class.mod-iconless]="!icon" [open]="open" (toggle)="onToggle($event)">
+<details class="calloutDisclosure" [ngClass]="calloutClasses" [class.mod-iconless]="!(state | luCalloutIcon: icon)"
+         [open]="open" (toggle)="onToggle($event)">
 	<summary class="calloutDisclosure-summary">
 		@if (state | luCalloutIcon: icon; as calloutIcon) {
-		<lu-icon class="calloutDisclosure-summary-icon" [icon]="calloutIcon"></lu-icon>
+			<lu-icon class="calloutDisclosure-summary-icon" [icon]="calloutIcon"></lu-icon>
 		}
 		<span class="calloutDisclosure-summary-title">
 			<ng-container *luPortal="heading"></ng-container>


### PR DESCRIPTION
## Description


We were using the icon input for `mod-iconless` class trigger, meaning that if icon was `null`, we had the class active, thus removing the said icon.
-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
