### PR TITLE
fix(page-header): typo in button style attribute

### DIFF
--- a/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
+++ b/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
@@ -82,7 +82,7 @@ export default {
 		></lu-text-input>
 	</lu-form-field>
 	<button type="button" luButton>Button</button>
-	<button type="button" luButton="outline">Button</button>
+	<button type="button" luButton="outlined">Button</button>
 	<button type="button" luButton="ghost"><lu-icon icon="menuDots" alt="Voir plus d’options" /></button>
 </ng-container>`
 			: ``;


### PR DESCRIPTION
Corrects a typographical error in the `luButton` attribute from "outline" to "outlined", ensuring the correct styling is applied and the mapping is correct with the `ButtonComponent`.
-----