### PR TITLE
fix: lulink broken with Angular 20

### DIFF
--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, Component, effect, ElementRef, HostBinding, inject, input, Input, Renderer2, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, Component, effect, HostBinding, inject, input, Input, ViewEncapsulation } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
 import { LU_LINK_TRANSLATIONS } from './link.translate';
 import { LuRouterLink } from './lu-router-link';
@@ -20,9 +20,6 @@ import { LuRouterLink } from './lu-router-link';
 })
 export class LinkComponent {
 	intl = getIntl(LU_LINK_TRANSLATIONS);
-
-	#elementRef = inject<ElementRef<HTMLLinkElement>>(ElementRef);
-	#renderer = inject(Renderer2);
 	#routerLink = inject(LuRouterLink);
 
 	routerLinkCommands = input<LuRouterLink['routerLink'] | null>(null, { alias: 'luLink' });
@@ -64,7 +61,7 @@ export class LinkComponent {
 	hrefBackup: string;
 
 	constructor() {
-		const href = this.#routerLink.publicReactiveHref;
+		const href = this.#routerLink.luHref;
 
 		effect(() => {
 			if (href()) {
@@ -73,9 +70,11 @@ export class LinkComponent {
 			if (this.disabled()) {
 				if (this.routerLinkCommands()) {
 					this.#routerLink.routerLink = null;
-					this.#renderer.removeAttribute(this.#elementRef.nativeElement, 'href');
+					this.#routerLink.publicReactiveHref.set(null);
+					// this.#renderer.removeAttribute(this.#elementRef.nativeElement, 'href');
 				} else {
-					this.#renderer.removeAttribute(this.#elementRef.nativeElement, 'href');
+					this.#routerLink.publicReactiveHref.set(null);
+					// this.#renderer.removeAttribute(this.#elementRef.nativeElement, 'href');
 				}
 			} else if (this.routerLinkCommands()) {
 				this.#routerLink.routerLink = this.routerLinkCommands();
@@ -83,7 +82,8 @@ export class LinkComponent {
 				// See https://github.com/angular/angular/blob/main/packages/router/src/directives/router_link.ts#L281
 				this.#routerLink.ngOnChanges({});
 			} else if (!href() && this.hrefBackup) {
-				this.#renderer.setAttribute(this.#elementRef.nativeElement, 'href', this.hrefBackup);
+				this.#routerLink.publicReactiveHref.set(this.hrefBackup);
+				// this.#renderer.setAttribute(this.#elementRef.nativeElement, 'href', this.hrefBackup);
 			}
 		});
 	}

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,7 +1,7 @@
-import { booleanAttribute, Component, effect, ElementRef, HostBinding, inject, input, Input, OnDestroy, Renderer2, signal, ViewEncapsulation } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { booleanAttribute, Component, effect, ElementRef, HostBinding, inject, input, Input, Renderer2, ViewEncapsulation } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
 import { LU_LINK_TRANSLATIONS } from './link.translate';
+import { LuRouterLink } from './lu-router-link';
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector
@@ -13,21 +13,19 @@ import { LU_LINK_TRANSLATIONS } from './link.translate';
 	host: { class: 'link' },
 	hostDirectives: [
 		{
-			directive: RouterLink,
+			directive: LuRouterLink,
 			inputs: ['preserveFragment', 'skipLocationChange', 'replaceUrl', 'queryParams', 'fragment', 'queryParamsHandling', 'state', 'info', 'relativeTo'],
 		},
 	],
 })
-export class LinkComponent implements OnDestroy {
+export class LinkComponent {
 	intl = getIntl(LU_LINK_TRANSLATIONS);
 
 	#elementRef = inject<ElementRef<HTMLLinkElement>>(ElementRef);
 	#renderer = inject(Renderer2);
-	#routerLink = inject(RouterLink);
+	#routerLink = inject(LuRouterLink);
 
-	#observer: MutationObserver;
-
-	routerLinkCommands = input<RouterLink['routerLink'] | null>(null, { alias: 'luLink' });
+	routerLinkCommands = input<LuRouterLink['routerLink'] | null>(null, { alias: 'luLink' });
 
 	disabled = input(false, { transform: booleanAttribute });
 
@@ -66,13 +64,7 @@ export class LinkComponent implements OnDestroy {
 	hrefBackup: string;
 
 	constructor() {
-		const href = signal<string>(this.#elementRef.nativeElement.href);
-
-		this.#observer = new MutationObserver(() => {
-			href.set(this.#elementRef.nativeElement.href);
-		});
-
-		this.#observer.observe(this.#elementRef.nativeElement, { attributes: true, attributeFilter: ['href'] });
+		const href = this.#routerLink.publicReactiveHref;
 
 		effect(() => {
 			if (href()) {
@@ -94,9 +86,5 @@ export class LinkComponent implements OnDestroy {
 				this.#renderer.setAttribute(this.#elementRef.nativeElement, 'href', this.hrefBackup);
 			}
 		});
-	}
-
-	ngOnDestroy(): void {
-		this.#observer.disconnect();
 	}
 }

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -10,7 +10,10 @@ import { LuRouterLink } from './lu-router-link';
 	templateUrl: './link.component.html',
 	styleUrls: ['./link.component.scss'],
 	encapsulation: ViewEncapsulation.None,
-	host: { class: 'link' },
+	host: {
+		class: 'link',
+		'[attr.href]': 'routerLink.publicReactiveHref()',
+	},
 	hostDirectives: [
 		{
 			directive: LuRouterLink,
@@ -20,7 +23,9 @@ import { LuRouterLink } from './lu-router-link';
 })
 export class LinkComponent {
 	intl = getIntl(LU_LINK_TRANSLATIONS);
-	#routerLink = inject(LuRouterLink);
+	routerLink = inject(LuRouterLink);
+
+	luHref = input('', { alias: 'href' });
 
 	routerLinkCommands = input<LuRouterLink['routerLink'] | null>(null, { alias: 'luLink' });
 
@@ -61,29 +66,25 @@ export class LinkComponent {
 	hrefBackup: string;
 
 	constructor() {
-		const href = this.#routerLink.luHref;
+		const href = this.luHref;
 
 		effect(() => {
 			if (href()) {
 				this.hrefBackup = href();
+				this.routerLink.publicReactiveHref.set(this.hrefBackup);
 			}
 			if (this.disabled()) {
 				if (this.routerLinkCommands()) {
-					this.#routerLink.routerLink = null;
-					this.#routerLink.publicReactiveHref.set(null);
-					// this.#renderer.removeAttribute(this.#elementRef.nativeElement, 'href');
-				} else {
-					this.#routerLink.publicReactiveHref.set(null);
-					// this.#renderer.removeAttribute(this.#elementRef.nativeElement, 'href');
+					this.routerLink.routerLink = null;
 				}
+				this.routerLink.publicReactiveHref.set(null);
 			} else if (this.routerLinkCommands()) {
-				this.#routerLink.routerLink = this.routerLinkCommands();
+				this.routerLink.routerLink = this.routerLinkCommands();
 				// We need to do this in order to have `routerLink` update the value for `href`:
 				// See https://github.com/angular/angular/blob/main/packages/router/src/directives/router_link.ts#L281
-				this.#routerLink.ngOnChanges({});
+				this.routerLink.ngOnChanges({});
 			} else if (!href() && this.hrefBackup) {
-				this.#routerLink.publicReactiveHref.set(this.hrefBackup);
-				// this.#renderer.setAttribute(this.#elementRef.nativeElement, 'href', this.hrefBackup);
+				this.routerLink.publicReactiveHref.set(this.hrefBackup);
 			}
 		});
 	}

--- a/packages/ng/link/lu-router-link.ts
+++ b/packages/ng/link/lu-router-link.ts
@@ -1,10 +1,16 @@
-import { RouterLink } from '@angular/router';
-import { Directive, WritableSignal } from '@angular/core';
+import { LocationStrategy } from '@angular/common';
+import { Attribute, Directive, ElementRef, Renderer2, WritableSignal } from '@angular/core';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 
 @Directive({
 	selector: '[luRouterLink]',
 })
 export class LuRouterLink extends RouterLink {
+	// Workaround for a storybook bug = implement the constructor https://github.com/storybookjs/storybook/issues/23534#issuecomment-2042888436
+	constructor(router: Router, route: ActivatedRoute, @Attribute('tabindex') tabIndexAttribute: string | null | undefined, renderer: Renderer2, el: ElementRef, locationStrategy?: LocationStrategy) {
+		super(router, route, tabIndexAttribute, renderer, el, locationStrategy);
+	}
+
 	// With angular 20, RouterLink changed to use an internal, protected, readonly signal that is directly bound to `attr.href`, breaking any possibility to override it
 	// So we had to do this to expose it to our `luLink` component.
 	get publicReactiveHref(): WritableSignal<string | null> {

--- a/packages/ng/link/lu-router-link.ts
+++ b/packages/ng/link/lu-router-link.ts
@@ -1,0 +1,14 @@
+import { RouterLink } from '@angular/router';
+import { Directive, WritableSignal } from '@angular/core';
+
+@Directive({
+	selector: '[luRouterLink]',
+	host: {
+		'[attr.href]': 'reactiveHref()',
+	},
+})
+export class LuRouterLink extends RouterLink {
+	get publicReactiveHref(): WritableSignal<string | null> {
+		return this.reactiveHref;
+	}
+}

--- a/packages/ng/link/lu-router-link.ts
+++ b/packages/ng/link/lu-router-link.ts
@@ -5,6 +5,8 @@ import { Directive, WritableSignal } from '@angular/core';
 	selector: '[luRouterLink]',
 })
 export class LuRouterLink extends RouterLink {
+	// With angular 20, RouterLink changed to use an internal, protected, readonly signal that is directly bound to `attr.href`, breaking any possibility to override it
+	// So we had to do this to expose it to our `luLink` component.
 	get publicReactiveHref(): WritableSignal<string | null> {
 		return this.reactiveHref;
 	}

--- a/packages/ng/link/lu-router-link.ts
+++ b/packages/ng/link/lu-router-link.ts
@@ -1,15 +1,10 @@
 import { RouterLink } from '@angular/router';
-import { Directive, input, WritableSignal } from '@angular/core';
+import { Directive, WritableSignal } from '@angular/core';
 
 @Directive({
 	selector: '[luRouterLink]',
-	host: {
-		'[attr.href]': 'reactiveHref()',
-	},
 })
 export class LuRouterLink extends RouterLink {
-	luHref = input('', { alias: 'href' });
-
 	get publicReactiveHref(): WritableSignal<string | null> {
 		return this.reactiveHref;
 	}

--- a/packages/ng/link/lu-router-link.ts
+++ b/packages/ng/link/lu-router-link.ts
@@ -1,5 +1,5 @@
 import { RouterLink } from '@angular/router';
-import { Directive, WritableSignal } from '@angular/core';
+import { Directive, input, WritableSignal } from '@angular/core';
 
 @Directive({
 	selector: '[luRouterLink]',
@@ -8,6 +8,8 @@ import { Directive, WritableSignal } from '@angular/core';
 	},
 })
 export class LuRouterLink extends RouterLink {
+	luHref = input('', { alias: 'href' });
+
 	get publicReactiveHref(): WritableSignal<string | null> {
 		return this.reactiveHref;
 	}

--- a/packages/ng/link/public-api.ts
+++ b/packages/ng/link/public-api.ts
@@ -1,1 +1,2 @@
 export * from './link.component';
+export * from './lu-router-link';

--- a/stories/documentation/actions/links/angular-testing.stories.ts
+++ b/stories/documentation/actions/links/angular-testing.stories.ts
@@ -1,9 +1,7 @@
-import { AsyncPipe } from '@angular/common';
-import { provideRouter, RouterLink, RouterOutlet, Routes } from '@angular/router';
-import { LinkComponent } from '@lucca-front/ng/link';
-import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { timer } from 'rxjs';
 import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { provideRouter, RouterOutlet, Routes } from '@angular/router';
+import { LinkComponent } from '@lucca-front/ng/link';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 
 @Component({
 	selector: 'first-page',
@@ -20,13 +18,13 @@ class SecondPageComponent {}
 @Component({
 	selector: 'base-component',
 	template: `
-		<a luLink="/first">Go to first page</a>
-		<br />
-		<a luLink="/second">Go to second page</a>
-		<br />
-		<a luLink [href]="url" target="_blank" external>Go to external page</a>
-		<br />
-		<a [luLink]="url" target="_blank" external>Go to external page as luLink input</a>
+		<div>
+			<a luLink="/first">Go to /first</a>
+			<br />
+			<a luLink="/second">Go to /second</a>
+			<br />
+			<a luLink [href]="url" target="_blank" external>Go to https://example.org</a>
+		</div>
 		<router-outlet></router-outlet>
 	`,
 	imports: [LinkComponent, RouterOutlet],

--- a/stories/documentation/actions/links/angular-testing.stories.ts
+++ b/stories/documentation/actions/links/angular-testing.stories.ts
@@ -1,0 +1,54 @@
+import { AsyncPipe } from '@angular/common';
+import { provideRouter, RouterLink, RouterOutlet, Routes } from '@angular/router';
+import { LinkComponent } from '@lucca-front/ng/link';
+import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { timer } from 'rxjs';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+	selector: 'first-page',
+	template: 'First page it is !',
+})
+class FirstPageComponent {}
+
+@Component({
+	selector: 'second-page',
+	template: 'And this is the second page !',
+})
+class SecondPageComponent {}
+
+@Component({
+	selector: 'base-component',
+	template: `
+		<a luLink="/first">Go to first page</a>
+		<br />
+		<a luLink="/second">Go to second page</a>
+		<br />
+		<a luLink [href]="url" target="_blank" external>Go to external page</a>
+		<br />
+		<router-outlet></router-outlet>
+	`,
+	imports: [LinkComponent, RouterOutlet],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class BaseComponent {
+	public url = 'https://example.org';
+}
+
+const routes: Routes = [
+	{ path: 'first', component: FirstPageComponent },
+	{ path: 'second', component: SecondPageComponent },
+	{ path: 'iframe.html', redirectTo: 'first', pathMatch: 'full' },
+];
+
+export default {
+	title: 'Documentation/Actions/Link/Angular/TEST',
+	decorators: [
+		applicationConfig({
+			providers: [provideRouter(routes)],
+		}),
+	],
+	component: BaseComponent,
+} as Meta;
+
+export const Basic: StoryObj = {};

--- a/stories/documentation/actions/links/angular-testing.stories.ts
+++ b/stories/documentation/actions/links/angular-testing.stories.ts
@@ -26,6 +26,7 @@ class SecondPageComponent {}
 		<br />
 		<a luLink [href]="url" target="_blank" external>Go to external page</a>
 		<br />
+		<a [luLink]="url" target="_blank" external>Go to external page as luLink input</a>
 		<router-outlet></router-outlet>
 	`,
 	imports: [LinkComponent, RouterOutlet],

--- a/stories/documentation/actions/links/angular.stories.ts
+++ b/stories/documentation/actions/links/angular.stories.ts
@@ -2,6 +2,7 @@ import { AsyncPipe } from '@angular/common';
 import { provideRouter, RouterLink } from '@angular/router';
 import { LinkComponent } from '@lucca-front/ng/link';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
+import { timer } from 'rxjs';
 
 export default {
 	title: 'Documentation/Actions/Link/Angular/Basic',
@@ -20,8 +21,11 @@ export default {
 		const externe = external ? ' external' : '';
 
 		return {
+			props: {
+				tick$: timer(0, 1000),
+			},
 			template: `<a href="${href}" luLink${externe}${disable}>${label}</a><br />
-<a [luLink]="'${routerLink}'"${externe}${disable}>${label}</a>`,
+<a luLink="${routerLink}"${externe}${disable}>${label}</a>`,
 		};
 	},
 	argTypes: {

--- a/stories/documentation/actions/links/angular.stories.ts
+++ b/stories/documentation/actions/links/angular.stories.ts
@@ -24,8 +24,11 @@ export default {
 			props: {
 				tick$: timer(0, 1000),
 			},
-			template: `<a href="${href}" luLink${externe}${disable}>${label}</a><br />
-<a luLink="${routerLink}"${externe}${disable}>${label}</a>`,
+			template: `
+Internal link: <a luLink="${routerLink}"${externe}${disable}>${label}</a>
+<br>
+External link: <a href="${href}" luLink${externe}${disable}>${label}</a>
+`,
 		};
 	},
 	argTypes: {

--- a/stories/documentation/actions/links/angular.stories.ts
+++ b/stories/documentation/actions/links/angular.stories.ts
@@ -40,6 +40,7 @@ export default {
 		},
 		href: {
 			type: 'string',
+			description: "A n'utiliser qu'en lien externe ou non connu par le routeur.",
 		},
 		routerLink: {
 			type: 'string',


### PR DESCRIPTION
## Description

Due to changes on RouterLink, Angular 20 broke our luLink component.

The fix was to expose their new internal signal and manipulate it directly from our own component, it's hacky but they didn't give us other choices.

Kudos to @LucasPerrault for the final fix!

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
