### PR TITLE
[Tooltip] fix wrong generated id

### DIFF
--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.html
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.html
@@ -9,7 +9,7 @@
 			/>
 		</label>
 		<button
-			[attr.id]="id"
+			[id]="id"
 			[attr.disabled]="disabled() ? 'disabled' : null"
 			class="filterPill-combobox"
 			type="button"

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -77,6 +77,8 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 
 	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin>(this.#host);
 
+	readonly id = input<string>(`${this.#host.nativeElement.tagName.toLowerCase()}-tooltip-${nextId++}`);
+
 	readonly resize$ = new Observable<void>((observer) => {
 		const resizeObserver = new ResizeObserver(() => {
 			observer.next();
@@ -144,10 +146,6 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	onBlur() {
 		this.#action.set('close');
 	}
-
-	readonly #generatedId = computed(() => `${this.#host.nativeElement.tagName.toLowerCase()}-tooltip-${nextId++}`);
-
-	readonly id = computed(() => this.#host.nativeElement.id || this.#generatedId());
 
 	readonly ariaDescribedBy = computed(() => {
 		if (this.luTooltipDisabled() || this.luTooltipWhenEllipsis() || this.luTooltipOnlyForDisplay()) {


### PR DESCRIPTION
## Description

Since the host id takes a bit longer to update, we pass the id directly as a component input to give the correct one.
This is non-breaking for BU and only used  this way on our filter bars on the LF side.


-----


-----
