### PR TITLE
[footer] buttons with wrap

### DIFF
--- a/packages/scss/src/components/footer/component.scss
+++ b/packages/scss/src/components/footer/component.scss
@@ -19,6 +19,7 @@
 		}
 
 		.footer-actions {
+			flex-shrink: 0;
 			margin-inline-start: var(--components-footer-actions-margin);
 			display: flex;
 			gap: var(--pr-t-spacings-200);


### PR DESCRIPTION
## Description

Now that text in buttons can be returned to the line, we need to correct some behavior in the footer.

-----



-----

Before:
![2025-04-03 10 41 25](https://github.com/user-attachments/assets/089823ae-81e5-4a56-a306-aea62687f9a0)


After:
![2025-04-03 10 42 10](https://github.com/user-attachments/assets/8f6a1b5a-7766-4090-b3eb-3b26c13e6c85)
