### PR TITLE
fix(user-directive): Use defaultScopedSearchUrl when uniqueOperationIds

### DIFF
--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -86,7 +86,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		});
 	}
 
-	protected defaultUrl = computed(() => (this.appInstanceId() && this.operationIds()?.length ? this.#defaultScopedSearchUrl : this.#defaultSearchUrl));
+	protected defaultUrl = computed(() => (this.uniqueOperationIds()?.length || (this.appInstanceId() && this.operationIds()?.length) ? this.#defaultScopedSearchUrl : this.#defaultSearchUrl));
 	protected urlOrDefault = computed(() => this.url() ?? this.defaultUrl());
 
 	protected clue = toSignal(this.clue$);


### PR DESCRIPTION
## Description

We need to use defaultScopedSearchUrl when `appInstanceId` && `operationIds` or `uniqueOperationIds`

-----
