### PR TITLE
[FormFieldComponent] Fix nullrefex

### DIFF
--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -126,7 +126,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	counter = input<number>(0);
 
 	get contentLength(): number {
-		return (this.#inputs[0]?.host?.nativeElement as HTMLInputElement)?.value.length || 0;
+		return (this.#inputs[0]?.host?.nativeElement as HTMLInputElement)?.value?.length || 0;
 	}
 
 	public addInput(input: InputDirective) {


### PR DESCRIPTION
## Description

Fix a nullrefex in the `FormFieldComponent`

-----

I randomly encountered this error while using the `lu-form-field` with a `lu-rich-text-input` and a `counter` input:

```html
<lu-form-field [counter]="maxLength">
   <lu-rich-text-input [formControl]="curBodyControl">
      <lu-rich-text-input-toolbar />
   </lu-rich-text-input>
</lu-form-field>
```

-----
