### PR TITLE
fix(select): luSelectPanelHeader works with multi select

### DIFF
--- a/packages/ng/core-select/panel/panel-header-template.directive.ts
+++ b/packages/ng/core-select/panel/panel-header-template.directive.ts
@@ -8,7 +8,7 @@ import { ALuSelectInputComponent } from '../input';
 export class LuCoreSelectPanelHeaderDirective {
 	readonly templateRef = inject<TemplateRef<void>>(TemplateRef);
 
-	readonly select = input.required<ALuSelectInputComponent<unknown, unknown>>({ alias: 'luSelectPanelHeader' });
+	readonly select = input.required<ALuSelectInputComponent<unknown, unknown> | ALuSelectInputComponent<unknown, unknown[]>>({ alias: 'luSelectPanelHeader' });
 
 	constructor() {
 		effect(() => {


### PR DESCRIPTION
## Description

We had an error when using `luSelectPanelHeader` with a multi-select ref.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
