### PR TITLE
[richTextInput]: add markdown shortcuts

### DIFF
--- a/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.ts
+++ b/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.ts
@@ -12,11 +12,13 @@ import {
 	ITALIC_UNDERSCORE,
 	LINK,
 	ORDERED_LIST,
+	registerMarkdownShortcuts,
 	STRIKETHROUGH,
 	Transformer,
 	UNORDERED_LIST,
 } from '@lexical/markdown';
 import { registerRichText } from '@lexical/rich-text';
+import { mergeRegister } from '@lexical/utils';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from '@lucca-front/ng/forms/rich-text-input';
 import { LexicalEditor } from 'lexical';
 
@@ -45,8 +47,8 @@ export class MarkdownFormatter extends RichTextFormatter {
 		}
 	}
 
-	override registerTextPlugin(editor: LexicalEditor) {
-		return registerRichText(editor);
+	override registerTextPlugin(editor: LexicalEditor): () => void {
+		return mergeRegister(registerMarkdownShortcuts(editor, this.#transformers), registerRichText(editor));
 	}
 
 	override parse(editor: LexicalEditor, markdown?: string | null): void {


### PR DESCRIPTION
## Description

Register markdown shortcuts

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
