### PR TITLE
feat(highlight-data): allow for portalContent in heading, value and subText inputs

### DIFF
--- a/packages/ng/highlight-data/highlight-data.component.html
+++ b/packages/ng/highlight-data/highlight-data.component.html
@@ -1,8 +1,8 @@
 <dl class="highlightData-content">
-	<dt class="highlightData-content-title">{{ heading() }}</dt>
-	<dd class="highlightData-content-value">{{ value() }}</dd>
+	<dt class="highlightData-content-title"><ng-container *luPortal="heading()" /></dt>
+	<dd class="highlightData-content-value"><ng-container *luPortal="value()" /></dd>
 	@if (subText()) {
-	<dd class="highlightData-content-subText">{{ subText() }}</dd>
+	<dd class="highlightData-content-subText"><ng-container *luPortal="subText()" /></dd>
 	}
 	<dd class="highlightData-content-action"><ng-content></ng-content></dd>
 </dl>

--- a/packages/ng/highlight-data/highlight-data.component.ts
+++ b/packages/ng/highlight-data/highlight-data.component.ts
@@ -1,5 +1,6 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, HostBinding, inject, input, ViewEncapsulation } from '@angular/core';
-import { LuClass } from '@lucca-front/ng/core';
+import { LuClass, PortalContent, PortalDirective } from '@lucca-front/ng/core';
+
 @Component({
 	selector: 'lu-highlight-data',
 	standalone: true,
@@ -11,12 +12,13 @@ import { LuClass } from '@lucca-front/ng/core';
 	host: {
 		class: 'highlightData',
 	},
+	imports: [PortalDirective],
 })
 export class HighlightDataComponent {
 	#luClass = inject(LuClass);
-	heading = input.required<string>();
-	value = input.required<string>();
-	subText = input<string>();
+	heading = input.required<PortalContent>();
+	value = input.required<PortalContent>();
+	subText = input<PortalContent>();
 	bubble = input<1 | 2 | 3 | 4 | number>();
 	bubbleSrc = computed(() => {
 		return `https://cdn.lucca.fr/transverse/prisme/visuals/highlight-data/${this.palette()}/bubbles-${this.bubbleTheme()}-${this.bubble()}.svg`;


### PR DESCRIPTION
## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
