### PR TITLE
fix(schematics): palettes uses the wrong dash char

### DIFF
--- a/packages/ng/schematics/palettes/index.ts
+++ b/packages/ng/schematics/palettes/index.ts
@@ -26,8 +26,8 @@ export default (options?: SchematicContextOpts): Rule => {
 					'--palettes-secondary-{val}': `--palettes-product-{val}`,
 					'--palettes-lucca-{val}': `--palettes-brand-{val}`,
 					'--colors-grey-{val}': `--palettes-neutral-{val}`,
-					'--colors-white-color': '—-palettes-neutral-0',
-					'--colors-black-color': '—-palettes-neutral-900'
+					'--colors-white-color': '--palettes-neutral-0',
+					'--colors-black-color': '--palettes-neutral-900'
 				},
 				mixins: {}
 			},


### PR DESCRIPTION
## Description

In the v21.0.1 release, there is an issue with a wrong dash character in the palettes generator schematic : https://github.com/LuccaSA/lucca-front/pull/4312

-----
