### PR TITLE
feat(tooltip): allow for external host

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -1,4 +1,13 @@
-import { FlexibleConnectedPositionStrategy, HorizontalConnectionPos, OriginConnectionPosition, Overlay, OverlayConnectionPosition, OverlayRef, VerticalConnectionPos } from '@angular/cdk/overlay';
+import {
+	FlexibleConnectedPositionStrategy,
+	FlexibleConnectedPositionStrategyOrigin,
+	HorizontalConnectionPos,
+	OriginConnectionPosition,
+	Overlay,
+	OverlayConnectionPosition,
+	OverlayRef,
+	VerticalConnectionPos,
+} from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import {
 	AfterContentInit,
@@ -70,6 +79,8 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 	luTooltipPosition: LuPopoverPosition = 'above';
 
 	luTooltipWhenEllipsis = input(false, { transform: booleanAttribute });
+
+	luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin>(this.#host);
 
 	resize$ = new Observable((observer) => {
 		const resizeObserver = new ResizeObserver(() => {
@@ -301,7 +312,7 @@ export class LuTooltipTriggerDirective implements AfterContentInit, OnDestroy {
 
 		return this.#overlay
 			.position()
-			.flexibleConnectedTo(this.#host)
+			.flexibleConnectedTo(this.luTooltipAnchor())
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -3,6 +3,7 @@ import { IconComponent } from '@lucca-front/ng/icon';
 import { LuTooltipModule, LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { generateInputs } from '../../../helpers/stories';
+import { ButtonComponent } from '../../../../packages/ng/button/button.component';
 
 export default {
 	title: 'Documentation/Overlays/Tooltip/Basic',
@@ -45,7 +46,7 @@ export default {
 	decorators: [
 		applicationConfig({ providers: [provideAnimations()] }),
 		moduleMetadata({
-			imports: [LuTooltipModule, IconComponent],
+			imports: [LuTooltipModule, IconComponent, ButtonComponent],
 		}),
 	],
 	render: (args, { argTypes }) => {
@@ -64,7 +65,7 @@ export default {
 			template: `<h3>Tooltip simple</h3>
 <button
 	type="button"
-	class="button"
+	luButton
 	luTooltip="👋 Hello"
 	${generateInputs(args, argTypes)}
 >Tooltip au survol</button>
@@ -84,6 +85,9 @@ export default {
 >Ce texte est affiché entièrement. Le tooltip n'apparait pas au survol.</div>
 <h3>Tooltip et icône (avec alternative)</h3>
 <lu-icon icon="star" alt="Favoris" luTooltip="Favoris" luTooltipOnlyForDisplay="true" />
+
+<h3 #tooltipTarget>Tooltip affiché avec un host séparé</h3>
+<p luTooltip="Tooltip déclenché depuis le paragraphe" [luTooltipAnchor]="tooltipTarget">Ce tooltip est déclenchée au hover de ce texte mais sa référence est le titre de cette section.</p>
 `,
 		};
 	},


### PR DESCRIPTION
## Description

This only works properly on non-component elements, just like for popover2, we might want to do it using a directive if any issue appears with that. Reason is that when using `#ref` on a component, it gives us a ref to the component, not the host's `elementRef` that we want.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

closes #3541

-----
