### PR TITLE
chore(stylelint): Update deprecated versions, changed on last release

### DIFF
--- a/packages/stylelint-config/LFDeprecatedProperties.mjs
+++ b/packages/stylelint-config/LFDeprecatedProperties.mjs
@@ -10,7 +10,7 @@ export default [
 	{
 		objectPattern: /--palettes-(grey|primary|secondary|lucca)-[0-9]{2,3}/,
 		versionDeprecated: '17.3.0',
-		versionDeleted: '20.1.0',
+		versionDeleted: '21.1.0',
 	},
 	{
 		objectPattern: /--spacings-X*(S|M|L)/,
@@ -20,7 +20,7 @@ export default [
 	{
 		objectPattern: /--colors-(black|white)-color/,
 		versionDeprecated: '18.2.0',
-		versionDeleted: '20.1.0',
+		versionDeleted: '21.1.0',
 	},
 	{
 		objectPattern: /--commons-navSide-compact-width/,

--- a/packages/stylelint-config/LFDeprecatedSelectors.mjs
+++ b/packages/stylelint-config/LFDeprecatedSelectors.mjs
@@ -14,7 +14,7 @@ export default [
 	{
 		objectPattern: /\.palette-(grey|primary|secondary|lucca)/,
 		versionDeprecated: '17.3.0',
-		versionDeleted: '20.1.0',
+		versionDeleted: '21.1.0',
 	},
 	{
 		objectPattern: /\.u-(padding|margin|gap)X*(S|M|L)/,
@@ -29,12 +29,12 @@ export default [
 	{
 		objectPattern: ['.u-textLeft', '.u-textCenter', '.u-textRight'],
 		versionDeprecated: '18.1.0',
-		versionDeleted: '20.1.0',
+		versionDeleted: '21.1.0',
 	},
 	{
 		objectPattern: ['.comment-content-textContainer', '.dialog-form', '.dialog-formOptional', '.mod-withMenuCompact'],
 		versionDeprecated: '18.3.0',
-		versionDeleted: '20.1.0',
+		versionDeleted: '21.1.0',
 	},
 	{
 		objectPattern: /\.lu-dropdown-(content|options|options-item|options-item-action)/,
@@ -50,5 +50,6 @@ export default [
 	{
 		objectPattern: /\.menu-?/,
 		versionDeprecated: '19.3.0',
+		versionDeleted: '21.1.0',
 	},
 ];


### PR DESCRIPTION
## Description

Deprecations for some selectors or properties were updated in Prisme, but not updated on the stylelint package.

That would trigger linting errors for people using the linter on the 20.1 version of lucca-front.

This fix should solve the problem.

-----
