### PR TITLE
fix(filter-pills): default value for isEmpty + clearable

### DIFF
--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -128,8 +128,8 @@ export class FilterPillComponent {
 
 	shouldHideCombobox = computed(() => this.inputComponentRef()?.hideCombobox?.() || false);
 
-	inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty());
-	inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable());
+	inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty() || true);
+	inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable() || false);
 
 	shouldShowColon = computed(() => this.inputComponentRef()?.showColon?.() || !this.inputIsEmpty());
 


### PR DESCRIPTION
## Description

These two signals don't have an initial value, as they refer to nullable signals via `inputComponentRef`. 

This causes an issue with the effects that handle the initial `displayed` property (introduced in PR https://github.com/LuccaSA/lucca-front/issues/3766). The signal `inputIsEmpty()` should be `true` by default, instead of `undefined`.

When it's undefined, `this.displayed.set(true);` is called but it shouldn't !

-----

We could backport this in LF 20.0 since we spotted it on an app that runs this version.