### PR TITLE
feat(core-select): adding occupation-category directive

### DIFF
--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -1,6 +1,17 @@
 import { delay, http, HttpResponse } from 'msw';
 import { applyFilter, applyV3Fields, applyV3Paging, applyV4Paging, applyV4Sorting, genericHandler, handleFieldsRoot } from './helpers';
-import { mockAxisSectionsV3, mockDepartmentsTree, mockEstablishments, mockJobQualifications, mockLegalUnits, mockMe, mockProjectUsers, mockUserPopover, mockUsers } from './mocks';
+import {
+	mockAxisSectionsV3,
+	mockDepartmentsTree,
+	mockEstablishments,
+	mockJobQualifications,
+	mockLegalUnits,
+	mockMe,
+	mockOccupationCategories,
+	mockProjectUsers,
+	mockUserPopover,
+	mockUsers,
+} from './mocks';
 
 const usersSearchHandler = genericHandler(
 	mockUsers,
@@ -105,6 +116,31 @@ export const handlers = [
 				limit: (items, { limit }) => items.slice(0, limit),
 			},
 			handleFieldsRoot(mockJobQualifications.length),
+		),
+	),
+
+	http.get(
+		'/organization/structure/api/occupation-categories',
+		genericHandler(
+			mockOccupationCategories,
+			// Get and parse params from query params
+			{
+				page: (p) => parseInt(p),
+				limit: (l) => parseInt(l),
+				search: (s) => s.toLowerCase(),
+				sort: (s) => s,
+				'fields.root': (f) => f,
+			},
+			{
+				// Apply filters to items
+				search: applyFilter((oc, { search }) => oc.name.toLowerCase().includes(search)),
+				// Then sorting
+				sort: (items, { sort }) => applyV4Sorting(items, sort),
+				// Then paging/limiting
+				page: applyV4Paging,
+				limit: (items, { limit }) => items.slice(0, limit),
+			},
+			handleFieldsRoot(mockOccupationCategories.length),
 		),
 	),
 

--- a/.storybook/msw/mocks.ts
+++ b/.storybook/msw/mocks.ts
@@ -134,6 +134,94 @@ export const mockJobQualifications = [
 		},
 	},
 ];
+export const mockOccupationCategories = [
+	{
+		id: 0,
+		name: 'Cadre',
+		createdAt: '2017-10-12T22:59:23.977',
+		createdBy: {
+			id: 0,
+			firstName: 'Lucca',
+			lastName: 'Admin',
+			fullName: 'Lucca Admin',
+			url: 'https://demo-ux1.ilucca.net/api/v3/users/0',
+		},
+		modifiedAt: '2017-10-12T22:59:23.977',
+		modifiedBy: {
+			id: 0,
+			firstName: 'Lucca',
+			lastName: 'Admin',
+			fullName: 'Lucca Admin',
+			url: 'https://demo-ux1.ilucca.net/api/v3/users/0',
+		},
+		usages: [
+			{
+				id: 1,
+				name: 'Lucca FR',
+				url: 'https://demo-ux1.ilucca.net/organization/structure/api/establishments/1',
+			},
+			{
+				id: 2,
+				name: 'Lucca UK',
+				url: 'https://demo-ux1.ilucca.net/organization/structure/api/establishments/2',
+			},
+		],
+	},
+	{
+		id: 9,
+		name: 'Cadre supérieur',
+		createdAt: '2017-10-12T22:59:23.977',
+		createdBy: {
+			id: 0,
+			firstName: 'Lucca',
+			lastName: 'Admin',
+			fullName: 'Lucca Admin',
+			url: 'https://demo-ux1.ilucca.net/api/v3/users/0',
+		},
+		modifiedAt: '2017-10-12T22:59:23.977',
+		modifiedBy: {
+			id: 0,
+			firstName: 'Lucca',
+			lastName: 'Admin',
+			fullName: 'Lucca Admin',
+			url: 'https://demo-ux1.ilucca.net/api/v3/users/0',
+		},
+		usages: [
+			{
+				id: 1,
+				name: 'Lucca FR',
+				url: 'https://demo-ux1.ilucca.net/organization/structure/api/establishments/1',
+			},
+		],
+	},
+	{
+		id: 18,
+		name: 'Cuadros medios',
+		createdAt: '2020-01-08T21:45:27.2983351',
+		createdBy: {
+			id: 0,
+			firstName: 'Lucca',
+			lastName: 'Admin',
+			fullName: 'Lucca Admin',
+			url: 'https://demo-ux1.ilucca.net/api/v3/users/0',
+		},
+		modifiedAt: '2020-01-08T21:45:27.2983351',
+		modifiedBy: {
+			id: 0,
+			firstName: 'Lucca',
+			lastName: 'Admin',
+			fullName: 'Lucca Admin',
+			url: 'https://demo-ux1.ilucca.net/api/v3/users/0',
+		},
+		usages: [
+			{
+				id: 3,
+				name: 'Lucca España',
+				url: 'https://demo-ux1.ilucca.net/organization/structure/api/establishments/3',
+			},
+		],
+	},
+];
 export const mockDepartmentsTree = [
 	{
 		node: { id: 17, name: 'Lucca France' },

--- a/packages/ng/core-select/occupation-category/models.ts
+++ b/packages/ng/core-select/occupation-category/models.ts
@@ -1,0 +1,3 @@
+import { ILuApiItem } from '@lucca-front/ng/api';
+
+export type LuCoreSelectOccupationCategory = ILuApiItem;

--- a/packages/ng/core-select/occupation-category/ng-package.json
+++ b/packages/ng/core-select/occupation-category/ng-package.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "public-api.ts",
+		"styleIncludePaths": ["../../styles"]
+	}
+}

--- a/packages/ng/core-select/occupation-category/occupation-category.directive.ts
+++ b/packages/ng/core-select/occupation-category/occupation-category.directive.ts
@@ -1,0 +1,76 @@
+import { HttpClient } from '@angular/common/http';
+import { Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
+import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
+import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { LuCoreSelectOccupationCategory } from './models';
+
+@Directive({
+	// The attribute is already prefixed with "lu-simple-select" / "lu-multi-select"
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'lu-simple-select[occupationCategories],lu-multi-select[occupationCategories]',
+	standalone: true,
+	exportAs: 'occupationCategories',
+	providers: [
+		{
+			provide: CORE_SELECT_API_TOTAL_COUNT_PROVIDER,
+			useExisting: forwardRef(() => LuCoreSelectOccupationCategoriesDirective),
+		},
+	],
+})
+export class LuCoreSelectOccupationCategoriesDirective<T extends LuCoreSelectOccupationCategory = LuCoreSelectOccupationCategory>
+	extends ALuCoreSelectApiDirective<T>
+	implements OnInit, CoreSelectApiTotalCountProvider
+{
+	protected httpClient = inject(HttpClient);
+
+	url = input<string>('/organization/structure/api/occupation-categories');
+	filters = input<Record<string, string | number | boolean> | null>(null);
+	searchDelimiter = input<string>(' ');
+
+	protected clue = toSignal(this.clue$);
+
+	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
+		return this.httpClient
+			.get<T[] | { items: T[] }>(this.url(), {
+				params: {
+					...params,
+					page: page + 1,
+					limit: this.pageSize,
+				},
+			})
+			.pipe(map((res) => (Array.isArray(res) ? res : res?.items) ?? []));
+	}
+
+	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+		computed(() => {
+			const filters = this.filters();
+			const clue = this.clue();
+			return {
+				...filters,
+				...(clue
+					? {
+							search: applySearchDelimiter(clue, this.searchDelimiter()),
+							sort: 'name',
+						}
+					: { sort: 'name' }),
+			};
+		}),
+	);
+
+	public totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
+		debounceTime(250),
+		switchMap(({ url, filters }) =>
+			this.httpClient.get<{ count: number }>(url, {
+				params: {
+					...filters,
+					['fields.root']: 'count',
+				},
+			}),
+		),
+		map((res) => res?.count ?? 0),
+	);
+
+	protected override optionKey = (option: T) => option.id;
+}

--- a/packages/ng/core-select/occupation-category/public-api.ts
+++ b/packages/ng/core-select/occupation-category/public-api.ts
@@ -1,0 +1,2 @@
+export * from './models';
+export * from './occupation-category.directive';

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -15,6 +15,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
+import { LuCoreSelectOccupationCategoriesDirective } from '@lucca-front/ng/core-select/occupation-category';
 import { LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
 import {
 	LuMultiDisplayerDirective,
@@ -543,7 +544,21 @@ export const JobQualification = generateStory({
 />`,
 	neededImports: {
 		'@lucca-front/ng/multi-select': ['LuMultiSelectInputComponent'],
-		'@lucca-front/ng/core-select/establishment': ['LuCoreSelectJobQualificationsDirective'],
+		'@lucca-front/ng/core-select/job-qualification': ['LuCoreSelectJobQualificationsDirective'],
+	},
+});
+
+export const OccupationCategory = generateStory({
+	name: 'OccupationCategory Select',
+	description: "Pour saisir une catégorie d'occupation, il suffit d'utiliser la directive `occupationCategories`",
+	template: `<lu-multi-select
+	placeholder="Placeholder..."
+	occupationCategories
+	[(ngModel)]="selectedOccupationCategories"
+/>`,
+	neededImports: {
+		'@lucca-front/ng/multi-select': ['LuMultiSelectInputComponent'],
+		'@lucca-front/ng/core-select/occupation-category': ['LuCoreSelectOccupationCategoriesDirective'],
 	},
 });
 
@@ -744,6 +759,7 @@ const meta: Meta<LuMultiSelectInputStoryComponent> = {
 				LuCoreSelectDepartmentsDirective,
 				LuCoreSelectUsersDirective,
 				LuCoreSelectJobQualificationsDirective,
+				LuCoreSelectOccupationCategoriesDirective,
 				LuCoreSelectPanelHeaderDirective,
 				LuDisabledOptionDirective,
 				LuMultiSelectDisplayerInputDirective,

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -14,6 +14,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
+import { LuCoreSelectOccupationCategoriesDirective } from '@lucca-front/ng/core-select/occupation-category';
 import { LuCoreSelectUserOptionDirective, LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { TreeSelectDirective } from '@lucca-front/ng/tree-select';
@@ -531,7 +532,21 @@ export const JobQualification = generateStory({
 ></lu-simple-select>`,
 	neededImports: {
 		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
-		'@lucca-front/ng/core-select/establishment': ['LuCoreSelectJobQualificationsDirective'],
+		'@lucca-front/ng/core-select/job-qualification': ['LuCoreSelectJobQualificationsDirective'],
+	},
+});
+
+export const OccupationCategory = generateStory({
+	name: 'OccupationCategory Select',
+	description: "Pour saisir une catégorie socioprofessionnelle (CSP), il suffit d'utiliser la directive `occupationCategories`",
+	template: `<lu-simple-select
+	placeholder="Placeholder…"
+	occupationCategories
+	[(ngModel)]="selectedOccupationCategories"
+></lu-simple-select>`,
+	neededImports: {
+		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
+		'@lucca-front/ng/core-select/occupation-category': ['LuCoreSelectOccupationCategoriesDirective'],
 	},
 });
 
@@ -671,6 +686,7 @@ const meta: Meta<LuSimpleSelectInputStoryComponent> = {
 				LuCoreSelectUsersDirective,
 				LuCoreSelectUserOptionDirective,
 				LuCoreSelectJobQualificationsDirective,
+				LuCoreSelectOccupationCategoriesDirective,
 				LuCoreSelectPanelHeaderDirective,
 				LuDisabledOptionDirective,
 				LuOptionGroupDirective,


### PR DESCRIPTION
## Description

Adds a new `LuCoreSelectOccupationCategoriesDirective` to provide occupation category selection for simple and multi selects.
It fetches data from the `/organization/structure/api/occupation-categories` endpoint and supports filtering and sorting.

-----

This introduces a new directive for selecting occupation categories. It also adds mock data for the API endpoint in the storybook environment.