### PR TITLE
chore: fix NodeJS security issue

### DIFF
--- a/packages/ng/schematics/lib/local-deps/package-lock.json
+++ b/packages/ng/schematics/lib/local-deps/package-lock.json
@@ -72,6 +72,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -167,6 +168,7 @@
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
       "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",

--- a/packages/ng/schematics/lib/local-deps/package.json
+++ b/packages/ng/schematics/lib/local-deps/package.json
@@ -17,7 +17,6 @@
     "postcss-value-parser": "4.2.0"
   },
   "volta": {
-    "node": "24.13.0",
-    "npm": "7.24.2"
+    "extends": "../../../../../package.json"
   }
 }


### PR DESCRIPTION
## Description

This PR updates the Node.js version go back on track for projects using unsuppored NodeJS versions.

LTS versions of NodeJS are the last three even versions (20, 22 and 24 as of today).
The "current" version is supported as well (ie 25 as of today).

As we use NodeJS only on local and CI side, no need to deploy this pull request once merged.

If this PR builds, it should be good to merge.

-----

## Checklist

- [x] Bump NodeJS to latest LTS version
- [ ] Check that project build
