### PR TITLE
fix(tree-select): simple select aria-selected status

### DIFF
--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -37,6 +37,7 @@
 								[branch]="branch"
 								[optionTpl]="optionTpl()"
 								[optionComparer]="optionComparer"
+								[selectedOptions]="[selected()]"
 								[optionIndex]="index"
 								(toggleOne)="panelRef.emitValue($event)"
 								simpleMode


### PR DESCRIPTION
## Description

Because simple select only has one selected option, `selectedOptions` wasn't properly sent to tree branches.

This PR fixes that by sending a one-item array to it containing the selected option.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
