### PR TITLE
fix(filterPill): do not display checkbox layout when select contains checkbox-input

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -24,20 +24,21 @@ import {
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor } from '@angular/forms';
 import { getIntl, PortalContent } from '@lucca-front/ng/core';
-import { FILTER_PILL_HOST_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
+import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { BehaviorSubject, defer, map, Observable, of, ReplaySubject, startWith, Subject, switchMap, take } from 'rxjs';
 import { LuOptionGrouping, LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
 import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
 import { LU_CORE_SELECT_TRANSLATIONS } from '../select.translate';
-import { TreeGenerator } from './tree-generator';
 import { TreeNode } from './model';
+import { TreeGenerator } from './tree-generator';
 
 export const coreSelectDefaultOptionComparer: LuOptionComparer<unknown> = (option1, option2) => JSON.stringify(option1) === JSON.stringify(option2);
 export const coreSelectDefaultOptionKey: (option: unknown) => unknown = (option) => option;
 
 @Directive()
 export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDestroy, OnInit, ControlValueAccessor, FilterPillInputComponent {
+	public parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	protected changeDetectorRef = inject(ChangeDetectorRef);
 	protected overlayContainerRef: HTMLElement = inject(OverlayContainer).getContainerElement();
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -68,6 +68,7 @@ export type DateInputValidatorErrorType = {
 	],
 })
 export class DateInputComponent extends AbstractDateComponent implements OnInit, ControlValueAccessor, Validator, FilterPillInputComponent {
+	public parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	#injector = inject(Injector);
 	#ngControl: NgControl; // Initialized in ngOnInit
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -69,6 +69,7 @@ let nextId = 0;
 	],
 })
 export class DateRangeInputComponent extends AbstractDateComponent implements OnInit, ControlValueAccessor, Validator, FilterPillInputComponent {
+	public parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	#injector = inject(Injector);
 	#ngControl: NgControl; // Initialized in ngOnInit
 	#luClass = inject(LuClass);

--- a/packages/ng/filter-pills/core/filter-pill-input-component.ts
+++ b/packages/ng/filter-pills/core/filter-pill-input-component.ts
@@ -4,6 +4,7 @@ import { LuccaIcon } from '@lucca-front/icons';
 export type FilterPillLayout = 'checkable';
 
 export interface FilterPillInputComponent {
+	parentInput?: FilterPillInputComponent | null;
 	isFilterPillEmpty: Signal<boolean>;
 	isFilterPillClearable: Signal<boolean>;
 	// If this is not here, we'll consider it's using default layout

--- a/packages/ng/filter-pills/core/filter-pill-label.directive.ts
+++ b/packages/ng/filter-pills/core/filter-pill-label.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, inject, TemplateRef } from '@angular/core';
 import { FilterPillComponent } from '../filter-pill/filter-pill.component';
+import { FILTER_PILL_INPUT_COMPONENT } from './tokens';
 
 interface FilterPillLabelContext {
 	label: string;
@@ -14,11 +15,12 @@ interface FilterPillLabelContext {
 })
 export class FilterPillLabelDirective {
 	#filterPillComponentRef = inject(FilterPillComponent, { optional: true });
+	#parentComponentRef = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 
 	#templateRef = inject(TemplateRef);
 
 	constructor() {
-		if (this.#filterPillComponentRef) {
+		if (this.#filterPillComponentRef && !this.#parentComponentRef.parentInput) {
 			this.#filterPillComponentRef.customLabelTpl.set(this.#templateRef);
 		}
 	}

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -28,6 +28,7 @@ let nextId = 0;
 	},
 })
 export class CheckboxInputComponent implements FilterPillInputComponent {
+	parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
 
 	isFilterPill = false;

--- a/stories/documentation/forms/filterPills/angular/filter-pills.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/filter-pills.stories.ts
@@ -3,15 +3,16 @@ import { provideHttpClient } from '@angular/common/http';
 import { LOCALE_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { provideAnimations } from '@angular/platform-browser/animations';
+import { LuCoreSelectTotalCountDirective } from '@lucca-front/ng/core-select';
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { DateInputComponent, DateRangeInputComponent } from '@lucca-front/ng/date2';
 import { FilterPillComponent } from '@lucca-front/ng/filter-pills';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent, TextInputComponent } from '@lucca-front/ng/forms';
+import { LuMultiSelectInputComponent, LuMultiSelectWithSelectAllDirective } from '@lucca-front/ng/multi-select';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { TreeSelectDirective } from '@lucca-front/ng/tree-select';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
-import { LuMultiSelectInputComponent } from '../../../../../packages/ng/multi-select/input';
-import { TreeSelectDirective } from '../../../../../packages/ng/tree-select/tree-select.directive';
 import { StoryModelDisplayComponent } from '../../../../helpers/story-model-display.component';
 
 export default {
@@ -33,6 +34,8 @@ export default {
 				TextInputComponent,
 				FilterLegumesPipe,
 				TreeSelectDirective,
+				LuMultiSelectWithSelectAllDirective,
+				LuCoreSelectTotalCountDirective,
 			],
 		}),
 		applicationConfig({
@@ -60,11 +63,8 @@ export default {
 			template: `<lu-filter-pill label="Inclure les collaborateurs partis">
 	<lu-checkbox-input [ngModel]="false"></lu-checkbox-input>
 </lu-filter-pill>
-<lu-filter-pill label="Simple" name="legume">
-		<lu-simple-select ${clearableProperty}[options]="legumes | filterLegumes:clue" (clueChange)="clue = $event" />
-</lu-filter-pill>
-<lu-filter-pill label="Multi" name="legume">
-	<lu-multi-select ${clearableProperty}	[options]="legumes | filterLegumes:clue" (clueChange)="clue = $event" filterPillLabelPlural="légumes" />
+<lu-filter-pill label="With Select all" name="legume">
+	<lu-multi-select ${clearableProperty}	[options]="legumes | filterLegumes:clue" [totalCount]="legumes.length" (clueChange)="clue = $event" filterPillLabelPlural="légumes" withSelectAll withSelectAllDisplayerLabel="Tous les légumés" />
 </lu-filter-pill>
 <lu-filter-pill label="Département" name="department">
 	<lu-simple-select ${clearableProperty} departments></lu-simple-select>


### PR DESCRIPTION

## Description

Fix issue when a checkbox-input is used inside a multi-select

<img width="386" height="72" alt="image" src="https://github.com/user-attachments/assets/63c4a7d3-648f-49a3-bca2-893c1a53f59d" />

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
