### PR TITLE
[readMore] fix line break for disabled state

### DIFF
--- a/packages/scss/src/components/readMore/states.scss
+++ b/packages/scss/src/components/readMore/states.scss
@@ -6,6 +6,8 @@
 }
 
 @mixin disabled {
+	--components-readMore-content-lastChild-content: none !important;
+
 	.readMore-link.link {
 		@include a11y.mask;
 	}


### PR DESCRIPTION
## Description



-----



-----

Before:
<img width="579" height="298" alt="Capture d’écran 2025-09-03 à 15 56 39" src="https://github.com/user-attachments/assets/0dea6c16-af4c-4b97-8cdb-1aad15526228" />

After:
<img width="585" height="277" alt="Capture d’écran 2025-09-03 à 15 56 05" src="https://github.com/user-attachments/assets/a3a7d7d0-d32d-4ad2-bca8-145967e3b59a" />

