### PR TITLE
[filterBar] wrap

### DIFF
--- a/packages/scss/src/components/filterBar/component.scss
+++ b/packages/scss/src/components/filterBar/component.scss
@@ -8,6 +8,7 @@
 @use '@lucca-front/scss/src/components/clear/exports' as clear;
 @use '@lucca-front/scss/src/components/segmentedControl/exports' as segmentedControl;
 @use '@lucca-front/scss/src/components/textField/exports' as textField;
+@use '@lucca-front/scss/src/components/divider/exports' as divider;
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;
@@ -21,6 +22,10 @@
 
 	@at-root ($atRoot) {
 		.filterBar-divider.divider {
+			@include divider.vertical;
+
+			margin-inline: var(--pr-t-spacings-50);
+
 			&:last-child {
 				display: none;
 			}
@@ -39,6 +44,7 @@
 			gap: var(--pr-t-spacings-100);
 			flex-wrap: var(--components-filterBar-scrollBox-group-flexWrap);
 			flex-grow: 1;
+			flex-shrink: 1 !important;
 		}
 
 		.filterBar-scrollBox-export {

--- a/packages/scss/src/components/filterBar/index.scss
+++ b/packages/scss/src/components/filterBar/index.scss
@@ -8,12 +8,8 @@
 	}
 
 	@layer mods {
-		@include media.max(XXS) {
-			@include compact;
-		}
-
-		@include media.min(XXS) {
-			@include notCompact;
+		@include media.max(XS) {
+			@include narrow;
 		}
 
 		@include media.pointer(coarse) {

--- a/packages/scss/src/components/filterBar/mods.scss
+++ b/packages/scss/src/components/filterBar/mods.scss
@@ -1,9 +1,9 @@
 @use '@lucca-front/scss/src/commons/utils/overflow';
-
-@use '@lucca-front/scss/src/components/divider/exports' as divider;
 @use '@lucca-front/scss/src/components/scrollBox/exports' as scrollBox;
 
-@mixin compact {
+@mixin narrow {
+	--components-filterBar-flexWrap: wrap;
+
 	.filterBar-segmentedControl.segmentedControl {
 		--components-segmentedControl-direction: row;
 		--components-segmentedControl-width: 100%;
@@ -11,16 +11,6 @@
 
 	.filterBar-divider.divider {
 		inline-size: 100%;
-	}
-}
-
-@mixin notCompact {
-	--components-filterBar-flexWrap: nowrap;
-
-	.filterBar-divider.divider {
-		margin-inline: var(--pr-t-spacings-50);
-
-		@include divider.vertical;
 	}
 }
 

--- a/packages/scss/src/components/filterBar/vars.scss
+++ b/packages/scss/src/components/filterBar/vars.scss
@@ -1,5 +1,5 @@
 @mixin vars {
 	--components-filterBar-scrollBox-flexGrow: 0;
 	--components-filterBar-scrollBox-group-flexWrap: wrap;
-	--components-filterBar-flexWrap: wrap;
+	--components-filterBar-flexWrap: nowrap;
 }

--- a/stories/documentation/forms/filterPills/angular/filter-bar.stories.ts
+++ b/stories/documentation/forms/filterPills/angular/filter-bar.stories.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { LuCoreSelectApiV4Directive } from '@lucca-front/ng/core-select/api';
 import { DateInputComponent, DateRangeInputComponent } from '@lucca-front/ng/date2';
+import { DividerComponent } from '@lucca-front/ng/divider';
 import { FilterBarComponent, FilterPillAddonAfterDirective, FilterPillAddonBeforeDirective, FilterPillComponent } from '@lucca-front/ng/filter-pills';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent, TextInputComponent } from '@lucca-front/ng/forms';
@@ -35,6 +36,7 @@ export default {
 				NumericBadgeComponent,
 				LuCoreSelectApiV4Directive,
 				LuMultiSelectInputComponent,
+				DividerComponent,
 			],
 		}),
 		applicationConfig({ providers: [provideHttpClient()] }),
@@ -78,7 +80,8 @@ export default {
 		<lu-checkbox-input [ngModel]="false" />
 	</lu-filter-pill>
 	<lu-filter-pill label="Date de début" optional name="startingDate">
-		<lu-date-input [(ngModel)]="example1" /></lu-filter-pill>
+		<lu-date-input [(ngModel)]="example1" />
+	</lu-filter-pill>
 	<lu-filter-pill label="Période">
 		<lu-date-range-input [(ngModel)]="examplePeriod" />
 	</lu-filter-pill>


### PR DESCRIPTION
## Description

There are three different display modes:

- wide: the export button is always in its column on the right (this is the default display), and if there are too many filters, they can wrap to the next line while remaining in their column
- narrow: the export button can move below the filters if there is not enough space; the filters behave as in wide mode
- touch: nothing wraps to the next line, and scrollbox is enabled to display a scrollbar and shadows

-----


-----

wide:
<img width="718" height="95" alt="Capture d’écran 2025-12-19 à 10 49 02" src="https://github.com/user-attachments/assets/9020f220-70fd-47aa-8a76-5a6b3900618e" />

narrow:
<img width="506" height="190" alt="Capture d’écran 2025-12-19 à 10 49 11" src="https://github.com/user-attachments/assets/137beedc-35e9-4025-96f7-229425f595d7" />

touch:
<img width="563" height="57" alt="Capture d’écran 2025-12-19 à 10 49 48" src="https://github.com/user-attachments/assets/a13944d3-2466-4a1e-bff9-e6970811f5b5" />
