### PR TITLE
fix(filter-pills): better handling of nested select inputs

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -40,7 +40,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	protected coreIntl = getIntl(LU_CORE_SELECT_TRANSLATIONS);
 
-	protected filterPillHost = inject(FILTER_PILL_HOST_COMPONENT);
+	protected filterPillHost = inject(FILTER_PILL_HOST_COMPONENT, { optional: true });
 	protected afterCloseFn?: () => void;
 	protected updatePositionFn?: () => void;
 	protected filterPillMode = false;

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -23,7 +23,7 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor } from '@angular/forms';
 import { getIntl, PortalContent } from '@lucca-front/ng/core';
-import { FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
+import { FILTER_PILL_HOST_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { BehaviorSubject, defer, map, Observable, of, ReplaySubject, startWith, Subject, switchMap, take } from 'rxjs';
 import { LuOptionGrouping, LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
@@ -40,6 +40,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	protected coreIntl = getIntl(LU_CORE_SELECT_TRANSLATIONS);
 
+	protected filterPillHost = inject(FILTER_PILL_HOST_COMPONENT);
 	protected afterCloseFn?: () => void;
 	protected updatePositionFn?: () => void;
 	protected filterPillMode = false;
@@ -219,6 +220,12 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	protected _panelRef?: LuSelectPanelRef<TOption, TValue>;
 
 	protected destroyed$ = new Subject<void>();
+
+	constructor() {
+		if (this.filterPillHost) {
+			this.filterPillHost.registerInput(this);
+		}
+	}
 
 	@HostListener('click', ['$event'])
 	onClickOpenPanel($event: KeyboardEvent) {

--- a/packages/ng/filter-pills/core/tokens.ts
+++ b/packages/ng/filter-pills/core/tokens.ts
@@ -1,6 +1,7 @@
 import { InjectionToken } from '@angular/core';
 import { FilterPillInputComponent } from './filter-pill-input-component';
+import { FilterPillComponent } from '../filter-pill/filter-pill.component';
 
 export const FILTER_PILL_INPUT_COMPONENT = new InjectionToken<FilterPillInputComponent>('FilterPills:InputComponent');
 
-export const FILTER_PILL_HOST_COMPONENT = new InjectionToken<FilterPillInputComponent>('FilterPills:HostComponent');
+export const FILTER_PILL_HOST_COMPONENT = new InjectionToken<FilterPillComponent>('FilterPills:HostComponent');

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -27,7 +27,7 @@ import { getIntl } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
-import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT } from '../core';
+import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '../core';
 import { LU_FILTER_PILLS_TRANSLATIONS } from '../filter-pills.translate';
 
 let nextId = 0;
@@ -61,7 +61,14 @@ export class FilterPillComponent {
 
 	layout = computed(() => this.inputComponentRef()?.filterPillLayout?.() || 'default');
 
-	inputComponentRef = contentChild(FILTER_PILL_INPUT_COMPONENT);
+	// The easy way to grab input component, will work in most cases
+	childInputComponentRef = contentChild(FILTER_PILL_INPUT_COMPONENT);
+
+	// The harder way, because child has to register itself to the host, might become the default approach if this is required too much
+	// (like when child isn't created when component inits or it's too deep)
+	registeredInputComponentRef = signal<FilterPillInputComponent | null>(null);
+
+	inputComponentRef = computed(() => this.registeredInputComponentRef() || this.childInputComponentRef());
 
 	popoverRef = viewChild(PopoverDirective);
 
@@ -186,5 +193,9 @@ export class FilterPillComponent {
 
 	clear(): void {
 		this.inputComponentRef()?.clearFilterPillValue();
+	}
+
+	registerInput(input: FilterPillInputComponent): void {
+		this.registeredInputComponentRef.set(input);
 	}
 }

--- a/stories/documentation/forms/filterPills/angular/filter-pill-child-component.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/filter-pill-child-component.stories.ts
@@ -1,0 +1,79 @@
+import { allLegumes, FilterLegumesPipe } from '@/stories/forms/select/select.utils';
+import { FormsModule } from '@angular/forms';
+import { DateInputComponent, DateRangeInputComponent } from '@lucca-front/ng/date2';
+import { FilterPillComponent } from '@lucca-front/ng/filter-pills';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { CheckboxInputComponent, TextInputComponent } from '@lucca-front/ng/forms';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { StoryModelDisplayComponent } from '../../../../helpers/story-model-display.component';
+import { Component, input } from '@angular/core';
+import { LuMultiDisplayerDirective, LuMultiSelectCounterDisplayerComponent } from '@lucca-front/ng/multi-select';
+import { LuDisplayerDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
+
+@Component({
+	selector: 'demo-child-component',
+	imports: [LuMultiSelectInputComponent, LuMultiSelectCounterDisplayerComponent, LuOptionDirective, LuMultiDisplayerDirective, FilterLegumesPipe, LuSimpleSelectInputComponent, LuDisplayerDirective],
+	template: `
+		@if (multiple()) {
+			<lu-multi-select #selectRef data-qa="cost-center-multi-select" [options]="legumes | filterLegumes: clue" clearable (clueChange)="clue = $event">
+				<ng-container *luOption="let costCenter; select: selectRef">{{ costCenter.name }}</ng-container>
+				<ng-container *luMultiDisplayer="let costCenters; select: selectRef">
+					<lu-multi-select-counter-displayer label="Selected" [selected]="costCenters" />
+				</ng-container>
+			</lu-multi-select>
+		} @else {
+			<lu-simple-select #selectRef data-qa="cost-center-simple-select" [options]="legumes | filterLegumes: clue" clearable (clueChange)="clue = $event">
+				<ng-container *luOption="let costCenter; select: selectRef">{{ costCenter.name }}</ng-container>
+				<ng-container *luDisplayer="let costCenter; select: selectRef">{{ costCenter.name }}</ng-container>
+			</lu-simple-select>
+		}
+	`,
+})
+class MyChildComponent {
+	legumes = allLegumes;
+	clue: string;
+	multiple = input<boolean>(false);
+}
+
+export default {
+	title: 'Documentation/Forms/FiltersPills/FilterPills/Child Select',
+	decorators: [
+		moduleMetadata({
+			imports: [
+				FilterPillComponent,
+				CheckboxInputComponent,
+				FormsModule,
+				DateRangeInputComponent,
+				DateInputComponent,
+				StoryModelDisplayComponent,
+				LuSimpleSelectInputComponent,
+				LuMultiSelectInputComponent,
+				FilterLegumesPipe,
+				FormFieldComponent,
+				TextInputComponent,
+				MyChildComponent,
+			],
+		}),
+	],
+	render: (args, { argTypes }) => {
+		return {
+			props: {
+				simpleSelect: null,
+				multiSelect: [],
+				date: null,
+				dateRange: null,
+				legumes: allLegumes,
+			},
+
+			template: `<lu-filter-pill label="Test inner select">
+	<demo-child-component></demo-child-component>
+</lu-filter-pill>`,
+		};
+	},
+} as Meta;
+
+export const Basic: StoryObj<FilterPillComponent> = {
+	args: {},
+};


### PR DESCRIPTION
## Description

When used deep inside the component tree, filter pill inputs might not register properly. This fixes the issue for the one input we've add issues with regarding this: select.

@GuillaumeNury Looks like the inject + register pattern is the solution once more.

-----

We might want to do this for all pills but this is more of a hotfix for now and we'll see how it goes in the future, it wouldn't be breaking for anyone anyways so it can wait a bit.

-----
