### PR TITLE
[Tooltip] Fix overflow

### DIFF
--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -17,7 +17,7 @@
 	animation-duration: var(--commons-animations-durations-fast);
 	animation-iteration-count: 1;
 	hyphens: auto;
-	word-break: break-word;
+	overflow-wrap: break-word;
 
 	@include keyframe.scaleIn;
 

--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -17,6 +17,7 @@
 	animation-duration: var(--commons-animations-durations-fast);
 	animation-iteration-count: 1;
 	hyphens: auto;
+	word-break: break-word;
 
 	@include keyframe.scaleIn;
 


### PR DESCRIPTION
## Description

[Tooltip] Fix overflow

-----

`hyphen: auto` cannot deal with all breaks (but still has priority on `word-break`)
<img width="299" height="161" alt="Capture d’écran 2025-08-12 à 17 45 41" src="https://github.com/user-attachments/assets/548bdd5d-569c-46b1-8dcb-18451fe359eb" />


-----
