### PR TITLE
feat(dialog): allow for type overriding in data config

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -2,7 +2,7 @@ import { Dialog, DialogRef } from '@angular/cdk/dialog';
 import { inject, Injectable, Injector, Renderer2 } from '@angular/core';
 import { isObservable, merge, of, take } from 'rxjs';
 import { filter, switchMap, takeUntil } from 'rxjs/operators';
-import { LuDialogConfig, LuDialogRef, LuDialogResult } from './model';
+import { LuDialogConfig, LuDialogData, LuDialogRef, LuDialogResult } from './model';
 import { DISMISSED_VALUE } from './model/dialog-ref';
 
 @Injectable()
@@ -11,8 +11,8 @@ export class LuDialogService {
 
 	#injector = inject(Injector);
 
-	open<C>(config: LuDialogConfig<C>): LuDialogRef<C> {
-		let luDialogRef: LuDialogRef<C>;
+	open<C, TData = LuDialogData<C>>(config: LuDialogConfig<C, TData>): LuDialogRef<C, TData> {
+		let luDialogRef: LuDialogRef<C, TData>;
 		let modeClasses: string[] = [];
 		switch (config.mode) {
 			case 'drawer':

--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -90,4 +90,4 @@ interface BaseLuDialogConfig<C, TData = LuDialogData<C>> {
 	panelClasses?: string[];
 }
 
-export type LuDialogConfig<T, TData = LuDialogData<T>> = TData extends never ? Omit<BaseLuDialogConfig<T, TData>, 'data'> : BaseLuDialogConfig<T, TData>;
+export type LuDialogConfig<T, TData = LuDialogData<T>> = [TData] extends [never] ? Omit<BaseLuDialogConfig<T, TData>, 'data'> : BaseLuDialogConfig<T, TData>;

--- a/packages/ng/dialog/model/dialog-config.ts
+++ b/packages/ng/dialog/model/dialog-config.ts
@@ -16,7 +16,7 @@ export type LuDialogData<T> = {
 type DialogRefProps<C> = { [K in keyof C]: C[K] extends ɵDialogResultFlag<unknown> ? K : never }[keyof C] & keyof C;
 export type LuDialogResult<C> = DialogRefProps<C> extends never ? void : C[DialogRefProps<C>] extends ɵDialogResultFlag<infer T> ? T : void;
 
-interface BaseLuDialogConfig<C> {
+interface BaseLuDialogConfig<C, TData = LuDialogData<C>> {
 	/**
 	 * The component or template to put inside the dialog container
 	 */
@@ -25,7 +25,7 @@ interface BaseLuDialogConfig<C> {
 	/**
 	 * Data to pass to the component, will be required if the component used `injectDialogData` in a field, specifying the data that's needed.
 	 */
-	data: LuDialogData<C>;
+	data: TData;
 
 	/**
 	 * Should we put a backdrop? Defaults to true
@@ -90,4 +90,4 @@ interface BaseLuDialogConfig<C> {
 	panelClasses?: string[];
 }
 
-export type LuDialogConfig<T> = LuDialogData<T> extends never ? Omit<BaseLuDialogConfig<T>, 'data'> : BaseLuDialogConfig<T>;
+export type LuDialogConfig<T, TData = LuDialogData<T>> = TData extends never ? Omit<BaseLuDialogConfig<T, TData>, 'data'> : BaseLuDialogConfig<T, TData>;

--- a/packages/ng/dialog/model/dialog-ref.ts
+++ b/packages/ng/dialog/model/dialog-ref.ts
@@ -1,6 +1,6 @@
 import { isObservable, Observable, of, take } from 'rxjs';
 import { DialogRef } from '@angular/cdk/dialog';
-import { LuDialogConfig, LuDialogResult } from './dialog-config';
+import { LuDialogConfig, LuDialogData, LuDialogResult } from './dialog-config';
 import { filter, map } from 'rxjs/operators';
 
 export const DISMISSED_VALUE = {} as const;
@@ -9,7 +9,7 @@ function isDismissed(v: unknown): v is typeof DISMISSED_VALUE {
 	return v === DISMISSED_VALUE;
 }
 
-export class LuDialogRef<C = unknown> {
+export class LuDialogRef<C = unknown, TData = LuDialogData<C>> {
 	/**
 	 * Instance of the component that's inside the dialog
 	 */
@@ -39,7 +39,7 @@ export class LuDialogRef<C = unknown> {
 
 	constructor(
 		public readonly cdkRef: DialogRef<LuDialogResult<C> | typeof DISMISSED_VALUE, C>,
-		public readonly config: LuDialogConfig<C>,
+		public readonly config: LuDialogConfig<C, TData>,
 	) {}
 
 	dismiss(): void {


### PR DESCRIPTION


## Description

You can now pass data type as second argument, allowing for custom types especially for when stores are being used for data.

⚠️ Using this will disable auto check that ensures consistency between opener and dialog, this shouldn't be the default usage ⚠️ 


-----

closes #2963

-----
