### PR TITLE
[filterPills] adjust tooltip

### DIFF
--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.html
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.html
@@ -21,6 +21,7 @@
 			(luPopoverOpened)="popoverOpened()"
 			luTooltip
 			luTooltipWhenEllipsis
+			[luTooltipDisabled]="inputIsEmpty()"
 			#comboboxRef
 			#popoverRef="luPopover2"
 			[attr.aria-expanded]="popoverRef.opened()"


### PR DESCRIPTION
## Description

The tooltip no longer displays when a field has no value. (And therefore its fake placeholder no longer appears.)

-----


-----

Without value or with a short value:
![2025-06-18 09 47 31](https://github.com/user-attachments/assets/7ef21e12-1dc8-422c-a403-c54026dd035d)

With a long value:
![2025-06-18 09 47 49](https://github.com/user-attachments/assets/c93b442c-5292-49af-a5e4-80d96d3f2377)

