### PR TITLE
Fix us date extraction

### DIFF
--- a/packages/ng/core/date/native/native-date.adapter.ts
+++ b/packages/ng/core/date/native/native-date.adapter.ts
@@ -57,6 +57,11 @@ export class LuNativeDateAdapter extends ALuDateAdapter<Date> implements ILuDate
 				month = parseInt(groups[this._order.month], 10);
 				year = parseInt(groups[this._order.year], 10) || new Date().getFullYear();
 		}
+
+		if (year.toString().length < 4) {
+			year += 2000;
+		}
+
 		return { date, month, year };
 	}
 	isParsable(text: string, granularity: LuDateGranularity = ELuDateGranularity.day): boolean {

--- a/packages/ng/core/date/string/string-date.adapter.spec.ts
+++ b/packages/ng/core/date/string/string-date.adapter.spec.ts
@@ -1,5 +1,5 @@
-import { LuStringDateAdapter } from './string-date.adapter';
 import { ELuDateGranularity } from '../date-granularity.enum';
+import { LuStringDateAdapter } from './string-date.adapter';
 
 describe('LuStringDateAdapter', () => {
 	let adapter: LuStringDateAdapter;
@@ -12,6 +12,7 @@ describe('LuStringDateAdapter', () => {
 		date             | expectedResult
 		${'01/01/2022'}  | ${'2022-01-01'}
 		${'01/01/20222'} | ${'Invalid Date'}
+		${'2/1/23'}      | ${'2023-02-01'}
 	`('should return $expectedResult when parsing $date', ({ date, expectedResult }: { date: string; expectedResult: string }) => {
 		// Act
 		const result = adapter.parse(date, ELuDateGranularity.day);


### PR DESCRIPTION
## Description

allow manual date selection using only the last digit for the year part.

-----
fix for: [LCM-537](https://linear.app/lucca/issue/LCM-537/bug-formulaire-onboarding-lorsque-la-date-est-au-format-us-mdyy-la)


-----
