### PR TITLE
refactor: migrate simple cases to output()

### DIFF
--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.ts
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation, booleanAttribute } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation, booleanAttribute, output } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
 import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -39,7 +39,7 @@ export class CalloutDisclosureComponent {
 
 	@Input({ transform: booleanAttribute }) open = false;
 
-	@Output() openChange = new EventEmitter<boolean>();
+	openChange = output<boolean>();
 
 	public onToggle(event: Event) {
 		if (event.target instanceof HTMLDetailsElement) {

--- a/packages/ng/callout/callout/callout.component.ts
+++ b/packages/ng/callout/callout/callout.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, HostBinding, input, Input, Output, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, HostBinding, input, Input, output, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
 import { getIntl, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -69,8 +69,7 @@ export class CalloutComponent {
 		return this.removed ? 'hidden' : null;
 	}
 
-	@Output()
-	removedChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+	removedChange = output<boolean>();
 
 	AI = input(false, { transform: booleanAttribute });
 

--- a/packages/ng/core-select/api/api-v3.directive.spec.ts
+++ b/packages/ng/core-select/api/api-v3.directive.spec.ts
@@ -1,13 +1,12 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { EventEmitter } from '@angular/core';
 import { TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ILuApiItem } from '@lucca-front/ng/api';
 import { ALuSelectInputComponent } from '@lucca-front/ng/core-select';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
-import { BehaviorSubject, ReplaySubject, first } from 'rxjs';
+import { BehaviorSubject, ReplaySubject, Subject, first } from 'rxjs';
 import { LuCoreSelectApiV3Directive } from './api-v3.directive';
-import { MAGIC_DEBOUNCE_DURATION, LU_SELECT_MAGIC_PAGE_SIZE } from './api.directive';
+import { LU_SELECT_MAGIC_PAGE_SIZE, MAGIC_DEBOUNCE_DURATION } from './api.directive';
 
 const itemsMocks = Array.from({ length: LU_SELECT_MAGIC_PAGE_SIZE * 2 + 5 }, (_, i) => ({ id: i, name: `item ${i}` }));
 
@@ -19,8 +18,8 @@ describe('CoreSelectApiV3Directive', () => {
 	beforeEach(() => {
 		selectMock = {
 			isPanelOpen$: new BehaviorSubject(false),
-			nextPage: new EventEmitter<void>(),
-			clueChange: new EventEmitter<string>(),
+			nextPage$: new Subject<void>(),
+			clueChange$: new Subject<string>(),
 			options$: new ReplaySubject(1),
 			loading$: new BehaviorSubject(false),
 		} as LuSimpleSelectInputComponent<ILuApiItem>;
@@ -82,7 +81,7 @@ describe('CoreSelectApiV3Directive', () => {
 		tick();
 
 		// Act
-		selectMock.nextPage.emit();
+		selectMock.nextPage$.next();
 
 		// Assert
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
@@ -108,13 +107,13 @@ describe('CoreSelectApiV3Directive', () => {
 		});
 		tick();
 
-		selectMock.nextPage.emit();
+		selectMock.nextPage$.next();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
 			data: { items: itemsMocks.slice(LU_SELECT_MAGIC_PAGE_SIZE, LU_SELECT_MAGIC_PAGE_SIZE * 2) },
 		});
 
 		// Act
-		selectMock.clueChange.emit('bob');
+		selectMock.clueChange$.next('bob');
 		tick(MAGIC_DEBOUNCE_DURATION);
 
 		// Assert

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -138,19 +138,19 @@ describe('ALuCoreSelectApiDirective', () => {
 				{ id: 4, name: 'test 4' },
 			]),
 		);
-		select.nextPage.emit();
+		select.nextPage$.next();
 		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
 		spectator.tick();
 
 		// // Act (Page 3)
 		getOptionsSpy.mockReturnValue(of([{ id: 5, name: 'test 5' }]));
-		select.nextPage.emit();
+		select.nextPage$.next();
 		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
 		spectator.tick();
 
 		// Act (do nothing)
-		select.nextPage.emit();
-		select.nextPage.emit();
+		select.nextPage$.next();
+		select.nextPage$.next();
 
 		// // Assert
 		expect(testApi.getOptions).toHaveBeenCalledTimes(3);
@@ -196,7 +196,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Act (Page 2)
-		select.nextPage.emit();
+		select.nextPage$.next();
 		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Assert

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -13,12 +13,12 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 
 	public select = inject<ALuSelectInputComponent<TOption, unknown>>(ALuSelectInputComponent);
 
-	protected page$ = this.select.nextPage.pipe(
+	protected page$ = this.select.nextPage$.pipe(
 		scan((page) => page + 1, 0),
 		startWith(0),
 	);
 
-	protected clue$ = this.select.clueChange.pipe(debounceTime(this.debounceDuration), startWith(''));
+	protected clue$ = this.select.clueChange$.pipe(debounceTime(this.debounceDuration), startWith(''));
 
 	/**
 	 * Create an object that will be used as params for the api call
@@ -56,7 +56,7 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 
 	protected buildOptions(): Observable<TOption[]> {
 		// Prevent a double call to getOptions when the clue is changed while the panel is closed
-		const clueIsPendingDebounce$ = merge(this.select.clueChange.pipe(map(() => true)), this.clue$.pipe(map(() => false))).pipe(distinctUntilChanged());
+		const clueIsPendingDebounce$ = merge(this.select.clueChange$.pipe(map(() => true)), this.clue$.pipe(map(() => false))).pipe(distinctUntilChanged());
 		const isOpen$ = combineLatest([this.select.isPanelOpen$, clueIsPendingDebounce$]).pipe(
 			debounceTime(0),
 			startWith([false, false]),

--- a/packages/ng/core-select/input/select-input.component.spec.ts
+++ b/packages/ng/core-select/input/select-input.component.spec.ts
@@ -43,8 +43,8 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 	it.each(['a', 'A', 'À'])('should openPanel and emit clueChange when pressing %s and select is searchable', async (key) => {
 		// Arrange
 		const event = new KeyboardEvent('keydown', { key });
-		const clueChangeSpy = jest.spyOn(component.clueChange, 'emit');
-		component.clueChange.subscribe(); // Emulate a `(clueChange)=""` binding
+		const clueChangeSpy = jest.spyOn(component.clueChange$, 'next');
+		component.clueChange$.subscribe(); // Emulate a `(clueChange)=""` binding
 
 		// Act
 		nativeElement.dispatchEvent(event);
@@ -58,7 +58,7 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 	it.each(['a', 'A', 'À'])('should openPanel and not emit clueChange when pressing %s and select is not searchable', async (key) => {
 		// Arrange
 		const event = new KeyboardEvent('keydown', { key });
-		const clueChangeSpy = jest.spyOn(component.clueChange, 'emit');
+		const clueChangeSpy = jest.spyOn(component.clueChange$, 'next');
 
 		// Act
 		nativeElement.dispatchEvent(event);
@@ -72,7 +72,7 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 	it('should openPanel and but not emit clueChange when pressing Space', async () => {
 		// Arrange
 		const event = new KeyboardEvent('keydown', { key: ' ' });
-		const clueChangeSpy = jest.spyOn(component.clueChange, 'emit');
+		const clueChangeSpy = jest.spyOn(component.clueChange$, 'next');
 
 		// Act
 		nativeElement.dispatchEvent(event);
@@ -106,7 +106,7 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 	it.each(['ArrowLeft', 'ArrowRight', 'Backspace', 'Meta'])('should not open the panel when sending not a letter events (%s)', (key) => {
 		// Arrange
 		const event = new KeyboardEvent('keydown', { key });
-		const clueChangeSpy = jest.spyOn(component.clueChange, 'emit');
+		const clueChangeSpy = jest.spyOn(component.clueChange$, 'next');
 
 		// Act
 		nativeElement.dispatchEvent(event);

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -15,13 +15,12 @@ import {
 	OnDestroy,
 	OnInit,
 	output,
-	Output,
 	signal,
 	TemplateRef,
 	Type,
 	ViewChild,
 } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { outputFromObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor } from '@angular/forms';
 import { getIntl, PortalContent } from '@lucca-front/ng/core';
 import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
@@ -85,7 +84,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	#defaultClearable = false;
 
 	get searchable(): boolean {
-		return this.clueChange.observed;
+		return this.clueChange$.observed;
 	}
 
 	@Input()
@@ -166,10 +165,12 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	grouping?: LuOptionGrouping<TOption, unknown>;
 	treeGenerator?: TreeGenerator<TOption, TreeNode<TOption>>;
 
-	@Output() clueChange = new EventEmitter<string>();
-	@Output() nextPage = new EventEmitter<void>();
-	@Output() previousPage = new EventEmitter<void>();
-	@Output() addOption = new EventEmitter<string>();
+	clueChange$ = new Subject<string>();
+	clueChange = outputFromObservable(this.clueChange$);
+	nextPage$ = new Subject<void>();
+	nextPage = outputFromObservable(this.nextPage$);
+	previousPage = output<void>();
+	addOption = output<string>();
 
 	public valueSignal = signal<TValue>(null);
 	isFilterPillEmpty = computed(() => this.valueSignal() === null);
@@ -196,7 +197,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		if (!skipPanelOpen && !this.isPanelOpen) {
 			this.openPanel(clue);
 		} else if (this.lastEmittedClue !== clue) {
-			this.clueChange.emit(clue);
+			this.clueChange$.next(clue);
 			this.lastEmittedClue = clue;
 		}
 	}
@@ -208,7 +209,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	clue: string | null = null;
 	// This is the clue stored after we selected an option to know if we should emit an empty clue on open or not
 	lastEmittedClue: string = '';
-	clue$ = defer(() => this.clueChange.pipe(startWith(this.clue)));
+	clue$ = defer(() => this.clueChange$.pipe(startWith(this.clue)));
 
 	addOptionStrategy$ = new BehaviorSubject<CoreSelectAddOptionStrategy>('never');
 	shouldDisplayAddOption$ = this.addOptionStrategy$.pipe(
@@ -382,7 +383,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 		this.panelRef.valueChanged.subscribe((value) => this.updateValue(value));
 
-		this.#pageChanged(this.panelRef.nextPage).subscribe(() => this.nextPage.emit());
+		this.#pageChanged(this.panelRef.nextPage).subscribe(() => this.nextPage$.next());
 		this.#pageChanged(this.panelRef.previousPage).subscribe(() => this.previousPage.emit());
 
 		this.panelRef.activeOptionIdChanged.subscribe((optionId) => {

--- a/packages/ng/core-select/no-clue/no-clue.directive.ts
+++ b/packages/ng/core-select/no-clue/no-clue.directive.ts
@@ -7,6 +7,6 @@ import { ALuSelectInputComponent } from '../input/index';
 })
 export class LuCoreSelectNoClueDirective {
 	constructor() {
-		inject(ALuSelectInputComponent).clueChange.complete();
+		inject(ALuSelectInputComponent).clueChange$.complete();
 	}
 }

--- a/packages/ng/core-select/user/user-option.component.ts
+++ b/packages/ng/core-select/user/user-option.component.ts
@@ -45,7 +45,7 @@ export class LuUserOptionComponent {
 	protected context = inject<ILuOptionContext<LuCoreSelectWithAdditionnalInformation<LuCoreSelectUser>>>(LU_OPTION_CONTEXT);
 	protected userDirective = inject(LuCoreSelectUsersDirective);
 	protected intl = getIntl(LU_CORE_SELECT_USER_TRANSLATIONS);
-	protected hasEmptyClue$ = this.userDirective.select.clueChange.pipe(
+	protected hasEmptyClue$ = this.userDirective.select.clueChange$.pipe(
 		startWith(this.userDirective.select.clue),
 		map((clue) => !clue),
 	);

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -143,7 +143,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		expect(options).toEqual([meUser, ...page1]);
 
 		// Act (Page 2)
-		simpleSelect.nextPage.emit();
+		simpleSelect.nextPage$.next();
 		fixture.detectChanges();
 		tick(MAGIC_OPTION_SCROLL_DELAY);
 

--- a/packages/ng/mobile-push/mobile-push.component.ts
+++ b/packages/ng/mobile-push/mobile-push.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, output, ViewEncapsulation } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LU_MOBILE_PUSH_TRANSLATIONS } from './mobile-push.translate';
@@ -14,6 +14,6 @@ import { LU_MOBILE_PUSH_TRANSLATIONS } from './mobile-push.translate';
 export class MobilePushComponent {
 	intl = getIntl(LU_MOBILE_PUSH_TRANSLATIONS);
 
-	@Output() appStoreLinkClicked = new EventEmitter<void>();
-	@Output() googlePlayLinkClicked = new EventEmitter<void>();
+	appStoreLinkClicked = output<void>();
+	googlePlayLinkClicked = output<void>();
 }

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -148,7 +148,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 			options$: this.options$,
 			optionComparer: this.optionComparer,
 			activeOptionIdChanged$: this.panelRef.activeOptionIdChanged,
-			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange : EMPTY,
+			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange$ : EMPTY,
 		});
 
 		if (this.selectedOptions?.length) {

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -103,7 +103,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 			options$: this.options$,
 			optionComparer: this.optionComparer,
 			activeOptionIdChanged$: this.panelRef.activeOptionIdChanged,
-			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange : EMPTY,
+			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange$ : EMPTY,
 		});
 
 		if (this.initialValue && !this.selectInput.clue) {

--- a/packages/ng/time/core/repeat-on-hold.directive.ts
+++ b/packages/ng/time/core/repeat-on-hold.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+import { Directive, ElementRef, OnDestroy, OnInit, output } from '@angular/core';
 
 const INITIAL_INTERVAL = 500;
 
@@ -6,7 +6,7 @@ const INITIAL_INTERVAL = 500;
 	selector: '[luRepeatOnHold]',
 })
 export class RepeatOnHoldDirective implements OnDestroy, OnInit {
-	@Output() hold = new EventEmitter<void>();
+	hold = output<void>();
 
 	onMouseDown = () => {
 		if (this.startTime !== undefined) {

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -1,20 +1,5 @@
 import { DecimalPipe, formatNumber } from '@angular/common';
-import {
-	ChangeDetectionStrategy,
-	Component,
-	ElementRef,
-	EventEmitter,
-	Inject,
-	LOCALE_ID,
-	ModelSignal,
-	Output,
-	ViewChild,
-	booleanAttribute,
-	computed,
-	input,
-	model,
-	numberAttribute,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Inject, LOCALE_ID, ModelSignal, ViewChild, booleanAttribute, computed, input, model, numberAttribute, output } from '@angular/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { PickerControlDirection } from './misc.utils';
 import { RepeatOnHoldDirective } from './repeat-on-hold.directive';
@@ -60,10 +45,10 @@ export class TimePickerPartComponent {
 		transform: booleanAttribute,
 	});
 
-	@Output() prevRequest = new EventEmitter<void>();
-	@Output() nextRequest = new EventEmitter<void>();
-	@Output() inputControlClick = new EventEmitter<PickerControlDirection>();
-	@Output() touched = new EventEmitter<void>();
+	prevRequest = output<void>();
+	nextRequest = output<void>();
+	inputControlClick = output<PickerControlDirection>();
+	touched = output<void>();
 
 	@ViewChild('timePickerInput') timePickerInput?: ElementRef<HTMLInputElement>;
 


### PR DESCRIPTION
## Description

Migrate simple `@Output` to `output()` syntax

-----

Most of the rest depends on interface and abstract classes breaking changes 😞 
