### PR TITLE
fix(date-range): #3689 removing effect to avoid null value emitted in…

### DIFF
--- a/jest-global-setup.js
+++ b/jest-global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+	process.env.TZ = 'UTC';
+};

--- a/jest.config.json
+++ b/jest.config.json
@@ -10,5 +10,6 @@
 		"^@/stories/(.*)$": "<rootDir>/stories/documentation/$1",
 		"^(\\.{1,2}/.*)\\.js$": "$1"
 	},
-	"roots": ["<rootDir>/packages/ng", "<rootDir>/stories/documentation"]
+	"roots": ["<rootDir>/packages/ng", "<rootDir>/stories/documentation"],
+  "globalSetup": "./jest-global-setup.js"
 }

--- a/packages/ng/date2/date-range-input/date-range-input.component.html
+++ b/packages/ng/date2/date-range-input/date-range-input.component.html
@@ -17,7 +17,7 @@
 					luInputStandalone
 					class="textField-input-value dateRangeField-fieldset-input-value"
 					[value]="startLabel()"
-					(input)="startTextInput.set(start.value)"
+					(input)="textInputChange(start.value, 'start')"
 					(blur)="inputBlur()"
 					(focus)="inputFocused.set(true); editedField.set(0); highlightedField.set(0)"
 					aria-haspopup="true"
@@ -41,7 +41,7 @@
 					luInputStandalone
 					class="textField-input-value dateRangeField-fieldset-input-value"
 					[value]="endLabel()"
-					(input)="endTextInput.set(end.value)"
+					(input)="textInputChange(start.value, 'end')"
 					(blur)="inputBlur(); fixOrderIfNeeded()"
 					(focus)="inputFocused.set(true); editedField.set(1); highlightedField.set(1)"
 					aria-haspopup="true"

--- a/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
@@ -59,7 +59,7 @@ describe('DateRangeInputComponent', () => {
 			},
 		});
 
-		const input = spectator.query('input#range-input-start-2'); // 2 because nextId is incremented outside the component
+		const input = spectator.query('.mod-start > input');
 		expect(input).toBeTruthy();
 
 		spectator.typeInElement('18/06/2025', input);

--- a/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
@@ -1,0 +1,73 @@
+import { DateRangeInputComponent } from './date-range-input.component';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
+import { FormsModule } from '@angular/forms';
+import { DateRange } from '../calendar2/date-range';
+import { addMonths } from 'date-fns/';
+import { fakeAsync } from '@angular/core/testing';
+import { LOCALE_ID } from '@angular/core';
+
+describe('DateRangeInputComponent', () => {
+	let spectator: SpectatorHost<DateRangeInputComponent>;
+
+	const createHost = createHostFactory({
+		component: DateRangeInputComponent,
+		imports: [FormsModule],
+		providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
+	});
+
+	it('should not called ngModelChange at init if null value', () => {
+		const ngModelChangeCallback = jest.fn();
+
+		spectator = createHost(`<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)"></lu-date-range-input>`, {
+			hostProps: {
+				selected: null,
+				ngModelChangeCallback,
+			},
+		});
+
+		expect(ngModelChangeCallback).toBeCalledTimes(0);
+	});
+
+	it('should not called ngModelChange at init if there is a value', fakeAsync(() => {
+		const ngModelChangeCallback = jest.fn();
+
+		const today = new Date();
+
+		const selected: DateRange = {
+			start: today,
+			end: addMonths(today, 1),
+		};
+
+		spectator = createHost(`<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)"></lu-date-range-input>`, {
+			hostProps: {
+				selected,
+				ngModelChangeCallback,
+			},
+		});
+
+		spectator.tick();
+		expect(ngModelChangeCallback).toBeCalledTimes(0);
+	}));
+
+	it('should called ngModelChange when the user enter a date with a keyboard', () => {
+		const ngModelChangeCallback = jest.fn();
+
+		spectator = createHost(`<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)"></lu-date-range-input>`, {
+			hostProps: {
+				selected: null,
+				ngModelChangeCallback,
+			},
+		});
+
+		const input = spectator.query('input#range-input-start-2'); // 2 because nextId is incremented outside the component
+		expect(input).toBeTruthy();
+
+		spectator.typeInElement('18/06/2025', input);
+
+		expect(ngModelChangeCallback).toBeCalledTimes(1);
+		expect(ngModelChangeCallback).toHaveBeenCalledWith({
+			start: new Date('2025-06-17T22:00:00.000Z'),
+			scope: 'day',
+		});
+	});
+});

--- a/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
@@ -66,7 +66,7 @@ describe('DateRangeInputComponent', () => {
 
 		expect(ngModelChangeCallback).toBeCalledTimes(1);
 		expect(ngModelChangeCallback).toHaveBeenCalledWith({
-			start: new Date('2025-06-17T22:00:00.000Z'),
+			start: new Date('2025-06-18T00:00:00.000Z'),
 			scope: 'day',
 		});
 	});

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -14,9 +14,7 @@ import {
 	Injector,
 	input,
 	OnInit,
-	Signal,
 	signal,
-	untracked,
 	viewChild,
 	viewChildren,
 	ViewEncapsulation,
@@ -429,8 +427,6 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		if (dateRange != null) {
 			this.selectedRange.set(_dateRange);
 			this.currentDate.set(startOfDay(dateRange.start));
-		} else {
-			this.clear();
 		}
 	}
 

--- a/stories/documentation/forms/date2/date-range-input.stories.ts
+++ b/stories/documentation/forms/date2/date-range-input.stories.ts
@@ -61,6 +61,7 @@ export default {
 				min: args['min'] ? minValue : null,
 				max: args['max'] ? maxValue : null,
 				focusedDate: args['focusedDate'] ? focusedDateValue : null,
+				selected: null,
 			},
 			template: cleanupTemplate(`<lu-form-field label="Date range input example" inlineMessage="Inline message example">
 				<lu-date-range-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" ${generateInputs(flags, argTypes)}></lu-date-range-input>
@@ -110,6 +111,7 @@ export const WithShortcuts: StoryObj<DateRangeInputComponent & { selected: DateR
 					},
 				] as CalendarShortcut[],
 				shortcutsStr,
+				selected: null,
 			},
 
 			template: cleanupTemplate(`

--- a/stories/documentation/forms/date2/date-range-input.stories.ts
+++ b/stories/documentation/forms/date2/date-range-input.stories.ts
@@ -61,7 +61,6 @@ export default {
 				min: args['min'] ? minValue : null,
 				max: args['max'] ? maxValue : null,
 				focusedDate: args['focusedDate'] ? focusedDateValue : null,
-				selected: null,
 			},
 			template: cleanupTemplate(`<lu-form-field label="Date range input example" inlineMessage="Inline message example">
 				<lu-date-range-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" ${generateInputs(flags, argTypes)}></lu-date-range-input>
@@ -111,7 +110,6 @@ export const WithShortcuts: StoryObj<DateRangeInputComponent & { selected: DateR
 					},
 				] as CalendarShortcut[],
 				shortcutsStr,
-				selected: null,
 			},
 
 			template: cleanupTemplate(`


### PR DESCRIPTION
… ngModelChange at init, using onChange in every case we should inform the parent instead, removing setupInputEffect in favor of textInputChange to avoid using an effect, unit tests with spectator

## Description

Closes https://github.com/LuccaSA/lucca-front/issues/3689 

At init, ngModelChange is no longer triggered with null and the initial value if there is one.

-----

It conflicts with https://github.com/LuccaSA/lucca-front/pull/3664.
But the bug is still present on the branch `fix/date2.allow.reset`.

-----
