### PR TITLE
fix(user-display): handle nullish values for user display tooling

### DIFF
--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -33,7 +33,10 @@ const formatUser: Record<LuDisplayFormat, (user: LuUserDisplayInput) => string> 
  * Displays a user name according to specified format. Supported formats: f for first name,
  * F for first initial, l for last name, L for last initial.
  */
-export function luUserDisplay(user: LuUserDisplayInput, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
+export function luUserDisplay(user?: LuUserDisplayInput, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
+	if (!user) {
+		return '';
+	}
 	return formatUser[format](user);
 }
 


### PR DESCRIPTION
## Description

This is mostly to prevent potential crashes and remove some meaningless nullish user errors from our Datadog reporting 🐶 

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
