### PR TITLE
fix(dialog): apply canMatch on main route to correctly go to the next sibling in app space

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
@@ -18,7 +18,7 @@ export function deferrableToObservable<T>(deferrable: Promise<T> | Observable<T>
 }
 
 export function createDialogRoute<C>(dialogRouteConfig: DialogRouteConfig<C>): Route {
-	const { dialogConfigFactory, dataFactory, ...baseRoute } = dialogRouteConfig;
+	const { dialogConfigFactory, dataFactory, canMatch, ...baseRoute } = dialogRouteConfig;
 
 	const data: DialogRouteData<C> = { dialogRouteConfig };
 
@@ -26,6 +26,7 @@ export function createDialogRoute<C>(dialogRouteConfig: DialogRouteConfig<C>): R
 		path: dialogRouteConfig.path,
 		component: DialogRoutingContainerComponent,
 		data,
+		canMatch,
 		children: [
 			{
 				...baseRoute,


### PR DESCRIPTION
## Description

Now the canMatch works when applied on a dialog route. It will not block the navigation.

-----

We move the canMatch on the main route to correctly search for other sibling routes in app space

-----
