### PR TITLE
[dataTable] fix background for groups

### DIFF
--- a/packages/scss/src/components/dataTable/mods.scss
+++ b/packages/scss/src/components/dataTable/mods.scss
@@ -40,7 +40,7 @@
 
 	font: var(--pr-t-font-heading-4);
 
-	--components-dataTable-cell-background: var(--palettes-neutral-25);
+	--components-dataTable-cell-background: var(--palettes-neutral-50);
 }
 
 @mixin selectable {


### PR DESCRIPTION
## Description



-----

fixes #3854 

-----

Before:
<img width="944" height="221" alt="Capture d’écran 2025-09-11 à 17 50 57" src="https://github.com/user-attachments/assets/61b753b4-f601-4944-8d7e-76a47b191396" />


After: 
<img width="939" height="219" alt="Capture d’écran 2025-09-11 à 17 49 17" src="https://github.com/user-attachments/assets/376f8724-0106-448b-b25d-3e5f28132c65" />

