### PR TITLE
[input framed] with illustration and no inline message

### DIFF
--- a/packages/scss/src/components/inputFramed/component.scss
+++ b/packages/scss/src/components/inputFramed/component.scss
@@ -56,6 +56,7 @@
 			justify-content: space-between;
 			align-content: flex-start;
 			gap: var(--pr-t-spacings-100);
+			align-items: var(--components-inputFramed-header-alignItems);
 		}
 
 		.inputFramed-header-illustration {

--- a/packages/scss/src/components/inputFramed/index.scss
+++ b/packages/scss/src/components/inputFramed/index.scss
@@ -9,6 +9,12 @@
 		@include hover;
 	}
 
+	&:has(.inputFramed-header-illustration) {
+		&:not(:has(.inlineMessage)) {
+			@include withIllustrationAndNoInlineMessage;
+		}
+	}
+
 	&:has(.inputFramed-header-input:checked) {
 		@include checked;
 

--- a/packages/scss/src/components/inputFramed/mods.scss
+++ b/packages/scss/src/components/inputFramed/mods.scss
@@ -1,0 +1,3 @@
+@mixin withIllustrationAndNoInlineMessage {
+	--components-inputFramed-header-alignItems: center;
+}

--- a/packages/scss/src/components/inputFramed/vars.scss
+++ b/packages/scss/src/components/inputFramed/vars.scss
@@ -5,4 +5,5 @@
 	--components-inputFramed-padding: var(--pr-t-spacings-150);
 	--components-inputFramed-header-backgroundColor: transparent;
 	--components-inputFramed-header-info-color: inherit;
+	--components-inputFramed-header-alignItems: normal;
 }


### PR DESCRIPTION
## Description

Added detection for input framed with illustration and no inline message to center content where appropriate.

-----



-----

Before:
<img width="444" height="85" alt="Capture d’écran 2025-08-25 à 16 42 51" src="https://github.com/user-attachments/assets/1bf5afcf-0201-4ce7-80b8-24801401719e" />

After: 
<img width="444" height="86" alt="Capture d’écran 2025-08-25 à 16 43 08" src="https://github.com/user-attachments/assets/858ea82a-d5ce-4d33-a88f-8f047e69da88" />

