### PR TITLE
fix(date-input): revert change of minMax validation, avoid code duplication

### DIFF
--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -71,34 +71,41 @@ export abstract class AbstractDateComponent {
 	}
 
 	isInMinMax(date: Date, mode: CalendarMode): boolean {
-		let result = true;
-		if (this.min()) {
-			switch (mode) {
-				case 'day':
-					result = result && this.min().getTime() <= date.getTime();
-					break;
-				case 'month':
-					result = (result && isBefore(startOfMonth(this.min()), startOfMonth(date))) || isSameMonth(this.min(), date);
-					break;
-				case 'year':
-					result = result && this.min().getFullYear() <= date.getFullYear();
-					break;
-			}
+		return this.isAfterMin(date, mode) && this.isBeforeMax(date, mode);
+	}
+
+	isAfterMin(date: Date, mode: CalendarMode): boolean {
+		if (!this.min()) {
+			return true;
 		}
-		if (this.max()) {
-			switch (mode) {
-				case 'day':
-					result = result && this.max().getTime() >= date.getTime();
-					break;
-				case 'month':
-					result = (result && isAfter(startOfMonth(this.max()), startOfMonth(date))) || isSameMonth(this.max(), date);
-					break;
-				case 'year':
-					result = result && this.max().getFullYear() >= date.getFullYear();
-					break;
-			}
+
+		switch (mode) {
+			case 'day':
+				return this.min().getTime() <= date.getTime();
+			case 'month':
+				return isBefore(startOfMonth(this.min()), startOfMonth(date)) || isSameMonth(this.min(), date);
+			case 'year':
+				return this.min().getFullYear() <= date.getFullYear();
+			default:
+				return true;
 		}
-		return result;
+	}
+
+	isBeforeMax(date: Date, mode: CalendarMode): boolean {
+		if (!this.max()) {
+			return true;
+		}
+
+		switch (mode) {
+			case 'day':
+				return this.max().getTime() >= date.getTime();
+			case 'month':
+				return isAfter(startOfMonth(this.max()), startOfMonth(date)) || isSameMonth(this.max(), date);
+			case 'year':
+				return this.max().getFullYear() >= date.getFullYear();
+			default:
+				return true;
+		}
 	}
 
 	isValidDate(date: Date): boolean {

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -16,7 +16,7 @@ import {
 	viewChild,
 	ViewEncapsulation,
 } from '@angular/core';
-import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
+import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, Validator } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { LuClass, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
@@ -29,6 +29,12 @@ import { CalendarMode } from '../calendar2/calendar-mode';
 import { Calendar2Component } from '../calendar2/calendar2.component';
 import { CellStatus } from '../calendar2/cell-status';
 import { comparePeriods, startOfPeriod, transformDateInputToDate, transformDateToDateISO } from '../utils';
+
+export type DateInputValidatorErrorType = {
+	min: true;
+	max: true;
+	date: true;
+};
 
 @Component({
 	selector: 'lu-date-input',
@@ -260,7 +266,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 		}
 	}
 
-	validate(control: AbstractControl<Date | string | null>): ValidationErrors | null {
+	validate(control: AbstractControl<Date | string | null>): Partial<DateInputValidatorErrorType> | null {
 		// null is not an error but means we'll skip everything else, we'll let the presence of a
 		// Validators.required (or not) decide if it's an error.
 		if (control.value === null || control.value === undefined) {
@@ -279,8 +285,10 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 			return { date: true };
 		}
 		// Check min and max
-		if (!this.isInMinMax(date, this.mode())) {
-			return { minMax: true };
+		if (this.min() && !this.isAfterMin(date, this.mode())) {
+			return { min: true };
+		} else if (this.max() && !this.isBeforeMax(date, this.mode())) {
+			return { max: true };
 		}
 		// Everything is valid
 		return null;


### PR DESCRIPTION
## Description

There was a breaking change with the modification of the 2 validators of date input component (`min` and `max` became `minMax`)

-----

Avoid code duplication by splitting isInMinMax methods in 2 separated methods
Code is easier to read by not mutating result and directly return it
There is a better typing for error code in validation function, to avoid breaking the contract in the future

-----
