### PR TITLE
fix(filter-pills): former employees adding checkbox layout to filter-pills

### DIFF
--- a/packages/ng/core-select/user/former-employees.component.scss
+++ b/packages/ng/core-select/user/former-employees.component.scss
@@ -1,3 +1,7 @@
+@use 'definitions';
+
+@include definitions.optionItemStyle;
+
 :host {
 	display: block;
 	background-color: var(--palettes-neutral-0);
@@ -6,34 +10,4 @@
 	padding-inline: var(--pr-t-spacings-50);
 	margin-block: 0 var(--components-options-item-padding-vertical);
 	margin-inline: calc(-1 * var(--pr-t-spacings-50));
-}
-
-.formerEmployeeDisplayer {
-	border-radius: var(--commons-borderRadius-M);
-	cursor: pointer;
-
-	&:hover {
-		background-color: var(--palettes-neutral-50);
-	}
-
-	&:has(.checkboxField-input:checked) {
-		background-color: var(--palettes-product-50);
-
-		&:hover {
-			background-color: var(--palettes-product-100);
-		}
-	}
-
-	::ng-deep {
-		.formLabel {
-			inline-size: 100%;
-			padding-block: var(--components-options-item-padding-vertical);
-			padding-inline: 0;
-		}
-	}
-}
-
-.formerEmployeeDisplayer-checkbox {
-	margin-block: var(--components-options-item-padding-vertical) 0;
-	margin-inline: var(--components-options-item-padding-horizontal) 0;
 }

--- a/packages/ng/core-select/user/former-employees.component.ts
+++ b/packages/ng/core-select/user/former-employees.component.ts
@@ -1,8 +1,6 @@
-import { Component, InjectionToken, WritableSignal, inject } from '@angular/core';
+import { Component, inject, InjectionToken, WritableSignal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { getIntl } from '@lucca-front/ng/core';
-import { FormFieldComponent } from '@lucca-front/ng/form-field';
-import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { LU_CORE_SELECT_USER_TRANSLATIONS } from './user.translate';
 
 export interface FormerEmployeesContext {
@@ -15,12 +13,12 @@ export const FORMER_EMPLOYEES_CONTEXT = new InjectionToken<FormerEmployeesContex
 	selector: 'lu-core-select-former-employees',
 	styleUrl: './former-employees.component.scss',
 	standalone: true,
-	imports: [FormsModule, CheckboxInputComponent, FormFieldComponent],
+	imports: [FormsModule],
 	template: `
-		<div class="formerEmployeeDisplayer">
-			<lu-form-field [label]="intl.includeFormerEmployees">
-				<lu-checkbox-input class="formerEmployeeDisplayer-checkbox" [(ngModel)]="context.includeFormerEmployees" [ngModelOptions]="{ standalone: true }" />
-			</lu-form-field>
+		<div class="formerEmployeeDisplayer optionItem">
+			<div class="optionItem-value" [class.is-selected]="context.includeFormerEmployees()" (click)="context.includeFormerEmployees.set(!context.includeFormerEmployees())">
+				{{ intl.includeFormerEmployees }}
+			</div>
 		</div>
 	`,
 })

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -106,7 +106,7 @@
 		}
 	}
 
-	:host-context(.mod-multiple) {
+	:host-context(.mod-multiple), .formerEmployeeDisplayer {
 		.optionItem-value {
 			position: relative;
 			padding-inline-start: var(--components-options-item-multiple-padding);

--- a/stories/documentation/forms/filterPills/angular/select-filter-pill.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/select-filter-pill.stories.ts
@@ -3,15 +3,20 @@ import { JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { FilterPillComponent } from '@lucca-front/ng/filter-pills';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
-import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { LuMultiSelectInputComponent } from '../../../../../packages/ng/multi-select/input';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
 import { StoryModelDisplayComponent } from '../../../../helpers/story-model-display.component';
+import { LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 
 export default {
 	title: 'Documentation/Forms/FiltersPills/Select/Angular',
 	decorators: [
+		applicationConfig({ providers: [provideAnimations(), provideHttpClient()] }),
 		moduleMetadata({
-			imports: [FilterPillComponent, LuSimpleSelectInputComponent, LuMultiSelectInputComponent, FormsModule, StoryModelDisplayComponent, JsonPipe, FilterLegumesPipe],
+			imports: [FilterPillComponent, LuSimpleSelectInputComponent, LuMultiSelectInputComponent, FormsModule, StoryModelDisplayComponent, JsonPipe, FilterLegumesPipe, LuCoreSelectUsersDirective],
+			providers: [provideCoreSelectCurrentUserId(() => 66)],
 		}),
 	],
 	render: (args, context) => {
@@ -19,6 +24,7 @@ export default {
 			props: {
 				example: null,
 				examples: [],
+				user: null,
 				legumes: allLegumes,
 			},
 			template: `<lu-filter-pill label="Légume" name="legume">
@@ -34,6 +40,14 @@ export default {
 </lu-filter-pill>
 
 <pr-story-model-display>{{examples | json}}</pr-story-model-display>
+
+<hr class="divider pr-u-marginBlock400" />
+
+<lu-filter-pill label="Utilisateur" name="user">
+	<lu-simple-select [(ngModel)]="user"	users enableFormerEmployees/>
+</lu-filter-pill>
+
+<pr-story-model-display>{{user | json}}</pr-story-model-display>
 `,
 		};
 	},


### PR DESCRIPTION
## Description

Using a select with `enableFormerEmployees` previously added a checkbox layout to the filter pill, resulting on a broken layout.

This PR switches the checkbox for a fake one using CSS? just like we're doing in other options.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
