### PR TITLE
fix(date-input): selecting initial value after a change doesn't reflect on model

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -184,6 +184,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 		effect(() => {
 			if (!this.#safeCompareDate(untracked(this.dateFromWriteValue), this.selectedDate())) {
 				this.#onChange?.(this.selectedDate());
+				this.dateFromWriteValue.set(null);
 			}
 		});
 

--- a/stories/documentation/forms/fields/date/date-input-field.stories.ts
+++ b/stories/documentation/forms/fields/date/date-input-field.stories.ts
@@ -105,8 +105,27 @@ export default {
 			await expectNgModelDisplay(canvasElement, 'Invalid Date');
 			await expect(input).toHaveAttribute('aria-invalid', 'true');
 		});
+
+		await context.step('Select today after another date', async () => {
+			await userEvent.clear(input);
+			const yesterday = today.getDate() <= 1 ? 2 : today.getDate() - 1;
+			await pickDay(input, yesterday);
+			await expectNgModelDisplay(canvasElement, new Date(today.getFullYear(), today.getMonth(), yesterday).toString());
+
+			await pickDay(input, today.getDate());
+			await expectNgModelDisplay(canvasElement, new Date(today.getFullYear(), today.getMonth(), today.getDate()).toString());
+		});
 	},
 } as Meta;
+
+async function pickDay(input: HTMLElement, targetDay: number) {
+	await userEvent.click(input);
+	await waitForAngular();
+	const table = screen.getByRole('grid');
+	const calendarComponent = table.parentElement.parentElement;
+	const calendar = within(calendarComponent);
+	await userEvent.click(calendar.getByText(targetDay.toString()));
+}
 
 export const Basic: StoryObj<DateInputComponent & FormFieldComponent> = {
 	args: {


### PR DESCRIPTION
## Description

Because of how we used to compare date with previous write value, resetting the input to its original value from write wasn't resulting in a change event being sent to the control. This has been fixed by resetting value from write call when selected date is being applied.

Also, this PR adds an e2e test to make sure it doesn't come back in the future (and I was able to TDD the fix ✨)

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
