### PR TITLE
[callout] fix popover size with XS

### DIFF
--- a/packages/ng/callout/callout-popover/callout-popover.component.ts
+++ b/packages/ng/callout/callout-popover/callout-popover.component.ts
@@ -125,7 +125,7 @@ export class CalloutPopoverComponent implements OnDestroy {
 
 	get calloutOverlayClasses() {
 		return {
-			[`mod-${this.size}`]: !!this.size,
+			[`mod-${this.contentSize}`]: !!this.contentSize,
 		};
 	}
 


### PR DESCRIPTION
## Description

When the callout is in mod-XS, its popover is in S (and not XS – which does not exist).

Fixes #3809 

-----


-----
![2025-08-08 12 06 52](https://github.com/user-attachments/assets/aff66a05-575d-4a7d-b019-3c4d20c4191f)

