### PR TITLE
feat(number-format): currency style -> display a trailing 0 on fraction part if only 1 non-zero digit set

### DIFF
--- a/.storybook/public/mockServiceWorker.js
+++ b/.storybook/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.6.8'
+const PACKAGE_VERSION = '2.7.0'
 const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/.storybook/public/mockServiceWorker.js
+++ b/.storybook/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.7.0'
+const PACKAGE_VERSION = '2.6.8'
 const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/packages/ng/number-format/number-format.spec.ts
+++ b/packages/ng/number-format/number-format.spec.ts
@@ -305,6 +305,60 @@ const blurFormatTests: FormatTestData[] = [
 	},
 ];
 
+const focusFormatTestsForCurrency: FormatTestData[] = [
+	{
+		value: null,
+		formatted: '',
+	},
+	{
+		value: 0,
+		formatted: '0',
+	},
+	{
+		value: 1.0,
+		formatted: '1',
+	},
+	{
+		value: 123245.5,
+		formatted: '123245.50',
+	},
+	{
+		value: -123245.5,
+		formatted: '-123245.50',
+	},
+	{
+		value: 123245.12345,
+		formatted: '123245.12345',
+	},
+];
+
+const blurFormatTestsForCurrency: FormatTestData[] = [
+	{
+		value: null,
+		formatted: '',
+	},
+	{
+		value: 0,
+		formatted: '0',
+	},
+	{
+		value: 1.0,
+		formatted: '1',
+	},
+	{
+		value: 123245.5,
+		formatted: '123 245,50',
+	},
+	{
+		value: -123245.5,
+		formatted: '−123 245,50',
+	},
+	{
+		value: 123245.12345,
+		formatted: '123 245,12345',
+	},
+];
+
 describe('NumberFormat', () => {
 	it.each<ParseTestData>(parseTests)("should parse '$input' to $value and clean to '$cleanInput'", ({ input, cleanInput, value }) => {
 		const numberFormat = new NumberFormat({ locale: LOCALE_FR, style: 'decimal' });
@@ -372,5 +426,21 @@ describe('NumberFormat', () => {
 		const numberFormat = new NumberFormat({ locale: LOCALE_FR, style: 'decimal' });
 
 		expect(numberFormat.getBlurFormat(value)).toBe(formatted);
+	});
+
+	describe('currency style case', () => {
+		it.each<FormatTestData>(focusFormatTestsForCurrency)("should format '$value' for focus into '$formatted'", ({ value, formatted }) => {
+			const numberFormat = new NumberFormat({ locale: LOCALE_FR, style: 'currency', currency: 'EUR' });
+
+			expect(numberFormat.getFocusFormat(value)).toBe(formatted);
+		});
+
+		it.each<FormatTestData>(blurFormatTestsForCurrency)("should format '$value' for blur into '$formatted'", ({ value, formatted }) => {
+			// Act
+			const numberFormat = new NumberFormat({ locale: LOCALE_FR, style: 'currency', currency: 'EUR' });
+
+			// Assert
+			expect(numberFormat.getBlurFormat(value)).toBe(formatted);
+		});
 	});
 });

--- a/packages/ng/number-format/number-format.spec.ts
+++ b/packages/ng/number-format/number-format.spec.ts
@@ -320,15 +320,19 @@ const focusFormatTestsForCurrency: FormatTestData[] = [
 	},
 	{
 		value: 123245.5,
-		formatted: '123245.50',
+		formatted: '123245.5',
 	},
 	{
 		value: -123245.5,
-		formatted: '-123245.50',
+		formatted: '-123245.5',
 	},
 	{
 		value: 123245.12345,
-		formatted: '123245.12345',
+		formatted: '123245.12',
+	},
+	{
+		value: 123245.12789,
+		formatted: '123245.13',
 	},
 ];
 
@@ -339,11 +343,11 @@ const blurFormatTestsForCurrency: FormatTestData[] = [
 	},
 	{
 		value: 0,
-		formatted: '0',
+		formatted: '0,00',
 	},
 	{
 		value: 1.0,
-		formatted: '1',
+		formatted: '1,00',
 	},
 	{
 		value: 123245.5,
@@ -355,7 +359,11 @@ const blurFormatTestsForCurrency: FormatTestData[] = [
 	},
 	{
 		value: 123245.12345,
-		formatted: '123 245,12345',
+		formatted: '123 245,12',
+	},
+	{
+		value: 123245.12789,
+		formatted: '123 245,13',
 	},
 ];
 

--- a/packages/ng/number-format/number-format.ts
+++ b/packages/ng/number-format/number-format.ts
@@ -144,7 +144,6 @@ export class NumberFormat {
 				return this.#parseAndSplitInput(this.getFocusFormat(valueInRange));
 			}
 		}
-
 		return splittedInput;
 	}
 
@@ -188,7 +187,7 @@ export class NumberFormat {
 		const decimal = parts.find((p) => p.type === 'decimal') ? '.' : '';
 		const fractionPart = parts
 			.filter((p) => p.type === 'fraction')
-			.map((p) => p.value)
+			.map((p) => (this.options.style === 'currency' && p.value.length === 1 ? p.value + '0' : p.value))
 			.join('');
 
 		return `${minusSign}${integerPart}${decimal}${fractionPart}`;
@@ -204,6 +203,10 @@ export class NumberFormat {
 			.map((p) => {
 				if (p.type === 'minusSign') {
 					return '−';
+				} else if (this.options.style === 'currency' && p.type === 'fraction') {
+					if (p.value.length === 1) {
+						return p.value + '0';
+					}
 				}
 				return p.value;
 			})

--- a/packages/ng/number-format/number-format.ts
+++ b/packages/ng/number-format/number-format.ts
@@ -36,16 +36,18 @@ export class NumberFormat {
 		...options
 	}: Intl.NumberFormatOptions): Intl.NumberFormatOptions {
 		style = style ?? 'decimal';
-		// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumfractiondigits
-		minimumFractionDigits = Math.min(Math.max(minimumFractionDigits ?? 0, 0), 20);
-		// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-		maximumFractionDigits = Math.min(Math.max(maximumFractionDigits ?? 2, minimumFractionDigits), 20);
-		// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
-		minimumIntegerDigits = Math.min(Math.max(minimumFractionDigits ?? 1, 1), 21);
-		// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumsignificantdigits
-		minimumSignificantDigits = Math.min(Math.max(minimumSignificantDigits ?? 1, 1), 21);
-		// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumsignificantdigits
-		maximumSignificantDigits = Math.min(Math.max(maximumSignificantDigits ?? 21, minimumSignificantDigits), 21);
+		if (style !== 'currency') {
+			// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumfractiondigits
+			minimumFractionDigits = Math.min(Math.max(minimumFractionDigits ?? 0, 0), 20);
+			// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
+			maximumFractionDigits = Math.min(Math.max(maximumFractionDigits ?? 2, minimumFractionDigits), 20);
+			// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumfractiondigits
+			minimumIntegerDigits = Math.min(Math.max(minimumFractionDigits ?? 1, 1), 21);
+			// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#minimumsignificantdigits
+			minimumSignificantDigits = Math.min(Math.max(minimumSignificantDigits ?? 1, 1), 21);
+			// https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#maximumsignificantdigits
+			maximumSignificantDigits = Math.min(Math.max(maximumSignificantDigits ?? 21, minimumSignificantDigits), 21);
+		}
 		return {
 			...options,
 			style,
@@ -187,7 +189,7 @@ export class NumberFormat {
 		const decimal = parts.find((p) => p.type === 'decimal') ? '.' : '';
 		const fractionPart = parts
 			.filter((p) => p.type === 'fraction')
-			.map((p) => (this.options.style === 'currency' && p.value.length === 1 ? p.value + '0' : p.value))
+			.map((p) => p.value)
 			.join('');
 
 		return `${minusSign}${integerPart}${decimal}${fractionPart}`;
@@ -203,10 +205,6 @@ export class NumberFormat {
 			.map((p) => {
 				if (p.type === 'minusSign') {
 					return '−';
-				} else if (this.options.style === 'currency' && p.type === 'fraction') {
-					if (p.value.length === 1) {
-						return p.value + '0';
-					}
 				}
 				return p.value;
 			})


### PR DESCRIPTION
## Description

Add the possibility to keep 2 digits after the comma even if these digits are 0s.

This request is for Angular lu-number-format-input with formatStyle="currency"

-----

We let `Intl` deal with max and min digits number.

-----
