### PR TITLE
fix(date-range-input): input always disabled

### DIFF
--- a/packages/ng/date2/date-range-input/date-range-input.component.html
+++ b/packages/ng/date2/date-range-input/date-range-input.component.html
@@ -25,7 +25,7 @@
 					(click)="editedField.set(0);openPopover(popoverRef, 'start')"
 					(keydown.arrowDown)="arrowDown(popoverRef, 'start')"
 					(keydown.escape)="popoverRef.close()"
-					[disabled]="disabled"
+					[disabled]="disabled()"
 					[attr.placeholder]="dateFormatLocalized()"
 					[attr.autocomplete]="autocomplete"
 				/>
@@ -49,7 +49,7 @@
 					(click)="editedField.set(1);openPopover(popoverRef, 'end')"
 					(keydown.arrowDown)="arrowDown(popoverRef, 'end')"
 					(keydown.escape)="popoverRef.close()"
-					[disabled]="disabled"
+					[disabled]="disabled()"
 					[attr.placeholder]="dateFormatLocalized()"
 					[attr.autocomplete]="autocomplete"
 				/>
@@ -64,7 +64,7 @@
 				} }
 				<button
 					[luPopover2]="calendar"
-					[disabled]="disabled"
+					[disabled]="disabled()"
 					[luPopoverNoCloseButton]="true"
 					[luPopoverAnchor]="popoverAnchor"
 					#popoverRef="luPopover2"


### PR DESCRIPTION
## Description

Because of a signal used as value instead of being read in template and it being non-`null`, it was always considered as true, hence input being disabled.

We might need a linter rule or something to prevent this in the future.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
