### PR TITLE
[luLink] improve documentation explain navigation handler

### DIFF
--- a/stories/documentation/actions/links/angular.stories.ts
+++ b/stories/documentation/actions/links/angular.stories.ts
@@ -26,9 +26,9 @@ export default {
 				tick$: timer(0, 1000),
 			},
 			template: `
-<a luLink="${routerLink}"${externe}${disable}${decoration}>${label}</a>
-<br /><br />
-<a href="${href}" luLink${externe}${disable}${decoration}>${label}</a>
+Angular Navigation side: <a luLink="${routerLink}"${externe}${disable}${decoration}>${label}</a>
+<br>
+Browser Navigation side: <a href="${href}" luLink${externe}${disable}${decoration}>${label}</a>
 `,
 		};
 	},


### PR DESCRIPTION
## Description

Since we have an external input, the BUs think that we need to use an href with an external URL along with Angular router-link navigation, even though that’s not the case. We need to specify which type of navigation we’re referring to

-----


-----
