### PR TITLE
feat(form-field): add extra describedBy input

### DIFF
--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -108,6 +108,11 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	size = input<FormFieldSize | null>(null);
 
+	/**
+	 * Extra aria-describedby attribute
+	 */
+	extraDescribedBy = input<string>('');
+
 	layout = model<'default' | 'checkable' | 'fieldset'>('default');
 
 	hasArrow = false;
@@ -148,7 +153,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	#ariaLabelledBy: string[] = [];
 
 	constructor() {
-		ɵeffectWithDeps([this.isInputRequired, this.invalidStatus], () => {
+		ɵeffectWithDeps([this.isInputRequired, this.invalidStatus, this.extraDescribedBy], () => {
 			this.updateAria();
 		});
 
@@ -200,7 +205,11 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 			this.#renderer.setAttribute(input.host.nativeElement, 'aria-invalid', this.invalidStatus()?.toString());
 			this.#renderer.setAttribute(input.host.nativeElement, 'aria-required', this.isInputRequired()?.toString());
 			if (!input.standalone) {
-				this.#renderer.setAttribute(input.host.nativeElement, 'aria-describedby', `${input.host.nativeElement.id}-message`);
+				let ariaDescribedBy = `${input.host.nativeElement.id}-message`;
+				if (this.extraDescribedBy()) {
+					ariaDescribedBy += ` ${this.extraDescribedBy()}`;
+				}
+				this.#renderer.setAttribute(input.host.nativeElement, 'aria-describedby', ariaDescribedBy);
 			}
 		});
 		if (this.id() && !this.#ariaLabelledBy.includes(`${this.id()}-label`)) {

--- a/stories/documentation/forms/fields/form-field.stories.ts
+++ b/stories/documentation/forms/fields/form-field.stories.ts
@@ -23,7 +23,7 @@ export default {
 	render: (args, { argTypes }) => {
 		const { required, ...fieldArgs } = args;
 		return {
-			template: `<lu-form-field ${generateInputs(fieldArgs, argTypes)}>
+			template: `<lu-form-field extraDescribedBy="extra-message" ${generateInputs(fieldArgs, argTypes)}>
 	<div class="textField">
 		<div class="textField-input">
 			<textarea

--- a/stories/qa/index-table/index-table.stories.ts
+++ b/stories/qa/index-table/index-table.stories.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { TagComponent } from '@lucca-front/ng/tag';
 import { LuUserPictureComponent } from '@lucca-front/ng/user';
 import { Meta, StoryFn } from '@storybook/angular';
-import { StatusBadgeComponent } from 'dist/ng/statusBadge';
+import { StatusBadgeComponent } from '@lucca-front/ng/statusBadge';
 
 @Component({
 	standalone: true,


### PR DESCRIPTION
## Description

Pour les profils de lieux de travail sur Office, nous avons besoin de relier plusieurs champs à un seul message d'erreur. 


-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
