### PR TITLE
[toast] import styles for Angular wrapper

### DIFF
--- a/packages/ng/toast/toasts.component.scss
+++ b/packages/ng/toast/toasts.component.scss
@@ -1,0 +1,1 @@
+@use '@lucca-front/scss/src/components/toast';

--- a/packages/ng/toast/toasts.component.ts
+++ b/packages/ng/toast/toasts.component.ts
@@ -10,6 +10,7 @@ import { LU_TOAST_TRANSLATIONS } from './toasts.translate';
 @Component({
 	selector: 'lu-toasts',
 	templateUrl: './toasts.component.html',
+	styleUrl: './toasts.component.scss',
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	standalone: true,
 	imports: [AsyncPipe, PortalDirective],


### PR DESCRIPTION
## Description

Fix missing Toast styles by manually importing the SCSS file (styles were not included with the Angular component)

-----



-----