### PR TITLE
[form] fix style for form header title

### DIFF
--- a/packages/scss/src/components/form/component.scss
+++ b/packages/scss/src/components/form/component.scss
@@ -1,7 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/form';
 @use '@lucca-front/scss/src/components/formLabel/exports' as formLabel;
 @use '@lucca-front/scss/src/components/inlineMessage/exports' as inlineMessage;
-@use '@lucca-front/scss/src/components/title/exports' as title;
 @use '@lucca-front/scss/src/commons/utils/namespace';
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
@@ -42,8 +41,7 @@
 		}
 
 		.form-header-title {
-			@include title.component;
-			@include title.h1;
+			font: var(--pr-t-font-heading-2);
 		}
 
 		.form-header-mandatory {


### PR DESCRIPTION
## Description



-----


-----
Before:
<img width="683" height="235" alt="Capture d’écran 2025-12-10 à 18 10 05" src="https://github.com/user-attachments/assets/81a0ec94-391b-4ce9-ad07-5a919200d31b" />


After: 
<img width="687" height="221" alt="Capture d’écran 2025-12-10 à 18 06 42" src="https://github.com/user-attachments/assets/164817f3-3e4a-40aa-8504-160882f00169" />