### PR TITLE
fix(dialog): fix typing import issue with dialogs

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
@@ -10,6 +10,7 @@ import { LuDialogConfig, LuDialogRef } from '../model';
 import { DialogRouteConfig } from './dialog-routing.models';
 import { deferrableToObservable, deferrableToPromise, DIALOG_ROUTE_CONFIG } from './dialog-routing.utils';
 import { OutletComponentInstanceDirective } from './outlet-component-instance.directive';
+import { ComponentType } from '@angular/cdk/overlay';
 
 export const defaultOnClosedFn = <C>(router = inject(Router), route = inject(ActivatedRoute), config = inject<DialogRouteConfig<C>>(DIALOG_ROUTE_CONFIG)): void =>
 	void router.navigate(
@@ -64,7 +65,7 @@ export class DialogRoutingComponent<C> implements OnInit {
 		const config = this.dialogConfig();
 		return config && config.content instanceof TemplateRef ? config.content : null;
 	});
-	readonly dialogComponentContent = computed(() => {
+	readonly dialogComponentContent = computed<ComponentType<C>>(() => {
 		const config = this.dialogConfig();
 		return config && !(config.content instanceof TemplateRef) ? config.content : null;
 	});

--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
@@ -1,7 +1,7 @@
-import { ComponentType } from '@angular/cdk/portal';
+import { ComponentType } from '@angular/cdk/overlay';
 import { InjectionToken } from '@angular/core';
 import { Route } from '@angular/router';
-import { Observable, firstValueFrom, from, isObservable, of } from 'rxjs';
+import { firstValueFrom, from, isObservable, Observable, of } from 'rxjs';
 import { LuDialogConfig, LuDialogData } from '../model';
 import { DialogRoutingComponent } from './dialog-routing.component';
 import { DialogRouteConfig } from './dialog-routing.models';


### PR DESCRIPTION
## Description

Fix typing import issue with dialogs

-----

Before the fix, `dialog.d.ts` would contain the following
<img width="878" height="42" alt="image" src="https://github.com/user-attachments/assets/0fac4e88-206a-4c67-ab7d-18eef511e642" />
Which breaks target app build when importing `@lucca-front/ng/dialog`

Also there was unnecessary duplication of `ComponentType` type because it was imported from both `@angular/cdk/overlay` and `@angular/cdk/portal`

-----
