### PR TITLE
[DateInput] change disabled prop to signal to trigger rendering

### DIFF
--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -26,7 +26,7 @@ export abstract class AbstractDateComponent {
 	intl = getIntl(LU_DATE2_TRANSLATIONS);
 
 	onTouched?: () => void;
-	disabled = false;
+	disabled = signal<boolean>(false);
 
 	format = input<DateFormat>(DATE_FORMAT.DATE);
 	protected inDateISOFormat = computed(() => this.format() === DATE_FORMAT.DATE_ISO);
@@ -118,7 +118,7 @@ export abstract class AbstractDateComponent {
 	}
 
 	setDisabledState?(isDisabled: boolean): void {
-		this.disabled = isDisabled;
+		this.disabled.set(isDisabled);
 	}
 
 	move(direction: 1 | -1, mode: CalendarMode): void {

--- a/packages/ng/date2/date-input/date-input.component.html
+++ b/packages/ng/date2/date-input/date-input.component.html
@@ -19,13 +19,13 @@
 			(keydown.arrowDown)="arrowDown(popoverRef)"
 			(keydown.escape)="popoverRef.close()"
 			(keydown.space)="spaceDown($event, popoverRef)"
-			[disabled]="disabled"
+			[disabled]="disabled()"
 			[attr.placeholder]="placeholder() || dateFormatLocalized()"
 			[attr.autocomplete]="autocomplete()"
 		/>
 
 		<div class="textField-input-affix">
-			@if (clearable() && !disabled && date.value !== '') {
+			@if (clearable() && !disabled() && date.value !== '') {
 			<button class="textField-input-affix-clear clear" type="button" (click)="clear()">
 				<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
 				<span class="u-mask">{{ intl.clear }}</span>
@@ -39,7 +39,7 @@
 			<button
 				[luPopover2]="calendar"
 				[luPopoverAnchor]="popoverAnchor"
-				[disabled]="disabled"
+				[disabled]="disabled()"
 				[luPopoverNoCloseButton]="true"
 				[luPopoverDisabled]="isFilterPill"
 				#popoverRef="luPopover2"


### PR DESCRIPTION
## Description

With disabled propertie as a boolean, rendering was not triggered when this property was updated. Making it a signal resolves this issue. 

-----

Before: 
![zen_JPWRQQj4lV](https://github.com/user-attachments/assets/b967fe9d-601b-4c17-a7d9-01f460ae4157)

After: 
![zen_DpTuh3UU9i](https://github.com/user-attachments/assets/e57bdf79-e9ed-4abc-88e8-f2cebe0a3ff6)


-----
