### PR TITLE
fix(dialog): call canDeactivate function the correct number of time

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
@@ -189,6 +189,8 @@ export class DialogRoutingContainerComponent<C> implements OnDestroy, OnInit {
 				defaultOnClosedFn();
 			}
 		});
+
+		this.#ref = undefined;
 	}
 
 	#onDialogClosed(result: LuDialogResult<C>): void {
@@ -210,6 +212,8 @@ export class DialogRoutingContainerComponent<C> implements OnDestroy, OnInit {
 				defaultOnClosedFn();
 			}
 		});
+
+		this.#ref = undefined;
 	}
 
 	async #resolve<T>(resolveFn: DialogResolveFn<T>): Promise<T | undefined> {

--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.spec.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.spec.ts
@@ -225,6 +225,62 @@ describe('dialog-routing.utils', () => {
 			expect(dialogRef.dismiss).toHaveBeenCalledTimes(1);
 		});
 
+		it('should call canDeactivate once when dialog is dismissed', async () => {
+			// Arrange
+			const canDeactivateGuard = jest.fn(() => true);
+
+			const route = addTestRoute({
+				path: 'test/:name',
+				dataFactory: () => ({ foo: 'bar' }),
+				dialogRouteConfig: {
+					canDeactivate: [canDeactivateGuard],
+				},
+			});
+			const { router, fixture } = initTest(route);
+
+			// Act
+			await router.navigateByUrl('/test/bar');
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Navigate away to trigger canDeactivate
+			dialogRef.dismiss();
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Assert
+			expect(canDeactivateGuard).toHaveBeenCalledTimes(1);
+			expect(dialogRef.dismiss).toHaveBeenCalledTimes(1);
+		});
+
+		it('should not call canDeactivate when dialog is closed', async () => {
+			// Arrange
+			const canDeactivateGuard = jest.fn(() => true);
+
+			const route = addTestRoute({
+				path: 'test/:name',
+				dataFactory: () => ({ foo: 'bar' }),
+				dialogRouteConfig: {
+					canDeactivate: [canDeactivateGuard],
+				},
+			});
+			const { router, fixture } = initTest(route);
+
+			// Act
+			await router.navigateByUrl('/test/bar');
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Navigate away to trigger canDeactivate
+			dialogRef.close();
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Assert
+			expect(canDeactivateGuard).toHaveBeenCalledTimes(0);
+			expect(dialogRef.close).toHaveBeenCalledTimes(1);
+		});
+
 		it('should keep dialog opened when canDeactivate return false', async () => {
 			// Arrange
 			const canDeactivateGuard = jest.fn(() => false);


### PR DESCRIPTION
## Description

- canDeactivate was called twice when dialog was dismissed
- canDeactivate was called even when dialog was closed

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
