### PR TITLE
[pageHeader] back button redesign

### DIFF
--- a/packages/scss/src/components/pageHeader/index.scss
+++ b/packages/scss/src/components/pageHeader/index.scss
@@ -35,5 +35,9 @@
 		&:has(.pageHeader-containerOptional) {
 			@include withContainer;
 		}
+
+		&:has(.pageHeader-content-title-back:not(:empty)) {
+			@include withBackButton;
+		}
 	}
 }

--- a/packages/scss/src/components/pageHeader/mods.scss
+++ b/packages/scss/src/components/pageHeader/mods.scss
@@ -1,3 +1,5 @@
+@use "@lucca-front/scss/src/components/button/exports" as button;
+
 @mixin horizontalNavigation {
 	padding-block-end: 0;
 
@@ -35,4 +37,14 @@
 
 @mixin wide {
 	--components-pageHeader-padding: var(--pr-t-spacings-300) var(--pr-t-spacings-400);
+}
+
+@mixin withBackButton {
+	.pageHeader-content-title-back {
+		.button {
+			@include button.outlined;
+			@include button.S;
+			@include button.onlyIconS;
+		}
+	}
 }

--- a/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
+++ b/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
@@ -57,7 +57,7 @@ export default {
 			: ``;
 		const backActionContainer = backAction
 			? `<ng-container pageHeaderBackAction>
-	<a href="#" luButton="ghost">
+	<a href="#" luButton>
 		<lu-icon icon="arrowLeft" alt="Retour" />
 	</a>
 </ng-container>`


### PR DESCRIPTION
## Description



-----



-----
Before: 
<img width="779" height="132" alt="Capture d’écran 2025-12-17 à 11 30 47" src="https://github.com/user-attachments/assets/c9edc5fe-b3fa-4a2a-b68e-8807a784da1a" />


After: 
<img width="720" height="127" alt="image" src="https://github.com/user-attachments/assets/2ba4e7df-7366-4f4b-beec-2209661e6cec" />

