### PR TITLE
[LuccaSans] change font-weight from 600 to 700

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -66,7 +66,7 @@ $fontTokens: (
 	heading-3-fontWeight: var(--pr-t-font-fontWeight-bold),
 	heading-4-fontSize: var(--pr-t-font-fontSize-200),
 	heading-4-lineHeight: var(--pr-t-font-lineHeight-300),
-	heading-4-fontWeight: var(--pr-t-font-fontWeight-semibold),
+	heading-4-fontWeight: var(--pr-t-font-fontWeight-bold),
 	highlight-XXL-fontSize: var(--pr-t-font-fontSize-350),
 	highlight-XXL-lineHeight: var(--pr-t-font-lineHeight-400),
 	highlight-XXL-fontWeight: var(--pr-t-font-fontWeight-black),


### PR DESCRIPTION
## Description

LuccaSans does not exist in 600 (semi-bold), so we switch to 700 (bold), both for LuccaSans and for SourceSans, which is currently replacing it on a temporary basis.

-----



-----
