### PR TITLE
fix(schematics): fix crash when migrating components with an empty imports array

### DIFF
--- a/packages/ng/schematics/lu-icon/tests/input/empty-imports.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/input/empty-imports.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
+	`,
+	imports: []
+})
+export class EmptyImportsComponent {
+}

--- a/packages/ng/schematics/lu-icon/tests/output/empty-imports.component.ts
+++ b/packages/ng/schematics/lu-icon/tests/output/empty-imports.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { IconComponent } from '@lucca-front/ng/icon';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<lu-icon icon="signClose" />
+	`,
+	imports: [IconComponent]
+})
+export class EmptyImportsComponent {
+}


### PR DESCRIPTION
## Description

Schematics' import modifier was crashing when entering empty imports due to it having no element to push the import after, this PR fixes that by handling empty import arrays and adds the test that checks it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
