### PR TITLE
chore(select-schematic): support `name` attribute as well as template references

### DIFF
--- a/packages/ng/schematics/lu-select/util.ts
+++ b/packages/ng/schematics/lu-select/util.ts
@@ -35,7 +35,8 @@ export interface SelectDisplayer {
 
 const allowedAttributes = [/class/, /ngModel/, /ngModelChange/, /ngClass/, /disabled/,
 	/title/, /formControl/, /formControlName/, /required/, /data-.+/, /attr\..+/, /class\..+/,
-	/placeholder/, /title/, /filters/, /multiple/, /api/, /orderBy/, /fields/, /id/, /luTooltip/];
+	/placeholder/, /title/, /filters/, /multiple/, /api/, /orderBy/, /fields/, /id/, /luTooltip/, /name/,
+	/#.+/];
 
 export function isRejection(value: unknown): value is Rejection {
 	return (value as Rejection)?.reason !== undefined && RejectionReason[(value as Rejection).reason] != undefined;


### PR DESCRIPTION
## Description

`name` property was considered as unhandled, same for any template references (`#something` on the select tag), now they are !

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
