### PR TITLE
[bubbleIcon] adjust contrast

### DIFF
--- a/packages/scss/src/components/bubbleIcon/vars.scss
+++ b/packages/scss/src/components/bubbleIcon/vars.scss
@@ -1,6 +1,6 @@
 @mixin vars {
 	--components-bubbleIcon-size: var(--pr-t-spacings-500);
-	--components-bubbleIcon-color: var(--palettes-600, var(--palettes-product-600));
+	--components-bubbleIcon-color: var(--palettes-700, var(--palettes-product-700));
 	--components-bubbleIcon-bubble-path-fill: var(--palettes-100, var(--palettes-product-100));
 	--components-bubbleIcon-bubble-pathBlock-display: none;
 	--components-bubbleIcon-bubble-pathInline-display: inherit;


### PR DESCRIPTION
## Description

The color of the icons changes from 600 to 700.

-----



-----

<img width="199" height="65" alt="Capture d’écran 2026-02-06 à 15 46 46" src="https://github.com/user-attachments/assets/26aad426-1025-4d86-8fdb-c7bb940b4245" />
