### PR TITLE
[palettes] brand contrasted

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -87,7 +87,7 @@ $fontTokens: (
 $product: 'brand' !default;
 $palettesShades: text, 0, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900; // text is deprecated
 $palettesStates: 'critical', 'error', 'warning', 'success';
-$palettesDefault: 'brand', 'neutral', 'navigation';
+$palettesDefault: 'brand', 'brandContrasted', 'neutral', 'navigation';
 $palettesProduct: 'product';
 $palettesOtherProduct: () !default;
 $palettesDecorative: 'kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin',
@@ -124,6 +124,22 @@ $brand: (
 	600: #ff7b3d,
 	700: #e06029,
 	800: #ae2e03,
+	900: #611405
+);
+
+$brandContrasted: (
+	// text is deprecated
+	text: #ffffff,
+	0: #ffffff,
+	50: #fff1eb,
+	100: #ffe0d1,
+	200: #ffccb3,
+	300: #ffbe9e,
+	400: #ffaa80,
+	500: #ff9361,
+	600: #ff7b3d,
+	700: #df3603,
+	800: #a52408,
 	900: #611405
 );
 
@@ -470,6 +486,7 @@ $productsInterpolation: (
 $palettesInterpolation: (
 	'lucca': $brand,
 	'brand': $brand,
+	'brandContrasted': $brandContrasted,
 	'grey': $neutral,
 	'neutral': $neutral,
 	'primary': map.get($productsInterpolation, $product),

--- a/packages/scss/src/commons/utils/color.scss
+++ b/packages/scss/src/commons/utils/color.scss
@@ -1,5 +1,6 @@
 @use 'sass:map';
 @use 'sass:math';
+@use '@lucca-front/scss/src/commons/core';
 @use '@lucca-front/scss/src/commons/config';
 
 // stylelint-disable-next-line scss/no-global-function-names -- This is a redefinition of a deprecated SCSS function.
@@ -21,4 +22,9 @@
 			--palettes-#{$shade}: var(--palettes-#{$name}-#{$shade});
 		}
 	}
+}
+
+@mixin contrasted {
+	@include core.cssvars('pr-t-color-input', config.$colorInputContrasted);
+	@include core.rosetta('--palettes-brand', '--palettes-brandContrasted', config.$palettesShades);
 }

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -4,6 +4,7 @@
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/core';
 @use '@lucca-front/scss/src/commons/function';
+@use '@lucca-front/scss/src/commons/utils/color';
 
 @mixin vars {
 	// TOKENS : TYPO
@@ -100,19 +101,19 @@
 
 	@media (prefers-contrast: more) {
 		@media (forced-colors: none) {
-			@include core.cssvars('pr-t-color-input', config.$colorInputContrasted);
+			@include color.contrasted;
 		}
 	}
 
 	@if (config.$prefersContrast == 'more') {
 		@media (forced-colors: none) {
-			@include core.cssvars('pr-t-color-input', config.$colorInputContrasted);
+			@include color.contrasted;
 		}
 	}
 
 	.u-prefersContrastMore {
 		@media (forced-colors: none) {
-			@include core.cssvars('pr-t-color-input', config.$colorInputContrasted);
+			@include color.contrasted;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Before: 
- [Grid contrast vs neutral](https://a11y-contrast-grid.netlify.app/?background-colors=%230B1732%2C%20900%0D%0A%232A3551%2C%20800%0D%0A%23445473%2C%20700%0D%0A%23586A8D%2C%20600%0D%0A%238396B9%2C%20500%0D%0A%23ACBBD7%2C%20400%0D%0A%23BECBE4%2C%20300%0D%0A%23CED9EE%2C%20200%0D%0A%23DBE3F5%2C%20100%0D%0A%23E7EDF9%2C%2050%0D%0A%23F3F6FC%2C%2025%0D%0A%23FFFFFF%2C%200%0D%0A&foreground-colors=%23611405%2C%20900%0D%0A%23AE2E03%2C%20800%0D%0A%23E06029%2C%20700%0D%0A%23FF7B3D%2C%20600%0D%0A%23FF9361%2C%20500%0D%0A%23FFAA80%2C%20400%0D%0A%23FFBE9E%2C%20300%0D%0A%23FFCCB3%2C%20200%0D%0A%23FFE0D1%2C%20100%0D%0A%23FFF1EB%2C%2050%0D%0A%23FFFFFF%2C%200%0D%0A&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__tile-size=compact)
- [Grid contrast](https://a11y-contrast-grid.netlify.app/?background-colors=&foreground-colors=%23611405%2C%20900%0D%0A%23AE2E03%2C%20800%0D%0A%23E06029%2C%20700%0D%0A%23FF7B3D%2C%20600%0D%0A%23FF9361%2C%20500%0D%0A%23FFAA80%2C%20400%0D%0A%23FFBE9E%2C%20300%0D%0A%23FFCCB3%2C%20200%0D%0A%23FFE0D1%2C%20100%0D%0A%23FFF1EB%2C%2050%0D%0A%23FFFFFF%2C%200%0D%0A&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__show-contrast=aa18&es-color-form__show-contrast=dnp&es-color-form__tile-size=compact)

After:
- [Grid contrast vs neutral](https://a11y-contrast-grid.netlify.app/?background-colors=%230B1732%2C%20900%0D%0A%232A3551%2C%20800%0D%0A%23445473%2C%20700%0D%0A%23586A8D%2C%20600%0D%0A%238396B9%2C%20500%0D%0A%23ACBBD7%2C%20400%0D%0A%23BECBE4%2C%20300%0D%0A%23CED9EE%2C%20200%0D%0A%23DBE3F5%2C%20100%0D%0A%23E7EDF9%2C%2050%0D%0A%23F3F6FC%2C%2025%0D%0A%23FFFFFF%2C%200%0D%0A&foreground-colors=%23611405%2C%20900%0D%0A%23A52408%2C%20800%0D%0A%23DF3603%2C%20700%0D%0A%23FF7B3D%2C%20600%0D%0A%23FF9361%2C%20500%0D%0A%23FFAA80%2C%20400%0D%0A%23FFBE9E%2C%20300%0D%0A%23FFCCB3%2C%20200%0D%0A%23FFE0D1%2C%20100%0D%0A%23FFF1EB%2C%2050%0D%0A%23FFFFFF%2C%200%0D%0A&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__tile-size=compact)
- [Grid contrast](https://a11y-contrast-grid.netlify.app/?background-colors=&foreground-colors=%23611405%2C%20900%0D%0A%23A52408%2C%20800%0D%0A%23DF3603%2C%20700%0D%0A%23FF7B3D%2C%20600%0D%0A%23FF9361%2C%20500%0D%0A%23FFAA80%2C%20400%0D%0A%23FFBE9E%2C%20300%0D%0A%23FFCCB3%2C%20200%0D%0A%23FFE0D1%2C%20100%0D%0A%23FFF1EB%2C%2050%0D%0A%23FFFFFF%2C%200&es-color-form__show-contrast=aaa&es-color-form__show-contrast=aa&es-color-form__tile-size=compact)

-----



-----
