### PR TITLE
[readMore] fix updating content leads to state issue

### DIFF
--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -8,7 +8,6 @@ import { LU_READMORE_TRANSLATIONS } from './read-more.translate';
 	templateUrl: './read-more.component.html',
 	styleUrl: './read-more.component.scss',
 	encapsulation: ViewEncapsulation.None,
-
 	host: {
 		class: 'readMore',
 	},
@@ -65,9 +64,14 @@ export class ReadMoreComponent implements OnInit {
 	ngOnInit(): void {
 		new ResizeObserver(() => {
 			const contentElement = this.contentRef()?.nativeElement;
+			const lineHeight = parseFloat(window.getComputedStyle(contentElement).lineHeight);
+			const totalLines = Math.round(contentElement.scrollHeight / lineHeight);
 
 			this.isClamped.set(contentElement.scrollHeight > contentElement.clientHeight);
-		}).observe(this.contentRef().nativeElement);
+			if (!this.isClamped() && totalLines <= this.lineClamp()) {
+				this.expanded.set(false);
+			}
+		}).observe(this.contentRef().nativeElement, { box: 'border-box' });
 	}
 
 	toggleExpanded() {


### PR DESCRIPTION
## Description

issue: https://github.com/LuccaSA/lucca-front/issues/4027

We assumed that when clamped is false and there is no line above the lineClamp input, the expanded state is always false.

We also added ResizeObserverOptions to detect more events.
By default, only the content box is observed, but that’s not always sufficient in this case, so we used `border-box` to observe all changes to the element’s box.
This option is supported by all browsers by default, just like the default value of ResizeObserver.

-----

result fix:

https://github.com/user-attachments/assets/10087103-51a4-4012-8202-fc7648c013fb


-----
