### PR TITLE
[numberPipe] remove hidden option

### DIFF
--- a/packages/ng/number/number.pipe.ts
+++ b/packages/ng/number/number.pipe.ts
@@ -14,9 +14,8 @@ export class LuNumberPipe implements PipeTransform {
 		const split = formatted.split(separator);
 		const integral = split[0];
 		const decimal = split[1];
-		const hideDecimal = Math.round(number) === number;
 		if (precision > 0) {
-			return `${integral}<span class="decimal-part${hideDecimal ? ' pr-u-hidden' : ''}">${separator}${decimal}</span>`;
+			return `${integral}${separator}${decimal}`;
 		} else {
 			return integral;
 		}


### PR DESCRIPTION
## Description

The guideline has changed, and the decimal part is no longer necessary because it must always be displayed.

-----



-----
