### PR TITLE
[formLabel] remove gap when label is hidden

### DIFF
--- a/packages/scss/src/components/form/index.scss
+++ b/packages/scss/src/components/form/index.scss
@@ -101,6 +101,12 @@
 				@include withArrowS;
 			}
 		}
+
+		&:has(.formLabel.pr-u-mask) {
+			&:not(:has(.inlineMessage)) {
+				@include hiddenLabel;
+			}
+		}
 	}
 }
 

--- a/packages/scss/src/components/form/mods.scss
+++ b/packages/scss/src/components/form/mods.scss
@@ -369,3 +369,7 @@
 		content: '*' / '';
 	}
 }
+
+@mixin hiddenLabel {
+	gap: 0;
+}


### PR DESCRIPTION
## Description

#4367 

-----



-----

<img width="407" height="73" alt="image" src="https://github.com/user-attachments/assets/4a00e45e-a0bb-4db4-907b-16ee9e4c25bf" />
