### PR TITLE
[FileUpload] Fix required

### DIFF
--- a/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
+++ b/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, Directive, computed, inject, input, LOCALE_ID, output } from '@angular/core';
+import { booleanAttribute, computed, Directive, effect, inject, input, LOCALE_ID, output } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
+import { FORM_FIELD_INSTANCE } from '@lucca-front/ng/form-field';
 import { LU_FILE_UPLOAD_TRANSLATIONS } from '../file-upload.translate';
 import { formatSize, MEGA_BYTE } from '../formatter';
 
@@ -14,6 +15,8 @@ export abstract class BaseFileUploadComponent {
 	protected droppable = false;
 
 	intl = getIntl(LU_FILE_UPLOAD_TRANSLATIONS);
+
+	protected formFieldRef = inject(FORM_FIELD_INSTANCE, { optional: true });
 
 	filePicked = output<File>();
 
@@ -58,6 +61,14 @@ export abstract class BaseFileUploadComponent {
 			return 'https://cdn.lucca.fr/transverse/prisme/visuals/empty-states/icons/iconPaperAction.svg';
 		}
 	});
+
+	required = input(false, { transform: booleanAttribute });
+
+	constructor() {
+		effect(() => {
+			this.formFieldRef?.forceInputRequired.set(this.required());
+		});
+	}
 
 	filesChange(event: Event) {
 		const host = event.target as HTMLInputElement;

--- a/packages/ng/file-upload/single/single-file-upload.component.html
+++ b/packages/ng/file-upload/single/single-file-upload.component.html
@@ -5,7 +5,6 @@
 		title=""
 		[attr.accept]="acceptAttribute().length > 0 ? acceptAttribute() : null"
 		luInput
-		luInputStandalone
 		(dragenter)="droppable = true"
 		(dragleave)="droppable = false"
 		(change)="filesChange($event)"

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -68,7 +68,8 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	ownControls = computed(() => this.ngControls().filter((c) => !this.ignoredControls().has(c)));
 
 	#hasInputRequired = signal(false);
-	isInputRequired = this.#hasInputRequired.asReadonly();
+	forceInputRequired = signal(false);
+	isInputRequired = computed(() => this.forceInputRequired() || this.#hasInputRequired());
 
 	label = input.required<PortalContent>();
 

--- a/stories/documentation/forms/fileUpload/angular/basic.stories.ts
+++ b/stories/documentation/forms/fileUpload/angular/basic.stories.ts
@@ -227,8 +227,8 @@ export const Single = {
 			props: { ...multi.props, accept },
 			template: `@let fileUpload = fileUploadFeature.fileUploads()[0];
 <lu-form-field label="Label">
-	<lu-single-file-upload${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])"
-		[entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload?.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload?.error?.detail" (deleteFile)="deleteFile(fileUpload)"/>
+	<lu-single-file-upload ${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])"
+		[entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload?.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload?.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
 </lu-form-field>`,
 		};
 	},


### PR DESCRIPTION
## Description

As the `fileUpload` has a special handling, we need to manage its required differently from other inputs. We add an option for this in the `formField`.

-----

Bonus: the `luInputStandalone` didn't seem necessary and correct the `for`/`id` binding.

-----

![Capture d’écran 2025-05-14 à 11 12 56](https://github.com/user-attachments/assets/0baee245-ad37-42cd-a549-8a0b666fc7f8)

