### PR TITLE
[dialog] Fix title overflow

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -138,7 +138,7 @@
 			padding: var(--components-dialog-insideHeaderTitlePadding);
 			text-align: var(--components-dialog-insideHeaderTitleAlign);
 			margin: 0;
-			overflow-wrap: break-word;
+			overflow-wrap: anywhere;
 		}
 
 		.dialog_backdrop {


### PR DESCRIPTION
## Description

`overflow-wrap: anywhere` works better.

-----

https://lucca.slack.com/archives/C3W78FWUU/p1765271216393109

-----
