### PR TITLE
refactor(core-select): allow optionComparer override for api-v4

### DIFF
--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { computed, Directive, forwardRef, inject, input, model } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiItem } from '@lucca-front/ng/api';
-import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
+import { applySearchDelimiter, CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
 import { debounceTime, map, Observable, switchMap } from 'rxjs';
 import { ALuCoreSelectApiDirective } from './api.directive';
 
@@ -66,6 +66,5 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 			.pipe(map((res) => (Array.isArray(res) ? res : res?.items) ?? []));
 	}
 
-	protected override optionComparer = (a: T, b: T) => a.id === b.id;
 	protected override optionKey = (option: T) => option.id;
 }


### PR DESCRIPTION
## Description

This `optionComparer` forced override was forgotten in https://github.com/LuccaSA/lucca-front/pull/3641

Removing it simplifies the api v4 select with custom key by only specifying the `optionKey` attribute. Right now, we have to specify both `optionKey` and `optionComparer`

-----

