### PR TITLE
fix(file-entry): use good file type for display

### DIFF
--- a/packages/ng/file-upload/file-entry/file-entry.component.ts
+++ b/packages/ng/file-upload/file-entry/file-entry.component.ts
@@ -125,22 +125,16 @@ export class FileEntryComponent {
 }
 
 function extractFileExtension(type: string): string {
-	let fileType: string;
 	switch (type) {
 		case 'application/vnd.ms-excel':
-			fileType = 'XLS';
-			break;
+			return 'XLS';
 		case 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet':
-			fileType = 'XLSX';
-			break;
+			return 'XLSX';
 		case 'application/msword':
-			fileType = 'DOC';
-			break;
+			return 'DOC';
 		case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
-			fileType = 'DOCX';
-			break;
+			return 'DOCX';
 		default:
-			fileType = type.split('/')[1].toUpperCase();
+			return type.split('/')[1].toUpperCase();
 	}
-	return fileType;
 }


### PR DESCRIPTION
## Description

Displays the correct file type, on file-entry component, for the following file formats: .xls, .xlsx, .doc, .docx

-----

Current display for a .docx document:
<img width="1310" height="326" alt="image" src="https://github.com/user-attachments/assets/8c85d8ed-ec2c-4f13-819e-fe8aacf7ab1b" />

-----
