### PR TITLE
fix(multi-select): do not open multi select with select-all on init

### DIFF
--- a/packages/ng/multi-select/displayer/displayer-input.directive.ts
+++ b/packages/ng/multi-select/displayer/displayer-input.directive.ts
@@ -105,7 +105,9 @@ export class LuMultiSelectDisplayerInputDirective<T> implements OnInit {
 	}
 
 	#clearText() {
-		this.elementRef.nativeElement.value = '';
-		this.select.clueChanged('');
+		if (this.elementRef.nativeElement.value) {
+			this.elementRef.nativeElement.value = '';
+			this.select.clueChanged('');
+		}
 	}
 }


### PR DESCRIPTION
## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
