### PR TITLE
[data-table] fix basic stories sticky header hidden arg

### DIFF
--- a/stories/documentation/listings/data-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/data-table/angular/basic.stories.ts
@@ -87,12 +87,7 @@ export default {
 			},
 			description: 'Affiche un footer.',
 		},
-		stickyHeader: {
-			control: {
-				type: 'boolean',
-			},
-			description: 'Conserve le header visible en cas de scroll.',
-		},
+		stickyHeader: HiddenArgType,
 		hover: {
 			control: {
 				type: 'boolean',


### PR DESCRIPTION
## Description

We remove the sticky header argument, we don’t need it in the basic story since we already have a dedicated example in the Sticky / Overflow tab.

-----


-----
