### PR TITLE
[Textfield] Add ellipsis

### DIFF
--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -67,6 +67,7 @@
 			padding-inline: var(--component-textField-padding) var(--component-textField-affix-padding);
 			background-color: transparent;
 			color: var(--component-textField-color);
+			text-overflow: ellipsis;
 
 			&:is(textarea, div) {
 				max-block-size: var(--component-textField-maxHeight);


### PR DESCRIPTION
## Description

Add ellipsis on textfield

-----

<img width="193" height="100" alt="image" src="https://github.com/user-attachments/assets/d767657a-2a56-47d9-9730-5370d85aa0b5" />
<img width="202" height="97" alt="image" src="https://github.com/user-attachments/assets/d8465986-dd21-4dd6-b4a9-234dfb863ac8" />


-----
