### PR TITLE
Fix(filter pills): clearable

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -147,6 +147,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	public valueSignal = signal<TValue>(null);
 	isFilterPillEmpty = computed(() => this.valueSignal() === null);
+	isFilterPillClearable = computed(() => this.clearable);
 
 	public get value(): TValue {
 		return this._value;

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -61,12 +61,15 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	@Input({ transform: booleanAttribute })
 	@HostBinding('class.is-clearable')
 	set clearable(value: boolean) {
-		this.#clearable.set(value);
+		this.#inputClearable.set(value);
 	}
 	get clearable(): boolean {
 		return this.#clearable();
 	}
-	#clearable = signal(false);
+	#clearable = computed(() => this.#inputClearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
+	#defaultFilterPillClearable = signal<boolean | null>(null);
+	#inputClearable = signal<boolean | null>(null);
+	#defaultClearable = false;
 
 	get searchable(): boolean {
 		return this.clueChange.observed;
@@ -425,6 +428,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	enableFilterPillMode() {
 		this.filterPillMode = true;
+		this.#defaultFilterPillClearable.set(true);
 		this._panelRef.closed.subscribe(this.afterCloseFn);
 		this.bindInputToPanelRefEvents();
 	}

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -60,7 +60,13 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	@Input({ transform: booleanAttribute })
 	@HostBinding('class.is-clearable')
-	clearable = false;
+	set clearable(value: boolean) {
+		this.#clearable.set(value);
+	}
+	get clearable(): boolean {
+		return this.#clearable();
+	}
+	#clearable = signal(false);
 
 	get searchable(): boolean {
 		return this.clueChange.observed;
@@ -147,7 +153,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	public valueSignal = signal<TValue>(null);
 	isFilterPillEmpty = computed(() => this.valueSignal() === null);
-	isFilterPillClearable = computed(() => this.clearable);
+	isFilterPillClearable = computed(() => this.#clearable());
 
 	public get value(): TValue {
 		return this._value;

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -34,7 +34,7 @@ export abstract class AbstractDateComponent {
 	ranges = input([], { transform: (v: readonly DateRange[] | readonly DateRangeInput[]) => v.map(transformDateRangeInputToDateRange) });
 	hideToday = input<boolean, boolean>(false, { transform: booleanAttribute });
 	hasTodayButton = input<boolean, boolean>(false, { transform: booleanAttribute });
-	clearable = input<boolean, boolean>(false, { transform: booleanAttribute });
+	clearable = input<boolean, boolean>(null, { transform: booleanAttribute });
 
 	mode = input<CalendarMode>('day');
 	hideWeekend = input<boolean, boolean>(false, { transform: booleanAttribute });

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -142,6 +142,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 	isFilterPill = false;
 
 	isFilterPillEmpty = computed(() => !this.selectedDate());
+	isFilterPillClearable = computed(() => this.clearable());
 
 	filterPillPopoverCloseFn?: () => void;
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -142,7 +142,9 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 	isFilterPill = false;
 
 	isFilterPillEmpty = computed(() => !this.selectedDate());
-	isFilterPillClearable = computed(() => this.clearable());
+	isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
+	#defaultClearable = false;
+	#defaultFilterPillClearable = signal<boolean | null>(null);
 
 	filterPillPopoverCloseFn?: () => void;
 
@@ -214,6 +216,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 
 	enableFilterPillMode(): void {
 		this.isFilterPill = true;
+		this.#defaultFilterPillClearable.set(true);
 	}
 
 	clearFilterPillValue(): void {

--- a/packages/ng/date2/date-range-input/date-range-input.component.html
+++ b/packages/ng/date2/date-range-input/date-range-input.component.html
@@ -56,12 +56,12 @@
 			</div>
 			<lu-icon [icon]="'arrowRight'" [alt]="''" class="dateRangeField-fieldset-arrow" />
 			<div class="textField-input-affix">
-				@if (clearable() && (start.value !== '' || end.value !== '')) {
+				@if (!isFilterPill) { @if (clearable() && (start.value !== '' || end.value !== '')) {
 				<button class="textField-input-affix-clear clear" type="button" (click)="clear(start, end)">
 					<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
 					<span class="u-mask">{{ intl.clear }}</span>
 				</button>
-				}
+				} }
 				<button
 					[luPopover2]="calendar"
 					[disabled]="disabled"

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -194,6 +194,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements Co
 	isFilterPill = false;
 
 	isFilterPillEmpty = computed(() => this.selectedRange() === null);
+	isFilterPillClearable = computed(() => this.clearable());
 
 	filterPillPopoverCloseFn?: () => void;
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -194,7 +194,9 @@ export class DateRangeInputComponent extends AbstractDateComponent implements Co
 	isFilterPill = false;
 
 	isFilterPillEmpty = computed(() => this.selectedRange() === null);
-	isFilterPillClearable = computed(() => this.clearable());
+	isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
+	#defaultClearable = false;
+	#defaultFilterPillClearable = signal<boolean | null>(null);
 
 	filterPillPopoverCloseFn?: () => void;
 
@@ -495,6 +497,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements Co
 
 	enableFilterPillMode(): void {
 		this.isFilterPill = true;
+		this.#defaultFilterPillClearable.set(true);
 	}
 
 	clearFilterPillValue(): void {

--- a/packages/ng/filter-pills/core/filter-pill-input-component.ts
+++ b/packages/ng/filter-pills/core/filter-pill-input-component.ts
@@ -5,6 +5,7 @@ export type FilterPillLayout = 'checkable';
 
 export interface FilterPillInputComponent {
 	isFilterPillEmpty: Signal<boolean>;
+	isFilterPillClearable: Signal<boolean>;
 	// If this is not here, we'll consider it's using default layout
 	filterPillLayout?: Signal<FilterPillLayout>;
 	hideCombobox?: Signal<boolean>;

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.html
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.html
@@ -25,9 +25,9 @@
 	@if (inputIsEmpty() && !disabled()) { {{ placeholder() }} }
 </button>
 @if (inputIsClearable()) {
-	<button type="button" class="filterPill-clear clear" (click)="$event.stopPropagation(); clear(); comboboxRef.focus()">
-		<span class="u-mask">{{ intl.clear }}</span>
-	</button>
+<button type="button" class="filterPill-clear clear" (click)="$event.stopPropagation(); clear(); comboboxRef.focus()">
+	<span class="u-mask">{{ intl.clear }}</span>
+</button>
 }
 <button
 	type="button"

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.html
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.html
@@ -24,9 +24,11 @@
 	<ng-container *ngTemplateOutlet="pillTpl; context:{label: label(), isEmpty: inputIsEmpty()}"></ng-container>
 	@if (inputIsEmpty() && !disabled()) { {{ placeholder() }} }
 </button>
-<button type="button" class="filterPill-clear clear" (click)="$event.stopPropagation(); clear(); comboboxRef.focus()">
-	<span class="u-mask">{{ intl.clear }}</span>
-</button>
+@if (inputIsClearable()) {
+	<button type="button" class="filterPill-clear clear" (click)="$event.stopPropagation(); clear(); comboboxRef.focus()">
+		<span class="u-mask">{{ intl.clear }}</span>
+	</button>
+}
 <button
 	type="button"
 	aria-hidden="true"

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -122,6 +122,7 @@ export class FilterPillComponent {
 	shouldHideCombobox = computed(() => this.inputComponentRef()?.hideCombobox?.() || false);
 
 	inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty());
+	inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable());
 
 	shouldShowColon = computed(() => this.inputComponentRef()?.showColon?.() || !this.inputIsEmpty());
 

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -34,6 +34,7 @@ export class CheckboxInputComponent implements FilterPillInputComponent {
 
 	filterPillLayout: Signal<FilterPillLayout> = signal('checkable');
 	isFilterPillEmpty: Signal<boolean> = signal(true);
+	isFilterPillClearable: Signal<boolean> = signal(false);
 	hideCombobox: Signal<boolean> = signal(true);
 	showColon: Signal<boolean> = signal(false);
 

--- a/packages/ng/multi-select/input/select-input.component.html
+++ b/packages/ng/multi-select/input/select-input.component.html
@@ -1,16 +1,11 @@
 <ng-container *luOptionOutlet="valuesTpl(); value: value || []"></ng-container>
 
-<button
-	*ngIf="hasValue() && clearable && (disabled$ | async) === false"
-	role="button"
-	type="button"
-	class="multipleSelect-clear clear"
-	(click)="clearValue($event)"
->
+@if (!filterPillMode) { @if (hasValue() && clearable && (disabled$ | async) === false) {
+<button role="button" type="button" class="multipleSelect-clear clear" (click)="clearValue($event)">
 	<span class="u-mask">{{ intl.clear }}</span>
 </button>
+}
 
-@if (!filterPillMode) {
 <span aria-hidden="true" class="multipleSelect-arrow lucca-icon icon-arrowChevronBottom"></span>
 <span aria-hidden="true" class="multipleSelect-searchIcon lucca-icon icon-searchMagnifyingGlass"></span>
 }

--- a/packages/ng/simple-select/input/select-input.component.html
+++ b/packages/ng/simple-select/input/select-input.component.html
@@ -21,8 +21,8 @@
 	<div class="simpleSelect-field-value">
 		<ng-container *ngTemplateOutlet="currentValueDisplayerTpl"></ng-container>
 	</div>
+	@if (!filterPillMode) { @if (clearable && hasValue() && (disabled$ | async) === false) {
 	<button
-		*ngIf="clearable && hasValue() && (disabled$ | async) === false"
 		class="simpleSelect-field-clear clear"
 		role="button"
 		type="button"
@@ -31,7 +31,7 @@
 	>
 		<span class="u-mask">{{ intl.clear }}</span>
 	</button>
-	@if (!filterPillMode) {
+	}
 	<lu-icon icon="arrowChevronBottom" class="simpleSelect-field-icon" />
 	<lu-icon icon="searchMagnifyingGlass" class="simpleSelect-field-icon mod-search" />
 	}

--- a/stories/documentation/forms/filterPills/angular/date-filter-pill.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/date-filter-pill.stories.ts
@@ -19,13 +19,14 @@ export default {
 				examplePeriod: null,
 				checkboxValue: false,
 			},
-			template: `<lu-filter-pill label="Date de début" name="startDate"><lu-date-input [(ngModel)]="example" /></lu-filter-pill>
+			template: `<lu-filter-pill label="Date de début" name="startDate">
+<lu-date-input [(ngModel)]="example" clearable /></lu-filter-pill>
 
 <pr-story-model-display>{{example}}</pr-story-model-display>
 
 <hr class="divider pr-u-marginBlock400" />
 
-<lu-filter-pill label="Période" name="periode"><lu-date-range-input [(ngModel)]="examplePeriod"/></lu-filter-pill>
+<lu-filter-pill label="Période" name="periode"><lu-date-range-input [(ngModel)]="examplePeriod" clearable/></lu-filter-pill>
 
 <pr-story-model-display>{{examplePeriod | json}}</pr-story-model-display>
 `,

--- a/stories/documentation/forms/filterPills/angular/filter-pills.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/filter-pills.stories.ts
@@ -43,16 +43,16 @@ export default {
 	<lu-checkbox-input [ngModel]="false"></lu-checkbox-input>
 </lu-filter-pill>
 <lu-filter-pill label="Légume" name="legume">
-		<lu-simple-select [(ngModel)]="simpleSelect"	[options]="legumes | filterLegumes:clue" (clueChange)="clue = $event" />
+		<lu-simple-select [(ngModel)]="simpleSelect"	[options]="legumes | filterLegumes:clue" clearable (clueChange)="clue = $event" />
 </lu-filter-pill>
 <lu-filter-pill label="Légume" name="legume">
-	<lu-multi-select [(ngModel)]="multiSelect"	[options]="legumes | filterLegumes:clue" (clueChange)="clue = $event" filterPillLabelPlural="légumes" />
+	<lu-multi-select [(ngModel)]="multiSelect"	[options]="legumes | filterLegumes:clue" clearable (clueChange)="clue = $event" filterPillLabelPlural="légumes" />
 </lu-filter-pill>
 <lu-filter-pill label="Date de début">
-	<lu-date-input [(ngModel)]="date" />
+	<lu-date-input [(ngModel)]="date" clearable />
 </lu-filter-pill>
 <lu-filter-pill label="Période">
-	<lu-date-range-input [(ngModel)]="dateRange"/>
+	<lu-date-range-input [(ngModel)]="dateRange" clearable/>
 </lu-filter-pill>`,
 			styles: [
 				`

--- a/stories/documentation/forms/filterPills/angular/filter-pills.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/filter-pills.stories.ts
@@ -43,16 +43,16 @@ export default {
 	<lu-checkbox-input [ngModel]="false"></lu-checkbox-input>
 </lu-filter-pill>
 <lu-filter-pill label="Légume" name="legume">
-		<lu-simple-select [(ngModel)]="simpleSelect"	[options]="legumes | filterLegumes:clue" clearable (clueChange)="clue = $event" />
+		<lu-simple-select [(ngModel)]="simpleSelect" [options]="legumes | filterLegumes:clue" (clueChange)="clue = $event" />
 </lu-filter-pill>
 <lu-filter-pill label="Légume" name="legume">
-	<lu-multi-select [(ngModel)]="multiSelect"	[options]="legumes | filterLegumes:clue" clearable (clueChange)="clue = $event" filterPillLabelPlural="légumes" />
+	<lu-multi-select [(ngModel)]="multiSelect" [clearable]="false"	[options]="legumes | filterLegumes:clue" (clueChange)="clue = $event" filterPillLabelPlural="légumes" />
 </lu-filter-pill>
 <lu-filter-pill label="Date de début">
-	<lu-date-input [(ngModel)]="date" clearable />
+	<lu-date-input [(ngModel)]="date" />
 </lu-filter-pill>
 <lu-filter-pill label="Période">
-	<lu-date-range-input [(ngModel)]="dateRange" clearable/>
+	<lu-date-range-input [(ngModel)]="dateRange"/>
 </lu-filter-pill>`,
 			styles: [
 				`


### PR DESCRIPTION
## Description

This pull request is a fix that allows enabling or disabling the clear button on a 'filter-pills' (date-range, select-input etc.) like 'lu-form-field'.

-----

## Our case

In our case, we use filter-pills on a date-range input that must be filled in. So we don't want a clear button.

-----
