### PR TITLE
[Input framed] Fix info flex wrap

### DIFF
--- a/packages/scss/src/components/inputFramed/component.scss
+++ b/packages/scss/src/components/inputFramed/component.scss
@@ -27,6 +27,8 @@
 		}
 
 		.inputFramed-header-field {
+			flex: 1;
+
 			&.form-field.form-field {
 				position: static;
 				margin-block: 0;
@@ -42,6 +44,7 @@
 			position: relative;
 			flex-grow: 1;
 			display: flex;
+			flex-wrap: wrap;
 			justify-content: space-between;
 			align-content: flex-start;
 			gap: var(--pr-t-spacings-100);


### PR DESCRIPTION
## Description

[Input framed] Fix info flex wrap & keep new illustration behavior

-----

<img width="650" height="462" alt="Capture d’écran 2025-11-21 à 11 05 28" src="https://github.com/user-attachments/assets/2bbc7367-87f6-4e8d-a3da-01441e60d797" />

-----
