### PR TITLE
[Index table] Fix sort & pagination button colors on hover

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -268,6 +268,11 @@
 				padding-inline: 0;
 				margin-inline-end: var(--pr-t-spacings-100);
 			}
+
+			.pagination-scrolling .button:hover {
+				--components-button-backgroundColor: var(--palettes-neutral-100);
+				--components-button-color: var(--palettes-neutral-700);
+			}
 		}
 	}
 
@@ -284,5 +289,10 @@
 
 	.avatarWrapper {
 		display: inline-flex;
+	}
+
+	.tableSortable.button:hover {
+		--components-button-backgroundColor: var(--palettes-neutral-100);
+		color: var(--palettes-neutral-700);
 	}
 }


### PR DESCRIPTION
## Description

Fix sort & pagination button colors on hover

-----

<img width="380" height="73" alt="Capture d’écran 2025-10-01 à 10 55 08" src="https://github.com/user-attachments/assets/c623a856-8c4a-47d0-9905-130e0b0a4232" />
<img width="206" height="80" alt="image" src="https://github.com/user-attachments/assets/35332ed3-9464-40d4-ac5e-708caa03e380" />


-----
