### PR TITLE
[tooltip] remove hypens

### DIFF
--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -16,7 +16,6 @@
 	animation-name: scaleIn;
 	animation-duration: var(--commons-animations-durations-fast);
 	animation-iteration-count: 1;
-	hyphens: auto;
 	overflow-wrap: break-word;
 
 	@include keyframe.scaleIn;


### PR DESCRIPTION
## Description

With hyphenation enabled, they are certainly present when long words need to be truncated, but also in short texts such as here:

<img width="263" height="119" alt="Capture d’écran 2025-11-12 à 09 53 56" src="https://github.com/user-attachments/assets/78bdd776-49f6-44d5-bbca-5c0c30ce6b41" />

<img width="131" height="109" alt="Capture d’écran 2025-11-12 à 09 45 26" src="https://github.com/user-attachments/assets/01c7c609-77f0-4d06-bd24-09f3519e46f2" />

In this PR, I suggest doing this instead: 

<img width="264" height="123" alt="Capture d’écran 2025-11-12 à 09 57 12" src="https://github.com/user-attachments/assets/00e5ed81-62bf-4292-924a-dd2674c1180c" />

<img width="146" height="120" alt="Capture d’écran 2025-11-12 à 09 57 42" src="https://github.com/user-attachments/assets/1dcff760-4fd0-44d2-969b-d8041576898f" />



-----



-----
