### PR TITLE
feat(lu-skeleton-field): add hiddenLabel input

### DIFF
--- a/packages/ng/skeleton/skeleton-field/skeleton-field.component.html
+++ b/packages/ng/skeleton/skeleton-field/skeleton-field.component.html
@@ -1,5 +1,7 @@
-<div class="form-field skeleton is-loading" [class.mod-dark]="dark" inert="inert">
+<div class="form-field skeleton is-loading" [class.mod-dark]="dark()" inert="inert">
+	@if (!hiddenLabel()) {
 	<span class="skeleton-item" style="--components-skeleton-text-width: 50%"></span>
+	}
 	<div class="textField">
 		<div class="textField-input">
 			<span class="textField-input-value">

--- a/packages/ng/skeleton/skeleton-field/skeleton-field.component.ts
+++ b/packages/ng/skeleton/skeleton-field/skeleton-field.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
 
 @Component({
 	selector: 'lu-skeleton-field',
@@ -8,6 +8,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, Input } from '@an
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SkeletonFieldComponent {
-	@Input({ transform: booleanAttribute })
-	dark = false;
+	readonly dark = input(false, { transform: booleanAttribute });
+
+	readonly hiddenLabel = input(false, { transform: booleanAttribute });
 }

--- a/stories/documentation/loaders/skeleton-field/angular/skeleton-field.stories.ts
+++ b/stories/documentation/loaders/skeleton-field/angular/skeleton-field.stories.ts
@@ -13,9 +13,15 @@ export const Template: StoryObj<SkeletonFieldComponent> = {
 				type: 'boolean',
 			},
 		},
+		hiddenLabel: {
+			control: {
+				type: 'boolean',
+			},
+		},
 	},
 
 	args: {
 		dark: false,
+		hiddenLabel: false,
 	},
 };


### PR DESCRIPTION
## Description

Add `hiddenLabel` input on `lu-skeleton-field` to better match the display once the data is loaded when using `hiddenLabel` on `lu-form-field`.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
