### PR TITLE
[select] fix id when group by

### DIFF
--- a/packages/ng/core-select/option/option.component.html
+++ b/packages/ng/core-select/option/option.component.html
@@ -7,7 +7,7 @@
 >
 	<ng-container *luOptionOutlet="optionTpl; value: option" />
 
-	<div *ngIf="grouping" class="optionItem-value-group">
+	<div *ngIf="groupTemplateLocation() === 'option'" class="optionItem-value-group">
 		<ng-container *luPortal="grouping.content; context: { $implicit: option | luOptionGroup:grouping.selector }" />
 	</div>
 </div>

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,8 +1,9 @@
 import { Highlightable } from '@angular/cdk/a11y';
 import { AsyncPipe, NgIf } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Input, OnDestroy, TemplateRef, Type, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, HostBinding, Input, OnDestroy, TemplateRef, Type, ViewChild, inject, input } from '@angular/core';
 import { PortalDirective } from '@lucca-front/ng/core';
 import { BehaviorSubject, Subscription, asyncScheduler, observeOn } from 'rxjs';
+import { GroupTemplateLocation } from '../panel/panel.utils';
 import { LuOptionContext, SELECT_ID } from '../select.model';
 import { LuOptionGrouping } from './group.directive';
 import { LuOptionGroupPipe } from './group.pipe';
@@ -33,11 +34,15 @@ export class LuOptionComponent<T> implements Highlightable, AfterViewInit, OnDes
 	@Input() option?: T;
 	@Input() grouping?: LuOptionGrouping<T, unknown>;
 
+	groupIndex = input<number>();
+
 	@Input()
 	public optionIndex = 0;
 
 	@Input()
 	scrollIntoViewOptions: ScrollIntoViewOptions = {};
+
+	groupTemplateLocation = input<GroupTemplateLocation>();
 
 	isHighlighted$ = new BehaviorSubject(false);
 
@@ -57,7 +62,9 @@ export class LuOptionComponent<T> implements Highlightable, AfterViewInit, OnDes
 
 	@HostBinding('attr.id')
 	public get id(): string {
-		return `lu-select-${this.selectId}-option-${this.optionIndex}`;
+		const groupPart = this.groupIndex() === undefined ? `` : `-group-${this.groupIndex()}`;
+
+		return `lu-select-${this.selectId}${groupPart}-option-${this.optionIndex}`;
 	}
 
 	protected elementRef = inject<ElementRef<HTMLElement>>(ElementRef);

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -12,7 +12,7 @@
 		<div role="listbox">
 			<ng-container *ngIf="grouping && ctx.groupTemplateLocation === 'group-header'">
 				<div
-					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector; trackBy: trackGroupsBy"
+					*ngFor="let group of ctx.options | luOptionGroup:grouping.selector; trackBy: trackGroupsBy; let groupIndex = index"
 					class="lu-picker-content-option-group"
 					role="group"
 					[attr.aria-labelledby]="selectId + '-group-' + group.key"
@@ -20,20 +20,22 @@
 					<span class="lu-picker-content-option-group-title" role="presentation" [id]="selectId + '-group-' + group.key">
 						<ng-container *luPortal="grouping.content; context: { $implicit: group }" />
 					</span>
-					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options }" />
+					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: group.options, groupIndex: groupIndex }" />
 				</div>
 			</ng-container>
 			<ng-container *ngIf="!grouping || ctx.groupTemplateLocation !== 'group-header'">
 				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
 			</ng-container>
 
-			<ng-template #optionsList let-options>
+			<ng-template #optionsList let-options let-groupIndex="groupIndex">
 				<lu-select-option
 					*ngFor="let option of options; let index = index; trackBy: trackOptionsBy"
 					[option]="option"
 					[optionTpl]="optionTpl()"
 					[optionIndex]="index"
-					[grouping]="ctx.groupTemplateLocation === 'option' ? grouping : undefined"
+					[groupTemplateLocation]="ctx.groupTemplateLocation"
+					[groupIndex]="groupIndex"
+					[grouping]="grouping"
 					[scrollIntoViewOptions]="{ block: 'center' }"
 					[isSelected]="option | luIsOptionSelected:optionComparer:selected()"
 					(click)="panelRef.emitValue(option)"


### PR DESCRIPTION
## Description

Identical ids were generated in lists with groups, which had an impact on screen readers. This has now been corrected.

-----

Thanks to @Supamiu!

-----




