### PR TITLE
fix: rename rich text tag component which has the same name has tag component

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
@@ -13,11 +13,11 @@ import type { Tag } from './tag.model';
 	providers: [
 		{
 			provide: RICH_TEXT_PLUGIN_COMPONENT,
-			useExisting: forwardRef(() => TagComponent),
+			useExisting: forwardRef(() => RichTextPluginTagComponent),
 		},
 	],
 })
-export class TagComponent implements RichTextPluginComponent, OnDestroy {
+export class RichTextPluginTagComponent implements RichTextPluginComponent, OnDestroy {
 	readonly #viewContainerRef = inject(ViewContainerRef);
 	readonly intl = getIntl(LU_RICH_TEXT_INPUT_TRANSLATIONS);
 

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -3,7 +3,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { DividerComponent } from '@lucca-front/ng/divider';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
-import { RichTextInputComponent, RichTextInputToolbarComponent, TagComponent, TAGS } from '@lucca-front/ng/forms/rich-text-input';
+import { RichTextInputComponent, RichTextInputToolbarComponent, RichTextPluginTagComponent, TAGS } from '@lucca-front/ng/forms/rich-text-input';
 import { provideLuRichTextHTMLFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/html';
 import { DEFAULT_MARKDOWN_TRANSFORMERS, provideLuRichTextMarkdownFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/markdown';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
@@ -138,7 +138,7 @@ export const WithTagPlugin: StoryObj<RichTextInputComponent & { value: string; d
 </lu-form-field>
 <pr-story-model-display>{{value}}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, TagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 				providers: [provideLuRichTextHTMLFormatter()],
 			},
 		};
@@ -181,7 +181,7 @@ export const WithTagPluginMarkdown: StoryObj<RichTextInputComponent & { value: s
 </lu-form-field>
 <pr-story-model-display>{{value}}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, TagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 				providers: [provideLuRichTextMarkdownFormatter([...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS])],
 			},
 		};


### PR DESCRIPTION
## Description

Rename TagComponent from @lucca-front/ng/forms/rich-text-input/plugins/tag which has the same name has :
`import { TagComponent } from '@lucca-front/ng/tag';` 

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
