### PR TITLE
fix(former-employees): don't focus checkbox when panel is opened

### DIFF
--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -17,8 +17,7 @@
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
 				>
-					<span class="lu-picker-content-option-group-title" role="presentation"
-					      [id]="selectId + '-group-' + group.key">
+					<span class="lu-picker-content-option-group-title" role="presentation" [id]="selectId + '-group-' + group.key">
 						<ng-container *luPortal="grouping.content; context: { $implicit: group }" />
 					</span>
 					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -6,7 +6,6 @@
 		groupTemplateLocation: groupTemplateLocation$ | async,
 		shouldDisplayAddOption: shouldDisplayAddOption$ | async,
 	} as ctx"
-	[cdkTrapFocusAutoCapture]="true"
 >
 	<div class="lu-picker-content" [class.is-loading]="loading$ | async" (scroll)="onScroll($event)">
 		<ng-container *luPortal="selectInput.panelHeaderTpl()" />
@@ -18,7 +17,8 @@
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
 				>
-					<span class="lu-picker-content-option-group-title" role="presentation" [id]="selectId + '-group-' + group.key">
+					<span class="lu-picker-content-option-group-title" role="presentation"
+					      [id]="selectId + '-group-' + group.key">
 						<ng-container *luPortal="grouping.content; context: { $implicit: group }" />
 					</span>
 					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />


### PR DESCRIPTION
## Description

This was due to cdk trap configured to grab focus on init, which made it focus the first input available.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
