### PR TITLE
[utils] scrollblock update

### DIFF
--- a/packages/scss/src/commons/utils/overflow.scss
+++ b/packages/scss/src/commons/utils/overflow.scss
@@ -8,11 +8,10 @@
 }
 
 @mixin scrollblock($suffix: '') {
+	overflow: hidden #{$suffix};
+	
 	&,
 	body {
 		touch-action: none #{$suffix};
-		overscroll-behavior: none #{$suffix};
-		-webkit-overflow-scrolling: auto #{$suffix};
-		overflow: hidden #{$suffix};
 	}
 }


### PR DESCRIPTION
## Description

A bit of tidying up in this mixin, which until now has been a piece of misunderstood magic code.


-----

- `overflow hidden` must only be applied to html, otherwise the sticky anchor changes
- `overscroll-behavior` should only be applied to dialog scrollbars (but is useless as we have a scrollblock)
- `overflow-scrolling` has no noticeable impact according to my tests
- `touch-action: none` remains in place only to ensure stronger support for older iOS devices

-----
