### PR TITLE
[Box] Fix border radius

### DIFF
--- a/packages/scss/src/components/box/component.scss
+++ b/packages/scss/src/components/box/component.scss
@@ -2,7 +2,7 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
-	border-radius: var(--pr-t-border-radius-default);
+	border-radius: var(--components-box-borderRadius);
 	padding: var(--components-box-padding);
 	background-color: var(--components-box-background, var(--pr-t-elevation-surface-raised));
 	display: block;

--- a/packages/scss/src/components/box/mods.scss
+++ b/packages/scss/src/components/box/mods.scss
@@ -44,6 +44,7 @@
 
 @mixin withArrow {
 	--components-box-padding: var(--pr-t-spacings-200);
+	--components-box-borderRadius: var(--pr-t-border-radius-small) var(--pr-t-border-radius-structure) var(--pr-t-border-radius-structure);
 
 	.box-arrow {
 		--components-box-arrow-bottom: 100%;

--- a/packages/scss/src/components/box/vars.scss
+++ b/packages/scss/src/components/box/vars.scss
@@ -2,6 +2,7 @@
 	--components-box-background: var(--pr-t-elevation-surface-raised);
 	--components-box-margin: 0 0 var(--pr-t-spacings-200);
 	--components-box-padding: var(--pr-t-spacings-300);
+	--components-box-borderRadius: var(--pr-t-border-radius-structure);
 	--components-box-toggle-arrow-size: 0.8rem;
 	--components-box-toggle-arrow-left: 2.5rem;
 }


### PR DESCRIPTION
## Description

- Border radius `default` → `structure`
- Apply small `border` radius on box top left if it has arrow to avoid UI issue

-----