### PR TITLE
fix(date): better handling of single-digit input on month and day

### DIFF
--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -4,7 +4,7 @@ import { addMonths, addYears, isAfter, isBefore, isSameMonth, startOfDay, startO
 import { CalendarMode } from './calendar2/calendar-mode';
 import { CellStatus } from './calendar2/cell-status';
 import { DateRange, DateRangeInput } from './calendar2/date-range';
-import { getDateFormat, getLocalizedDateFormat } from './date-format';
+import { getDateFormat, getLocalizedDateFormat, getSeparator } from './date-format';
 import { DATE_FORMAT, DateFormat } from './date.const';
 import { LU_DATE2_TRANSLATIONS } from './date2.translate';
 import { transformDateInputToDate, transformDateRangeInputToDateRange } from './utils';
@@ -18,6 +18,7 @@ export abstract class AbstractDateComponent {
 	protected locale = inject(LOCALE_ID);
 	// Contains the current date format (like dd/mm/yy etc) based on current locale
 	protected dateFormat = getDateFormat(this.locale);
+	protected separator = getSeparator(this.locale);
 	intlDateTimeFormat = new Intl.DateTimeFormat(this.locale);
 
 	intlDateTimeFormatMonth = new Intl.DateTimeFormat(this.locale, { month: 'numeric', year: 'numeric' });

--- a/packages/ng/date2/date-format.ts
+++ b/packages/ng/date2/date-format.ts
@@ -14,6 +14,10 @@ export function getDateFormat(locale: string): string {
 	}, '');
 }
 
+export function getSeparator(locale: string): string {
+	return new Intl.DateTimeFormat(locale).formatToParts(new Date('01/01/2024')).find((part) => part.type === 'literal')?.value || '/';
+}
+
 // Warning: it works on Latin languages, but deserves to be tested on non-Latin languages
 export function getLocalizedDateFormat(locale: string, period: 'year' | 'month' | 'day' = 'day'): string {
 	const letterLocalizedForDay = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' }).formatToParts(100, 'day')[2]['value'].charAt(1).toUpperCase();

--- a/packages/ng/date2/date-input/date-input.component.html
+++ b/packages/ng/date2/date-input/date-input.component.html
@@ -10,7 +10,7 @@
 			luInput
 			class="textField-input-value"
 			(input)="userTextInput.set(date.value)"
-			(blur)="onTouched?.(); inputFocused.set(false)"
+			(blur)="inputBlurred()"
 			(focus)="inputFocused.set(true)"
 			aria-haspopup="true"
 			role="combobox"

--- a/packages/ng/date2/date-input/date-input.component.html
+++ b/packages/ng/date2/date-input/date-input.component.html
@@ -9,7 +9,6 @@
 			#date
 			luInput
 			class="textField-input-value"
-			[value]="displayValue()"
 			(input)="userTextInput.set(date.value)"
 			(blur)="onTouched?.(); inputFocused.set(false)"
 			(focus)="inputFocused.set(true)"

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -111,6 +111,13 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 	inputRef = viewChild<ElementRef<HTMLInputElement>>('date');
 
 	displayValue = computed(() => {
+		const textInput = this.userTextInput();
+		if (textInput !== 'ɵ') {
+			const parsedInput = parse(textInput, this.dateFormat, startOfDay(new Date()));
+			if (this.isValidDate(parsedInput)) {
+				return textInput;
+			}
+		}
 		if (this.selectedDate() && this.isValidDate(this.selectedDate())) {
 			let formatter: Intl.DateTimeFormat;
 			switch (this.mode()) {
@@ -126,7 +133,6 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 			}
 			return formatter.format(this.selectedDate());
 		}
-		const textInput = this.userTextInput();
 		// If we are initializing the component, we don't want to display the value
 		if (textInput === 'ɵ') {
 			return '';
@@ -172,6 +178,18 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 
 	constructor() {
 		super();
+
+		effect(() => {
+			const nativeElement = this.inputRef().nativeElement;
+			const cursorPositionBefore = nativeElement.selectionStart;
+			const displayValue = this.displayValue();
+			nativeElement.value = this.displayValue();
+			if (displayValue.endsWith(this.separator)) {
+				nativeElement.setSelectionRange(cursorPositionBefore + 1, cursorPositionBefore + 1);
+			} else {
+				nativeElement.setSelectionRange(cursorPositionBefore, cursorPositionBefore);
+			}
+		});
 
 		effect(() => {
 			const inputValue = this.userTextInput();

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -114,7 +114,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		const textInput = this.userTextInput();
 		if (textInput !== 'ɵ') {
 			const parsedInput = parse(textInput, this.dateFormat, startOfDay(new Date()));
-			if (this.isValidDate(parsedInput)) {
+			if (this.isValidDate(parsedInput) && this.inputFocused()) {
 				return textInput;
 			}
 		}
@@ -389,5 +389,10 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 			this.inputRef().nativeElement.focus();
 		}
 		this.filterPillPopoverCloseFn?.();
+	}
+
+	inputBlurred(): void {
+		this.onTouched?.();
+		this.inputFocused.set(false);
 	}
 }

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -394,5 +394,6 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 	inputBlurred(): void {
 		this.onTouched?.();
 		this.inputFocused.set(false);
+		this.userTextInput.set('ɵ');
 	}
 }


### PR DESCRIPTION
## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
