### PR TITLE
ref(dialog): delete almost all breaking changes

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.models.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.models.ts
@@ -1,6 +1,6 @@
 import { ComponentType } from '@angular/cdk/overlay';
 import { InjectionToken } from '@angular/core';
-import { CanDeactivateFn, Route } from '@angular/router';
+import { Route } from '@angular/router';
 import { LuDialogConfig, LuDialogData, LuDialogResult } from '../model';
 import { DialogResolveFn } from './dialog-routing.utils';
 
@@ -32,12 +32,7 @@ export type DialogRouteConfig<C> = DialogRouteComponentLoader<C> & {
 	 * If needed, the reason the dialog was dismissed can retrieved using `inject(DIALOG_ROUTE_DISMISS_TRIGGER)`
 	 */
 	onDismissed?: () => unknown;
-
-	/**
-	 * Override canDeactivate to have a stricter type
-	 */
-	canDeactivate?: CanDeactivateFn<C>[];
-} & Omit<Route, 'component' | 'loadComponent' | 'canDeactivate'>;
+} & Omit<Route, 'component' | 'loadComponent'>;
 
 export type DialogRouteDialogConfig<C> = Omit<LuDialogConfig<C>, 'data' | 'content'>;
 

--- a/packages/ng/dialog/dialog-routing/index.ts
+++ b/packages/ng/dialog/dialog-routing/index.ts
@@ -8,4 +8,4 @@ export {
 	DialogRouteDialogConfig,
 	DialogRouteDismissTrigger,
 } from './dialog-routing.models';
-export * from './dialog-routing.utils';
+export { createDialogRoute, DialogFactoryConfig, DialogFactoryResult, DialogFactoryResultOptions, dialogLazyRouteFactory, dialogRouteFactory } from './dialog-routing.utils';


### PR DESCRIPTION
## Description

- trigger can be retrieved using DI to avoid padding all parameters by one
- `DIALOG_ROUTE_CONFIG` was used, let's keep it
- who use `DeprecatedGuard`s in 2025?! Well, let's support it 🙈

It is too hard to support `content` in `dialogConfig` along the new `loadComponent`/`component`. `createDialogRoute` is almost not used directly. I keep this breaking 🙈 

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
