### PR TITLE
Fix/richtext sanitize class

### DIFF
--- a/packages/ng/forms/rich-text-input/formatters/html/html-formatter.ts
+++ b/packages/ng/forms/rich-text-input/formatters/html/html-formatter.ts
@@ -31,7 +31,7 @@ export class HtmlFormatter extends RichTextFormatter {
 		let result = '';
 		editor.getEditorState().read(() => (result = $generateHtmlFromNodes(editor)));
 		return sanitize(result, {
-			FORBID_ATTR: ['style'],
+			FORBID_ATTR: ['style', 'class'],
 		});
 	}
 }


### PR DESCRIPTION
## Description

RichTextInput html formatter currently has a different sanitization for parsing (bypass `style` and `class` attributes) than for output (bypass only `style` attributes) : this PR homogenize those sanitizations with a `class` bypass on both.

-----

-----
