### PR TITLE
[readMore] fix detection for contents with lists or headings

### DIFF
--- a/packages/scss/src/components/readMore/component.scss
+++ b/packages/scss/src/components/readMore/component.scss
@@ -44,7 +44,8 @@
 			content: var(--components-readMore-content-lastChild-content) / '';
 			visibility: hidden;
 			white-space: nowrap;
-			font-weight: 600;
+			font: var(--pr-t-font-body-M);
+			font-weight: var(--pr-t-font-fontWeight-semibold);
 			padding-inline-start: var(--components-readMore-link-paddingInlineStart);
 		}
 
@@ -56,17 +57,29 @@
 			padding: var(--pr-t-spacings-50);
 			margin: calc(var(--pr-t-spacings-50) * -1);
 
-			&:not(:has(> p)) {
+			&:not(:has(> p, > ul, > ol, > h1, > h2, > h3, > h4, > h5, > h6)) {
 				&::after {
 					@extend %after;
 				}
 			}
 
-			&:has(> p) {
+			&:has(> p, > ul, > ol, > h1, > h2, > h3, > h4, > h5, > h6) {
 				> * {
 					&:last-child {
-						&::after {
-							@extend %after;
+						&:not(ul, ol) {
+							&::after {
+								@extend %after;
+							}
+						}
+
+						&:is(ul, ol) {
+							li {
+								&:last-child {
+									&::after {
+										@extend %after;
+									}
+								}
+							}
 						}
 					}
 				}

--- a/packages/scss/src/components/readMore/component.scss
+++ b/packages/scss/src/components/readMore/component.scss
@@ -57,23 +57,26 @@
 			padding: var(--pr-t-spacings-50);
 			margin: calc(var(--pr-t-spacings-50) * -1);
 
-			&:not(:has(> p, > ul, > ol, > h1, > h2, > h3, > h4, > h5, > h6)) {
+			$notPlainText: '> p, > ul, > ol, > h1, > h2, > h3, > h4, > h5, > h6';
+			$wrappingElements: 'ol, ul';
+
+			&:not(:has(#{$notPlainText})) {
 				&::after {
 					@extend %after;
 				}
 			}
 
-			&:has(> p, > ul, > ol, > h1, > h2, > h3, > h4, > h5, > h6) {
+			&:has(#{$notPlainText}) {
 				> * {
 					&:last-child {
-						&:not(ul, ol) {
+						&:not(#{$wrappingElements}) {
 							&::after {
 								@extend %after;
 							}
 						}
 
-						&:is(ul, ol) {
-							li {
+						&:is(#{$wrappingElements}) {
+							> * {
 								&:last-child {
 									&::after {
 										@extend %after;

--- a/packages/scss/src/components/textFlow/component.scss
+++ b/packages/scss/src/components/textFlow/component.scss
@@ -36,5 +36,11 @@
 
 	& > :last-child {
 		margin-block-end: 0;
+
+		&:is(ul, ol) {
+			> :last-child {
+				margin-block-end: 0;
+			}
+		}
 	}
 }


### PR DESCRIPTION
## Description

The component needs to know where to insert the placeholder text “Read less” that reserves the necessary space for the collapse button. To do this, it used to detect the presence of paragraphs (`p`).

It now detects the presence of lists (`ol`, `ul`) and titles (`hx`), and inserts the placeholder text in the right place.

-----



-----

<img width="480" height="339" alt="image" src="https://github.com/user-attachments/assets/8be43f7e-b89c-4d42-844e-1bc09ae949f2" />
