### PR TITLE
[dropDown] Be more specific in documentation for anchor element angular routing

### DIFF
--- a/stories/documentation/overlays/dropdown/angular/dropdown-component.stories.ts
+++ b/stories/documentation/overlays/dropdown/angular/dropdown-component.stories.ts
@@ -28,7 +28,8 @@ const code = `
 
   /* Ajouter la directive luDropdownItem pour lier le parent luDropdown à ses enfants */
   <li class="dropdown-list-option">
-    <a luDropdownItem routerLink="." fragment="link2" class="dropdown-list-option-action">Link 2</a>
+		/* Mettre un relativeTo afin de conserver la navigation relative au chemin courant */
+    <a luDropdownItem routerLink="." [relativeTo]="activatedRoute" fragment="link2" class="dropdown-list-option-action">Link 2</a>
   </li>
 
   /* Vous pouvez disable un enfant avec 'is-disabled' */


### PR DESCRIPTION
## Description

Ajout de `relativeTo` dans la documentation du composant avec un commentaire lié.
Issue slack: https://lucca.slack.com/archives/C3W78FWUU/p1762958236756849

-----

-----
