### PR TITLE
[Tag] Fix vertical alignement

### DIFF
--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -13,7 +13,7 @@
 	display: inline-flex;
 	align-items: center;
 	text-align: center;
-	vertical-align: baseline;
+	vertical-align: top;
 	white-space: nowrap;
 	border: 0;
 	font: var(--components-tag-font);


### PR DESCRIPTION
## Description

We have vertical alignement issue is tags have icons and other have not.
A way to fix it would be to get rid of `vertical-alignment: baseline`, but it could lead to breakings on product side.
-----

Before:
<img width="342" height="195" alt="image" src="https://github.com/user-attachments/assets/9fe8b0bf-2d53-45ed-bb70-7389de10a743" />

After:
<img width="328" height="191" alt="image" src="https://github.com/user-attachments/assets/022941e2-53f2-4907-be04-e8340541ffdd" />


-----
