### PR TITLE
fix(formly): select displayer always empty

### DIFF
--- a/packages/ng/formly/types/select.ts
+++ b/packages/ng/formly/types/select.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { LuDisplayerDirective } from '@lucca-front/ng/core-select';
-import { LuInputClearerComponent } from '@lucca-front/ng/input';
+import { LuInputClearerComponent, LuInputDisplayerDirective } from '@lucca-front/ng/input';
 import { LuOptionPickerModule } from '@lucca-front/ng/option';
 import { LuSelectInputComponent } from '@lucca-front/ng/select';
 import { FieldType, FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
@@ -12,7 +11,7 @@ import { FieldType, FieldTypeConfig, FormlyModule } from '@ngx-formly/core';
 	templateUrl: './select.html',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
-	imports: [ReactiveFormsModule, FormlyModule, LuSelectInputComponent, LuDisplayerDirective, LuOptionPickerModule, LuInputClearerComponent],
+	imports: [ReactiveFormsModule, FormlyModule, LuSelectInputComponent, LuOptionPickerModule, LuInputClearerComponent, LuInputDisplayerDirective],
 })
 export class LuFormlyFieldSelect extends FieldType<FieldTypeConfig> {
 	get _options() {


### PR DESCRIPTION
## Description

We had a wrong import for `*luDisplayer` directive.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
