### PR TITLE
Revert h4 font-weight

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -66,7 +66,7 @@ $fontTokens: (
 	heading-3-fontWeight: var(--pr-t-font-fontWeight-bold),
 	heading-4-fontSize: var(--pr-t-font-fontSize-200),
 	heading-4-lineHeight: var(--pr-t-font-lineHeight-300),
-	heading-4-fontWeight: var(--pr-t-font-fontWeight-bold),
+	heading-4-fontWeight: var(--pr-t-font-fontWeight-semibold),
 	highlight-XXL-fontSize: var(--pr-t-font-fontSize-350),
 	highlight-XXL-lineHeight: var(--pr-t-font-lineHeight-400),
 	highlight-XXL-fontWeight: var(--pr-t-font-fontWeight-black),


### PR DESCRIPTION
## Description

Error on the `font-weight`, which does not apply here on Lucca Sans.

-----



-----
