### PR TITLE
fix(callout-popover): Icon in popover is not deducted by state when not provided

### DIFF
--- a/packages/ng/callout/callout-popover/callout-popover.component.html
+++ b/packages/ng/callout/callout-popover/callout-popover.component.html
@@ -1,3 +1,5 @@
+@let calloutIcon = state | luCalloutIcon: icon;
+
 <button
 	type="button"
 	class="calloutPopover"
@@ -8,7 +10,7 @@
 	(mouseleave)="hideContent($event)"
 	(blur)="hideContent(null)"
 >
-	@if (state | luCalloutIcon: icon; as calloutIcon) {
+	@if (calloutIcon) {
 		<lu-icon class="calloutPopover-icon" [icon]="calloutIcon" />
 	}
 	{{ buttonLabel }}
@@ -22,7 +24,9 @@
 		(mouseleave)="hideContent($event)"
 	>
 		<div class="calloutPopover-overlay-head">
-			<lu-icon class="calloutPopover-overlay-head-icon" [class]="calloutOverlayHeadClasses" *ngIf="icon" [icon]="icon" />
+			@if (calloutIcon) {
+				<lu-icon class="calloutPopover-overlay-head-icon" [class]="calloutOverlayHeadClasses" [icon]="calloutIcon" />
+			}
 			<strong class="calloutPopover-overlay-head-title">
 				<ng-container *luPortal="heading"></ng-container>
 			</strong>

--- a/packages/ng/callout/callout-popover/callout-popover.component.ts
+++ b/packages/ng/callout/callout-popover/callout-popover.component.ts
@@ -1,7 +1,6 @@
 import { animate, state, style, transition, trigger } from '@angular/animations';
 import { Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { TemplatePortal } from '@angular/cdk/portal';
-import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ElementRef, inject, Input, numberAttribute, OnDestroy, TemplateRef, ViewChild, ViewContainerRef, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
@@ -13,7 +12,7 @@ import { getCalloutPalette } from '../callout.utils';
 @Component({
 	selector: 'lu-callout-popover',
 	standalone: true,
-	imports: [CommonModule, IconComponent, PortalDirective, CalloutIconPipe],
+	imports: [IconComponent, PortalDirective, CalloutIconPipe],
 	animations: [
 		trigger('tooltip', [
 			state(


### PR DESCRIPTION
## Description

Icon in popover is not deducted by state when not provided.

-----

Add missing `luCalloutIcon` call for the popover icon.

-----
