### PR TITLE
feat(multilanguage-input): new openOnFocus input to open panel on focus

### DIFF
--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
@@ -9,12 +9,14 @@
 			(ngModelChange)="valueChange()"
 			[ngModelOptions]="{ standalone: true }"
 			(blur)="onTouched?.()"
+			(focus)="openOnFocus() ? popoverRef.openPopover(true, true, true) : null"
 			[disabled]="disabledInternal()"
 			#inputElement
 		/>
 		<div class="textField-input-affix">
 			<button
 				[luPopover2]="popoverMultilanguage"
+				#popoverRef="luPopover2"
 				luPopoverNoCloseButton
 				[customPositions]="popoverPositions"
 				[luTooltip]="intl.toggleMultilanguage"

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -1,12 +1,10 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
-import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, forwardRef, inject, input, LOCALE_ID, signal, ViewEncapsulation, WritableSignal } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, inject, input, LOCALE_ID, signal, ViewEncapsulation, WritableSignal } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { getIntl, IntlParamsPipe } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
-import { FormFieldIdDirective } from '../form-field-id.directive';
 import { TextInputComponent } from '../text-input/text-input.component';
 import { MultilanguageTranslation } from './model/multilanguage-translation';
 import { LU_MULTILANGUAGE_INPUT_TRANSLATIONS } from './multilanguage-input.translate';
@@ -14,19 +12,7 @@ import { LU_MULTILANGUAGE_INPUT_TRANSLATIONS } from './multilanguage-input.trans
 @Component({
 	selector: 'lu-multilanguage-input',
 	standalone: true,
-	imports: [
-		FormFieldComponent,
-		ReactiveFormsModule,
-		FormFieldIdDirective,
-		NgTemplateOutlet,
-		PopoverDirective,
-		TextInputComponent,
-		FormFieldComponent,
-		FormsModule,
-		InputDirective,
-		IntlParamsPipe,
-		LuTooltipTriggerDirective,
-	],
+	imports: [FormFieldComponent, ReactiveFormsModule, PopoverDirective, TextInputComponent, FormFieldComponent, FormsModule, InputDirective, IntlParamsPipe, LuTooltipTriggerDirective],
 	templateUrl: './multilanguage-input.component.html',
 	styleUrl: './multilanguage-input.component.scss',
 	providers: [
@@ -55,6 +41,8 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 	protected onChange = (_value: MultilanguageTranslation[]) => {};
 
 	placeholder = input('');
+
+	openOnFocus = input(false, { transform: booleanAttribute });
 
 	// Suffixed with Internal to avoid conflict with NgModel's disabled attribute
 	disabledInternal = signal(false);

--- a/stories/documentation/forms/fields/multilanguage/angular/multilanguagefield.stories.ts
+++ b/stories/documentation/forms/fields/multilanguage/angular/multilanguagefield.stories.ts
@@ -86,5 +86,6 @@ export const Basic: StoryObj<
 		inlineMessageState: 'default',
 		placeholder: 'Placeholder',
 		tooltip: 'Je suis un message d’aide',
+		openOnFocus: false,
 	},
 };


### PR DESCRIPTION
## Description

Add a new `openOnFocus` input to `lu-multilanguage-input` to open the panel on focus, without pushing focus inside the first input.

closes #3718

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
