### PR TITLE
[Date] Fix overflow disabled color

### DIFF
--- a/packages/scss/src/components/calendar/component.scss
+++ b/packages/scss/src/components/calendar/component.scss
@@ -220,17 +220,11 @@
 			display: var(--components-calendar-table-body-row-cell-actionDisplay);
 			block-size: 100%;
 			text-transform: lowercase;
+			cursor: var(--components-calendar-table-body-row-cell-actionCursor);
+			text-decoration: var(--components-calendar-table-body-row-cell-actionTextDecoration);
 			box-shadow:
 				0 0 0 1px var(--components-calendar-table-body-row-cell-actionHighlight),
 				0 0 0 1px var(--components-calendar-table-body-row-cell-actionHighlight) inset;
-
-			&:disabled,
-			&[aria-disabled='true'] {
-				--components-calendar-table-body-row-cell-actionColor: var(--palettes-neutral-500);
-
-				text-decoration: line-through;
-				cursor: default;
-			}
 
 			&:not(:disabled, [aria-disabled='true']) {
 				&:hover {

--- a/packages/scss/src/components/calendar/index.scss
+++ b/packages/scss/src/components/calendar/index.scss
@@ -84,5 +84,13 @@
 				@include endInProgress;
 			}
 		}
+
+		.calendar-table-body-row-cell-action {
+			&:disabled,
+			&[aria-disabled='true'] {
+				@include disabled;
+			}
+		}
 	}
 }
+

--- a/packages/scss/src/components/calendar/states.scss
+++ b/packages/scss/src/components/calendar/states.scss
@@ -168,3 +168,9 @@
 		--components-calendar-table-body-row-cell-actionColor: var(--palettes-neutral-600);
 	}
 }
+
+@mixin disabled {
+	--components-calendar-table-body-row-cell-actionColor: var(--palettes-neutral-500);
+	--components-calendar-table-body-row-cell-actionTextDecoration: line-through;
+	--components-calendar-table-body-row-cell-actionCursor: default;
+}

--- a/packages/scss/src/components/calendar/vars.scss
+++ b/packages/scss/src/components/calendar/vars.scss
@@ -11,6 +11,8 @@
 	--components-calendar-table-body-row-cell-actionColor: var(--palettes-neutral-700);
 	--components-calendar-table-body-row-cell-actionOutlineWidth: 2px;
 	--components-calendar-table-body-row-cell-actionOutlineOffset: -1px;
+	--components-calendar-table-body-row-cell-actionCursor: pointer;
+	--components-calendar-table-body-row-cell-actionTextDecoration: none;
 	--components-calendar-table-body-row-cellSelectedBeforeContent: none;
 	--components-calendar-table-body-row-cellSelectedBeforeBorderRadius: 0;
 	--components-calendar-table-body-row-cell-actionDisplay: block;


### PR DESCRIPTION
## Description

[Date] Fix overflow disabled color

-----

Before
<img width="352" height="365" alt="Capture d’écran 2025-11-26 à 18 18 21" src="https://github.com/user-attachments/assets/ca18cee8-e511-48b6-a1b8-4260dac9016a" />

After
<img width="340" height="429" alt="Capture d’écran 2025-11-26 à 18 17 48" src="https://github.com/user-attachments/assets/b52728fc-aabc-4fd0-a73b-de47dbead683" />


-----
