### PR TITLE
fix(rich-textfield): #3583 replace grey with neutral

### DIFF
--- a/packages/scss/src/components/richText/vars.scss
+++ b/packages/scss/src/components/richText/vars.scss
@@ -2,7 +2,7 @@
 	--components-richTextField-borderColor: var(--pr-t-color-input-border);
 	--components-richTextField-backgroundColor: var(--pr-t-color-input-background);
 	--components-richTextField-color: var(--pr-t-color-input-text);
-	--components-richTextField-toolbar-backgroundColor: var(--palettes-grey-25);
+	--components-richTextField-toolbar-backgroundColor: var(--palettes-neutral-25);
 	--components-richTextField-resize: vertical;
 	--components-richTextField-height: 3lh;
 	--components-richTextField-minHeight: 2lh;


### PR DESCRIPTION
## Description

This PR replaces the deprecated "grey" palette used on the toolbar's background with the "neutral" palette.

-----

-----
