### PR TITLE
fix(autocomplete): DOM type and off for default

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -76,7 +76,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 
 	#luClass = inject(LuClass);
 
-	autocomplete = input<string>('');
+	autocomplete = input<AutoFill>('off');
 
 	placeholder = input<string>();
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -122,7 +122,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	shortcuts = input<readonly CalendarShortcut[]>();
 
-	autocomplete = input<string>('');
+	autocomplete = input<AutoFill>('off');
 
 	protected currentRightDate = computed(() => {
 		return this.hasTwoCalendars() ? this.getNextCalendarDate(this.currentDate()) : this.currentDate();

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -27,7 +27,7 @@ export class TextInputComponent {
 	placeholder: string = '';
 
 	@Input()
-	autocomplete: string = null;
+	autocomplete: AutoFill = 'off';
 
 	@Input({ transform: booleanAttribute })
 	hasClearer = false;

--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -45,7 +45,7 @@ export class LuSimpleSelectInputComponent<T> extends ALuSelectInputComponent<T, 
 		return this.filterPillMode;
 	}
 
-	autocomplete = input<string>('off');
+	autocomplete = input<AutoFill>('off');
 
 	filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 

--- a/stories/documentation/forms/date2/date-input.stories.ts
+++ b/stories/documentation/forms/date2/date-input.stories.ts
@@ -69,7 +69,7 @@ export default {
 			},
 			template: `
 			<lu-form-field label="Date input example" inlineMessage="Inline message example">
-				<lu-date-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" autocomplete="false" ${generateInputs(flags, argTypes)}></lu-date-input>
+				<lu-date-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" autocomplete="off" ${generateInputs(flags, argTypes)}></lu-date-input>
 			</lu-form-field>
 
 			<pr-story-model-display>{{selected}}</pr-story-model-display>

--- a/stories/documentation/forms/fields/date/date-input-field.stories.ts
+++ b/stories/documentation/forms/fields/date/date-input-field.stories.ts
@@ -75,7 +75,7 @@ export default {
 				},
 				argTypes,
 			)}>
-<lu-date-input [(ngModel)]="selected" [min]="min" [max]="max" autocomplete="false" ${generateInputs(flags, argTypes)}></lu-date-input>
+<lu-date-input [(ngModel)]="selected" [min]="min" [max]="max" autocomplete="off" ${generateInputs(flags, argTypes)}></lu-date-input>
 </lu-form-field>
 <pr-story-model-display>{{selected}}</pr-story-model-display>`),
 		};


### PR DESCRIPTION
## Description

There is a DOM type for the `autocomplete` attribute, we may as well use it!

Also fixes `autocomplete="false"`, it's `off`. https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/autocomplete#value

-----

