### PR TITLE
chore(eslint): restrict bad local imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,7 +62,8 @@ export default typescript.config(
 			'@typescript-eslint/no-restricted-imports': [
 				'error',
 				{
-					paths: ['rxjs/Rx', '@ngneat/spectator'],
+					paths: ['rxjs/Rx', '@ngneat/spectator', '@lucca-front/ng'],
+					patterns: [{ group: ['dist/ng/*', 'packages/ng/*'], message: 'Use @lucca-front/ng/* instead.' }],
 				},
 			],
 			'@typescript-eslint/no-unused-vars': [


### PR DESCRIPTION
## Description

Restrict bad local imports (`dist/ng/*` and `packages/ng/*`). This is plain wrong.

-----

Examples:

<img width="1306" height="128" alt="Screenshot 2025-11-18 at 10 33 43" src="https://github.com/user-attachments/assets/a9e1187b-75a3-42a2-a24d-a5a1a81e00e3" />

<img width="1353" height="132" alt="Screenshot 2025-11-18 at 10 35 14" src="https://github.com/user-attachments/assets/b8ce3965-cade-44ec-a82a-ce8618eb2ffe" />

