### PR TITLE
[phoneNumber – simpleSelect – filterPills] fix ellipsis (#3470)

### DIFF
--- a/packages/scss/src/components/dataTable/index.scss
+++ b/packages/scss/src/components/dataTable/index.scss
@@ -23,6 +23,7 @@
 		@include layoutFixedWithBreakpoint;
 	}
 
+	// Allow selection of mod-layoutFixed with or without breakpoints like mod-layoutFixedAtMediaMinXS or mod-layoutFixedAtMediaMaxL
 	&[class*='mod-layoutFixed'] {
 		@include layoutFixedCells;
 	}

--- a/packages/scss/src/components/indexTable/index.scss
+++ b/packages/scss/src/components/indexTable/index.scss
@@ -20,6 +20,7 @@
 		@include stickyHeader;
 	}
 
+	// Allow selection of mod-layoutFixed with or without breakpoints like mod-layoutFixedAtMediaMinXS or mod-layoutFixedAtMediaMaxL
 	&[class*='mod-layoutFixed'] {
 		@include layoutFixed;
 	}


### PR DESCRIPTION
## Description
it's not clear at glance why it's an attribute selector that is used here with the `*=` option, so i just add an explanation of what this selector can achieve.

-----
