### PR TITLE
fix(departments): simple select optionComparer crash

### DIFF
--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -99,6 +99,9 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 	}
 
 	protected override optionKey = (option: TreeNode<T> | T) => {
+		if (!option) {
+			return null;
+		}
 		return 'node' in option ? option.node.id : option.id;
 	};
 }


### PR DESCRIPTION
## Description

A nullish value would create a crash due to the use of `in` operator on a `null` value.

This has been fixed by returning `null`in the default option key mapper if the option itself is falsy.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
