### PR TITLE
[date-input/date-range-input] import styles for Angular wrapper

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.scss
+++ b/packages/ng/date2/date-input/date-input.component.scss
@@ -1,3 +1,4 @@
 @use '@lucca-front/scss/src/components/calendar';
 @use '@lucca-front/scss/src/components/dateField';
 @use '@lucca-front/scss/src/components/button';
+@use '@lucca-front/scss/src/components/clear';

--- a/packages/ng/date2/date-range-input/date-range-input.component.scss
+++ b/packages/ng/date2/date-range-input/date-range-input.component.scss
@@ -1,3 +1,4 @@
 @use '@lucca-front/scss/src/components/calendar';
 @use '@lucca-front/scss/src/components/textField';
 @use '@lucca-front/scss/src/components/dateRangeField';
+@use '@lucca-front/scss/src/components/clear';


### PR DESCRIPTION
## Description

Fix missing DatePicker styles by manually importing the SCSS file (clearable element styles were not included in the Angular component).

<img width="299" height="185" alt="image" src="https://github.com/user-attachments/assets/09a6ccf6-7b23-45ea-a0bc-e7b77fa1e816" />

-----

