### PR TITLE
fix(richtext): Resolve some scss on tag chips

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
@@ -107,6 +107,7 @@ export class TagNode extends DecoratorNode<string> {
 			const textNode = document.createTextNode(this.#tagDescription ?? this.#tagKey);
 			componentElement.insertBefore(textNode, componentElement.firstChild);
 			componentElement.classList.add('mod-S');
+			componentElement.classList.add('richTextField-content-chip');
 
 			// Add click handler ONLY to the delete button, not the whole chip
 			this.#componentRef.instance.kill.subscribe(() => {

--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.html
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.html
@@ -3,7 +3,7 @@
 	@for (tag of tags(); track tag) {
 		<button
 			type="button"
-			class="chip richTextField-content-chip richTextField-toolbar-chips-item"
+			class="chip richTextField-toolbar-chips-item"
 			(click)="insertTag(tag)"
 			[attr.tabindex]="$first ? 0 : -1"
 			[disabled]="isDisabled()"

--- a/packages/scss/src/components/richText/component.scss
+++ b/packages/scss/src/components/richText/component.scss
@@ -131,9 +131,7 @@
 		}
 
 		.richTextField-toolbar-chips-item {
-			@include reset.button;
-
-			width: auto;
+			border: 0;
 		}
 
 		.richTextField-content {


### PR DESCRIPTION
## Description

- Remove @include reset.button; because scss already on `chip` class. So add missing border attribute.
- Remove `richTextField-content-chip` on tags list and use it in editor

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
