### PR TITLE
[richTextInput] fix: markdown preserve new lines

### DIFF
--- a/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.ts
+++ b/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.ts
@@ -18,7 +18,7 @@ import {
 } from '@lexical/markdown';
 import { registerRichText } from '@lexical/rich-text';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from '@lucca-front/ng/forms/rich-text-input';
-import { sanitize } from 'dompurify';
+import { sanitize } from 'isomorphic-dompurify';
 import { LexicalEditor } from 'lexical';
 
 export const DEFAULT_MARKDOWN_TRANSFORMERS: Transformer[] = [
@@ -54,7 +54,6 @@ export class MarkdownFormatter extends RichTextFormatter {
 		editor.update(() => {
 			$convertFromMarkdownString(sanitize(markdown ?? ''), this.#transformers, null, true);
 		});
-		$convertFromMarkdownString(markdown ?? '', this.#transformers);
 	}
 
 	override format(editor: LexicalEditor): string {


### PR DESCRIPTION
## Description

Preserve new lines on markdown when parsing and formating 

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
