### PR TITLE
[date-input-field] fix storybook basic test today after another date

### DIFF
--- a/stories/documentation/forms/fields/date/date-input-field.stories.ts
+++ b/stories/documentation/forms/fields/date/date-input-field.stories.ts
@@ -137,12 +137,15 @@ export const BasicTEST = createTestStory(Basic, async ({ canvasElement, args, co
 
 	await context.step('Select today after another date', async () => {
 		await userEvent.clear(input);
-		const yesterday = today.getDate() <= 1 ? 2 : today.getDate() - 1;
+		// We pick 15 because it should show only once
+		// Fallback if we're the 15th, pick 16
+		const targetDay = today.getDate() === 15 ? 16 : 15;
+		const yesterday = targetDay - 1;
 		await pickDay(input, yesterday);
 		await expectNgModelDisplay(canvasElement, new Date(today.getFullYear(), today.getMonth(), yesterday).toString());
 
-		await pickDay(input, today.getDate());
-		await expectNgModelDisplay(canvasElement, new Date(today.getFullYear(), today.getMonth(), today.getDate()).toString());
+		await pickDay(input, targetDay);
+		await expectNgModelDisplay(canvasElement, new Date(today.getFullYear(), today.getMonth(), targetDay).toString());
 	});
 });
 


### PR DESCRIPTION
## Description

We don’t use the current date because we might run into a situation where the 27, 28, 29... appear multiple times in the calendar.

-----


-----
