### PR TITLE
chore(errorPage): fix image ratio

### DIFF
--- a/packages/scss/src/components/errorPage/component.scss
+++ b/packages/scss/src/components/errorPage/component.scss
@@ -41,6 +41,7 @@
 		inline-size: 50%;
 		max-inline-size: 580px;
 		min-inline-size: 350px;
+		block-size: auto;
 	}
 }
 


### PR DESCRIPTION
## Description

Fix ratio of `.errorPage-section-image`

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
