### PR TITLE
fix(filter-pills): nullish coalescing default

### DIFF
--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -122,14 +122,14 @@ export class FilterPillComponent {
 
 	icon = input<LuccaIcon>();
 
-	defaultIcon = computed<LuccaIcon>(() => this.inputComponentRef()?.getDefaultFilterPillIcon?.() || 'arrowChevronBottom');
+	defaultIcon = computed<LuccaIcon>(() => this.inputComponentRef()?.getDefaultFilterPillIcon?.() ?? 'arrowChevronBottom');
 
 	displayedIcon = computed(() => this.icon() || this.defaultIcon());
 
-	shouldHideCombobox = computed(() => this.inputComponentRef()?.hideCombobox?.() || false);
+	shouldHideCombobox = computed(() => this.inputComponentRef()?.hideCombobox?.() ?? false);
 
-	inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty() || true);
-	inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable() || false);
+	inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty() ?? true);
+	inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable() ?? false);
 
 	shouldShowColon = computed(() => this.inputComponentRef()?.showColon?.() || !this.inputIsEmpty());
 


### PR DESCRIPTION
## Description

The PR https://github.com/LuccaSA/lucca-front/pull/3821 fixed an issue with the filter pills default values but used the wrong operator (`false || true` is always `true` 😬)

We also change the other instances of a bad use of `||` instead of `??`

-----

Sorry @jeremie-lucca 