### PR TITLE
[footer] fix footer sticky without display contents

### DIFF
--- a/packages/ng/footer/footer.component.scss
+++ b/packages/ng/footer/footer.component.scss
@@ -1,5 +1,10 @@
 @use '@lucca-front/scss/src/components/footer';
 
-lu-footer {
-	display: contents;
+lu-footer:has(.footer.mod-sticky) {
+	inset-block-end: 0;
+	position: var(--components-footer-position);
+
+	.footer.mod-sticky {
+		--components-footer-position: static;
+	}
 }


### PR DESCRIPTION
## Description

`display: contents` prevents events from being added to `lu-footer`, so we prefer to move the sticky positioning to the parent.

-----

NB: placing the `.footer` class at the same level as `lu-footer` would have caused an accessibility issue, since `role="contentinfo"` [must only be present on the main footer of the page for RGAA](https://accessibilite.numerique.gouv.fr/methode/glossaire/#zone-de-pied-de-page).

-----
