### PR TITLE
fix(rich-text-tag-plugin): make rich-text tag plugin import chip styles

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.scss
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.scss
@@ -1,0 +1,1 @@
+@use '@lucca-front/scss/src/components/chip';

--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
@@ -12,6 +12,7 @@ const areSetsEqual = (a: Set<string>, b: Set<string>): boolean => a.size === b.s
 	selector: 'lu-rich-text-plugin-tag',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	templateUrl: './tag.component.html',
+	styleUrl: './tag.component.scss',
 	providers: [
 		{
 			provide: RICH_TEXT_PLUGIN_COMPONENT,


### PR DESCRIPTION
## Description

Make rich-text tag plugin import chip styles

-----

Projects not importing chips globally have the following issue
![Slack_KKJFL0UFUW](https://github.com/user-attachments/assets/b1c75f7d-150a-4477-8ad3-92fd14392503)


-----
