### PR TITLE
[loading] Remove redundant code:

### DIFF
--- a/packages/scss/src/components/loading/mods.scss
+++ b/packages/scss/src/components/loading/mods.scss
@@ -26,7 +26,6 @@
 }
 
 @mixin popin {
-	@include block;
 	@include L;
 }
 
@@ -38,7 +37,6 @@
 }
 
 @mixin fullPage {
-	@include block;
 	@include L;
 
 	// legacy, approximate centering


### PR DESCRIPTION
## Description

The `L` mixin already includes the `block` mixin, but both are called in other mixins, in the same order.

-----
