### PR TITLE
[Rich text] Fix disabled chip colors + update color tokens

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -604,11 +604,11 @@ $elevation: (
 
 // Tokens : Colors
 $colorInput: (
-	text: var(--palettes-neutral-800),
+	text: var(--pr-t-color-text),
 	text-placeholder: var(--palettes-neutral-400),
 	text-placeholder-critical: var(--palettes-critical-400),
-	text-suffix: var(--palettes-neutral-600),
-	text-disabled: var(--palettes-neutral-500),
+	text-suffix: var(--pr-t-color-text-subtle),
+	text-disabled: var(--palettes-neutral-700),
 	icon: var(--palettes-neutral-600),
 	icon-disabled: var(--palettes-neutral-500),
 	background: var(--palettes-neutral-0),

--- a/packages/scss/src/components/richText/component.scss
+++ b/packages/scss/src/components/richText/component.scss
@@ -123,11 +123,6 @@
 			&:focus-visible {
 				@include a11y.focusVisible;
 			}
-
-			&.is-disabled {
-				--components-chip-backgroundColor: var(--palettes-neutral-200);
-				--components-chip-color: var(--pr-t-color-input-text-disabled);
-			}
 		}
 
 		.richTextField-content-placeholder {

--- a/packages/scss/src/components/richText/index.scss
+++ b/packages/scss/src/components/richText/index.scss
@@ -26,6 +26,10 @@
 
 		&.is-disabled {
 			@include disabled;
+
+			.richTextField-content-chip {
+				@include chipDisabled;
+			}
 		}
 
 		&.mod-autoResize {

--- a/packages/scss/src/components/richText/states.scss
+++ b/packages/scss/src/components/richText/states.scss
@@ -16,6 +16,11 @@
 	--components-richTextField-borderColor: var(--pr-t-color-input-border);
 }
 
+@mixin chipDisabled {
+	--components-chip-backgroundColor: var(--palettes-neutral-200);
+	--components-chip-color: var(--pr-t-color-text-subtle);
+}
+
 @mixin error {
 	--components-richTextField-borderColor: var(--pr-t-color-input-border-critical);
 	--components-richTextField-backgroundColor: var(--pr-t-color-input-background-critical);


### PR DESCRIPTION
## Description

- Update `--pr-t-color-input-text-disabled`
- Apply some color tokens in color input tokens
- Fix Chip disabled colors in Rich Text

-----

<img width="518" height="171" alt="image" src="https://github.com/user-attachments/assets/7ea937cd-0cc3-4ff0-9d8d-7620975f8198" />


-----
