### PR TITLE
doc(stylelint): Explain what to do with Github API rate limit…

### DIFF
--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -49,7 +49,7 @@ To avoid hitting Github’s rate limit, the script caches Milestones versions in
 Webstorm has an [issue with outputting the information during the linting](https://youtrack.jetbrains.com/issue/WEB-71871/stylelint-console.log-written-in-the-linted-file-instead-of-console), so outputting the path is optional with a parameter:
 
 ```sh
-npx stylelint \"./**/*.scss\" showCachePath
+npx stylelint "./**/*.scss" showCachePath
 ```
 
 ### Breaking the rules
@@ -79,7 +79,19 @@ module.exports = {
 
 If needed, each rule can be ignored with [stylelint-(dis|en)able](https://stylelint.io/user-guide/ignore-code).
 
-Please explain why with a comment if you're doing so. Use `styleling-disable[-*] -- Comment` and enable stylelint back as soon as possible: `styleling-enable`.
+Please explain why with a comment if you’re doing so. Use `stylelint-disable[-*] -- Comment` and enable stylelint back as soon as possible: `stylelint-enable`.
+
+## LF versions and Github rate limit
+
+Dates or versions from LF might not show in Stylelint messages.
+
+The cause can be the request to the Github API is blocked because of rate limits on your current IP, resulting in an empty file.
+
+### Workaround
+
+1. Delete the cache file ([showCachePath](#user-content-showcachepath-parameter) tells you where).
+2. Change the IP used to connect to Github (enable or disable your VPN, for example).
+3. Launch linting again: `npx stylelint "./**/*.scss"`.
 
 ## Testing locally
 


### PR DESCRIPTION
## Description

We have recurring issues with requests to Github API being blocked.

Being able to make authenticated requests would prevent the issue.

 This PR gives a workaround in the meantime, and fix some typos.

-----
