### PR TITLE
fix(core-select): option comparer overridable

### DIFF
--- a/docs/core-select-api-directive.md
+++ b/docs/core-select-api-directive.md
@@ -1,4 +1,3 @@
-
 ### Appeler une API
 
 Pour un format de retour V3 ou V4 sans customisation de l'affichage (l'entité doit avoir une propriété `name`), il suffit de donner l'API à appeler :
@@ -51,7 +50,7 @@ export class LuCoreSelectLegumesDirective extends LuCoreSelectApiV4Directive<Leg
 </lu-simple-select>
 ```
 
-### API non conventionnelle
+### API non conventionnelle (sans id)
 
 Dans le cas d'un appel API ne rentrant pas dans le moule habituel, il est nécessaire de créer votre propre directive en s'aidant de `ALuCoreSelectApiDirective` :
 
@@ -62,6 +61,7 @@ import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 interface MyCustomEntity {
   code: number;
   name: string;
+  ownerId: number;
 }
 
 interface MyCustomApiQuery {
@@ -84,7 +84,9 @@ export class LuCoreSelectMyCustomApiDirective extends ALuCoreSelectApiDirective<
     this.clue$, // ALuCoreSelectApiDirective is bound to the select's clue
   ]).pipe(map(([exampleFilter, clue]) => ({ exampleFilter, clue })));
 
-  protected optionComparer = (a: MyCustomEntity, b: MyCustomEntity) => a.code === b.code;
+  // Default value is option.id but here we want the code to be the key.
+  // optionKey must return a unique value as it is used in track functions
+  protected optionKey = (option: MyCustomEntity) => `${option.code}-${option.ownerId}`;
 
   protected getOptions(params: MyCustomApiQuery, page: number): Observable<MyCustomEntity[]> {
     return this.#customApiService.getAll(params, page);

--- a/packages/ng/core-select/api/api-v3.directive.ts
+++ b/packages/ng/core-select/api/api-v3.directive.ts
@@ -82,6 +82,5 @@ export class LuCoreSelectApiV3Directive<T extends ILuApiItem> extends ALuCoreSel
 		);
 	}
 
-	protected override optionComparer = (a: T, b: T) => a.id === b.id;
 	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -23,8 +23,6 @@ class TestDirective extends ALuCoreSelectApiDirective<TestEntity> {
 		})),
 	);
 
-	protected override optionComparer = (a: TestEntity, b: TestEntity) => a.id === b.id;
-
 	protected override optionKey = (option: TestEntity) => option.id;
 
 	public override getOptions(): Observable<TestEntity[]> {

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -28,10 +28,10 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	/**
 	 * Compare two options to know if they are the same. For example, compare by id or by JSON
 	 */
-	protected abstract optionComparer: LuOptionComparer<TOption>;
+	protected optionComparer: LuOptionComparer<TOption> = (a, b) => this.optionKey(a) === this.optionKey(b);
 
 	/**
-	 * Return a key to identify the option in for-of loops
+	 * Return a unique key to identify the option in for-of loops
 	 */
 	protected abstract optionKey: (option: TOption) => unknown;
 

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, inject, OnDestroy, OnInit } from '@angular/core';
-import { ALuSelectInputComponent, LuOptionComparer } from '@lucca-front/ng/core-select';
+import { ALuSelectInputComponent, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey, LuOptionComparer } from '@lucca-front/ng/core-select';
 import { catchError, combineLatest, concatMap, debounceTime, distinctUntilChanged, map, merge, Observable, of, pairwise, scan, startWith, Subject, switchMap, takeUntil, takeWhile, tap } from 'rxjs';
 
 export const LU_SELECT_MAGIC_PAGE_SIZE = 20;
@@ -41,8 +41,13 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	protected abstract getOptions(params: TParams, page: number): Observable<TOption[]>;
 
 	public ngOnInit(): void {
-		this.select.optionComparer = this.optionComparer;
-		this.select.optionKey = this.optionKey;
+		if (this.select.optionComparer === coreSelectDefaultOptionComparer) {
+			this.select.optionComparer = this.optionComparer;
+		}
+
+		if (this.select.optionKey === coreSelectDefaultOptionKey) {
+			this.select.optionKey = this.optionKey;
+		}
 
 		this.buildOptions()
 			.pipe(takeUntil(this.destroy$))

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -99,6 +99,5 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		map((res) => res?.count ?? 0),
 	);
 
-	protected override optionComparer = (a: T, b: T) => a.id === b.id;
 	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -30,6 +30,9 @@ import { LuSelectPanelRef } from '../panel';
 import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
 import { LU_CORE_SELECT_TRANSLATIONS } from '../select.translate';
 
+export const coreSelectDefaultOptionComparer: LuOptionComparer<unknown> = (option1, option2) => JSON.stringify(option1) === JSON.stringify(option2);
+export const coreSelectDefaultOptionKey: (option: unknown) => unknown = (option) => option;
+
 @Directive()
 export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDestroy, OnInit, ControlValueAccessor, FilterPillInputComponent {
 	protected changeDetectorRef = inject(ChangeDetectorRef);
@@ -131,8 +134,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		}
 	}
 
-	@Input() optionComparer: LuOptionComparer<TOption> = (option1, option2) => JSON.stringify(option1) === JSON.stringify(option2);
-	@Input() optionKey: (option: TOption) => unknown = (option) => option;
+	@Input() optionComparer: LuOptionComparer<TOption> = coreSelectDefaultOptionComparer;
+	@Input() optionKey: (option: TOption) => unknown = coreSelectDefaultOptionKey;
 
 	noClueIcon = input(false, { transform: booleanAttribute });
 	inputTabindex = input<number>(0);

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -82,6 +82,5 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 		map((res) => res?.count ?? 0),
 	);
 
-	protected override optionComparer = (a: T, b: T) => a.id === b.id;
 	protected override optionKey = (option: T) => option.id;
 }

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -208,7 +208,6 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		);
 	}
 
-	protected override optionComparer = (a: T, b: T) => a.id === b.id;
 	protected override optionKey = (option: T) => option.id;
 }
 


### PR DESCRIPTION
## Description

- Allow API selects to override the `optionComparer` and `optionKey` inputs. Very useful when using an API without ids (weird but yes, that exists)
- Refactors the default `optionComparer` for API selects, it is now based on the comparison result of the `optionKey`. It's still overridable.

-----

