### PR TITLE
fix(divider) mod vertical margins

### DIFF
--- a/packages/scss/src/components/divider/component.scss
+++ b/packages/scss/src/components/divider/component.scss
@@ -4,13 +4,10 @@
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	border: 0;
 	display: block;
-	margin-block: var(--components-divider-marginBlock);
-	margin-inline: var(--components-divider-marginInline);
+	margin: var(--components-divider-margin);
 	align-self: var(--components-divider-alignSelf);
 
 	&:where(:empty) {
-		--components-divider-marginInline: 0;
-
 		block-size: auto;
 
 		&:not(.mod-vertical) {

--- a/packages/scss/src/components/divider/mods.scss
+++ b/packages/scss/src/components/divider/mods.scss
@@ -14,6 +14,8 @@
 }
 
 @mixin vertical {
+	--components-divider-marginBlock: 0;
+	--components-divider-marginInline: var(--components-divider-margin-value);
 	--components-divider-alignSelf: stretch;
 
 	&:where(:empty) {

--- a/packages/scss/src/components/divider/mods.scss
+++ b/packages/scss/src/components/divider/mods.scss
@@ -15,7 +15,7 @@
 
 @mixin vertical {
 	--components-divider-marginBlock: 0;
-	--components-divider-marginInline: var(--components-divider-margin-value);
+	--components-divider-marginInline: var(--pr-t-spacings-50);
 	--components-divider-alignSelf: stretch;
 
 	&:where(:empty) {

--- a/packages/scss/src/components/divider/vars.scss
+++ b/packages/scss/src/components/divider/vars.scss
@@ -1,7 +1,7 @@
 @mixin vars {
 	--components-divider-font: var(--pr-t-font-body-M);
-	--components-divider-marginBlock: var(--pr-t-spacings-50);
-	--components-divider-marginInline: 0;
+	--components-divider-margin-value: var(--pr-t-spacings-50);
+	--components-divider-marginBlock: var(--components-divider-margin-value);
 	--components-divider-minSize: var(--pr-t-spacings-150);
 	--components-divider-direction: row;
 	--components-divider-iconBottom: 0;

--- a/packages/scss/src/components/divider/vars.scss
+++ b/packages/scss/src/components/divider/vars.scss
@@ -1,7 +1,8 @@
 @mixin vars {
 	--components-divider-font: var(--pr-t-font-body-M);
-	--components-divider-margin-value: var(--pr-t-spacings-50);
-	--components-divider-marginBlock: var(--components-divider-margin-value);
+	--components-divider-marginBlock: var(--pr-t-spacings-50);
+	--components-divider-marginInline: 0;
+	--components-divider-margin: var(--components-divider-marginBlock) var(--components-divider-marginInline);
 	--components-divider-minSize: var(--pr-t-spacings-150);
 	--components-divider-direction: row;
 	--components-divider-iconBottom: 0;


### PR DESCRIPTION
## Description

fix: #3741

Both `--components-divider-marginBlock` and `--components-divider-marginInline` rely on the new `--components-divider-margin-value` var which can be easily overridden.

> [!NOTE]
> I'm just not sure about the new variable name, if you have a better idea… 💡 

-----
