### PR TITLE
fix(simple-select): space not opening panel properly

### DIFF
--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -57,9 +57,11 @@ export class LuSimpleSelectInputComponent<T> extends ALuSelectInputComponent<T, 
 	}
 
 	inputSpace(event: Event): void {
-		if (this.clue.length === 0) {
-			event.preventDefault();
-			this.panelRef?.selectCurrentlyHighlightedValue();
+		if (this.filterPillMode) {
+			if (this.clue.length === 0) {
+				event.preventDefault();
+				this.panelRef?.selectCurrentlyHighlightedValue();
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Filter Pills implementation made it skip space event and thus closing panel right after it was opened, selecting the very first element in the list that was available.

-----


-----
