### PR TITLE
[Titles] Prevent dialogs from overriding titles spacings 

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.scss
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.scss
@@ -1,1 +1,0 @@
-@use '@lucca-front/scss/src/components/title';


### PR DESCRIPTION
## Description

Prevent dialogs from overriding titles spacings 

-----

CSS is compiled by LF on Angular components. It results to ignore `$deprecatedSpacings` when dialog is opened / override titles spacings.

-----
