### PR TITLE
fix(simple-select): focus input after panel is closed

### DIFF
--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -13,7 +13,10 @@ abstract class BaseSelectPanelRef<T> extends LuSelectPanelRef<T, T> {
 
 	protected panelRef: ComponentRef<LuSelectPanelComponent<T>>;
 
-	protected constructor(parentInjector: Injector, selectInput: LuSimpleSelectInputComponent<T>) {
+	protected constructor(
+		parentInjector: Injector,
+		protected selectInput: LuSimpleSelectInputComponent<T>,
+	) {
 		super();
 
 		this.portalRef = new ComponentPortal<LuSelectPanelComponent<T>>(LuSelectPanelComponent, undefined, this.createInjector(selectInput, parentInjector));
@@ -66,6 +69,7 @@ class SelectPanelRef<T> extends BaseSelectPanelRef<T> {
 		super.close();
 		this.panelRef.destroy();
 		this.overlayRef.detach();
+		this.selectInput.focusInput();
 	}
 
 	updatePosition(): void {


### PR DESCRIPTION
## Description

Simply adding a focus call did the trick, but I couldn't add a test for it yet as there's a lot of select-related tests in rc and I'd like to avoid having to reimplement them in this PR.

I tested manually tho.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
