### PR TITLE
ref(title): better DX

### DIFF
--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -6,20 +6,20 @@ Add `title` properties in your routes config:
 
 ```typescript
 const routes: Routes = [
-	{
-		path: '',
-		data: {
-			title: 'Parent title',
-		},
-		children: [
-			{
-				path: ':requestId',
-				data: {
-					title: 'Sub route title',
-				},
-			},
-		],
-	},
+  {
+    path: '',
+    data: {
+      title: 'Parent title',
+    },
+    children: [
+      {
+        path: ':requestId',
+        data: {
+          title: 'Sub route title',
+        },
+      },
+    ],
+  },
 ];
 ```
 
@@ -27,26 +27,26 @@ The service should now be able to collect all `title` properties defined for the
 
 ex: `Sub route title - Parent title - YourAppName - Lucca`
 
-For dynamic titles, the `prependTitle` method from `LuTitleService` enables you to add a custom title.
+For dynamic titles, the `prependTitle` method from `LuTitleStrategy` enables you to add a custom title.
 In a component, you could do the following:
 
 ```typescript
 const userName: string = this.userService.getCurrentUser();
-this.luTitleService.prependTitle(userName);
+this.luTitleStrategy.prependTitle(userName);
 ```
 
 You can also replace the first fragment using:
 
 ```typescript
 const userName: string = this.userService.getOtherUser();
-this.luTitleService.overrideFirstTitlePart(userName);
+this.luTitleStrategy.overrideFirstTitlePart(userName);
 ```
 
 Both `prependTitle` and `overrideFirstTitlePart` can also be called using `Observable<string>` :
 
 ```typescript
 const selectedUser$ = this.userStore.selected$;
-this.luTitleService.prependTitle(selectedUser$);
+this.luTitleStrategy.prependTitle(selectedUser$);
 ```
 
 ## Quickstart
@@ -55,8 +55,14 @@ You will need to:
 
 - Install `@lucca-front/ng`
 - Create a service (`YourAppNameTranslateService`) that implements the `ILuTitleTranslateService`
-- Provide this service in the `app.module.ts` and import `LuTitleModule`
-- Init the `LuTitleService` in your `app.component.ts`
+- Call `provideLuTitleStrategy` in your `app.module.ts` / `app.config.ts`
+
+```ts
+provideLuTitleStrategy({
+  appName: () => 'YourAppName',
+  translateService: () => inject(YourAppNameTranslateService),
+}),
+```
 
 ### Let's start by creating the service
 
@@ -69,10 +75,10 @@ You should end up with the following if you are using `ngx-translate`:
 ```typescript
 @Injectable({ providedIn: 'root' })
 export class CoreRhTranslateService implements ILuTitleTranslateService {
-	constructor(private translateService: TranslateService) {}
-	translate(key: string, args: unknown): string {
-		return this.translateService.instant(key, args);
-	}
+  constructor(private translateService: TranslateService) {}
+  translate(key: string, args: unknown): string {
+    return this.translateService.instant(key, args);
+  }
 }
 ```
 
@@ -81,34 +87,22 @@ or if you are using `transloco`:
 ```typescript
 @Injectable({ providedIn: 'root' })
 export class CoreRhTranslateService implements ILuTitleTranslateService {
-	constructor(private translateService: TranslocoService) {}
-	translate(key: string, args: HashMap): string {
-		return this.translateService.translate(key, args);
-	}
+  constructor(private translateService: TranslocoService) {}
+  translate(key: string, args: HashMap): string {
+    return this.translateService.translate(key, args);
+  }
 }
 ```
 
 ### Adapt `app.module.ts` config
 
-Import the `LuTitleModule` and provide the service you just created to the token `LU_TITLE_TRANSLATE_SERVICE` in the `app.module.ts` :
+In the `app.module.ts`, you need to call `provideLuTitleStrategy` in the `providers` array:
 
 ```typescript
 @NgModule({
- imports: [
-  LuTitleModule
- ],
- provide: [
-  {
-   provide: LU_TITLE_TRANSLATE_SERVICE,
-   useExisting: YourAppNameTranslateService
-  }
- ]
-```
-
-### Init the `LuTitleService`
-
-In the the `app.component.ts`, init the LuTitleService by passing the name of you app:
-
-```typescript
-this.luTitleService.init('**YourAppName**');
+  providers: [
+    provideLuTitleStrategy({ translateService: () => inject(YourAppNameTranslateService) }),
+  ]
+})
+export class AppModule {}
 ```

--- a/packages/ng/title/title-translate.service.ts
+++ b/packages/ng/title/title-translate.service.ts
@@ -1,7 +1,8 @@
 import { InjectionToken } from '@angular/core';
+import { Observable } from 'rxjs';
 
 export const LU_TITLE_TRANSLATE_SERVICE = new InjectionToken<ILuTitleTranslateService>('LU_TITLE_TRANSLATE_SERVICE');
 
 export interface ILuTitleTranslateService {
-	translate(key: string, args?: Record<string, unknown>): string;
+	translate(key: string, args?: Record<string, unknown>): string | Observable<string>;
 }

--- a/packages/ng/title/title.strategy.spec.ts
+++ b/packages/ng/title/title.strategy.spec.ts
@@ -5,9 +5,9 @@ import { ActivatedRouteSnapshot, RouterLink, RouterOutlet, TitleStrategy } from 
 import { SpectatorRouting, createRoutingFactory, mockProvider } from '@ngneat/spectator/jest';
 import { of, timer } from 'rxjs';
 import { map, skip } from 'rxjs/operators';
-import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
+import { ILuTitleTranslateService } from './title-translate.service';
 import { TitleSeparator } from './title.model';
-import { APP_TITLE, LuTitleStrategy } from './title.strategy';
+import { LuTitleStrategy, provideLuTitleStrategy } from './title.strategy';
 
 class TranslateService implements ILuTitleTranslateService {
 	translate(key: string, args: Record<string, unknown> = null): string {
@@ -82,18 +82,10 @@ describe('TitleService', () => {
 		component: AppComponent,
 		providers: [
 			mockProvider(Title),
-			{
-				provide: LU_TITLE_TRANSLATE_SERVICE,
-				useClass: TranslateService,
-			},
-			{
-				provide: TitleStrategy,
-				useClass: LuTitleStrategy,
-			},
-			{
-				provide: APP_TITLE,
-				useValue: 'BU',
-			},
+			provideLuTitleStrategy({
+				appTitle: () => 'BU',
+				translateService: () => new TranslateService(),
+			}),
 		],
 		stubsEnabled: false,
 		routes: [

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -1,15 +1,24 @@
-import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { inject, Injectable, InjectionToken, Provider } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, TitleStrategy } from '@angular/router';
-import { BehaviorSubject, combineLatest, ObservableInput, of } from 'rxjs';
+import { BehaviorSubject, combineLatest, Observable, ObservableInput, of } from 'rxjs';
 import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
 import { PageTitle, TitleSeparator } from './title.model';
 
-export const APP_TITLE = new InjectionToken('APP_TITLE');
+export const ɵAPP_TITLE = new InjectionToken<string | Observable<string>>('APP_TITLE');
+
+/**
+ * @deprecated Use `provideLuTitleStrategy` instead.
+ */
+export const APP_TITLE = ɵAPP_TITLE;
 
 @Injectable({ providedIn: 'root' })
 export class LuTitleStrategy extends TitleStrategy {
+	private title = inject(Title);
+	private translateService = inject<ILuTitleTranslateService>(LU_TITLE_TRANSLATE_SERVICE, { optional: true });
+	private appTitle = inject(ɵAPP_TITLE);
+
 	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>(['Lucca']);
 	titleParts$ = this.titlePartsSubject.asObservable();
 	title$ = this.titleParts$.pipe(
@@ -17,11 +26,7 @@ export class LuTitleStrategy extends TitleStrategy {
 		map((parts) => parts.join(TitleSeparator)),
 		distinctUntilChanged(),
 	);
-	constructor(
-		private title: Title,
-		@Inject(LU_TITLE_TRANSLATE_SERVICE) private translateService: ILuTitleTranslateService,
-		@Inject(APP_TITLE) private appTitle: string,
-	) {
+	constructor() {
 		super();
 		this.title$.pipe(tap((title) => this.title.setTitle(title))).subscribe();
 	}
@@ -31,9 +36,9 @@ export class LuTitleStrategy extends TitleStrategy {
 		const pageTitles = this.#getPageTitleParts(routerState.root).reverse();
 		const translatedPageTitles = uniqTitle(pageTitles)
 			.filter(({ title }) => title !== '')
-			.map(({ title, params }) => this.translateService.translate(title, params));
+			.map(({ title, params }) => (this.translateService ? this.translateService.translate(title, params) : title));
 		// Add the name app and 'Lucca' at the end of the title
-		const titleParts = [...translatedPageTitles, this.translateService.translate(this.appTitle), 'Lucca'].filter((x) => !!x);
+		const titleParts = [...translatedPageTitles, this.appTitle, 'Lucca'].filter((x) => !!x);
 		this.titlePartsSubject.next(titleParts);
 	}
 
@@ -56,4 +61,22 @@ export class LuTitleStrategy extends TitleStrategy {
 
 function uniqTitle(titleParts: Array<PageTitle>): Array<PageTitle> {
 	return titleParts.filter(({ title }, index) => titleParts.findIndex((pageTitle) => pageTitle.title === title) === index);
+}
+
+export interface LuTitleStrategyOptions {
+	appTitle?: () => string | Observable<string>;
+	translateService?: () => ILuTitleTranslateService;
+}
+
+export function provideLuTitleStrategy(options: LuTitleStrategyOptions): Provider[] {
+	const providers: Provider[] = [{ provide: TitleStrategy, useClass: LuTitleStrategy }];
+
+	if (options.appTitle) {
+		providers.push({ provide: ɵAPP_TITLE, useFactory: options.appTitle });
+	}
+	if (options.translateService) {
+		providers.push({ provide: LU_TITLE_TRANSLATE_SERVICE, useFactory: options.translateService });
+	}
+
+	return providers;
 }


### PR DESCRIPTION
## Description

💥 Breaking when using `APP_TITLE` (but no usages on Lucca's side)

Some improvement on DX:
- Translate service is optional if you want to handle translations on your side
- deprecate APP_TITLE and add a `provideAppTitle(() => 'title')`
- add a `provideLuTitleTranslateService(() => inject(TranslocoService))`

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
