### PR TITLE
fix(breadcrumbs): add missing import of `BreadcrumbsLinkDirective`

### DIFF
--- a/packages/ng/breadcrumbs/public-api.ts
+++ b/packages/ng/breadcrumbs/public-api.ts
@@ -1,1 +1,2 @@
+export * from './breadcrumbs-link.directive';
 export * from './breadcrumbs.component';

--- a/stories/documentation/navigation/breadcrumbs/angular/breadcrumbs-basic.stories.ts
+++ b/stories/documentation/navigation/breadcrumbs/angular/breadcrumbs-basic.stories.ts
@@ -1,6 +1,5 @@
-import { BreadcrumbsComponent } from '@lucca-front/ng/breadcrumbs';
+import { BreadcrumbsComponent, BreadcrumbsLinkDirective } from '@lucca-front/ng/breadcrumbs';
 import { Meta, moduleMetadata } from '@storybook/angular';
-import { BreadcrumbsLinkDirective } from 'packages/ng/breadcrumbs/breadcrumbs-link.directive';
 import { generateInputs } from 'stories/helpers/stories';
 
 export default {
@@ -25,6 +24,5 @@ export default {
 } as Meta;
 
 export const Basic = {
-	args: {
-	},
+	args: {},
 };

--- a/stories/documentation/navigation/horizontalNavigation/angular/horizontalNavigation-basic.stories.ts
+++ b/stories/documentation/navigation/horizontalNavigation/angular/horizontalNavigation-basic.stories.ts
@@ -1,10 +1,8 @@
 import { provideRouter } from '@angular/router';
-import { HorizontalNavigationComponent } from '@lucca-front/ng/horizontal-navigation';
+import { HorizontalNavigationComponent, HorizontalNavigationLinkDirective } from '@lucca-front/ng/horizontal-navigation';
 import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
 import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
-import { HorizontalNavigationLinkDirective } from 'packages/ng/horizontal-navigation/horizontal-navigation-link.directive';
 import { generateInputs } from 'stories/helpers/stories';
-
 
 export default {
 	title: 'Documentation/Navigation/HorizontalNavigation/Angular',

--- a/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
+++ b/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
@@ -1,6 +1,6 @@
 import { FormsModule } from '@angular/forms';
 import { provideRouter } from '@angular/router';
-import { BreadcrumbsComponent } from '@lucca-front/ng/breadcrumbs';
+import { BreadcrumbsComponent, BreadcrumbsLinkDirective } from '@lucca-front/ng/breadcrumbs';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TextInputComponent } from '@lucca-front/ng/forms';
@@ -10,7 +10,6 @@ import { LinkComponent } from '@lucca-front/ng/link';
 import { PageHeaderComponent } from '@lucca-front/ng/page-header';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
-import { BreadcrumbsLinkDirective } from 'packages/ng/breadcrumbs/breadcrumbs-link.directive';
 import { generateInputs } from 'stories/helpers/stories';
 
 export default {

--- a/stories/qa/breadcrumb/breadcrumb.stories.ts
+++ b/stories/qa/breadcrumb/breadcrumb.stories.ts
@@ -1,7 +1,6 @@
 import { Component } from '@angular/core';
-import { BreadcrumbsComponent } from '@lucca-front/ng/breadcrumbs';
+import { BreadcrumbsComponent, BreadcrumbsLinkDirective } from '@lucca-front/ng/breadcrumbs';
 import { Meta, StoryFn } from '@storybook/angular';
-import { BreadcrumbsLinkDirective } from 'packages/ng/breadcrumbs/breadcrumbs-link.directive';
 
 @Component({
 	standalone: true,


### PR DESCRIPTION
## Description

Add missing `BreadcrumbsLinkDirective` import in `public-api.ts`

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
