### PR TITLE
fix(lint): force ignore unused vars in schematic test cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26958,7 +26958,7 @@
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "stylelint": "^16.14.1",
+        "stylelint": "^16.17.0",
         "stylelint-config-prettier-scss": "^1.0.0",
         "stylelint-config-standard-scss": "^14.0.0"
       }

--- a/packages/ng/schematics/lu-select/tests/input/simple-case.component.ts
+++ b/packages/ng/schematics/lu-select/tests/input/simple-case.component.ts
@@ -7,7 +7,9 @@ import {
 import { FormsModule } from '@angular/forms';
 import { LuInputClearerComponent } from '@lucca-front/ng/input';
 import {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	type ILuUser,
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	LuUserDisplayPipe,
   LuUserSelectModule,
 } from '@lucca-front/ng/user';

--- a/packages/ng/schematics/lu-select/tests/output/simple-case.component.ts
+++ b/packages/ng/schematics/lu-select/tests/output/simple-case.component.ts
@@ -1,7 +1,9 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	type ILuUser,
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	LuUserDisplayPipe,
   } from '@lucca-front/ng/user';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';

--- a/packages/scss/src/components/indexTable/mods.scss
+++ b/packages/scss/src/components/indexTable/mods.scss
@@ -321,6 +321,7 @@
 
 	&.mod-layoutFixed {
 		table-layout: fixed;
+
 		[class*='row-cell'] {
 			@include cellFixedWidth;
 		}

--- a/stories/documentation/forms/fileToolbar/html&css/basic.stories.ts
+++ b/stories/documentation/forms/fileToolbar/html&css/basic.stories.ts
@@ -1,7 +1,7 @@
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { Meta, moduleMetadata } from '@storybook/angular';
-import { ButtonComponent } from 'dist/ng/button';
+import { ButtonComponent } from '@lucca-front/ng/button';
 
 export default {
 	title: 'Documentation/File/FileToolbar/HTML&CSS/Basic',

--- a/stories/documentation/forms/fileUpload/angular/basic.stories.ts
+++ b/stories/documentation/forms/fileUpload/angular/basic.stories.ts
@@ -5,7 +5,7 @@ import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TextInputComponent } from '@lucca-front/ng/forms';
 import { LuInputDirective } from '@lucca-front/ng/input';
 import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
-import { ButtonComponent } from 'dist/ng/button';
+import { ButtonComponent } from '@lucca-front/ng/button';
 import { map, Observable, switchMap, throwError, timer } from 'rxjs';
 import { generateInputs } from 'stories/helpers/stories';
 


### PR DESCRIPTION
## Description

New lint update broke due to eslint thinking unused imports are unused vars, meaning that we can only ignore them in the test.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
