### PR TITLE
fix(text-input): fixed missing addon export

### DIFF
--- a/packages/ng/forms/public-api.ts
+++ b/packages/ng/forms/public-api.ts
@@ -12,6 +12,7 @@ export * from './radio-group-input/radio-group-input.component';
 export * from './radio-group-input/radio/radio.component';
 export * from './switch-input/switch-input.component';
 export * from './text-input/text-input.component';
+export * from './text-input/text-input-addon';
 export * from './textarea-input/textarea-input.component';
 
 export * from './number-input/number-input.translate';


### PR DESCRIPTION
## Description

Importing `TextfieldIconAddon`, `TextfieldTextAddon` and `TextInputAddon` is not allowed from `@lucca-front/ng/forms/text-input/text-input-addon` because of the moduleResolution: 'bundler' .

We need to use import from `@lucca-front/ng/forms` instead.

-----

fixed missing `text-input-addon` export in `public-api.ts`

-----
