### PR TITLE
fix(rich-text): better handling of empty input (#4045)

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
@@ -88,7 +88,7 @@ export class TagNode extends DecoratorNode<string> {
 	 * This method must be implemented but has no purpose outside of react
 	 */
 	override decorate(): string {
-		return `{{${this.getKey()}}}`;
+		return this.getTextContent();
 	}
 
 	override createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
@@ -132,7 +132,7 @@ export class TagNode extends DecoratorNode<string> {
 	}
 
 	override exportDOM(): DOMExportOutput {
-		const element = document.createTextNode(`{{${this.#tagKey}}}`);
+		const element = document.createTextNode(this.getTextContent());
 		return { element };
 	}
 
@@ -161,6 +161,11 @@ export class TagNode extends DecoratorNode<string> {
 			...super.exportJSON(),
 			...{ tagDescription: this.#tagDescription, tagKey: this.#tagKey, disabled: this.#disabled },
 		};
+	}
+
+	override getTextContent(): string {
+		// node must have text content or it will be ignored when formatting
+		return `{{${this.#tagKey}}}`;
 	}
 }
 

--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -19,10 +19,10 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { createEmptyHistoryState, registerHistory } from '@lexical/history';
-import { $canShowPlaceholderCurry } from '@lexical/text';
+import { $canShowPlaceholderCurry, $isRootTextContentEmpty } from '@lexical/text';
 import { mergeRegister } from '@lexical/utils';
 import { FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
-import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement } from 'lexical';
+import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement, UpdateListenerPayload } from 'lexical';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from './formatters';
 
 export const INITIAL_UPDATE_TAG = 'initial-update';
@@ -109,15 +109,7 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 		this.#cleanup = mergeRegister(
 			this.#richTextFormatter.registerTextPlugin(this.#editor),
 			registerHistory(this.#editor, createEmptyHistoryState(), 300),
-			this.#editor.registerUpdateListener(({ tags, dirtyElements }) => {
-				if (!tags.has(INITIAL_UPDATE_TAG) && dirtyElements.size) {
-					const result = this.#richTextFormatter.format(this.#editor);
-					this.touch();
-					this.#onChange?.(result);
-				}
-				const currentCanShowPlaceholder = this.#editor.getEditorState().read($canShowPlaceholderCurry(this.#editor.isComposing()));
-				this.currentCanShowPlaceholder.set(currentCanShowPlaceholder);
-			}),
+			this.#editor.registerUpdateListener((payload) => this.#onEditorUpdate(payload)),
 		);
 		this.#editor.setRootElement(this.content().nativeElement);
 
@@ -192,5 +184,22 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 				return p;
 			}
 		});
+	}
+
+	#onEditorUpdate({ tags, dirtyElements }: UpdateListenerPayload) {
+		const isComposing = this.#editor.isComposing();
+		if (!tags.has(INITIAL_UPDATE_TAG) && dirtyElements.size) {
+			this.#editor.read(() => {
+				let result = '';
+				// ignore empty nodes
+				if (!$isRootTextContentEmpty(isComposing, false)) {
+					result = this.#richTextFormatter.format(this.#editor);
+				}
+				this.touch();
+				this.#onChange?.(result);
+			});
+		}
+		const currentCanShowPlaceholder = this.#editor.getEditorState().read($canShowPlaceholderCurry(isComposing));
+		this.currentCanShowPlaceholder.set(currentCanShowPlaceholder);
 	}
 }


### PR DESCRIPTION
## Description

If `rich-text-input` is empty, exported value will be an empty string (#4045) . 

-----

Note:
* spaces and line breaks are not considered as empty content
* nodes without text content are considered 'empty' => an empty list will be automatically truncated from output 

-----


