### PR TITLE
[dataTable] change group background color

### DIFF
--- a/packages/scss/src/components/dataTable/mods.scss
+++ b/packages/scss/src/components/dataTable/mods.scss
@@ -40,7 +40,7 @@
 
 	font: var(--pr-t-font-heading-4);
 
-	--components-dataTable-cell-background: var(--palettes-neutral-25);
+	--components-dataTable-cell-background: var(--palettes-neutral-50);
 }
 
 @mixin selectable {


### PR DESCRIPTION
## Description

fixes #3854 

-----



-----

Before:
<img width="957" height="216" alt="Capture d’écran 2025-08-28 à 12 29 09" src="https://github.com/user-attachments/assets/a729e33b-1b08-4d26-b710-a557c85966bc" />

After: 
<img width="957" height="222" alt="Capture d’écran 2025-08-28 à 12 28 53" src="https://github.com/user-attachments/assets/085a4fbc-a0a6-4ee1-ab48-1eadce80bb7d" />


