### PR TITLE
[callout] fix description with DOM structure and inline actions

### DIFF
--- a/packages/scss/src/components/callout/component.scss
+++ b/packages/scss/src/components/callout/component.scss
@@ -43,8 +43,14 @@
 		.callout-content-description {
 			display: var(--components-callout-content-description-display);
 			justify-content: space-between;
-			gap: var(--pr-t-spacings-150);
+			column-gap: var(--pr-t-spacings-150);
 			align-items: flex-start;
+			grid-template-columns: 1fr auto;
+			grid-auto-flow: row;
+
+			> * {
+				grid-column-start: 1;
+			}
 
 		}
 
@@ -54,6 +60,8 @@
 			margin-block-start: var(--components-callout-content-description-action-marginBlockStart);
 			padding-block: var(--components-callout-content-description-action-paddingBlock);
 			padding-inline: 0;
+			grid-column-start: 2;
+			grid-row-start: 1;
 
 			.button {
 				@include color.palette('neutral');

--- a/packages/scss/src/components/callout/mods.scss
+++ b/packages/scss/src/components/callout/mods.scss
@@ -43,7 +43,7 @@
 }
 
 @mixin actionsInline {
-	--components-callout-content-description-display: flex;
+	--components-callout-content-description-display: grid;
 	--components-callout-content-description-action-marginBlockStart: 0;
 	--components-callout-content-description-action-paddingBlock: 0;
 

--- a/stories/documentation/feedback/callout/angular/callout-basic.stories.ts
+++ b/stories/documentation/feedback/callout/angular/callout-basic.stories.ts
@@ -20,7 +20,8 @@ export default {
 
 		const actionsInlineArg = actionsInline ? ` inline` : ``;
 		const actionsTemplate = actions
-			? `<lu-callout-actions${actionsInlineArg}>
+			? `
+	<lu-callout-actions${actionsInlineArg}>
 		<button luButton="outlined">Action</button>
 		<button luButton="ghost">Action</button>
 	</lu-callout-actions>`
@@ -28,8 +29,7 @@ export default {
 
 		return {
 			template: `<lu-callout${headingArg}${paletteArg}${generateInputs(inputs, context.argTypes)}>
-	Feedback description
-	${actionsTemplate}
+	Feedback description${actionsTemplate}
 </lu-callout>`,
 		};
 	},


### PR DESCRIPTION
## Description

#4349 

-----

Simply placing these two HTML blocks in a single container will resolve the issue. I am still proposing a fix in this PR, but it seems a little complicated compared to the solution presented here.

-----

<img width="1033" height="408" alt="Capture d’écran 2026-01-15 à 17 18 40" src="https://github.com/user-attachments/assets/93b8644e-fd77-4341-b07a-1cd4d83b20c6" />