### PR TITLE
feat(schematics): HTML icons to lu-icon migration

### DIFF
--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -35,6 +35,11 @@
       "description": "Replace cdn urls with their new location",
       "factory": "./cdn-urls/index",
       "schema": "./cdn-urls/schema.json"
+    },
+    "lu-icon": {
+      "description": "Migrate HTML icons to the new lu-icon component",
+      "factory": "./lu-icon/index",
+      "schema": "./lu-icon/schema.json"
     }
   }
 }

--- a/packages/ng/schematics/lib/html-ast.ts
+++ b/packages/ng/schematics/lib/html-ast.ts
@@ -11,7 +11,7 @@ import { currentSchematicContext } from './lf-schematic-context';
 export type TemplateNode = ParsedTemplate['nodes'] extends Array<infer S> ? S : never;
 
 export class HtmlAstVisitor<TNode extends TemplateNode> {
-	private nodes: TNode[];
+	public readonly nodes: TNode[];
 
 	public constructor(
 		nodes: TNode[] | TNode

--- a/packages/ng/schematics/lib/html-ast.ts
+++ b/packages/ng/schematics/lib/html-ast.ts
@@ -67,33 +67,33 @@ export class HtmlAstVisitor<TNode extends TemplateNode> {
 		});
 	}
 
-	public visitNodes(cb: (node: TemplateNode) => void): void {
+	public visitNodes(cb: (node: TemplateNode, parent?: TemplateNode) => void): void {
 		this.visit(cb, this.nodes);
 	}
 
-	private visit(cb: (node: TemplateNode) => void, nodes: TemplateNode[]): void {
+	private visit(cb: (node: TemplateNode, parent?: TemplateNode) => void, nodes: TemplateNode[], parent?: TemplateNode): void {
 		for (const node of nodes) {
-			cb(node);
+			cb(node, parent);
 			if (node instanceof currentSchematicContext.angularCompiler.TmplAstIfBlock) {
 				// Visit @if branches
 				node.branches.forEach((branch) => {
-					this.visit(cb, branch.children);
+					this.visit(cb, branch.children, node);
 				});
 			} else if (node instanceof currentSchematicContext.angularCompiler.TmplAstForLoopBlock) {
 				// Visit @for's children
-				this.visit(cb, node.children);
+				this.visit(cb, node.children, node);
 
 				if (node.empty) {
 					// If we have an @empty block, visit its children too
-					this.visit(cb, node.empty.children);
+					this.visit(cb, node.empty.children, node);
 				}
 			} else if (node instanceof currentSchematicContext.angularCompiler.TmplAstSwitchBlock) {
 				node.cases.forEach((caseNode) => {
-					this.visit(cb, caseNode.children);
+					this.visit(cb, caseNode.children, node);
 				});
 			} else if (node instanceof currentSchematicContext.angularCompiler.TmplAstDeferredBlock || node instanceof currentSchematicContext.angularCompiler.TmplAstElement || node instanceof currentSchematicContext.angularCompiler.TmplAstTemplate) {
 				// Visit @defer and classic AST elements
-				this.visit(cb, node.children);
+				this.visit(cb, node.children, node);
 			}
 		}
 	}

--- a/packages/ng/schematics/lu-icon/index.ts
+++ b/packages/ng/schematics/lu-icon/index.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { Rule } from '@angular-devkit/schematics';
+import { createSourceFile, ScriptTarget } from 'typescript';
+import { currentSchematicContext, SchematicContextOpts } from '../lib/lf-schematic-context';
+import { migrateFile } from '../lib/schematics';
+import { migrateComponent } from './migration';
+
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
+export default (options?: SchematicContextOpts): Rule => {
+
+	return async (tree, context) => {
+		await currentSchematicContext.init(context, options);
+
+		tree.visit((path, entry) => {
+			if (path.includes('node_modules') || !entry) {
+				return;
+			}
+			if (path.endsWith('.ts')) {
+				migrateFile(path, entry, tree, (content) => {
+					const sourceFile = createSourceFile(path, content, ScriptTarget.ESNext);
+					return migrateComponent(sourceFile, path, tree);
+				});
+			}
+		});
+	};
+};

--- a/packages/ng/schematics/lu-icon/migration.spec.ts
+++ b/packages/ng/schematics/lu-icon/migration.spec.ts
@@ -1,0 +1,24 @@
+import * as path from 'path';
+import { createTreeFromFolder, expectTree, runSchematic } from '../lib/migration-test.js';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.json'));
+const testsRoot = path.join(__dirname, 'tests');
+
+describe('lu-icon Migration', () => {
+	it('should handle basic case files', async () => {
+		// Arrange
+		const tree = createTreeFromFolder(path.join(testsRoot, 'input'));
+		const expectedTree = createTreeFromFolder(path.join(testsRoot, 'output'));
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'lu-icon', { skipInstallation: true }, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+});

--- a/packages/ng/schematics/lu-icon/migration.ts
+++ b/packages/ng/schematics/lu-icon/migration.ts
@@ -117,8 +117,9 @@ function findHTMLIcons(sourceFile: SourceFile, basePath: string, tree: Tree): Ht
 							filePath: template.filePath,
 							componentTS: sourceFile
 						}
-						if(isInterestingNode(parent)) {
-							const altSpan= parent.children.find(child => {
+						const siblings = isInterestingNode(parent) ? parent?.children : htmlAst.nodes;
+						if(siblings.length > 0) {
+							const altSpan= siblings.find(child => {
 								if(isInterestingNode(child)) {
 									const childClasses = child.attributes.find(attr => attr.name === 'class')?.value;
 									return childClasses === 'u-mask';

--- a/packages/ng/schematics/lu-icon/migration.ts
+++ b/packages/ng/schematics/lu-icon/migration.ts
@@ -1,0 +1,139 @@
+import { HtmlAst } from '../lib/html-ast.js';
+import { SourceFile } from 'typescript';
+import { extractNgTemplatesIncludingHtml } from '../lib/angular-template';
+import { Tree } from '@angular-devkit/schematics';
+import { currentSchematicContext } from '../lib/lf-schematic-context';
+import type { TmplAstElement } from '@angular/compiler';
+import { insertAngularImportIfNeeded,insertTSImportIfNeeded } from '../lib/angular-component-ast';
+import { applyToUpdateRecorder } from '@schematics/angular/utility/change';
+
+
+interface HtmlIcon {
+	node: TmplAstElement;
+	icon: string;
+	alt?: string;
+	altSpan?: TmplAstElement;
+	nodeOffset: number;
+	filePath: string;
+	componentTS: SourceFile;
+}
+
+export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tree): string {
+	const htmlIcons = findHTMLIcons(sourceFile, path, tree);
+	if(htmlIcons.length > 0){
+		const tsUpdate = tree.beginUpdate(path);
+		const isInlineTemplate = htmlIcons[0].filePath === path;
+		const templateUpdate = isInlineTemplate ? tsUpdate : tree.beginUpdate(htmlIcons[0].filePath);
+		htmlIcons.forEach((icon) => {
+			/**
+			 * Remove stuff
+			 */
+			const endSpanOffset = icon.node.endSourceSpan?.start.offset || -1;
+			// Remove content if there's any (content in icon, wtf?)
+			templateUpdate.remove(icon.nodeOffset + icon.node.startSourceSpan.end.offset, endSpanOffset - icon.node.startSourceSpan.end.offset);
+			// Remove icon classes
+			templateUpdate.remove(icon.nodeOffset + icon.node.startSourceSpan.start.offset + 1, icon.node.name.length);
+			// Remove closing tag
+			if(icon.node.endSourceSpan?.start?.offset) {
+				templateUpdate.remove(icon.nodeOffset + icon.node.endSourceSpan?.start?.offset, icon.node.endSourceSpan?.toString().length);
+			}
+			// If there's an aria-hidden, remove it
+			const ariaHidden = icon.node.attributes.find(attr => attr.name === 'aria-hidden');
+			if(ariaHidden) {
+				const attrLength = (ariaHidden.valueSpan?.end?.offset || 0) - (ariaHidden.keySpan?.start?.offset || 0);
+				templateUpdate.remove(icon.nodeOffset + (ariaHidden.keySpan?.start?.offset || 0), attrLength + 1);
+			}
+			// If there's an alt span, remove it
+			if(icon.altSpan) {
+				let previousEndSpanOffset = 0;
+				while([' ', '\n', '\t'].includes(sourceFile.text.charAt(icon.nodeOffset - previousEndSpanOffset + icon.altSpan.startSourceSpan.start.offset - 1))) {
+					previousEndSpanOffset++;
+				}
+				templateUpdate.remove(icon.nodeOffset - previousEndSpanOffset + icon.altSpan.startSourceSpan.start.offset, icon.altSpan.sourceSpan.toString().length + previousEndSpanOffset);
+			}
+
+			/**
+			 * Add stuff
+			 */
+			// First of all, add opening tag, icon name and alt if it's here
+			let openingTag = `lu-icon icon="${icon.icon}"`;
+			if (icon.alt) {
+				openingTag += ` alt="${icon.alt}"`;
+			}
+			templateUpdate.insertRight(icon.nodeOffset + icon.node.startSourceSpan.start.offset + 1, openingTag);
+			// Self close this tag
+			templateUpdate.insertRight(icon.nodeOffset + icon.node.startSourceSpan.end.offset - 1, '/');
+
+
+			/**
+			 * Modify classes
+			 */
+			const classesNode = icon.node.attributes.find(attr => attr.name === 'class');
+			if(classesNode && classesNode.keySpan){
+				const classes = classesNode.value;
+				const cleanedClasses = classes.split(' ').filter(c => {
+					return !['lucca-icon', `icon-${icon.icon}`].includes(c);
+				}).join(' ');
+				templateUpdate.remove(icon.nodeOffset + classesNode.keySpan.start.offset, classesNode.sourceSpan.toString().length);
+				// TODO if remaining classes after cleanup, write them
+			}
+
+		});
+		// Add import if needed
+		applyToUpdateRecorder(tsUpdate, [insertTSImportIfNeeded(sourceFile, path, 'IconComponent', '@lucca-front/ng/icon'), insertAngularImportIfNeeded(sourceFile, path, 'IconComponent')]);
+		tree.commitUpdate(tsUpdate);
+		if (!isInlineTemplate) {
+			tree.commitUpdate(templateUpdate);
+		}
+	}
+	return tree.readText(path);
+}
+
+function findHTMLIcons(sourceFile: SourceFile, basePath: string, tree: Tree): HtmlIcon[] {
+	const htmlIcons: HtmlIcon[] = [];
+	const ngTemplates = extractNgTemplatesIncludingHtml(sourceFile, tree, basePath);
+
+	ngTemplates.forEach((template) => {
+		const htmlAst = new HtmlAst(template.content);
+		htmlAst.visitNodes((node, parent) => {
+			if (isInterestingNode(node)) {
+				const classes = node.attributes.find(attr => attr.name === 'class')?.value;
+				if (classes?.includes("lucca-icon")){
+					const iconClass = classes.split(' ').find(c => c.startsWith('icon-'));
+					if (iconClass) {
+						const iconName = iconClass.replace('icon-', '');
+						const icon: HtmlIcon = {
+							node: node,
+							icon: iconName,
+							nodeOffset: template.offsetStart,
+							filePath: template.filePath,
+							componentTS: sourceFile
+						}
+						if(isInterestingNode(parent)) {
+							const altSpan= parent.children.find(child => {
+								if(isInterestingNode(child)) {
+									const childClasses = child.attributes.find(attr => attr.name === 'class')?.value;
+									return childClasses === 'u-mask';
+								}
+								return false;
+							});
+							// We know it's one of these types but TS doesn't find that info from the above call so here we go again
+							if (isInterestingNode(altSpan)) {
+								icon.alt = altSpan.children.find(c => c instanceof currentSchematicContext.angularCompiler.TmplAstText)?.value;
+								icon.altSpan = altSpan;
+							}
+						}
+						htmlIcons.push(icon);
+					}
+
+				}
+			}
+		});
+	});
+
+	return htmlIcons;
+}
+
+function isInterestingNode(node: unknown): node is TmplAstElement {
+	return node instanceof currentSchematicContext.angularCompiler.TmplAstElement;
+}

--- a/packages/ng/schematics/lu-icon/schema.json
+++ b/packages/ng/schematics/lu-icon/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "LuccaFrontLuIcon",
+  "title": "Migrate HTML icons to the new lu-icon component",
+  "type": "object",
+  "properties": {
+    "dryRun": {
+      "type": "boolean",
+      "description": "Run through the migration without making any changes.",
+      "default": false
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip installing dependencies.",
+      "default": false
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose logging.",
+      "default": false
+    }
+  }
+}

--- a/packages/ng/schematics/lu-icon/tests/input/external-template.component.html
+++ b/packages/ng/schematics/lu-icon/tests/input/external-template.component.html
@@ -1,0 +1,6 @@
+<button luButton>
+  <span aria-hidden="true" class="lucca-icon icon-signClose"></span>
+  <span class="u-mask">Close</span>Fermer
+</button>
+<span aria-hidden="true" class="lucca-icon icon-signClose mod-S"></span>
+<span aria-hidden="true" class="lucca-icon icon-signClose keepme"></span>

--- a/packages/ng/schematics/lu-icon/tests/input/external-template.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/input/external-template.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	templateUrl: './external-template.component.html',
+	imports: [
+		ButtonComponent
+	]
+})
+export class SimpleCasesComponent {
+}

--- a/packages/ng/schematics/lu-icon/tests/input/simple-cases.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/input/simple-cases.component.ts
@@ -9,6 +9,8 @@ import { ButtonComponent } from '@lucca-front/ng/button';
 			<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
 			<span class="u-mask">Close</span>
 		</button>
+		<span aria-hidden="true" class="lucca-icon icon-signClose mod-S"></span>
+		<span aria-hidden="true" class="lucca-icon icon-signClose keepme"></span>
 	`,
 	imports: [
 		ButtonComponent

--- a/packages/ng/schematics/lu-icon/tests/input/simple-cases.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/input/simple-cases.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<button luButton>
+			<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
+			<span class="u-mask">Close</span>
+		</button>
+	`,
+	imports: [
+		ButtonComponent
+	]
+})
+export class SimpleCasesComponent {
+}

--- a/packages/ng/schematics/lu-icon/tests/output/external-template.component.html
+++ b/packages/ng/schematics/lu-icon/tests/output/external-template.component.html
@@ -1,0 +1,6 @@
+<button luButton>
+  <lu-icon icon="signClose" alt="Close" />
+  Fermer
+</button>
+<lu-icon icon="signClose" size="S" />
+<lu-icon icon="signClose" class="keepme"/>

--- a/packages/ng/schematics/lu-icon/tests/output/external-template.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/output/external-template.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { IconComponent } from '@lucca-front/ng/icon';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	templateUrl: './external-template.component.html',
+	imports: [
+		ButtonComponent, IconComponent
+	]
+})
+export class SimpleCasesComponent {
+}

--- a/packages/ng/schematics/lu-icon/tests/output/simple-cases.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/output/simple-cases.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { IconComponent } from '@lucca-front/ng/icon';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<button luButton>
+			<lu-icon icon="signClose" alt="Close"  />
+		</button>
+	`,
+	imports: [
+		ButtonComponent, IconComponent
+	]
+})
+export class SimpleCasesComponent {
+}

--- a/packages/ng/schematics/lu-icon/tests/output/simple-cases.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/output/simple-cases.component.ts
@@ -7,8 +7,10 @@ import { IconComponent } from '@lucca-front/ng/icon';
 	standalone: true,
 	template: `
 		<button luButton>
-			<lu-icon icon="signClose" alt="Close"  />
+			<lu-icon icon="signClose" alt="Close" />
 		</button>
+		<lu-icon icon="signClose" size="S" />
+		<lu-icon icon="signClose" class="keepme"/>
 	`,
 	imports: [
 		ButtonComponent, IconComponent


### PR DESCRIPTION
## Description

Using `ng g @lucca-front/ng:lu-icon` migrates your HTML icons into shiny new `lu-icon`s.

Examples:

Input: 
```html
<button luButton>
  <span aria-hidden="true" class="lucca-icon icon-signClose"></span>
  <span class="u-mask">Close</span>Fermer
</button>
<span aria-hidden="true" class="lucca-icon icon-signClose mod-S"></span>
<span aria-hidden="true" class="lucca-icon icon-signClose keepme"></span>
```

Output:

```html
<button luButton>
  <lu-icon icon="signClose" alt="Close" />
  Fermer
</button>
<lu-icon icon="signClose" size="S" />
<lu-icon icon="signClose" class="keepme"/>

```

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
