### PR TITLE
[numberPipe] replace hidden by opacity

### DIFF
--- a/packages/ng/number/number.pipe.ts
+++ b/packages/ng/number/number.pipe.ts
@@ -13,9 +13,8 @@ export class LuNumberPipe implements PipeTransform {
 		const split = formatted.split(separator);
 		const integral = split[0];
 		const decimal = split[1];
-		const hideDecimal = Math.round(number) === number;
 		if (precision > 0) {
-			return `${integral}<span class="decimal-part${hideDecimal ? ' pr-u-opacity0' : ''}">${separator}${decimal}</span>`;
+			return `${integral}${separator}${decimal}`;
 		} else {
 			return integral;
 		}

--- a/packages/scss/src/commons/utils/a11y.scss
+++ b/packages/scss/src/commons/utils/a11y.scss
@@ -19,7 +19,3 @@
 		border-radius: $borderRadius #{$suffix};
 	}
 }
-
-@mixin opacity($level, $suffix: '') {
-	opacity: $level #{$suffix};
-}

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -274,10 +274,6 @@
 		}
 	}
 
-	%opacity0 {
-		@include a11y.opacity(0.0001, '!important');
-	}
-
 
 	[data-content-before] {
 		&::before {
@@ -436,10 +432,6 @@
 
 	.pr-u-focusVisible {
 		@extend %focusVisible;
-	}
-
-	.pr-u-opacity0 {
-		@extend %opacity0;
 	}
 
 	@include core.classes('float', core.$float);


### PR DESCRIPTION
## Description

The `pr-u-hidden` class did not exist, so it has been replaced by `pr-u-opacity0`, which:
- visually hides the decimals;
- does not remove their space in the layout (in order to preserve alignment);
- does not remove the semantic value of the text (which was a problem with `visibility: hidden`).

-----



-----



