### PR TITLE
tech(QA): add test for inlineMessage component 

### DIFF
--- a/stories/qa/inline-message/inline-message.stories.html
+++ b/stories/qa/inline-message/inline-message.stories.html
@@ -1,15 +1,32 @@
 <table class="demo-QAtable">
 	<tbody>
 		<tr>
+			<td></td>
+			<td style="width: 50%">
+				<div class="demo-QAtable-list">HTML</div>
+			</td>
+			<td style="width: 50%">
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
 			<td>Default</td>
 			<td>
-				<div class="demo-QAtable-list"><div class="inlineMessage">Inline message</div></div>
+				<div class="demo-QAtable-list">
+					<div class="inlineMessage">Inline message</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-inline-message [label]="'Inline message'" />
+				</div>
 			</td>
 		</tr>
 		<tr>
 			<td>States</td>
 			<td>
 				<div class="demo-QAtable-list">
+					<div class="inlineMessage">Inline message</div>
 					<div class="inlineMessage is-success">
 						<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
 						<p class="inlineMessage-content">Inline message</p>
@@ -22,6 +39,14 @@
 						<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
 						<p class="inlineMessage-content">Inline message</p>
 					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-inline-message [label]="'Inline message'" [state]="'default'" />
+					<lu-inline-message [label]="'Inline message'" [state]="'success'" />
+					<lu-inline-message [label]="'Inline message'" [state]="'warning'" />
+					<lu-inline-message [label]="'Inline message'" [state]="'error'" />
 				</div>
 			</td>
 		</tr>
@@ -46,102 +71,69 @@
 					</div>
 				</div>
 			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-inline-message [label]="'Inline message'" [state]="'default'" [size]="'S'" />
+					<lu-inline-message [label]="'Inline message'" [state]="'success'" [size]="'S'" />
+					<lu-inline-message [label]="'Inline message'" [state]="'warning'" [size]="'S'" />
+					<lu-inline-message [label]="'Inline message'" [state]="'error'" [size]="'S'" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>PortalContent</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<section class="contentSection">
+						<div class="inlineMessage">
+							<div class="inlineMessage-content">
+								<p>Inline message</p>
+							</div>
+						</div>
+						<div class="inlineMessage is-success">
+							<div class="inlineMessage-content">
+								<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
+								<p>Inline message</p>
+							</div>
+						</div>
+						<div class="inlineMessage is-warning">
+							<div class="inlineMessage-content">
+								<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
+								<p>Inline message</p>
+							</div>
+						</div>
+						<div class="inlineMessage is-error">
+							<div class="inlineMessage-content">
+								<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
+								<p>Inline message</p>
+							</div>
+						</div>
+					</section>
+				</div>
+			</td>
+			<td></td>
 		</tr>
 		<tr>
 			<td>Deprecated</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="inlineMessage">Inline message</div>
-					<div class="inlineMessage is-success">
-						<span aria-hidden="true" class="lucca-icon"></span>
-						Inline message
-					</div>
-					<div class="inlineMessage mod-S is-warning">
-						<span aria-hidden="true" class="lucca-icon"></span>
-						Inline message
+					<div class="demo-QAtable-list">
+						<div class="inlineMessage">Inline message</div>
+						<div class="inlineMessage is-success">
+							<span aria-hidden="true" class="lucca-icon"></span>
+							Inline message
+						</div>
+						<div class="inlineMessage mod-S is-warning">
+							<span aria-hidden="true" class="lucca-icon"></span>
+							Inline message
+						</div>
 					</div>
 				</div>
 			</td>
+			<td></td>
 		</tr>
 	</tbody>
 </table>
-<h1 class="demo-divider">Inline Message</h1>
-
-<!-- Basics -->
-<section class="contentSection">
-	<div class="inlineMessage">Inline message</div>
-	<div class="inlineMessage is-success">
-		<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-	<div class="inlineMessage is-warning">
-		<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-	<div class="inlineMessage is-error">
-		<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-</section>
-
-<!-- portal content -->
-<section class="contentSection">
-	<div class="inlineMessage">
-		<div class="inlineMessage-content">
-			<p>Inline message</p>
-		</div>
-	</div>
-	<div class="inlineMessage is-success">
-		<div class="inlineMessage-content">
-			<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-			<p>Inline message</p>
-		</div>
-	</div>
-	<div class="inlineMessage is-warning">
-		<div class="inlineMessage-content">
-			<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-			<p>Inline message</p>
-		</div>
-	</div>
-	<div class="inlineMessage is-error">
-		<div class="inlineMessage-content">
-			<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-			<p>Inline message</p>
-		</div>
-	</div>
-</section>
-
-<!-- Size -->
-<section class="contentSection">
-	<div class="inlineMessage mod-S">
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-	<div class="inlineMessage mod-S is-success">
-		<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-	<div class="inlineMessage mod-S is-warning">
-		<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-	<div class="inlineMessage mod-S is-error">
-		<span aria-hidden="true" class="lucca-icon inlineMessage-statusIcon"></span>
-		<p class="inlineMessage-content">Inline message</p>
-	</div>
-</section>
-
-<!-- Deprecated -->
-<section class="contentSection">
-	<div class="inlineMessage">Inline message</div>
-	<div class="inlineMessage is-success">
-		<span aria-hidden="true" class="lucca-icon"></span>
-		Inline message
-	</div>
-	<div class="inlineMessage mod-S is-warning">
-		<span aria-hidden="true" class="lucca-icon"></span>
-		Inline message
-	</div>
-</section>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->
 <span id="ready"></span>

--- a/stories/qa/inline-message/inline-message.stories.ts
+++ b/stories/qa/inline-message/inline-message.stories.ts
@@ -1,9 +1,11 @@
 import { Component } from '@angular/core';
+import { InlineMessageComponent } from '@lucca-front/ng/inline-message';
 import { Meta, StoryFn, moduleMetadata } from '@storybook/angular';
 
 @Component({
 	selector: 'inline-message-stories',
 	templateUrl: './inline-message.stories.html',
+	imports: [InlineMessageComponent],
 })
 class InlineMessageStory {}
 


### PR DESCRIPTION
## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

<img width="950" height="384" alt="Capture d’écran 2025-12-08 à 14 43 07" src="https://github.com/user-attachments/assets/d1db0161-987c-4a43-8b15-7271b9834658" />

-----
