### PR TITLE
fix(peerDeps): Missing peer deps for ngx-mask on ng

### DIFF
--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -31,6 +31,7 @@
     "@lucca-front/scss": "*",
     "isomorphic-dompurify": "^2.17.0",
     "date-fns": "^3.6.0",
+    "ngx-mask": "^20.0.3",
     "rxjs": "^7.8.0",
     "@lexical/html": "^0.30.0",
     "@lexical/text": "^0.30.0",


### PR DESCRIPTION
## Description

To prevent build error with new deps `ngx-mask`, we add it to peer deps in `package.json` from package ng

-----
