### PR TITLE
[dataTable] padding inline for actions

### DIFF
--- a/packages/scss/src/components/dataTable/mods.scss
+++ b/packages/scss/src/components/dataTable/mods.scss
@@ -95,7 +95,7 @@
 
 @mixin actions {
 	padding-block: 0;
-	padding-inline: 0 var(--pr-t-spacings-50);
+	padding-inline: var(--pr-t-spacings-50);
 	text-align: end;
 	white-space: nowrap;
 


### PR DESCRIPTION
## Description



-----



-----

To fix that:
<img width="100" height="217" alt="image" src="https://github.com/user-attachments/assets/78b55ee0-b79e-4db6-abb1-0af7b6d08481" />
