### PR TITLE
fix(date-input): invalid format to date ISO

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -314,7 +314,7 @@ export class DateInputComponent extends AbstractDateComponent implements Control
 
 	registerOnChange(fn: (value: Date | string | null) => void): void {
 		this.#onChange = (date: Date | null) => {
-			fn(date && this.inDateISOFormat() ? transformDateToDateISO(date) : date);
+			fn(date && this.inDateISOFormat() && this.isValidDate(date) ? transformDateToDateISO(date) : date);
 		};
 	}
 


### PR DESCRIPTION
## Description

Fix an issue on date-input with date-ISO format where non valid string value like 'bug' where missinterpreted and caused an error to be thrown from date-fns librairy.

-----

Prefer checking if date is in valid format before formatting it.

-----
