### PR TITLE
fix(front) : [indexTable] reduce specificity of actions buttons to allow override from mods, like mod-delete

### DIFF
--- a/packages/scss/src/components/indexTable/index.scss
+++ b/packages/scss/src/components/indexTable/index.scss
@@ -29,7 +29,7 @@
 		@include massSelection;
 	}
 
-	.indexTable-body-row-cell.mod-actions {
+	:where(.indexTable-body-row-cell.mod-actions) {
 		@include actions;
 	}
 

--- a/packages/scss/src/components/indexTable/mods.scss
+++ b/packages/scss/src/components/indexTable/mods.scss
@@ -42,10 +42,10 @@
 		// because we can't set an individual spacing for each row, transparent border are used for this
 		border-block-end: var(--components-indexTable-row-stack-border-bottom) solid transparent;
 		// stack apparence
-		background-image:
-			var(--components-indexTable-row-stack2-background-image, none), var(--components-indexTable-row-stack3-background-image, none);
-		background-position:
-			var(--components-indexTable-row-stack2-background-position, 0 0), var(--components-indexTable-row-stack3-background-position, 0 0);
+		background-image: var(--components-indexTable-row-stack2-background-image, none),
+			var(--components-indexTable-row-stack3-background-image, none);
+		background-position: var(--components-indexTable-row-stack2-background-position, 0 0),
+			var(--components-indexTable-row-stack3-background-position, 0 0);
 		background-repeat: no-repeat, no-repeat;
 		transition-property: background-image, background-position;
 		transition-duration: var(--commons-animations-durations-fast);
@@ -230,10 +230,10 @@
 			position: absolute;
 			inset-block-start: 0;
 			inset-block-end: calc((var(--components-indexTable-row-spacing-responsive) + var(--components-indexTable-stack3-row-spacing)) * -1);
-			background-image:
-				var(--components-indexTable-row-stack2-background-image, none), var(--components-indexTable-row-stack3-background-image, none);
-			background-position:
-				var(--components-indexTable-row-stack2-background-position, 0 0), var(--components-indexTable-row-stack3-background-position, 0 0);
+			background-image: var(--components-indexTable-row-stack2-background-image, none),
+				var(--components-indexTable-row-stack3-background-image, none);
+			background-position: var(--components-indexTable-row-stack2-background-position, 0 0),
+				var(--components-indexTable-row-stack3-background-position, 0 0);
 			background-repeat: no-repeat, no-repeat;
 			transition-property: background-image, background-position;
 			transition-duration: var(--commons-animations-durations-fast);
@@ -263,7 +263,7 @@
 	padding: var(--pr-t-spacings-50);
 	white-space: nowrap;
 
-	.button {
+	:where(.button) {
 		@include button.S;
 		@include button.text;
 		@include button.onlyIconS;

--- a/stories/documentation/listings/index-table/index-table-actions.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions.stories.ts
@@ -30,7 +30,7 @@ function getTemplate(args: IndexTableActionsStory): string {
 				<button type="button" class="button indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-officePen"></span>
 				</button>
-				<button type="button" class="button indexTable-body-row-cell-subAction">
+				<button type="button" class="button mod-delete indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
 				</button>
 			</td>


### PR DESCRIPTION
## Description

Reduce specificity of actions buttons to allow override from mods, like mod-delete

Fixe https://github.com/LuccaSA/lucca-front/issues/3474

-----

