### PR TITLE
[DateInput] fix: clear and calendar move

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -308,6 +308,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 	clear() {
 		this.inputRef().nativeElement.value = '';
 		this.selectedDate.set(null);
+		this.#onChange?.(null);
 		this.onTouched?.();
 	}
 
@@ -319,6 +320,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 	dateClicked(date: Date, popoverRef: PopoverDirective): void {
 		this.selectedDate.set(date);
 		this.currentDate.set(date);
+		this.tabbableDate.set(date);
 		if (!this.isFilterPill) {
 			popoverRef.close();
 			this.inputRef().nativeElement.focus();


### PR DESCRIPTION
## Description

Two bugs are fixed in this PR: 
- Clear sends `null` `onChange`. This allows, for instance, to trigger validation checks.
- If a date of another month (previous or next) is selected, when reopening calendar, it moves correctly between months. 

-----

For the sake of these examples, input is set to required.
Before: 
![zen_00pl8NNBhQ](https://github.com/user-attachments/assets/0010fef5-b5bb-479f-a0d8-b0ad847d5067)

After: 
![zen_rJVtxWT3rM](https://github.com/user-attachments/assets/d87fa9dc-5db0-4b9e-a324-cf37d48fe6e4)


-----
