### PR TITLE
[Dialog] Fix footer shadow

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -19,6 +19,7 @@
 	position: fixed !important;
 	max-inline-size: var(--components-dialog-maxWidth) !important;
 	max-block-size: var(--components-dialog-maxHeight) !important;
+	overflow: hidden;
 
 	@supports not (height: 1dvh) {
 		--components-dialog-maxHeight: var(--components-dialog-maxHeightFallback);


### PR DESCRIPTION
## Description

Fix dialog's foot by adding overflow on dialog.

-----

https://github.com/user-attachments/assets/46d5c580-2661-4d79-8250-a1cd517464ad

It seems ok as overflow might come from tooltips / overlays but are usually outside dialog's dom.
If overflow is overkill, it's possible to add a border radius to the footer, but it won't fix overlapping shadows.
Let's discuss it anyway.

-----
