### PR TITLE
[select-input] - Fix auto open panel in all mode

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -210,7 +210,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	public clueChanged(clue: string, skipPanelOpen = false): void {
 		this.clue = clue;
 
-		if (!skipPanelOpen && !this.isPanelOpen) {
+		if (!skipPanelOpen && this.isPanelOpen) {
 			this.openPanel(clue);
 		} else if (this.lastEmittedClue !== clue) {
 			this.clueChange$.next(clue);


### PR DESCRIPTION
## Description

cc: https://lucca.slack.com/archives/C3W78FWUU/p1766052529115679

If the selection mode is all, the select opens automatically even though nothing was clicked.
We fix the condition here: we want to open the panel when isPanelOpen, not when it is false.

-----


https://github.com/user-attachments/assets/115f6d52-2e4c-4224-b042-cca22432f7e7



-----
