### PR TITLE
fix(link): when external, support navigationExtras and UrlTree

### DIFF
--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,5 +1,5 @@
 import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, inject, Injector, input, ViewEncapsulation } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, UrlTree } from '@angular/router';
 import { getIntl } from '@lucca-front/ng/core';
 import { LU_LINK_TRANSLATIONS } from './link.translate';
 import { LuRouterLink } from './lu-router-link';
@@ -75,9 +75,16 @@ export class LinkComponent {
 	redirect(): void {
 		const routerLinkCommands = this.routerLinkCommands();
 		if (!this.disabled() && routerLinkCommands && this.external()) {
-			afterNextRender(() => window.open(this.router.serializeUrl(this.router.createUrlTree(Array.isArray(routerLinkCommands) ? routerLinkCommands : [routerLinkCommands])), '_blank'), {
-				injector: this.#injector,
-			});
+			const urlTree =
+				routerLinkCommands instanceof UrlTree
+					? routerLinkCommands
+					: this.router.createUrlTree(Array.isArray(routerLinkCommands) ? routerLinkCommands : [routerLinkCommands], {
+							queryParams: this.routerLink.queryParams,
+							fragment: this.routerLink.fragment,
+							queryParamsHandling: this.routerLink.queryParamsHandling,
+							preserveFragment: this.routerLink.preserveFragment,
+						});
+			afterNextRender(() => window.open(this.router.serializeUrl(urlTree), '_blank'), { injector: this.#injector });
 		}
 	}
 }


### PR DESCRIPTION
## Description

Adds support for `navigationExtras` and `UrlTree` when using `external` from `luLink`

-----

We could potentially add `relativeTo` by injecting `ActivatedRoute`. But it will ignore the base href set in app.
So we will need something like `location.prepareExternalUrl` but if we specify an absolute path, we will have two base href. So we need a way to know if we need to use this method. Maybe by looking for a slash as first character?

-----
