### PR TITLE
[textFlow] Remove margins on both ends of `.textFlow`

### DIFF
--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -32,10 +32,10 @@
 	}
 
 	& > :first-child {
-  	margin-block-start: unset;
+		margin-block-start: unset;
 	}
 
 	& > :last-child {
-  	margin-block-end: unset;
+		margin-block-end: unset;
 	}
 }

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -1,8 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
-	margin-block-end: var(--pr-t-spacings-300);
-
 	h1 {
 		margin-block: var(--pr-t-spacings-300);
 	}

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -30,4 +30,12 @@
 	li {
 		margin-block: var(--pr-t-spacings-50);
 	}
+
+	& > :first-child {
+  	margin-block-start: unset;
+	}
+
+	& > :last-child {
+  	margin-block-end: unset;
+	}
 }

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -32,10 +32,10 @@
 	}
 
 	& > :first-child {
-		margin-block-start: unset;
+		margin-block-start: 0;
 	}
 
 	& > :last-child {
-		margin-block-end: unset;
+		margin-block-end: 0;
 	}
 }


### PR DESCRIPTION
## Description

To avoid extra margins, we can remove first-child’s start margin and last-child’s end margin.

This is especially useful in isolated context (eg: modals’ content), which seems to be the use-case for `.textFlow`.

Their container can be added extra margins if need be.

-----

<img src="https://github.com/user-attachments/assets/1e80487a-9df5-449d-b69b-832ff8d302c3" width="49%" alt="">
<img src="https://github.com/user-attachments/assets/53660384-3670-40dc-8210-3caab4c6aeab" width="49%" alt="">

-----
