### PR TITLE
[dialog] fix focus-visible on scroll

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -43,7 +43,7 @@
 					flex-grow: 1;
 					min-block-size: 0;
 
-					&:has(.dialog-content:focus-visible) {
+					&:has(.dialog-inside-content:focus-visible) {
 						&::after {
 							@include a11y.focusVisible($offset: -4px);
 
@@ -64,7 +64,7 @@
 				flex-grow: 1;
 				min-block-size: 0;
 
-				&:has(.dialog-content:focus-visible) {
+				&:has(.dialog-inside-content:focus-visible) {
 					&::after {
 						@include a11y.focusVisible($offset: -4px);
 


### PR DESCRIPTION
## Description

With Firefox, containers with a scroll bar have their focus-visible enabled when navigating with the keyboard. This was handled for dialogs, but the selector had not been updated.

-----



-----

<img width="663" height="472" alt="Capture d’écran 2025-09-18 à 10 00 17" src="https://github.com/user-attachments/assets/778645d2-a86e-431e-a671-b4ccb67167b7" />

