### PR TITLE
fix(core-select): custom core-select user directive typing

### DIFF
--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -13,7 +13,7 @@ import { LuCoreSelectUserHomonymsService } from './user-homonym.service';
 import { LuUserOptionComponent } from './user-option.component';
 import { LuCoreSelectUser, LuCoreSelectWithAdditionnalInformation } from './user-option.model';
 
-export function provideCoreSelectUsersContext(directiveFn: () => Type<LuCoreSelectUsersDirective>): Provider[] {
+export function provideCoreSelectUsersContext<T extends LuCoreSelectUser = LuCoreSelectUser>(directiveFn: () => Type<LuCoreSelectUsersDirective<T>>): Provider[] {
 	return [
 		...provideBaseCoreSelectUsersContext(directiveFn),
 		{
@@ -23,7 +23,7 @@ export function provideCoreSelectUsersContext(directiveFn: () => Type<LuCoreSele
 	];
 }
 
-function provideBaseCoreSelectUsersContext(directiveFn: () => Type<LuCoreSelectUsersDirective>): Provider[] {
+function provideBaseCoreSelectUsersContext<T extends LuCoreSelectUser = LuCoreSelectUser>(directiveFn: () => Type<LuCoreSelectUsersDirective<T>>): Provider[] {
 	return [
 		{
 			provide: CORE_SELECT_API_TOTAL_COUNT_PROVIDER,


### PR DESCRIPTION
## Description

A generic was missing so it was not possible to override CoreSelectUserDirective with a custom User type.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
