### PR TITLE
[formField] fix gap when label is hidden

### DIFF
--- a/packages/scss/src/components/form/index.scss
+++ b/packages/scss/src/components/form/index.scss
@@ -101,6 +101,12 @@
 				@include withArrowS;
 			}
 		}
+
+		&:has(.formLabel.pr-u-mask) {
+			&:not(:has(.inlineMessage)) {
+				@include hiddenLabel;
+			}
+		}
 	}
 }
 

--- a/packages/scss/src/components/form/mods.scss
+++ b/packages/scss/src/components/form/mods.scss
@@ -361,6 +361,10 @@
 	}
 }
 
+@mixin hiddenLabel {
+	gap: 0;
+}
+
 %isRequired {
 	@layer mods {
 		color: var(--palettes-error-700);


### PR DESCRIPTION
## Description

#4367 


-----



-----

<img width="407" height="73" alt="Capture d’écran 2026-01-16 à 10 16 47" src="https://github.com/user-attachments/assets/47ab144d-c157-412d-8c9f-a26499a73579" />