### PR TITLE
[richText] Prevent focus when updating tag description

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, effect, ElementRef, forwardRef, inject, input, OnDestroy, signal, viewChildren, ViewContainerRef } from '@angular/core';
 import { getIntl } from '@lucca-front/ng/core';
 import { $getNodeByKey, $getRoot, $getSelection, type Klass, type LexicalEditor, type LexicalNode, type NodeKey } from 'lexical';
-import { RICH_TEXT_PLUGIN_COMPONENT, RichTextPluginComponent } from '../../rich-text-input.component';
+import { INITIAL_UPDATE_TAG, RICH_TEXT_PLUGIN_COMPONENT, RichTextPluginComponent, SKIP_DOM_SELECTION_TAG } from '../../rich-text-input.component';
 import { LU_RICH_TEXT_INPUT_TRANSLATIONS } from '../../rich-text-input.translate';
 import { $createTagNode, TagNode } from './tag-node';
 import type { Tag } from './tag.model';
@@ -46,20 +46,23 @@ export class RichTextPluginTagComponent implements RichTextPluginComponent, OnDe
 			const nodes = this.#tagNodeKeys();
 			const isDisabled = this.isDisabled();
 
-			this.editor?.update(() => {
-				nodes.forEach((node) => {
-					const tagNode = $getNodeByKey<TagNode>(node);
-					if (!tagNode) {
-						return;
-					}
-					const tag = tags.find((t) => t.key === tagNode.getTagKey());
-					if (tag) {
-						tagNode.setTagDescription(tag.description ?? '').setDisabled(isDisabled);
-					} else {
-						tagNode.remove();
-					}
-				});
-			});
+			this.editor?.update(
+				() => {
+					nodes.forEach((node) => {
+						const tagNode = $getNodeByKey<TagNode>(node);
+						if (!tagNode) {
+							return;
+						}
+						const tag = tags.find((t) => t.key === tagNode.getTagKey());
+						if (tag) {
+							tagNode.setTagDescription(tag.description ?? '').setDisabled(isDisabled);
+						} else {
+							tagNode.remove();
+						}
+					});
+				},
+				{ tag: [SKIP_DOM_SELECTION_TAG, INITIAL_UPDATE_TAG] },
+			);
 		});
 	}
 

--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -25,7 +25,9 @@ import { FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement } from 'lexical';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from './formatters';
 
-const INITIAL_UPDATE_TAG = 'initial-update';
+export const INITIAL_UPDATE_TAG = 'initial-update';
+// TODO replace by lexical import when upgrade lexical
+export const SKIP_DOM_SELECTION_TAG = 'skip-dom-selection';
 
 export interface RichTextPluginComponent {
 	setEditorInstance(editor: LexicalEditor): void;
@@ -131,7 +133,7 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 	}
 
 	writeValue(value: string | null): void {
-		const updateTags = ['skip-dom-selection', INITIAL_UPDATE_TAG];
+		const updateTags = [SKIP_DOM_SELECTION_TAG, INITIAL_UPDATE_TAG];
 		if (value) {
 			this.#editor?.update(
 				() => {


### PR DESCRIPTION
## Description

With Tag plugin, when tag descriptions was updated by the component, the field was focus.
Add 'skip-dom-selection' which prevents Lexical from focusing the input.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
