### PR TITLE
[indexTable] stories

### DIFF
--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -29,6 +29,7 @@ $verticalAlign: 'baseline', 'sub', 'super', 'text-top', 'text-bottom', 'middle',
 $position: 'absolute', 'relative', 'static', 'fixed', 'sticky';
 $decoration: 'underline', 'line-through', 'none';
 $overflow: 'hidden', 'auto', 'visible', 'scroll';
+$cursor: 'pointer', 'auto';
 
 /* Tokens */
 

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -183,10 +183,6 @@
 	@include text.ellipsis('!important');
 }
 
-.u-maxWidth100\% {
-	max-width: 100%;
-}
-
 .u-h1,
 .u-h2,
 .u-h3,
@@ -312,6 +308,7 @@
 @include core.classes('block-size', core.$contents);
 @include core.classes('min-inline-size', '0');
 @include core.classes('min-block-size', '0');
+@include core.classes('max-inline-size', core.$contents);
 
 @include core.classes('visibility', core.$visibility);
 @include core.classes('font-weight', core.$fontWeight);

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -183,6 +183,10 @@
 	@include text.ellipsis('!important');
 }
 
+.u-maxWidth100\% {
+	max-width: 100%;
+}
+
 .u-h1,
 .u-h2,
 .u-h3,
@@ -313,6 +317,7 @@
 @include core.classes('font-weight', core.$fontWeight);
 @include core.classes('font-style', core.$fontStyle);
 @include core.classes('pointer-events', core.$pointerEvents);
+@include core.classes('cursor', core.$cursor);
 @include core.classes('text-align', core.$textAlign);
 @include core.classes('text-decoration', core.$decoration);
 @include core.classes('overflow', core.$overflow);

--- a/packages/scss/src/components/indexTable/mods.scss
+++ b/packages/scss/src/components/indexTable/mods.scss
@@ -205,9 +205,9 @@
 @mixin selectableResponsiveCardList {
 	.indexTable-body-row {
 		grid-template-columns: var(--components-indexTable-row-cell-transparent-width) var(
-				--components-indexTable-row-responsive-grid-template-columns,
-				1fr
-			);
+			--components-indexTable-row-responsive-grid-template-columns,
+			1fr
+		);
 	}
 
 	.indexTable-body-row-transparentCell {
@@ -289,39 +289,22 @@
 		@include button.text;
 		@include button.onlyIconS;
 	}
-
-	// All devices expect touch ones : subActions are hidden and appears when their row is hover or selected
-	// see mixin visibleSubActions() in states.scss
-	@include media.isNotTouchDevice {
-		.indexTable-body-row-cell-subAction {
-			opacity: var(--components-indexTable-cell-subAction-opacity, 0);
-			transition: opacity ease var(--commons-animations-durations-fast);
-		}
-
-		// If there are 4 actions or more, the buttons are hidden (not on touch device) and replaced should be replaced with a dropdown
-		&:has(.indexTable-body-row-cell-subActionDropdownTrigger) {
-			.indexTable-body-row-cell-subAction {
-				display: none;
-			}
-		}
-	}
-
-	// All touch devices : subActions are always visibles, subActionDropdownTrigger is hidden
-	@include media.isTouchDevice {
-		.indexTable-body-row-cell-subActionDropdownTrigger {
-			display: none;
-		}
-	}
 }
 
 @mixin layoutFixed {
-	[class*='row-cell'] {
+	.indexTable-head-row-cell,
+	.indexTable-body-row-cell,
+	.indexTable-foot-row-cell {
 		--cell-width: calc(var(--components-indexTable-cell-fixed-width, var(--components-index-table-cell-fixed-width)) * 1rem);
 	}
 
 	&.mod-layoutFixed {
 		table-layout: fixed;
-		[class*='row-cell'] {
+
+		.indexTable-head-row-cell,
+		.indexTable-body-row-cell,
+		.indexTable-foot-row-cell {
+
 			@include cellFixedWidth;
 		}
 	}
@@ -332,7 +315,9 @@
 			&.mod-layoutFixedAtMediaMin#{$breakpoint} {
 				table-layout: fixed;
 
-				[class*='row-cell'] {
+				.indexTable-head-row-cell,
+				.indexTable-body-row-cell,
+				.indexTable-foot-row-cell {
 					@include cellFixedWidth;
 				}
 			}

--- a/packages/scss/src/components/tableSticked/mods.scss
+++ b/packages/scss/src/components/tableSticked/mods.scss
@@ -149,7 +149,9 @@
 ****/
 
 @mixin stickyHeaderShadow {
-	[class*='row-cell'] {
+	.indexTable-head-row-cell,
+	.indexTable-body-row-cell,
+	.indexTable-foot-row-cell {
 		position: sticky;
 		inset-block-start: var(--table-stickyHeader-shadow-offset);
 		z-index: 4;
@@ -177,7 +179,8 @@
 
 	+ .table-body-row,
 	+ .table-foot-row {
-		[class*='row-cell'] {
+		.indexTable-body-row-cell,
+		.indexTable-foot-row-cell {
 			border-block-start: 0;
 		}
 	}

--- a/stories/documentation/listings/index-table/index-table-actions-dropdown.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-dropdown.stories.ts
@@ -1,13 +1,12 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableActionsTouchDetectionStory {}
+interface IndexTableActionsDropdownStory {}
 
 export default {
-	title: 'Documentation/Listings/Index Table/Actions touch detection',
-	argTypes: {},
+	title: 'Documentation/Listings/Index Table/Actions/Dropdown',
 } as Meta;
 
-function getTemplate(args: IndexTableActionsTouchDetectionStory): string {
+function getTemplate(args: IndexTableActionsDropdownStory): string {
 	return `<table class="indexTable">
 	<thead class="indexTable-head">
 		<tr class="indexTable-head-row">
@@ -27,32 +26,19 @@ function getTemplate(args: IndexTableActionsTouchDetectionStory): string {
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell mod-actions">
-				<button type="button" class="button indexTable-body-row-cell-subAction">
-					<span aria-hidden="true" class="lucca-icon icon-officePen"></span>
-				</button>
-				<button type="button" class="button indexTable-body-row-cell-subAction">
-					<span aria-hidden="true" class="lucca-icon icon-copy"></span>
-				</button>
-				<button type="button" class="button indexTable-body-row-cell-subAction">
-					<span aria-hidden="true" class="lucca-icon icon-archive"></span>
-				</button>
-				<button type="button" class="button indexTable-body-row-cell-subAction">
-					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
-				</button>
-				<!-- Implement dropdown on this button clic-->
 				<button type="button" class="button indexTable-body-row-cell-subActionDropdownTrigger mod-text mod-onlyIcon mod-S">
 					<span aria-hidden="true" class="lucca-icon icon-ellipsis"></span>
 				</button>
 			</td>
 		</tr>
 	</tbody>
-</table>`;
+</table>
+`;
 }
 
-const Template: StoryFn<IndexTableActionsTouchDetectionStory> = (args) => ({
+const Template: StoryFn<IndexTableActionsDropdownStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
 });
 
-export const ActionsTouchDetection = Template.bind({});
-ActionsTouchDetection.args = {};
+export const Dropdown = Template.bind({});

--- a/stories/documentation/listings/index-table/index-table-actions-selectable.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-selectable.stories.ts
@@ -1,0 +1,47 @@
+import { Meta, StoryFn } from '@storybook/angular';
+
+interface IndexTableActionsSelectableStory {}
+
+export default {
+	title: 'Documentation/Listings/Index Table/Actions/Selectable',
+} as Meta;
+
+function getTemplate(args: IndexTableActionsSelectableStory): string {
+	return `<table class="indexTable">
+	<thead class="indexTable-head">
+		<tr class="indexTable-head-row">
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+		</tr>
+	</thead>
+	<tbody class="indexTable-body">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell">
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+			</td>
+			<td class="indexTable-body-row-cell mod-allowTextSelection">
+				Content selectable
+			</td>
+			<td class="indexTable-body-row-cell">
+				Content
+			</td>
+		</tr>
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell">
+				<a href="#" class="indexTable-body-row-cell-link">Content</a>
+			</td>
+			<td class="indexTable-body-row-cell"><a href="#">Content actionable</a></td>
+			<td class="indexTable-body-row-cell">Content</td>
+		</tr>
+	</tbody>
+</table>
+`;
+}
+
+const Template: StoryFn<IndexTableActionsSelectableStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+});
+
+export const Selectable = Template.bind({});

--- a/stories/documentation/listings/index-table/index-table-actions-subAction.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-subAction.stories.ts
@@ -1,13 +1,12 @@
 import { Meta, StoryFn } from '@storybook/angular';
 
-interface IndexTableActionsStory {}
+interface IndexTableActionsSubActionStory {}
 
 export default {
-	title: 'Documentation/Listings/Index Table/Actions',
-	argTypes: {},
+	title: 'Documentation/Listings/Index Table/Actions/SubAction',
 } as Meta;
 
-function getTemplate(args: IndexTableActionsStory): string {
+function getTemplate(args: IndexTableActionsSubActionStory): string {
 	return `<table class="indexTable">
 	<thead class="indexTable-head">
 		<tr class="indexTable-head-row">
@@ -28,6 +27,9 @@ function getTemplate(args: IndexTableActionsStory): string {
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell mod-actions">
 				<button type="button" class="button indexTable-body-row-cell-subAction">
+					<span aria-hidden="true" class="lucca-icon icon-copy"></span>
+				</button>
+				<button type="button" class="button indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-officePen"></span>
 				</button>
 				<button type="button" class="button mod-delete indexTable-body-row-cell-subAction">
@@ -36,13 +38,13 @@ function getTemplate(args: IndexTableActionsStory): string {
 			</td>
 		</tr>
 	</tbody>
-</table>`;
+</table>
+`;
 }
 
-const Template: StoryFn<IndexTableActionsStory> = (args) => ({
+const Template: StoryFn<IndexTableActionsSubActionStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
 });
 
-export const Actions = Template.bind({});
-Actions.args = {};
+export const SubActions = Template.bind({});

--- a/stories/documentation/listings/index-table/index-table-actions-tooltipsCell.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-tooltipsCell.stories.ts
@@ -31,8 +31,8 @@ function getTemplate(args: IndexTableActionsTooltipsCellStory): string {
 				<!-- real link with navigation and stopPropagation to prevent double navigation -->
 				<!-- preventDefault is only here for demonstration -->
 				<a href="#" class="indexTable-body-row-cell-link" (click)=" $event.preventDefault(); $event.stopPropagation(); message('Primary action')"><span class="u-mask">See details</span></a>
-				<!-- u-widthFitContent and u-maxWidth100% to contain de width and center the tooltip -->
-				<div class="u-ellipsis u-widthFitContent u-maxWidth100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">a</code></div>
+				<!-- u-widthFitContent and u-maxInlineSize100% to contain de width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent u-maxInlineSize100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">a</code></div>
 			</td>
 			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div>
@@ -53,8 +53,8 @@ function getTemplate(args: IndexTableActionsTooltipsCellStory): string {
 			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- nothing here, the event will be bubbling -->
 				<button type="button" class="indexTable-body-row-cell-link"><span class="u-mask">See details</span></button>
-				<!-- u-widthFitContent and u-maxWidth100% to contain de width and center the tooltip -->
-				<div class="u-ellipsis u-widthFitContent u-maxWidth100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">button</code></div>
+				<!-- u-widthFitContent and u-maxInlineSize100% to contain de width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent u-maxInlineSize100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">button</code></div>
 			</td>
 			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div>

--- a/stories/documentation/listings/index-table/index-table-actions-tooltipsCell.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-tooltipsCell.stories.ts
@@ -1,0 +1,93 @@
+import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+import { Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+
+interface IndexTableActionsTooltipsCellStory {}
+
+export default {
+	title: 'Documentation/Listings/Index Table/Actions/Tooltips/Cell',
+	argTypes: {},
+	decorators: [
+		moduleMetadata({
+			imports: [LuTooltipModule],
+		}),
+	],
+} as Meta;
+
+function getTemplate(args: IndexTableActionsTooltipsCellStory): string {
+	return `<table class="indexTable mod-layoutFixed">
+	<thead class="indexTable-head">
+		<tr class="indexTable-head-row">
+			<th class="indexTable-head-row-cell" scope="col">Action</th>
+			<th class="indexTable-head-row-cell" scope="col">Content</th>
+			<th class="indexTable-head-row-cell" scope="col">Content</th>
+			<th class="indexTable-head-row-cell" scope="col">Content</th>
+			<th class="indexTable-head-row-cell" scope="col" style="--components-indexTable-cell-fixed-width: 8">Content</th>
+			<th class="indexTable-head-row-cell mod-alignRight" scope="col" style="--components-indexTable-cell-fixed-width: 3"><span class="u-mask">Secondary action</span></th>
+		</tr>
+	</thead>
+	<tbody class="indexTable-body">
+		<!-- (click) with navigation on table row -->
+		<!-- u-cursorPointer on the cells without stopPropagation -->
+		<tr class="indexTable-body-row" (click)="message('Primary action')">
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- real link with navigation and stopPropagation to prevent double navigation -->
+				<!-- preventDefault is only here for demonstration -->
+				<a href="#" class="indexTable-body-row-cell-link" (click)=" $event.preventDefault(); $event.stopPropagation(); message('Primary action')"><span class="u-mask">See details</span></a>
+				<!-- u-widthFitContent and u-maxWidth100% to contain de width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent u-maxWidth100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">a</code></div>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
+			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- u-widthFitContent to contain the width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
+			<!-- stopPropagation on the table data cell with secondary action -->
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
+					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
+				</button>
+			</td>
+		</tr>
+		<!-- (click) with navigation on table row -->
+		<!-- u-cursorPointer on the cells without stopPropagation -->
+		<tr class="indexTable-body-row" (click)="message('Primary action')">
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- nothing here, the event will be bubbling -->
+				<button type="button" class="indexTable-body-row-cell-link"><span class="u-mask">See details</span></button>
+				<!-- u-widthFitContent and u-maxWidth100% to contain de width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent u-maxWidth100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">button</code></div>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
+			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- u-widthFitContent to contain the width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
+			<!-- stopPropagation on the table data cell with secondary action -->
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
+					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
+				</button>
+			</td>
+		</tr>
+	</tbody>
+</table>
+`;
+}
+
+const Template: StoryFn<IndexTableActionsTooltipsCellStory> = (args) => ({
+	props: {
+		...args,
+		message: (msg) => {
+			alert(msg);
+		},
+	},
+	template: getTemplate(args),
+});
+
+export const TooltipsCell = Template.bind({});

--- a/stories/documentation/listings/index-table/index-table-actions-tooltipsCell.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-tooltipsCell.stories.ts
@@ -26,50 +26,46 @@ function getTemplate(args: IndexTableActionsTooltipsCellStory): string {
 		</tr>
 	</thead>
 	<tbody class="indexTable-body">
-		<!-- (click) with navigation on table row -->
-		<!-- u-cursorPointer on the cells without stopPropagation -->
-		<tr class="indexTable-body-row" (click)="message('Primary action')">
-			<td class="indexTable-body-row-cell u-cursorPointer">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- real link with navigation and stopPropagation to prevent double navigation -->
 				<!-- preventDefault is only here for demonstration -->
 				<a href="#" class="indexTable-body-row-cell-link" (click)=" $event.preventDefault(); $event.stopPropagation(); message('Primary action')"><span class="u-mask">See details</span></a>
 				<!-- u-widthFitContent and u-maxWidth100% to contain de width and center the tooltip -->
 				<div class="u-ellipsis u-widthFitContent u-maxWidth100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">a</code></div>
 			</td>
-			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
-			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
-			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
-			<td class="indexTable-body-row-cell u-cursorPointer">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
+				<div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div>
+			</td>
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- u-widthFitContent to contain the width and center the tooltip -->
 				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
 			</td>
 			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
-			<!-- stopPropagation on the table data cell with secondary action -->
 			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
 				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
 				</button>
 			</td>
 		</tr>
-		<!-- (click) with navigation on table row -->
-		<!-- u-cursorPointer on the cells without stopPropagation -->
-		<tr class="indexTable-body-row" (click)="message('Primary action')">
-			<td class="indexTable-body-row-cell u-cursorPointer">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- nothing here, the event will be bubbling -->
 				<button type="button" class="indexTable-body-row-cell-link"><span class="u-mask">See details</span></button>
 				<!-- u-widthFitContent and u-maxWidth100% to contain de width and center the tooltip -->
 				<div class="u-ellipsis u-widthFitContent u-maxWidth100% pr-u-focusVisible u-borderRadiusM" luTooltip="Primary action (you can click)">Tooltip for the cell <code class="code">button</code></div>
 			</td>
-			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
-			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
-			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
-			<td class="indexTable-body-row-cell u-cursorPointer">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
+				<div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div>
+			</td>
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- u-widthFitContent to contain the width and center the tooltip -->
 				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
 			</td>
 			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
-			<!-- stopPropagation on the table data cell with secondary action -->
-			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions">
 				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
 				</button>

--- a/stories/documentation/listings/index-table/index-table-actions-tooltipsRow.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-tooltipsRow.stories.ts
@@ -1,0 +1,96 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/popup-employee';
+import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+import { LuUserDisplayModule, LuUserPictureComponent } from '@lucca-front/ng/user';
+import { applicationConfig, Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+
+interface IndexTableActionsTooltipsRowStory {}
+
+export default {
+	title: 'Documentation/Listings/Index Table/Actions/Tooltips/Row',
+	argTypes: {},
+	decorators: [
+		moduleMetadata({
+			imports: [LuTooltipModule, LuUserPopoverDirective, LuUserDisplayModule, LuUserPictureComponent],
+		}),
+		applicationConfig({
+			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
+		}),
+	],
+} as Meta;
+
+function getTemplate(args: IndexTableActionsTooltipsRowStory): string {
+	return `<table class="indexTable mod-layoutFixed">
+	<thead class="indexTable-head">
+		<tr class="indexTable-head-row">
+			<th class="indexTable-head-row-cell" scope="col">Action</th>
+			<th class="indexTable-head-row-cell" scope="col">Content</th>
+			<th class="indexTable-head-row-cell" scope="col">Content</th>
+			<th class="indexTable-head-row-cell" scope="col">Content</th>
+			<th class="indexTable-head-row-cell" scope="col" style="--components-indexTable-cell-fixed-width: 8">Content</th>
+			<th class="indexTable-head-row-cell mod-alignRight" scope="col" style="--components-indexTable-cell-fixed-width: 3"><span class="u-mask">Secondary action</span></th>
+		</tr>
+	</thead>
+	<tbody class="indexTable-body">
+		<!-- (click) with navigation on table row -->
+		<tr class="indexTable-body-row" (click)="message('Primary action')">
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- real link with navigation and stopPropagation to prevent double navigation -->
+				<!-- u-widthFitContent to contain de width and center the tooltip -->
+				<!-- preventDefault is only here for demonstration -->
+				<a href="#primaryNavigation" luTooltip="Primary action (you can click)" class="indexTable-body-row-cell-link u-widthFitContent u-ellipsis" (click)=" $event.preventDefault(); $event.stopPropagation(); message('Primary action')">Tooltip for the row <code class="code">a</code></a>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
+			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- u-widthFitContent to contain the width and center the tooltip -->
+				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
+			<!-- stopPropagation on the table data cell with secondary action -->
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
+					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
+				</button>
+			</td>
+		</tr>
+		<!-- (click) with action on table row -->
+		<tr class="indexTable-body-row" (click)="message('Primary action')">
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<!-- nothing here, the event will be bubbling -->
+				<!-- u-widthFitContent to contain de width and center the tooltip -->
+				<button luTooltip="Primary action (you can click)" type="button" class="indexTable-body-row-cell-link u-widthFitContent u-ellipsis">Tooltip for the row <code class="code">button</code></button>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
+			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
+			<!-- u-widthFitContent to contain de width and center the tooltip -->
+			<td class="indexTable-body-row-cell u-cursorPointer">
+				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
+			</td>
+			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
+			<!-- stopPropagation to prevent bubbling -->
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
+					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
+				</button>
+			</td>
+		</tr>
+	</tbody>
+</table>
+`;
+}
+
+const Template: StoryFn<IndexTableActionsTooltipsRowStory> = (args) => ({
+	props: {
+		...args,
+		message: (msg) => {
+			alert(msg);
+		},
+	},
+	template: getTemplate(args),
+});
+
+export const TooltipsRow = Template.bind({});

--- a/stories/documentation/listings/index-table/index-table-actions-tooltipsRow.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-tooltipsRow.stories.ts
@@ -33,46 +33,48 @@ function getTemplate(args: IndexTableActionsTooltipsRowStory): string {
 		</tr>
 	</thead>
 	<tbody class="indexTable-body">
-		<!-- (click) with navigation on table row -->
-		<tr class="indexTable-body-row" (click)="message('Primary action')">
-			<td class="indexTable-body-row-cell u-cursorPointer">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- real link with navigation and stopPropagation to prevent double navigation -->
 				<!-- u-widthFitContent to contain de width and center the tooltip -->
 				<!-- preventDefault is only here for demonstration -->
 				<a href="#primaryNavigation" luTooltip="Primary action (you can click)" class="indexTable-body-row-cell-link u-widthFitContent u-ellipsis" (click)=" $event.preventDefault(); $event.stopPropagation(); message('Primary action')">Tooltip for the row <code class="code">a</code></a>
 			</td>
-			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
-			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
-			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
-			<td class="indexTable-body-row-cell u-cursorPointer">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
+				<div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div>
+			</td>
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- u-widthFitContent to contain the width and center the tooltip -->
 				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
 			</td>
-			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
-			<!-- stopPropagation on the table data cell with secondary action -->
-			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap" (click)="message('Primary action')">
+				Content
+			</td>
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions">
 				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
 				</button>
 			</td>
 		</tr>
-		<!-- (click) with action on table row -->
-		<tr class="indexTable-body-row" (click)="message('Primary action')">
-			<td class="indexTable-body-row-cell u-cursorPointer">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<!-- nothing here, the event will be bubbling -->
 				<!-- u-widthFitContent to contain de width and center the tooltip -->
 				<button luTooltip="Primary action (you can click)" type="button" class="indexTable-body-row-cell-link u-widthFitContent u-ellipsis">Tooltip for the row <code class="code">button</code></button>
 			</td>
-			<td class="indexTable-body-row-cell u-cursorPointer"><div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div></td>
-			<!-- stopPropagation on the table data cell with a mod-allowTextSelection -->
-			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection" (click)="$event.stopPropagation()">Selectable</td>
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
+				<div class="u-ellipsis" luTooltip luTooltipWhenEllipsis>Tooltip when ellipsis</div>
+			</td>
+			<td class="indexTable-body-row-cell u-whiteSpaceNowrap mod-allowTextSelection">Selectable</td>
 			<!-- u-widthFitContent to contain de width and center the tooltip -->
-			<td class="indexTable-body-row-cell u-cursorPointer">
+			<td class="indexTable-body-row-cell u-cursorPointer" (click)="message('Primary action')">
 				<div class="u-ellipsis u-widthFitContent pr-u-focusVisible u-borderRadiusM" luTooltip="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.">Tooltip</div>
 			</td>
-			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap">Content</td>
-			<!-- stopPropagation to prevent bubbling -->
-			<td class="indexTable-body-row-cell mod-alignRight mod-actions" (click)="$event.stopPropagation()">
+			<td class="indexTable-body-row-cell u-cursorPointer u-whiteSpaceNowrap" (click)="message('Primary action')">
+				Content
+			</td>
+			<td class="indexTable-body-row-cell mod-alignRight mod-actions">
 				<button luTooltip="Secondary action (you can click)" luTooltipOnlyForDisplay (click)="message('Secondary action')" type="button" class="button mod-delete indexTable-body-row-cell-subAction">
 					<span aria-hidden="true" class="lucca-icon icon-trashDelete"></span>
 				</button>

--- a/stories/documentation/listings/index-table/index-table-actions-userPopover.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-actions-userPopover.stories.ts
@@ -1,0 +1,55 @@
+import { bob } from '@/stories/users/user.mocks';
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/popup-employee';
+import { LuUserDisplayModule, LuUserPictureComponent } from '@lucca-front/ng/user';
+import { applicationConfig, Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+
+interface IndexTableActionsUserPopoverCellStory {}
+
+export default {
+	title: 'Documentation/Listings/Index Table/Actions/User popover',
+	argTypes: {},
+	decorators: [
+		moduleMetadata({
+			imports: [LuUserPopoverDirective, LuUserDisplayModule, LuUserPictureComponent],
+		}),
+		applicationConfig({
+			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
+		}),
+	],
+} as Meta;
+
+function getTemplate(args: IndexTableActionsUserPopoverCellStory): string {
+	return `<table class="indexTable">
+	<thead class="indexTable-head">
+		<tr class="indexTable-head-row">
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+		</tr>
+	</thead>
+	<tbody class="indexTable-body">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell">
+				<button class="indexTable-body-row-cell-link" type="button"><span class="u-mask">See details</span></button>
+				<div class="u-displayFlex u-widthFitContent pr-u-gap50 pr-u-focusVisible u-borderRadiusM" [luUserPopover]="bob">
+					<lu-user-picture class="mod-XS" [user]="bob" />
+					{{ bob | luUserDisplay:'lf' }} with userPopover
+				</div>
+			</td>
+			<td class="indexTable-body-row-cell">Content</td>
+			<td class="indexTable-body-row-cell">Content</td>
+		</tr>
+	</tbody>
+</table>
+`;
+}
+
+const Template: StoryFn<IndexTableActionsUserPopoverCellStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+});
+
+export const UserPopover = Template.bind({});
+UserPopover.args = { bob };

--- a/stories/documentation/listings/index-table/index-table-basic.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-basic.stories.ts
@@ -1,24 +1,9 @@
-import { bob } from '@/stories/users/user.mocks';
-import { provideHttpClient } from '@angular/common/http';
-import { provideAnimations } from '@angular/platform-browser/animations';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/popup-employee';
-import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { LuUserDisplayModule, LuUserPictureComponent } from '@lucca-front/ng/user';
-import { applicationConfig, Meta, moduleMetadata, StoryFn } from '@storybook/angular';
+import { Meta, StoryFn } from '@storybook/angular';
 
 interface IndexTableBasicStory {}
 
 export default {
 	title: 'Documentation/Listings/Index Table/Basic',
-	argTypes: {},
-	decorators: [
-		moduleMetadata({
-			imports: [LuTooltipModule, LuUserPopoverDirective, LuUserDisplayModule, LuUserPictureComponent],
-		}),
-		applicationConfig({
-			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
-		}),
-	],
 } as Meta;
 
 function getTemplate(args: IndexTableBasicStory): string {
@@ -52,44 +37,9 @@ function getTemplate(args: IndexTableBasicStory): string {
 			<td class="indexTable-body-row-cell">Content</td>
 			<td class="indexTable-body-row-cell">Content</td>
 		</tr>
-		<tr class="indexTable-body-row">
-			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-link">Content</a>
-			</td>
-			<td class="indexTable-body-row-cell mod-allowTextSelection">
-				Content selectable
-			</td>
-			<td class="indexTable-body-row-cell">
-				Content
-			</td>
-		</tr>
-		<tr class="indexTable-body-row">
-			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-link"><span class="u-mask">See details</span></a>
-				<span luTooltip="This is a tooltip">Content with tooltip</span>
-			</td>
-			<td class="indexTable-body-row-cell"><a href="#">Content actionable</a></td>
-			<td class="indexTable-body-row-cell">Content</td>
-		</tr>
-		<tr class="indexTable-body-row">
-			<td class="indexTable-body-row-cell">
-				<button class="indexTable-body-row-cell-link" type="button"><span class="u-mask">See details</span></button>
-				<div class="u-displayFlex pr-u-gap50" [luUserPopover]="bob"><lu-user-picture class="mod-XS" [user]="bob"></lu-user-picture>{{ bob | luUserDisplay:'lf' }} (with userPopover)</div>
-			</td>
-			<td class="indexTable-body-row-cell"><span luTooltip="This is a tooltip">Content with tooltip</span></td>
-			<td class="indexTable-body-row-cell">Content</td>
-		</tr>
-		<!-- indexTable-body-row-cell-action is deprecated -->
-		<tr class="indexTable-body-row">
-			<td class="indexTable-body-row-cell">
-				<a href="#" class="indexTable-body-row-cell-action">Action</a>
-				Content (with deprecated action)
-			</td>
-			<td class="indexTable-body-row-cell">Content</td>
-			<td class="indexTable-body-row-cell">Content</td>
-		</tr>
 	</tbody>
-</table>`;
+</table>
+`;
 }
 
 const Template: StoryFn<IndexTableBasicStory> = (args) => ({
@@ -98,4 +48,3 @@ const Template: StoryFn<IndexTableBasicStory> = (args) => ({
 });
 
 export const Basic = Template.bind({});
-Basic.args = { bob };

--- a/stories/documentation/listings/index-table/index-table-deprecated.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-deprecated.stories.ts
@@ -1,0 +1,38 @@
+import { Meta, StoryFn } from '@storybook/angular';
+
+interface IndexTableDeprecatedStory {}
+
+export default {
+	title: 'Documentation/Listings/Index Table/Deprecated',
+} as Meta;
+
+function getTemplate(args: IndexTableDeprecatedStory): string {
+	return `
+<table class="indexTable">
+	<thead class="indexTable-head">
+		<tr class="indexTable-head-row">
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+		</tr>
+	</thead>
+	<tbody class="indexTable-body">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell">
+				<!-- indexTable-body-row-cell-action is deprecated -->
+				<a href="#" class="indexTable-body-row-cell-action">Action</a>
+				Content (with deprecated action)
+			</td>
+			<td class="indexTable-body-row-cell">Content</td>
+			<td class="indexTable-body-row-cell">Content</td>
+		</tr>
+	</tbody>
+</table>`;
+}
+
+const Template: StoryFn<IndexTableDeprecatedStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+});
+
+export const Deprecated = Template.bind({});

--- a/stories/documentation/listings/index-table/index-table-input.stories.ts
+++ b/stories/documentation/listings/index-table/index-table-input.stories.ts
@@ -1,0 +1,43 @@
+import { Meta, StoryFn } from '@storybook/angular';
+
+interface IndexTableInputStory {}
+
+export default {
+	title: 'Documentation/Listings/Index Table/Input',
+	argTypes: {},
+} as Meta;
+
+function getTemplate(args: IndexTableInputStory): string {
+	return `<table class="indexTable mod-selectable">
+	<thead class="indexTable-head">
+		<tr class="indexTable-head-row">
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+			<th class="indexTable-head-row-cell" scope="col">Label</th>
+		</tr>
+	</thead>
+	<tbody class="indexTable-body">
+		<tr class="indexTable-body-row">
+			<td class="indexTable-body-row-cell">
+				<label class="indexTable-body-row-cell-link" for="myInput">
+					<span>Importer un ficher</span>
+				</label>
+				<input
+					id="myInput"
+					type="file"
+					accept=".pdf, .jpg, .jpeg, .png"
+					class="indexTable-body-row-cell-link u-mask"
+				/>
+			</td>
+			<td class="indexTable-body-row-cell">Content</td>
+		</tr>
+	</tbody>
+</table>`;
+}
+
+const Template: StoryFn<IndexTableInputStory> = (args) => ({
+	props: args,
+	template: getTemplate(args),
+});
+
+export const Input = Template.bind({});
+Input.args = {};


### PR DESCRIPTION
## Description

Stories for index table with:
- tooltips
- user popover
- text selectionable or actionable
- dropdown or sub actions

-----

`[class*='row-cell']` has been replaced by `.indexTable-head-row-cell, .indexTable-body-row-cell, .indexTable-foot-row-cell` so that it no longer applies to `indexTable-body-row-cell-link`.

-----
