### PR TITLE
fix(phone-number): sort by country name after translation

### DIFF
--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -78,11 +78,13 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 
 	#displayNames = new Intl.DisplayNames(this.#locale, { type: 'region' });
 
-	prefixEntries = getCountries().map((country) => ({
-		country,
-		prefix: getCountryCallingCode(country),
-		name: this.#displayNames.of(country),
-	}));
+	prefixEntries = getCountries()
+		.map((country) => ({
+			country,
+			prefix: getCountryCallingCode(country),
+			name: this.#displayNames.of(country),
+		}))
+		.sort((a, b) => a.name.localeCompare(b.name));
 
 	/**
 	 * Which countries should be shown? Defaults to empty array which means all of them.


### PR DESCRIPTION
## Description

In PhoneNumberInput, the list of countries was not sorted by internationalized name of country.

-----

Before :
<img width="329" height="438" alt="unnamed" src="https://github.com/user-attachments/assets/9cdfc3c3-b31d-4a76-9b10-78f398d7ebd0" />

After: 
<img width="472" height="475" alt="image" src="https://github.com/user-attachments/assets/30145e77-3b9e-41dc-9d1c-d1ee39dda5f4" />


-----

