### PR TITLE
feat(title): new product guideline

### DIFF
--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -121,3 +121,18 @@ In the `app.module.ts`, you need to call `provideLuTitleStrategy` in the `provid
 })
 export class AppModule {}
 ```
+
+### Example with lucca-cdk
+
+lucca-cdk provides a `getStoreModuleName(moduleId)` function that will fetch the name of your module from the Lucca Store API.
+
+Use it like this in your `app.config.ts` / `main.ts` file:
+
+```ts
+import { provideLuTitleStrategy } from '@lucca-front/ng/title';
+import { getStoreModuleName } from '@lucca/cdk/remote-entity';
+
+provideLuTitleStrategy({
+  appTitle: () => getStoreModuleName('my-module-id'),
+}),
+```

--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -1,4 +1,6 @@
-### Usage
+# LuTitleStrategy
+
+## Usage
 
 Add `title` properties in your routes config:
 
@@ -21,9 +23,9 @@ const routes: Routes = [
 ];
 ```
 
-The service should now be able to collect all `title` properties defined for the current url. Each time a new `title` is found for a child, it will be translated and prepended, ending with `YourAppName - Lucca`.
+The service should now be able to collect all `title` properties defined for the current url. Each time a new `title` is found for a child, it will be translated and prepended, ending with `– Lucca YourAppName`.
 
-ex: `Sub route title - Parent title - YourAppName - Lucca`
+ex: `Sub route title – Parent title – Lucca YourAppName`
 
 For dynamic titles, the `prependTitle` method from `LuTitleStrategy` enables you to add a custom title.
 In a component, you could do the following:
@@ -47,7 +49,7 @@ const selectedUser$ = this.userStore.selected$;
 this.luTitleStrategy.prependTitle(selectedUser$);
 ```
 
-### Quickstart
+## Quickstart
 
 You will need to:
 
@@ -58,11 +60,28 @@ You will need to:
 ```ts
 provideLuTitleStrategy({
   appName: () => 'YourAppName',
-  translateService: () => inject(YourAppNameTranslateService),
+  translateService: () => inject(YourAppNameTranslateService), // optional
 }),
 ```
 
-#### Let's start by creating the service
+### Naming Strategy
+
+Two naming strategies are available:
+
+- The app is a product (default: `'product'`), the title must end with `– Lucca YourAppName`
+- The app is something else (`'other'`), the title must end with `– YourAppName – Lucca`
+
+In this case, you must provide the optional parameter `namingStrategy: 'other'` like so:
+
+```ts
+provideLuTitleStrategy({
+  appName: () => 'YourAppName',
+  translateService: () => inject(YourAppNameTranslateService), // optional
+  namingStrategy: 'other',
+}),
+```
+
+### Handling translations
 
 `YourAppNameTranslateService` be used in combination with the token `LU_TITLE_TRANSLATE_SERVICE`.
 
@@ -72,7 +91,7 @@ You should end up with the following if you are using `ngx-translate`:
 
 ```typescript
 @Injectable({ providedIn: 'root' })
-export class CoreRhTranslateService implements ILuTitleTranslateService {
+export class CoreHRTranslateService implements ILuTitleTranslateService {
   constructor(private translateService: TranslateService) {}
   translate(key: string, args: unknown): string {
     return this.translateService.instant(key, args);
@@ -84,7 +103,7 @@ or if you are using `transloco`:
 
 ```typescript
 @Injectable({ providedIn: 'root' })
-export class CoreRhTranslateService implements ILuTitleTranslateService {
+export class CoreHRTranslateService implements ILuTitleTranslateService {
   constructor(private translateService: TranslocoService) {}
   translate(key: string, args: HashMap): string {
     return this.translateService.translate(key, args);
@@ -92,15 +111,13 @@ export class CoreRhTranslateService implements ILuTitleTranslateService {
 }
 ```
 
-#### Adapt `app.module.ts` config
+### Adapt `app.module.ts` config
 
 In the `app.module.ts`, you need to call `provideLuTitleStrategy` in the `providers` array:
 
 ```typescript
 @NgModule({
-  providers: [
-    provideLuTitleStrategy({ translateService: () => inject(YourAppNameTranslateService) }),
-  ]
+  providers: [provideLuTitleStrategy({ translateService: () => inject(YourAppNameTranslateService) })],
 })
 export class AppModule {}
 ```

--- a/packages/ng/title/title.strategy.spec.ts
+++ b/packages/ng/title/title.strategy.spec.ts
@@ -74,7 +74,7 @@ export class OverrideTitlePartComponent implements OnInit {
 	}
 }
 
-describe('TitleService', () => {
+describe('TitleStrategy', () => {
 	let spectator: SpectatorRouting<AppComponent>;
 	let pageTitleService: LuTitleStrategy;
 
@@ -156,7 +156,7 @@ describe('TitleService', () => {
 
 		await spectator.fixture.whenStable();
 		expect(spectator.inject(Location).path()).toBe('/');
-		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca BU`);
 	});
 
 	it('should ignore empty or absent titles', async () => {
@@ -165,7 +165,7 @@ describe('TitleService', () => {
 
 		spectator.click('.link-2');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca BU`);
 	});
 
 	it('should include named params in title', async () => {
@@ -174,7 +174,7 @@ describe('TitleService', () => {
 
 		spectator.click('.link-3');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
 	it('should prepend title when a component forces its own title', async () => {
@@ -185,7 +185,7 @@ describe('TitleService', () => {
 
 		spectator.click('.link-4');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
 	it('should override title part when a component forces its own title part', async () => {
@@ -195,7 +195,7 @@ describe('TitleService', () => {
 
 		spectator.click('.link-5');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`New title part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`New title part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
 	it('should handle observable inputs', async () => {
@@ -205,7 +205,7 @@ describe('TitleService', () => {
 
 		spectator.click('.link-6');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Delayed part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Delayed part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
 	it('should include named params in title', async () => {
@@ -214,6 +214,6 @@ describe('TitleService', () => {
 
 		spectator.click('.link-7');
 		await spectator.fixture.whenStable();
-		expect(resultTitle).toEqual(`Stubs' child Name 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
+		expect(resultTitle).toEqual(`Stubs' child Name 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 });

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -1,25 +1,32 @@
 import { inject, Injectable, InjectionToken, Provider } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, TitleStrategy } from '@angular/router';
-import { BehaviorSubject, combineLatest, Observable, ObservableInput, of } from 'rxjs';
+import { BehaviorSubject, combineLatest, isObservable, Observable, ObservableInput, of } from 'rxjs';
 import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
 import { PageTitle, TitleSeparator } from './title.model';
 
 export const ɵAPP_TITLE = new InjectionToken<string | Observable<string>>('APP_TITLE');
+export type LuTitleNamingStrategy = 'product' | 'other';
+export const ɵNAMING_STRATEGY = new InjectionToken<LuTitleNamingStrategy>('NAMING_STRATEGY');
 
 /**
  * @deprecated Use `provideLuTitleStrategy` instead.
  */
 export const APP_TITLE = ɵAPP_TITLE;
 
+const Lucca = 'Lucca';
+
 @Injectable({ providedIn: 'root' })
 export class LuTitleStrategy extends TitleStrategy {
 	private title = inject(Title);
 	private translateService = inject<ILuTitleTranslateService>(LU_TITLE_TRANSLATE_SERVICE, { optional: true });
 	private appTitle = inject(ɵAPP_TITLE);
+	private namingStrategy = inject(ɵNAMING_STRATEGY);
 
-	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>(['Lucca']);
+	private luccaTitle$ = isObservable(this.appTitle) ? this.appTitle.pipe(map((title) => this.#luccaTitle(title))) : of(this.#luccaTitle(this.appTitle));
+
+	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>([Lucca]);
 	titleParts$ = this.titlePartsSubject.asObservable();
 	title$ = this.titleParts$.pipe(
 		switchMap((titleParts) => combineLatest(titleParts.map((part) => (typeof part === 'string' ? of(part) : part)))),
@@ -37,8 +44,8 @@ export class LuTitleStrategy extends TitleStrategy {
 		const translatedPageTitles = uniqTitle(pageTitles)
 			.filter(({ title }) => title !== '')
 			.map(({ title, params }) => (this.translateService ? this.translateService.translate(title, params) : title));
-		// Add the name app and 'Lucca' at the end of the title
-		const titleParts = [...translatedPageTitles, this.appTitle, 'Lucca'].filter((x) => !!x);
+		// Add the name app
+		const titleParts = [...translatedPageTitles, this.luccaTitle$].filter((x) => !!x);
 		this.titlePartsSubject.next(titleParts);
 	}
 
@@ -57,6 +64,13 @@ export class LuTitleStrategy extends TitleStrategy {
 		};
 		return snapshot.firstChild ? [pageTitle, ...this.#getPageTitleParts(snapshot.firstChild)] : [pageTitle];
 	}
+
+	#luccaTitle(appTitle: string) {
+		if (this.namingStrategy === 'product') {
+			return appTitle.includes(Lucca) ? appTitle : `${Lucca} ${appTitle}`;
+		}
+		return `${appTitle}${TitleSeparator}${Lucca}`;
+	}
 }
 
 function uniqTitle(titleParts: Array<PageTitle>): Array<PageTitle> {
@@ -66,6 +80,7 @@ function uniqTitle(titleParts: Array<PageTitle>): Array<PageTitle> {
 export interface LuTitleStrategyOptions {
 	appTitle?: () => string | Observable<string>;
 	translateService?: () => ILuTitleTranslateService;
+	namingStrategy?: LuTitleNamingStrategy;
 }
 
 export function provideLuTitleStrategy(options: LuTitleStrategyOptions): Provider[] {
@@ -77,6 +92,9 @@ export function provideLuTitleStrategy(options: LuTitleStrategyOptions): Provide
 	if (options.translateService) {
 		providers.push({ provide: LU_TITLE_TRANSLATE_SERVICE, useFactory: options.translateService });
 	}
+
+	const namingStrategy = options.namingStrategy ?? 'product';
+	providers.push({ provide: ɵNAMING_STRATEGY, useValue: namingStrategy });
 
 	return providers;
 }

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -66,8 +66,11 @@ export class LuTitleStrategy extends TitleStrategy {
 	}
 
 	#luccaTitle(appTitle: string) {
+		if (appTitle.includes(Lucca)) {
+			return appTitle;
+		}
 		if (this.namingStrategy === 'product') {
-			return appTitle.includes(Lucca) ? appTitle : `${Lucca} ${appTitle}`;
+			return `${Lucca} ${appTitle}`;
 		}
 		return `${appTitle}${TitleSeparator}${Lucca}`;
 	}

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -8,7 +8,7 @@ import { PageTitle, TitleSeparator } from './title.model';
 
 export const ɵAPP_TITLE = new InjectionToken<string | Observable<string>>('APP_TITLE');
 export type LuTitleNamingStrategy = 'product' | 'other';
-export const ɵNAMING_STRATEGY = new InjectionToken<LuTitleNamingStrategy>('NAMING_STRATEGY');
+export const ɵNAMING_STRATEGY = new InjectionToken<LuTitleNamingStrategy>('NAMING_STRATEGY', { factory: () => 'product' });
 
 /**
  * @deprecated Use `provideLuTitleStrategy` instead.
@@ -95,9 +95,9 @@ export function provideLuTitleStrategy(options: LuTitleStrategyOptions): Provide
 	if (options.translateService) {
 		providers.push({ provide: LU_TITLE_TRANSLATE_SERVICE, useFactory: options.translateService });
 	}
-
-	const namingStrategy = options.namingStrategy ?? 'product';
-	providers.push({ provide: ɵNAMING_STRATEGY, useValue: namingStrategy });
+	if (options.namingStrategy) {
+		providers.push({ provide: ɵNAMING_STRATEGY, useValue: options.namingStrategy });
+	}
 
 	return providers;
 }


### PR DESCRIPTION
## Description

The title strategy guideline has been updated.

Product must display `Lucca ProductName` while other software may keep the current suffix strategy (`AppName – Lucca`)

-----

This PR will be backported to all v19 releases