### PR TITLE
fix(dialog): Fix dialog data check type

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -11,7 +11,7 @@ export class LuDialogService {
 
 	#injector = inject(Injector);
 
-	open<C, TData = LuDialogData<C>>(config: LuDialogConfig<C, TData>): LuDialogRef<C, TData> {
+	open<C, TData = LuDialogData<C>>(config: LuDialogConfig<C, NoInfer<TData>>): LuDialogRef<C, TData> {
 		let luDialogRef: LuDialogRef<C, TData>;
 		let modeClasses: string[] = [];
 		switch (config.mode) {


### PR DESCRIPTION
## Description

### Issue

Since 20.1.X (I'm not sure which one), we've lost the `data` type check based on `injectDialogData` when opening a dialog.

### Technical explanation

We now have the option to specify the data type as generic when calling `dialog.open`. This allows us to avoid having to specify an unnecessary injectDialogData in the component when injecting `data` only into the dialog's store, for example.

The problem is that Typescript automatically infers the `data` type and therefore no longer checks that `data` is typed the same as `injectDialogData`.

### Solution

We're missing a [NoInfer](https://www.typescriptlang.org/docs/handbook/utility-types.html#noinfertype) to tell Typescript not to infer the type, so it only works when the generic is specified manually.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
