### PR TITLE
fix(multi-select): group template was not displayed when a clue was used

### DIFF
--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -52,6 +52,7 @@
 					[optionTpl]="optionTpl()"
 					[optionIndex]="index"
 					[grouping]="ctx.groupTemplateLocation === 'option' ? grouping : undefined"
+					[groupTemplateLocation]="ctx.groupTemplateLocation"
 					[scrollIntoViewOptions]="{ block: 'nearest' }"
 					[isSelected]="option | luIsOptionSelected:optionComparer:selectedOptions"
 					(click)="toggleOption(option)"


### PR DESCRIPTION
## Description

Group template was not displayed when a clue was used

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
