### PR TITLE
fix(status-badge): accept 'M' for size input, migrating to si…

### DIFF
--- a/packages/ng/statusBadge/statusBadge.component.ts
+++ b/packages/ng/statusBadge/statusBadge.component.ts
@@ -17,11 +17,13 @@ export class StatusBadgeComponent implements OnChanges {
 
 	label = input.required<string>();
 
-	size = input<'M' | 'S' | null>(null);
+	size = input<'L' | 'M' | null>(null);
 
 	palette = input<Palette | null>(null);
 
 	ngOnChanges(): void {
-		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${this.size()}`]: !!this.size() && this.size() !== 'M' });
+		const size = this.size() ?? 'M';
+
+		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${size}`]: size !== 'M' });
 	}
 }

--- a/packages/ng/statusBadge/statusBadge.component.ts
+++ b/packages/ng/statusBadge/statusBadge.component.ts
@@ -1,10 +1,10 @@
-import { Component, inject, Input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { Component, inject, input, OnChanges, ViewEncapsulation } from '@angular/core';
 import { LuClass, Palette } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-status-badge',
 	standalone: true,
-	template: '{{label}}',
+	template: '{{label()}}',
 	styleUrls: ['./statusBadge.component.scss'],
 	encapsulation: ViewEncapsulation.None,
 	providers: [LuClass],
@@ -15,16 +15,13 @@ import { LuClass, Palette } from '@lucca-front/ng/core';
 export class StatusBadgeComponent implements OnChanges {
 	#luClass = inject(LuClass);
 
-	@Input({ required: true })
-	label: string;
+	label = input.required<string>();
 
-	@Input()
-	size: 'L' = null;
+	size = input<'M' | 'S' | null>(null);
 
-	@Input()
-	palette: Palette = null;
+	palette = input<Palette | null>(null);
 
 	ngOnChanges(): void {
-		this.#luClass.setState({ [`palette-${this.palette}`]: !!this.palette, [`mod-${this.size}`]: !!this.size });
+		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${this.size()}`]: !!this.size && this.size() !== 'M' });
 	}
 }

--- a/packages/ng/statusBadge/statusBadge.component.ts
+++ b/packages/ng/statusBadge/statusBadge.component.ts
@@ -24,6 +24,6 @@ export class StatusBadgeComponent implements OnChanges {
 	ngOnChanges(): void {
 		const size = this.size() ?? 'M';
 
-		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${size}`]: size !== 'M' });
+		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${size}`]: true });
 	}
 }

--- a/packages/ng/statusBadge/statusBadge.component.ts
+++ b/packages/ng/statusBadge/statusBadge.component.ts
@@ -22,6 +22,6 @@ export class StatusBadgeComponent implements OnChanges {
 	palette = input<Palette | null>(null);
 
 	ngOnChanges(): void {
-		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${this.size()}`]: !!this.size && this.size() !== 'M' });
+		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${this.size()}`]: !!this.size() && this.size() !== 'M' });
 	}
 }

--- a/packages/ng/statusBadge/statusBadge.component.ts
+++ b/packages/ng/statusBadge/statusBadge.component.ts
@@ -17,13 +17,11 @@ export class StatusBadgeComponent implements OnChanges {
 
 	label = input.required<string>();
 
-	size = input<'L' | 'M' | null>(null);
+	size = input<'L' | 'M'>('M');
 
 	palette = input<Palette | null>(null);
 
 	ngOnChanges(): void {
-		const size = this.size() ?? 'M';
-
-		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${size}`]: true });
+		this.#luClass.setState({ [`palette-${this.palette()}`]: !!this.palette(), [`mod-${this.size()}`]: true });
 	}
 }

--- a/stories/documentation/texts/status-badge/angular/status-badge-angular.stories.ts
+++ b/stories/documentation/texts/status-badge/angular/status-badge-angular.stories.ts
@@ -23,7 +23,7 @@ export default {
 			description: '[v19.2] Neutral',
 		},
 		size: {
-			options: ['', 'L'],
+			options: ['', 'M', 'L'],
 			control: {
 				type: 'select',
 			},


### PR DESCRIPTION
…gnal inputs

## Description

Better typing for size input of status-badge to be able to pass 'M' for standard size

-----

Migration to signal inputs

-----
