### PR TITLE
[Input framed] Fix default panel spacing

### DIFF
--- a/packages/scss/src/components/inputFramed/vars.scss
+++ b/packages/scss/src/components/inputFramed/vars.scss
@@ -6,7 +6,7 @@
 	--components-inputFramed-padding: var(--pr-t-spacings-25);
 	--components-inputFramed-header-padding: var(--pr-t-spacings-75);
 	--components-inputFramed-content-padding: var(--pr-t-spacings-75);
-	--components-inputFramed-content-marginBlockStart: 0;
+	--components-inputFramed-content-marginBlockStart: var(--pr-t-spacings-25);
 	--components-inputFramed-header-backgroundColor: transparent;
 	--components-inputFramed-header-alignItems: normal;
 	--components-inputFramed-header-label-fontWeight: var(--pr-t-font-fontWeight-regular);


### PR DESCRIPTION
## Description

[Input framed] Fix default panel spacing

-----

<img width="171" height="123" alt="image" src="https://github.com/user-attachments/assets/45f9f876-a448-44d2-94d0-6d83e242c163" />

-----
