### PR TITLE
fix(paginator): authorize display paginator with zero

### DIFF
--- a/packages/ng/pagination/pagination.component.ts
+++ b/packages/ng/pagination/pagination.component.ts
@@ -27,7 +27,7 @@ export class PaginationComponent {
 
 	constructor() {
 		effect(() => {
-			if (this.mod() === 'default' && (!this.from() || !this.to() || !this.itemsCount())) {
+			if (this.mod() === 'default' && (this.from() === null || this.to() === null || this.itemsCount() === null)) {
 				throw new Error('Pagination in "default" mode requires "from", "to", and "itemsCount" inputs.');
 			}
 		});


### PR DESCRIPTION
## Description

Authorize displya paginator with zero.
This can happen with filters that return no results, for example.

-----

Check `null` instead of falsy.

-----
