### PR TITLE
fix(dialog): manage detach subscription to prevent submitting not beign emitted

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -71,17 +71,11 @@ export class LuDialogService {
 				)
 				.subscribe((canClose) => {
 					if (canClose) {
+						luDialogRef.detachSubscription?.unsubscribe();
 						cdkRef.close(DISMISSED_VALUE);
 					}
 				});
 		}
-
-		cdkRef.overlayRef
-			.detachments()
-			.pipe(takeUntil(luDialogRef.closed$))
-			.subscribe(() => {
-				cdkRef.close(DISMISSED_VALUE);
-			});
 
 		return luDialogRef;
 	}

--- a/packages/ng/dialog/model/dialog-ref.ts
+++ b/packages/ng/dialog/model/dialog-ref.ts
@@ -1,7 +1,7 @@
-import { isObservable, Observable, of, take } from 'rxjs';
 import { DialogRef } from '@angular/cdk/dialog';
+import { isObservable, Observable, of, Subscription, take } from 'rxjs';
+import { filter, map, takeUntil } from 'rxjs/operators';
 import { LuDialogConfig, LuDialogResult } from './dialog-config';
-import { filter, map } from 'rxjs/operators';
 
 export const DISMISSED_VALUE = {} as const;
 
@@ -16,6 +16,12 @@ export class LuDialogRef<C = unknown> {
 	get instance(): C {
 		return this.cdkRef.componentInstance;
 	}
+
+	/**
+	 * Subscription to the detachments of the dialog
+	 * This is used to close the dialog when it is detached
+	 */
+	detachSubscription: Subscription | null = null;
 
 	/**
 	 * Emits when the dialog is closed
@@ -40,7 +46,14 @@ export class LuDialogRef<C = unknown> {
 	constructor(
 		public readonly cdkRef: DialogRef<LuDialogResult<C> | typeof DISMISSED_VALUE, C>,
 		public readonly config: LuDialogConfig<C>,
-	) {}
+	) {
+		this.detachSubscription = cdkRef.overlayRef
+			.detachments()
+			.pipe(takeUntil(this.closed$))
+			.subscribe(() => {
+				cdkRef.close(DISMISSED_VALUE);
+			});
+	}
 
 	dismiss(): void {
 		// If we can't dismiss this dialog box, just ignore the dismiss call.
@@ -51,12 +64,14 @@ export class LuDialogRef<C = unknown> {
 		const canClose$ = isObservable(canClose) ? canClose : of(canClose);
 		canClose$.pipe(take(1)).subscribe((close) => {
 			if (close) {
+				this.detachSubscription?.unsubscribe();
 				this.cdkRef.close(DISMISSED_VALUE);
 			}
 		});
 	}
 
 	close(res: LuDialogResult<C>): void {
+		this.detachSubscription?.unsubscribe();
 		this.cdkRef.close(res);
 	}
 }


### PR DESCRIPTION
## Description

Detach event will cancel other closed observable, we need to cancel detach subscription when closing manually by calling cdkRef.close

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
