### PR TITLE
fix(multi-select): manage toggle options for disabled group options

### DIFF
--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -36,15 +36,18 @@
 								<span #groupingTitleRef>
 									<ng-container *luPortal="grouping.content; context: { $implicit: group }" />
 								</span>
-								<button
-									type="button"
-									class="link"
-									(click)="toggleOptions(groupCtx.notSelectedOptions, group.options)"
-									[id]="selectId + '-group-' + group.key"
-								>
-									<span class="pr-u-mask">{{ groupingTitleRef.innerText }}&nbsp;– </span
-									>{{ groupCtx.isGroupSelected ? intl.unselectAll : intl.selectAll }}
-								</button>
+
+								@if (someGroupOptionEnabled()(group.options)) {
+									<button
+										type="button"
+										class="link"
+										(click)="toggleOptions(groupCtx.notSelectedOptions, group.options)"
+										[id]="selectId + '-group-' + group.key"
+									>
+										<span class="pr-u-mask">{{ groupingTitleRef.innerText }}&nbsp;– </span
+										>{{ groupCtx.isGroupSelected ? intl.unselectAll : intl.selectAll }}
+									</button>
+								}
 							</div>
 							<ng-template
 								[ngTemplateOutlet]="optionsList"


### PR DESCRIPTION
## Description
This PR fixes toggle button behavior in multi-select groups to properly handle disabled options. It ensures that "Select All" and "Unselect All" actions only affect enabled options and hides the toggle button when all group options are disabled.

- Adds logic to filter out disabled options when toggling group selections
- Introduces a computed function to check if any group options are enabled
- Conditionally renders toggle buttons only when enabled options exist in the group
-----

Select All / Unselect All from Multiselect groups should not toggle disabled options.
If all options are disabled for a group, hide toggle button.

-----

Refers https://github.com/LuccaSA/Pagga.Remuneration/issues/6169
