### PR TITLE
[breadcrumbs] second selector for breadcrumbs-list-item anchor element

### DIFF
--- a/packages/scss/src/components/breadcrumbs/component.scss
+++ b/packages/scss/src/components/breadcrumbs/component.scss
@@ -31,7 +31,8 @@
 			}
 		}
 
-		.breadcrumbs-list-item-action {
+		// Second selector to get rid of breadcrumbs-list-item-action on angular component
+		.breadcrumbs-list-item-action, .breadcrumbs-list-item > a  {
 			color: var(--pr-t-color-text-subtle);
 			transition-duration: var(--commons-animations-durations-fast);
 			transition-property: color;

--- a/packages/scss/src/components/breadcrumbs/index.scss
+++ b/packages/scss/src/components/breadcrumbs/index.scss
@@ -14,7 +14,8 @@
 	}
 }
 
-.breadcrumbs-list-item-action {
+// Second selector to get rid of breadcrumbs-list-item-action on angular component
+.breadcrumbs-list-item-action, .breadcrumbs-list-item > a {
 	@layer mods {
 		// .active is deprecated
 		&.is-active,

--- a/packages/scss/src/components/breadcrumbs/mods.scss
+++ b/packages/scss/src/components/breadcrumbs/mods.scss
@@ -10,7 +10,8 @@
 			}
 
 			&:first-child {
-				.breadcrumbs-list-item-action {
+				// Second selector to get rid of breadcrumbs-list-item-action on angular component
+				.breadcrumbs-list-item-action, .breadcrumbs-list-item > a {
 					&::before {
 						@include icon.generate('arrow_left');
 

--- a/stories/documentation/navigation/breadcrumbs/angular/breadcrumbs-basic.stories.ts
+++ b/stories/documentation/navigation/breadcrumbs/angular/breadcrumbs-basic.stories.ts
@@ -15,9 +15,9 @@ export default {
 
 		return {
 			template: `<lu-breadcrumbs ${generateInputs(otherArgs, argTypes)}>
-	<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" routerLink="/" ariaCurrentWhenActive="page">You</a>
-	<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" ariaCurrentWhenActive="page" href="#2">are</a>
-	<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" aria-current="page">here</a>
+	<a *luBreadcrumbsLink routerLink="/" ariaCurrentWhenActive="page">You</a>
+	<a *luBreadcrumbsLink ariaCurrentWhenActive="page" href="#2">are</a>
+	<a *luBreadcrumbsLink aria-current="page">here</a>
 </lu-breadcrumbs>`,
 		};
 	},

--- a/stories/qa/breadcrumb/breadcrumb.stories.html
+++ b/stories/qa/breadcrumb/breadcrumb.stories.html
@@ -25,9 +25,9 @@
 			</td>
 			<td>
 				<lu-breadcrumbs>
-					<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" routerLink="/" ariaCurrentWhenActive="page">You</a>
-					<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" ariaCurrentWhenActive="page" href="#2">are</a>
-					<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" aria-current="page">here</a>
+					<a *luBreadcrumbsLink routerLink="/" ariaCurrentWhenActive="page">You</a>
+					<a *luBreadcrumbsLink ariaCurrentWhenActive="page" href="#2">are</a>
+					<a *luBreadcrumbsLink aria-current="page">here</a>
 				</lu-breadcrumbs>
 			</td>
 		</tr>
@@ -46,8 +46,8 @@
 			</td>
 			<td>
 				<lu-breadcrumbs>
-					<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" ariaCurrentWhenActive="page" href="#2">Previous page</a>
-					<a *luBreadcrumbsLink class="breadcrumbs-list-item-action" aria-current="page">mode</a>
+					<a *luBreadcrumbsLink ariaCurrentWhenActive="page" href="#2">Previous page</a>
+					<a *luBreadcrumbsLink aria-current="page">mode</a>
 				</lu-breadcrumbs>
 			</td>
 		</tr>


### PR DESCRIPTION
## Description

We used to removed class from angular component of breadcrumbs.
We used a second selector to get rid of breadcrumbs-list-item-action.
Update stories & QA.

Notes: we should tell to user that class breadcrumbs-list-item-action can be removed.

-----

