### PR TITLE
fix(multilanguage-input): add invariant required validator

### DIFF
--- a/packages/ng/forms/multilanguage-input/model/multilanguage-translation.ts
+++ b/packages/ng/forms/multilanguage-input/model/multilanguage-translation.ts
@@ -2,3 +2,5 @@ export interface MultilanguageTranslation {
 	cultureCode: string;
 	value: string;
 }
+
+export const INVARIANT_CULTURE_CODE = 'invariant';

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -6,7 +6,7 @@ import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective } from '@lucca-
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { TextInputComponent } from '../text-input/text-input.component';
-import { MultilanguageTranslation } from './model/multilanguage-translation';
+import { INVARIANT_CULTURE_CODE, MultilanguageTranslation } from './model/multilanguage-translation';
 import { LU_MULTILANGUAGE_INPUT_TRANSLATIONS } from './multilanguage-input.translate';
 
 @Component({
@@ -49,11 +49,11 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 	model: WritableSignal<MultilanguageTranslation[]> = signal([] as MultilanguageTranslation[]);
 
 	invariant = computed(() => {
-		return this.model().find((row) => row.cultureCode === 'invariant') || { value: '' };
+		return this.model().find((row) => row.cultureCode === INVARIANT_CULTURE_CODE) || { value: '' };
 	});
 
 	panelInputs = computed(() => {
-		return this.model().filter((row) => row.cultureCode !== 'invariant');
+		return this.model().filter((row) => row.cultureCode !== INVARIANT_CULTURE_CODE);
 	});
 
 	popoverPositions: ConnectionPositionPair[] = [
@@ -70,7 +70,7 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 			value = [];
 		}
 		if (value.length > 0) {
-			if (!value.some((row) => row.cultureCode === 'invariant')) {
+			if (!value.some((row) => row.cultureCode === INVARIANT_CULTURE_CODE)) {
 				throw new Error('Please provide an invariant translation in translation array');
 			}
 			this.model.set(value);

--- a/packages/ng/forms/multilanguage-input/validators.ts
+++ b/packages/ng/forms/multilanguage-input/validators.ts
@@ -1,10 +1,16 @@
-import { MultilanguageTranslation } from './model/multilanguage-translation';
+import { INVARIANT_CULTURE_CODE, MultilanguageTranslation } from './model/multilanguage-translation';
 import { AbstractControl, ValidatorFn } from '@angular/forms';
 
 export function areAllLanguagesFilled(model: MultilanguageTranslation[]): boolean {
 	return model.every((row) => row.value?.length > 0);
 }
 
-export const MultiLanguageInputValidators: Record<string, ValidatorFn> = {
+export function isInvariantFilled(model: MultilanguageTranslation[]): boolean {
+	const invariantTranslation = model.find((row) => row.cultureCode === INVARIANT_CULTURE_CODE);
+	return invariantTranslation && invariantTranslation.value?.length > 0;
+}
+
+export const MultiLanguageInputValidators: Record<'allLanguagesFilled' | 'invariantFilled', ValidatorFn> = {
 	allLanguagesFilled: (control: AbstractControl<MultilanguageTranslation[]>) => (areAllLanguagesFilled(control.value) ? null : { missingLang: true }),
+	invariantFilled: (control: AbstractControl<MultilanguageTranslation[]>) => (isInvariantFilled(control.value) ? null : { missingInvariant: true }),
 };

--- a/stories/documentation/forms/fields/multilanguage/angular/multilanguagefield.stories.ts
+++ b/stories/documentation/forms/fields/multilanguage/angular/multilanguagefield.stories.ts
@@ -1,7 +1,7 @@
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
-import { MultilanguageInputComponent, MultilanguageTranslation } from '@lucca-front/ng/forms';
+import { MultilanguageInputComponent, MultiLanguageInputValidators, MultilanguageTranslation } from '@lucca-front/ng/forms';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 import { StoryModelDisplayComponent } from 'stories/helpers/story-model-display.component';
@@ -11,7 +11,7 @@ export default {
 	title: 'Documentation/Forms/Fields/MultilanguageField/Angular',
 	decorators: [
 		moduleMetadata({
-			imports: [MultilanguageInputComponent, FormFieldComponent, FormsModule, ReactiveFormsModule, BrowserAnimationsModule, StoryModelDisplayComponent],
+			imports: [MultilanguageInputComponent, FormFieldComponent, ReactiveFormsModule, BrowserAnimationsModule, StoryModelDisplayComponent],
 		}),
 		applicationConfig({
 			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
@@ -35,6 +35,18 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+		},
+		allLanguagesFilled: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Ajoute le validateur marquant toutes les traductions comme obligatoires.',
+		},
+		invariantFilled: {
+			control: {
+				type: 'boolean',
+			},
+			description: `Ajoute le validateur marquant l'invariant comme obligatoire.`,
 		},
 		size: {
 			options: ['M', 'S'],
@@ -84,30 +96,35 @@ export const Basic: StoryObj<
 		FormFieldComponent & {
 			disabled: boolean;
 			required: boolean;
+			allLanguagesFilled: boolean;
+			invariantFilled: boolean;
 		}
 > = {
 	render: (args, { argTypes }) => {
-		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, ...inputArgs } = args;
+		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, allLanguagesFilled, invariantFilled, ...inputArgs } = args;
 		return {
 			props: {
-				example: [
-					{
-						cultureCode: 'invariant',
-						value: '',
-					},
-					{
-						cultureCode: 'fr-FR',
-						value: '',
-					},
-					{
-						cultureCode: 'en-EN',
-						value: '',
-					},
-					{
-						cultureCode: 'de-DE',
-						value: '',
-					},
-				] as MultilanguageTranslation[],
+				formControl: new FormControl<MultilanguageTranslation[]>(
+					[
+						{
+							cultureCode: 'invariant',
+							value: '',
+						},
+						{
+							cultureCode: 'fr-FR',
+							value: '',
+						},
+						{
+							cultureCode: 'en-EN',
+							value: '',
+						},
+						{
+							cultureCode: 'de-DE',
+							value: '',
+						},
+					],
+					allLanguagesFilled ? MultiLanguageInputValidators.allLanguagesFilled : invariantFilled ? MultiLanguageInputValidators.invariantFilled : undefined,
+				),
 			},
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
@@ -121,9 +138,9 @@ export const Basic: StoryObj<
 				},
 				argTypes,
 			)}>
-	<lu-multilanguage-input [(ngModel)]="example"${generateInputs(inputArgs, argTypes)} />
+	<lu-multilanguage-input [formControl]="formControl" ${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example | json }}</pr-story-model-display>`),
+<pr-story-model-display>{{ formControl.value | json }}</pr-story-model-display>`),
 		};
 	},
 	args: {
@@ -136,5 +153,7 @@ export const Basic: StoryObj<
 		placeholder: 'Placeholder',
 		tooltip: 'Je suis un message d’aide',
 		openOnFocus: false,
+		allLanguagesFilled: false,
+		invariantFilled: false,
 	},
 };


### PR DESCRIPTION
## Description

Add "invariant required" custom validator to multilanguage field.

-----

Story has been updated to test both validators.
All language required:
![firefox_bGvKsvklQx](https://github.com/user-attachments/assets/ba41cc91-b950-48cc-9b02-e02a05e4921e)
Only invariant required:
![firefox_zzS0bqhVmY](https://github.com/user-attachments/assets/df83067b-3272-4e36-8b14-cea8d4073aa0)


-----
