### PR TITLE
[skeleton] fix square default radius

### DIFF
--- a/packages/scss/src/components/skeleton/mods.scss
+++ b/packages/scss/src/components/skeleton/mods.scss
@@ -4,7 +4,7 @@
 }
 
 @mixin square {
-	border-radius: var(--pr-t-border-radius-structure);
+	border-radius: var(--pr-t-border-radius-small);
 	block-size: var(--components-skeleton-shape-height);
 	inline-size: var(--components-skeleton-shape-width);
 }


### PR DESCRIPTION
## Description



-----



-----

Before:
<img width="398" height="177" alt="Capture d’écran 2025-09-04 à 14 17 36" src="https://github.com/user-attachments/assets/d2a4b799-5033-4b9e-94ff-5d3c18fe0467" />

After:
<img width="401" height="181" alt="Capture d’écran 2025-09-04 à 14 17 23" src="https://github.com/user-attachments/assets/4c864710-f5a7-4975-acb9-3f7e286863ad" />
