### PR TITLE
[luLink] fix url tree generation with link command array

### DIFF
--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -68,8 +68,11 @@ export class LinkComponent {
 
 	@HostListener('click')
 	redirect(): void {
-		if (!this.disabled() && this.routerLinkCommands() && this.external) {
-			afterNextRender(() => window.open(this.router.serializeUrl(this.router.createUrlTree([this.routerLinkCommands()])), '_blank'), { injector: this.#injector });
+		const routerLinkCommands = this.routerLinkCommands();
+		if (!this.disabled() && routerLinkCommands && this.external) {
+			afterNextRender(() => window.open(this.router.serializeUrl(this.router.createUrlTree(Array.isArray(routerLinkCommands) ? routerLinkCommands : [routerLinkCommands])), '_blank'), {
+				injector: this.#injector,
+			});
 		}
 	}
 


### PR DESCRIPTION
## Description

We were putting an array inside another array, which created an incorrect route behind the scenes.
So if we have a string we put it into an array to create the urlTree otherwise we leave the default value.

-----



-----
