### PR TITLE
fix: richtext placeholder was not shown at init when no content

### DIFF
--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -104,7 +104,6 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 			nodes: [...this.#customNodes()],
 		});
 
-		this.#editor.setRootElement(this.content().nativeElement);
 		this.#cleanup = mergeRegister(
 			registerRichText(this.#editor),
 			registerHistory(this.#editor, createEmptyHistoryState(), 300),
@@ -118,6 +117,7 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 				this.currentCanShowPlaceholder.set(currentCanShowPlaceholder);
 			}),
 		);
+		this.#editor.setRootElement(this.content().nativeElement);
 
 		this.pluginComponents().forEach((plugin) => plugin.setEditorInstance(this.#editor));
 

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -52,6 +52,36 @@ export const Basic: StoryObj<RichTextInputComponent & { value: string; disabled:
 	},
 };
 
+
+export const WithNoInitialValue: StoryObj<RichTextInputComponent & { value: string; disabled: boolean; required: boolean } & FormFieldComponent> = {
+	render: (args, { argTypes }) => {
+		const { value, disabled, required, ...inputArgs } = args;
+		return {
+			props: { value, disabled, required },
+			template: cleanupTemplate(`<lu-form-field label="Label">
+	<lu-rich-text-input
+	${generateInputs(inputArgs, argTypes)}
+		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+			<lu-rich-text-input-toolbar />
+	</lu-rich-text-input>
+</lu-form-field>
+<pr-story-model-display>{{value}}</pr-story-model-display>`),
+			moduleMetadata: {
+				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+				providers: [provideLuRichTextMarkdownFormatter()],
+			},
+		};
+	},
+	args: {
+		value: '',
+		placeholder: 'Placeholder…',
+		disabled: false,
+		required: false,
+		disableSpellcheck: false,
+		autoResize: true,
+	},
+};
+
 export const WithHtmlFormatter: StoryObj<RichTextInputComponent & { value: string; disabled: boolean; required: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, ...inputArgs } = args;


### PR DESCRIPTION
## Description

The richtext placeholder was not shown at init if the content is empty.
It appeared only at first click or after content edition

![chrome_3OPrLmbMPR](https://github.com/user-attachments/assets/e5f8643a-6882-45d8-98dc-8d75faa53fef)

-----

A new story has been added to highlight the problem

-----
