### PR TITLE
[formField] fix gap only for checkbox

### DIFF
--- a/packages/scss/src/components/form/index.scss
+++ b/packages/scss/src/components/form/index.scss
@@ -102,9 +102,11 @@
 			}
 		}
 
-		&:has(.formLabel.pr-u-mask) {
-			&:not(:has(.inlineMessage)) {
-				@include hiddenLabel;
+		&:has(.checkboxField-input) {
+			&:has(.formLabel.pr-u-mask) {
+				&:not(:has(.inlineMessage)) {
+					@include hiddenLabel;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Description



-----



-----

Before: the gap is reset to 0 when it shouldn't be on the time picker

<img width="158" height="102" alt="Capture d’écran 2026-02-05 à 11 51 48" src="https://github.com/user-attachments/assets/e505e213-6345-4dd3-a67f-f5a095bc3868" />


After: the gap is only reset to 0 if the field contains a checkbox

<img width="154" height="107" alt="Capture d’écran 2026-02-05 à 11 52 00" src="https://github.com/user-attachments/assets/47197db4-02c0-42d6-9b4e-fdfd2ee834a7" />
