### PR TITLE
[Navide] Fix long module label

### DIFF
--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -116,6 +116,10 @@
 			font-weight: var(--pr-t-font-fontWeight-semibold);
 		}
 
+		.navSide-item-link-title {
+			overflow-wrap: anywhere;
+		}
+
 		.navSide-item-link-badgesOptional {
 			display: flex;
 			column-gap: var(--pr-t-spacings-150);


### PR DESCRIPTION
## Description

[Navide] Fix long module label

-----

<img width="462" height="558" alt="Capture d’écran 2026-01-19 à 15 45 30" src="https://github.com/user-attachments/assets/98d8f2a2-f3cb-40bf-8ee0-a38036c8c0b7" />

-----
