### PR TITLE
feat(empty-state): Allow using string instead of number for `hx` input

### DIFF
--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
@@ -1,7 +1,8 @@
 import { NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, numberAttribute, ViewEncapsulation } from '@angular/core';
 import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
+import { Hx } from '../empty-state.model';
 
 @Component({
 	selector: 'lu-empty-state-page',
@@ -59,6 +60,8 @@ export class EmptyStatePageComponent {
 	@Input()
 	description: PortalContent;
 
-	@Input()
-	hx: 1 | 2 | 3 | 4 | 5 | 6 = 1;
+	@Input({
+		transform: numberAttribute as (value: Hx | `${Hx}`) => Hx,
+	})
+	hx: Hx = 1;
 }

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -1,7 +1,8 @@
 import { NgClass, NgIf } from '@angular/common';
-import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, booleanAttribute } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, booleanAttribute, numberAttribute } from '@angular/core';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
+import { Hx } from '../empty-state.model';
 
 @Component({
 	selector: 'lu-empty-state-section',
@@ -33,8 +34,10 @@ export class EmptyStateSectionComponent {
 	@Input()
 	description: PortalContent;
 
-	@Input()
-	hx: 1 | 2 | 3 | 4 | 5 | 6 = 3;
+	@Input({
+		transform: numberAttribute as (value: Hx | `${Hx}`) => Hx,
+	})
+	hx: Hx = 3;
 
 	get emptyStateClasses() {
 		return {

--- a/packages/ng/empty-state/empty-state.model.ts
+++ b/packages/ng/empty-state/empty-state.model.ts
@@ -1,0 +1,1 @@
+export type Hx = 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
## Description

Allow using string instead of number for `hx` input

-----

Add `transform` with `numberAttribute`

-----
