### PR TITLE
[Dropdown] Disabled has priority over critical

### DIFF
--- a/packages/scss/src/components/dropdown/index.scss
+++ b/packages/scss/src/components/dropdown/index.scss
@@ -13,14 +13,14 @@
 .dropdown-list-option-action,
 .lu-dropdown-options-item-action {
 	@layer mods {
-		&[disabled],
-		&.is-disabled {
-			@include disabled;
-		}
-
 		&.mod-critical,
 		&.mod-delete {
 			@include critical;
+		}
+
+		&[disabled],
+		&.is-disabled {
+			@include disabled;
 		}
 	}
 }


### PR DESCRIPTION
## Description

Fix Disabled + Critical combo to give priority to Disabled UI. 

-----

As component will always add an extra `.is-disabled` class to `disabled` html button state, it seems enough to only switch declarations cascading order. (Tested with both `<a>` and `<button>` elements)

<img width="599" height="675" alt="Capture d’écran 2026-02-04 à 14 38 49" src="https://github.com/user-attachments/assets/5823243f-38c7-4223-a0e1-3a19cb3af7ac" />


-----
