### PR TITLE
[*select] fix overlay pane max inline size

### DIFF
--- a/packages/ng/styles/components/cdk/_overlay.scss
+++ b/packages/ng/styles/components/cdk/_overlay.scss
@@ -30,7 +30,6 @@
 	position: absolute;
 	pointer-events: auto;
 	z-index: 1000;
-	max-inline-size: 35rem !important;
 
 	> * {
 		flex-grow: 1;
@@ -40,6 +39,10 @@
 	&.mod-optionPicker {
 		min-inline-size: 13rem;
 		max-inline-size: 30rem;
+	}
+
+	&:has(> lu-select-panel) {
+		max-inline-size: 35rem !important;
 	}
 }
 


### PR DESCRIPTION
## Description

The maximum width is applied only to single and multi-select components (avoiding the risk of applying this value to other components).

-----



-----
