### PR TITLE
fix(ng): date2 input null value at initialisation

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -116,7 +116,8 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 		return this.userTextInput();
 	});
 
-	userTextInput = signal<string>('');
+	// We need to use a "magic key" here to avoid sending a null value change on initialization
+	userTextInput = signal<string>('ɵ');
 
 	combinedGetCellInfo = (date: Date, mode: CalendarMode): CellStatus => {
 		const infoFromInput = this.getCellInfo()?.(date, mode);
@@ -147,6 +148,10 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 		super();
 		effect(() => {
 			const inputValue = this.userTextInput();
+			// If we are initializing the component, we don't want to parse the value
+			if (inputValue === 'ɵ') {
+				return;
+			}
 			if (inputValue.length > 0) {
 				let parsed: Date;
 				try {


### PR DESCRIPTION
## Description

The initial value set to the date-input was overridden by a null value, due to the text-input field value check triggered on init. 

-----

-----
