### PR TITLE
[Input framed] Remove wrap

### DIFF
--- a/packages/scss/src/components/inputFramed/component.scss
+++ b/packages/scss/src/components/inputFramed/component.scss
@@ -52,7 +52,6 @@
 			position: relative;
 			flex-grow: 1;
 			display: flex;
-			flex-wrap: wrap;
 			justify-content: space-between;
 			align-content: flex-start;
 			gap: var(--pr-t-spacings-100);


### PR DESCRIPTION
## Description

Having this wrap made the illustration to wrap as soon the label or description is larger than one line. 
As the illustration is usually small, it seems better to keep it on the right and allow text to line break. 

[Slack discussion](https://lucca.slack.com/archives/C3W78FWUU/p1761909378805639)

-----