### PR TITLE
[filtersPills] fix group name overlapping focus style

### DIFF
--- a/packages/scss/src/components/multiSelect/mods.scss
+++ b/packages/scss/src/components/multiSelect/mods.scss
@@ -61,7 +61,7 @@
 		border-radius: 0;
 		background-color: transparent;
 		padding: var(--pr-t-spacings-50);
-		margin: var(--pr-t-spacings-50) calc(var(--pr-t-spacings-100) * -1) calc(var(--pr-t-spacings-100) * -1);
+		margin: var(--pr-t-spacings-75) calc(var(--pr-t-spacings-100) * -1) calc(var(--pr-t-spacings-100) * -1);
 
 		lu-simple-select-default-option.pr-u-ellipsis {
 			white-space: normal !important;

--- a/packages/scss/src/components/simpleSelect/mods.scss
+++ b/packages/scss/src/components/simpleSelect/mods.scss
@@ -62,6 +62,6 @@
 		border-radius: 0;
 		background-color: transparent;
 		padding: var(--pr-t-spacings-50);
-		margin: var(--pr-t-spacings-50) calc(var(--pr-t-spacings-100) * -1) calc(var(--pr-t-spacings-100) * -1);
+		margin: var(--pr-t-spacings-75) calc(var(--pr-t-spacings-100) * -1) calc(var(--pr-t-spacings-100) * -1);
 	}
 }


### PR DESCRIPTION
## Description

Fixes #3646 

-----



-----
<img width="467" height="438" alt="Capture d’écran 2026-01-21 à 10 06 44" src="https://github.com/user-attachments/assets/16b872e1-62f4-466c-87ab-911c14f65ce9" />
