### PR TITLE
[Page header] Fix title gap

### DIFF
--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -20,7 +20,7 @@
 
 		.pageHeader-content-title {
 			display: flex;
-			column-gap: var(--pr-t-spacings-100);
+			column-gap: var(--pr-t-spacings-150);
 			align-items: center;
 			flex-wrap: wrap;
 			min-block-size: var(--pr-t-spacings-500);


### PR DESCRIPTION
## Description

Fix title gap

-----

<img width="463" height="180" alt="image" src="https://github.com/user-attachments/assets/6d0aaa6e-6344-475e-a8a7-a7b92bec33c5" />

-----
