### PR TITLE
fix(date2): date-input shouldn't call onChange from writeValue

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -294,7 +294,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 			this.selectedDate.set(start);
 			this.currentDate.set(start);
 		} else {
-			this.clear();
+			this.reset();
 		}
 	}
 
@@ -309,9 +309,14 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 		super.setDisabledState(isDisabled);
 	}
 
-	clear() {
+	reset() {
 		this.inputRef().nativeElement.value = '';
+		this.dateFromWriteValue.set(null);
 		this.selectedDate.set(null);
+	}
+
+	clear() {
+		this.reset();
 		this.#onChange?.(null);
 		this.onTouched?.();
 	}


### PR DESCRIPTION
## Description

When resetting a form, setting its value to null, `onChange` is called again because of how it's implement using the same logic we're using for `clear` method.

Decoupling them should fix that and the issue with pristine/dirty state that it brought.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
