### PR TITLE
fix(richtext): update lists buttons when switching list mode

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/list-format/list-format.command.ts
+++ b/packages/ng/forms/rich-text-input/plugins/list-format/list-format.command.ts
@@ -18,6 +18,7 @@ export function registerListsGlobal(editor: LexicalEditor) {
 						$removeList();
 					} else if (parent) {
 						parent.setListType(type);
+						editor.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
 					} else {
 						$insertList(type);
 					}


### PR DESCRIPTION
## Description

Switching between the two list modes was updating correctly the content but not the buttons activation.
insertList or removeList are not concerned by the bug has they trigger a selection change, hence buttons update.

https://github.com/user-attachments/assets/be13a67a-0022-4f81-8343-f071921deaab


-----

choosed solution: manually trigger a selection update to ensure all buttons are updated.

-----
