### PR TITLE
feat(schematics): new token-typo schematic

### DIFF
--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -21,6 +21,11 @@
       "factory": "./tokens-spacing/index",
       "schema": "./tokens-spacing/schema.json"
     },
+    "tokens-typo": {
+      "description": "Replace typography tokens with new names.",
+      "factory": "./tokens-typo/index",
+      "schema": "./tokens-typo/schema.json"
+    },
     "palettes": {
       "description": "Replace palettes with new names.",
       "factory": "./palettes/index",

--- a/packages/ng/schematics/tokens-typo/index.ts
+++ b/packages/ng/schematics/tokens-typo/index.ts
@@ -1,0 +1,40 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { CssMapper } from '../lib/css-mapper';
+import { currentSchematicContext, SchematicContextOpts } from '../lib/lf-schematic-context';
+
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('@angular-devkit/schematics');
+
+export default (options?: SchematicContextOpts): Rule => {
+
+	return async (tree, context) => {
+		await currentSchematicContext.init(context, options);
+
+		await new CssMapper(
+			tree,
+			{
+				classes: {},
+				variables: {
+					'--commons-font-family':	'--pr-t-font-family',
+					'--commons-font-family-brand':	'--pr-t-font-family-brand',
+					'--commons-font-family-cursive':	'--pr-t-font-family-cursive',
+					'--sizes-XXL-fontSize':	'--pr-t-font-heading-1-fontSize',
+					'--sizes-XL-fontSize':	'--pr-t-font-heading-2-fontSize',
+					'--sizes-L-fontSize':	'--pr-t-font-heading-3-fontSize',
+					'--sizes-M-fontSize':	'--pr-t-font-body-M-fontSize /* [LF] Prefer --pr-t-font-heading-4-fontSize for H4 style */',
+					'--sizes-S-fontSize':	'--pr-t-font-body-S-fontSize',
+					'--sizes-XS-fontSize':	'--pr-t-font-body-XS-fontSize',
+					'--sizes-XXL-lineHeight':	'--pr-t-font-heading-1-lineHeight',
+					'--sizes-XL-lineHeight':	'--pr-t-font-heading-2-lineHeight',
+					'--sizes-L-lineHeight':	'--pr-t-font-heading-3-lineHeight',
+					'--sizes-M-lineHeight':	'--pr-t-font-body-M-lineHeight /* [LF] Prefer --pr-t-font-heading-4-lineHeight for H4 style */',
+					'--sizes-S-lineHeight':	'--pr-t-font-body-S-lineHeight',
+					'--sizes-XS-lineHeight':	'--pr-t-font-body-XS-lineHeight',
+				},
+				mixins: {}
+			},
+			{}
+		).run();
+	};
+};

--- a/packages/ng/schematics/tokens-typo/migration.spec.ts
+++ b/packages/ng/schematics/tokens-typo/migration.spec.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as glob from 'glob';
+import * as path from 'path';
+import { createTreeFromFiles, expectTree, runSchematic } from '../lib/migration-test.js';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.json'));
+const testsRoot = path.join(__dirname, 'tests');
+const files = fs.readdirSync(testsRoot);
+
+describe('Tokens typo Migration', () => {
+	it('should update files', async () => {
+		// Arrange
+		const tree = createTreeFromFiles(testsRoot, files, '.input.');
+		const expectedTree = createTreeFromFiles(testsRoot, files, '.output.');
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'tokens-typo', { skipInstallation: true }, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+
+	// Use this to migrate @lucca-front/* packages
+	it.skip('should migrate @lucca-front/*', async () => {
+		// Arrange
+		const lfRoot = path.normalize(path.join(__dirname, '..', '..', '..', '..'));
+		const lfFiles = [
+			...glob.sync('packages/icons/**/*.scss', { cwd: lfRoot, nodir: true }),
+			...glob.sync('packages/scss/**/*.scss', { cwd: lfRoot, nodir: true }),
+			...glob.sync('packages/ng/**/*', { cwd: lfRoot, nodir: true, ignore: ['**/schematics/**'] }),
+			...glob.sync('stories/**', { cwd: lfRoot, nodir: true }),
+		];
+
+		const treeOriginalTree = createTreeFromFiles(lfRoot, lfFiles, '.');
+		const tree = createTreeFromFiles(lfRoot, lfFiles, '.');
+
+		// Act
+		await runSchematic('collection', collectionPath, 'tokens-typo', { skipInstallation: true }, tree);
+
+		// Assert
+		tree.visit((p, entry) => {
+			const original = treeOriginalTree.get(p)?.content.toString() || '';
+			const updated = entry?.content.toString() || '';
+
+			if (original !== updated) {
+				const fromRootPath = path.join(lfRoot, p);
+				fs.writeFileSync(fromRootPath, updated);
+			}
+		});
+	});
+});

--- a/packages/ng/schematics/tokens-typo/schema.json
+++ b/packages/ng/schematics/tokens-typo/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "LuccaFrontTokensTypo",
+  "title": "Lucca Front Tokens Typo Schema",
+  "type": "object",
+  "properties": {
+    "dryRun": {
+      "type": "boolean",
+      "description": "Run through the migration without making any changes.",
+      "default": false
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip installing dependencies.",
+      "default": false
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose logging.",
+      "default": false
+    }
+  }
+}

--- a/packages/ng/schematics/tokens-typo/tests/component.input.scss
+++ b/packages/ng/schematics/tokens-typo/tests/component.input.scss
@@ -1,0 +1,4 @@
+.css-vars {
+	font-family: var(--commons-font-family);
+	font-size: var(--sizes-XS-fontSize);
+}

--- a/packages/ng/schematics/tokens-typo/tests/component.output.scss
+++ b/packages/ng/schematics/tokens-typo/tests/component.output.scss
@@ -1,0 +1,4 @@
+.css-vars {
+	font-family: var(--pr-t-font-family);
+	font-size: var(--pr-t-font-body-XS-fontSize);
+}


### PR DESCRIPTION
## Description

Use `ng g @lucca-front/ng:tokens-typo` to migrate typo tokens in your project.

Example input:

```scss
.css-vars {
	font-family: var(--commons-font-family);
	font-size: var(--sizes-XS-fontSize);
}
```
Example output:

```scss
.css-vars {
	font-family: var(--pr-t-font-family);
	font-size: var(--pr-t-font-body-XS-fontSize);
}
```
-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
