### PR TITLE
[DateInputComponent] fix: the min/max in month mode

### DIFF
--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -1,6 +1,6 @@
 import { booleanAttribute, Component, computed, effect, inject, input, LOCALE_ID, signal } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
-import { addMonths, addYears, startOfDay, startOfMonth } from 'date-fns';
+import { addMonths, addYears, isAfter, isBefore, isSameMonth, startOfDay, startOfMonth } from 'date-fns';
 import { CalendarMode } from './calendar2/calendar-mode';
 import { CellStatus } from './calendar2/cell-status';
 import { DateRange, DateRangeInput } from './calendar2/date-range';
@@ -78,7 +78,7 @@ export abstract class AbstractDateComponent {
 					result = result && this.min().getTime() <= date.getTime();
 					break;
 				case 'month':
-					result = result && this.min().getMonth() + startOfMonth(this.min()).getTime() <= date.getMonth() + startOfMonth(date).getTime();
+					result = (result && isBefore(startOfMonth(this.min()), startOfMonth(date))) || isSameMonth(this.min(), date);
 					break;
 				case 'year':
 					result = result && this.min().getFullYear() <= date.getFullYear();
@@ -91,7 +91,7 @@ export abstract class AbstractDateComponent {
 					result = result && this.max().getTime() >= date.getTime();
 					break;
 				case 'month':
-					result = result && this.max().getMonth() + startOfMonth(this.max()).getTime() >= date.getMonth() + startOfMonth(date).getTime();
+					result = (result && isAfter(startOfMonth(this.max()), startOfMonth(date))) || isSameMonth(this.max(), date);
 					break;
 				case 'year':
 					result = result && this.max().getFullYear() >= date.getFullYear();

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -1,6 +1,6 @@
 import { booleanAttribute, Component, computed, effect, inject, input, LOCALE_ID, signal } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
-import { addMonths, addYears, startOfDay } from 'date-fns';
+import { addMonths, addYears, startOfDay, startOfMonth } from 'date-fns';
 import { CalendarMode } from './calendar2/calendar-mode';
 import { CellStatus } from './calendar2/cell-status';
 import { DateRange, DateRangeInput } from './calendar2/date-range';
@@ -78,7 +78,7 @@ export abstract class AbstractDateComponent {
 					result = result && this.min().getTime() <= date.getTime();
 					break;
 				case 'month':
-					result = result && this.min().getMonth() <= date.getMonth();
+					result = result && this.min().getMonth() + startOfMonth(this.min()).getTime() <= date.getMonth() + startOfMonth(date).getTime();
 					break;
 				case 'year':
 					result = result && this.min().getFullYear() <= date.getFullYear();
@@ -91,7 +91,7 @@ export abstract class AbstractDateComponent {
 					result = result && this.max().getTime() >= date.getTime();
 					break;
 				case 'month':
-					result = result && this.max().getMonth() >= date.getMonth();
+					result = result && this.max().getMonth() + startOfMonth(this.max()).getTime() >= date.getMonth() + startOfMonth(date).getTime();
 					break;
 				case 'year':
 					result = result && this.max().getFullYear() >= date.getFullYear();

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -23,7 +23,7 @@ import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillIn
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
-import { isAfter, isBefore, isSameDay, parse, startOfDay } from 'date-fns';
+import { isSameDay, parse, startOfDay } from 'date-fns';
 import { AbstractDateComponent } from '../abstract-date-component';
 import { CalendarMode } from '../calendar2/calendar-mode';
 import { Calendar2Component } from '../calendar2/calendar2.component';

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -273,10 +273,8 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 			return { date: true };
 		}
 		// Check min and max
-		if (this.min() && isBefore(date, this.min())) {
-			return { min: true };
-		} else if (this.max() && isAfter(date, this.max())) {
-			return { max: true };
+		if (!this.isInMinMax(date, this.mode())) {
+			return { minMax: true };
 		}
 		// Everything is valid
 		return null;


### PR DESCRIPTION
## Description

When in month mode, the min and max are now only applied to the corresponding year, and not all years.

-----

Note that the use of `startOfMonth` is to prevent that no month is selectable if min and max are in the same month. 

Before: 
![zen_xI0RpgnUIT](https://github.com/user-attachments/assets/2b39a484-17e1-46c2-b749-a1640c724795)

After: 
![zen_MbfAA3Q9W7](https://github.com/user-attachments/assets/b17ba6e5-d6fc-4df9-a1d4-dffede8d2d29)



-----
