### PR TITLE
[link] focus-visible with Chrome

### DIFF
--- a/packages/scss/src/components/link/mods.scss
+++ b/packages/scss/src/components/link/mods.scss
@@ -4,8 +4,9 @@
 	.lucca-icon {
 		text-decoration: none;
 		font-size: 1em;
-		line-height: 1lh;
-		vertical-align: bottom;
+		vertical-align: baseline;
+		position: relative;
+		top: 0.075rem; // magic number
 	}
 
 	&:has(.link-text) {

--- a/stories/documentation/actions/links/angular.stories.ts
+++ b/stories/documentation/actions/links/angular.stories.ts
@@ -26,9 +26,9 @@ export default {
 				tick$: timer(0, 1000),
 			},
 			template: `
-Internal link: <a luLink="${routerLink}"${externe}${disable}${decoration}>${label}</a>
-<br>
-External link: <a href="${href}" luLink${externe}${disable}${decoration}>${label}</a>
+<a luLink="${routerLink}"${externe}${disable}${decoration}>${label}</a>
+<br /><br />
+<a href="${href}" luLink${externe}${disable}${decoration}>${label}</a>
 `,
 		};
 	},

--- a/stories/documentation/actions/links/link-basic.stories.ts
+++ b/stories/documentation/actions/links/link-basic.stories.ts
@@ -9,6 +9,7 @@ export default {
 
 function getTemplate(args: LinkBasicStory): string {
 	return `<a href="#" class="link">Text link</a>
+<br /><br />
 <a class="link mod-icon" href="#" target="_blank">Text link<!-- no text node here --><span aria-hidden="true" class="lucca-icon icon-arrowExternal"></span><span class="pr-u-mask">Open in a new window</span></a>
 `;
 }
@@ -16,14 +17,6 @@ function getTemplate(args: LinkBasicStory): string {
 const Template: StoryFn<LinkBasicStory> = (args) => ({
 	props: args,
 	template: getTemplate(args),
-	styles: [
-		`
-		:host {
-			display: flex;
-			gap: var(--pr-t-spacings-200);
-		}
-		`,
-	],
 });
 
 export const BasicLink = Template.bind({});


### PR DESCRIPTION
## Description

#4162 

-----



-----

Before – Chrome only :
<img width="111" height="57" alt="Capture d’écran 2025-12-08 à 17 28 26" src="https://github.com/user-attachments/assets/9ec43718-5110-4a61-bcac-b425bb12e49c" />

After – Safari, Chrome, Firefox, Edge : 

<img width="119" height="108" alt="Capture d’écran 2025-12-08 à 17 20 37" src="https://github.com/user-attachments/assets/ee886102-f3f2-4642-8bcb-9e5bdbf90fdd" />
<img width="128" height="112" alt="Capture d’écran 2025-12-08 à 17 20 44" src="https://github.com/user-attachments/assets/086e847e-833e-4d4e-b961-7d867c379d27" />
<img width="120" height="114" alt="Capture d’écran 2025-12-08 à 17 20 53" src="https://github.com/user-attachments/assets/714cb26a-755d-40c3-942b-837e286fef41" />
<img width="131" height="107" alt="Capture d’écran 2025-12-08 à 17 22 25" src="https://github.com/user-attachments/assets/0f6c4f52-c3e3-488a-9ec9-c02cf38a11c2" />



