### PR TITLE
fix(tree-select): handle undefined parent

### DIFF
--- a/packages/ng/tree-select/tree-select.directive.ts
+++ b/packages/ng/tree-select/tree-select.directive.ts
@@ -41,8 +41,8 @@ export class TreeSelectDirective<T, V> implements TreeGenerator<T, TreeNode<T>> 
 					node: item,
 					children: [],
 				};
-				// Parent null means it's a root element
-				if (parent === null) {
+				// Parent null or undefined means it's a root element
+				if (!parent) {
 					res.push(itemNode);
 					itemToNode.set(item, itemNode);
 					handled.push(item);


### PR DESCRIPTION
## Description

Our tree select mapper didn't handle `undefined` in the grouping logic, which is bad due to `Array.find` returning `undefined` when something isn't found.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
