### PR TITLE
feat(rich-text-input): add formatter directives

### DIFF
--- a/docs/rich-text-input.md
+++ b/docs/rich-text-input.md
@@ -1,6 +1,4 @@
-### Configuration
-
-#### Dépendances
+### Dépendances
 
 Avant toute utilisation de `lu-rich-text-input`, il est nécessaire d'ajouter les `peerDependencies` suivantes à votre projet :
 
@@ -28,51 +26,58 @@ npm i @lexical/markdown
 npm i @lexical/plain-text
 ```
 
-#### Formats d'entrée/sortie
+### Formats d'entrée/sortie
 Avant toute utilisation du composant, il est nécessaire de définir le formateur à utiliser.
-Trois formateurs par défaut sont disponibles, à provide au niveau du composant parent de l'input :
 
-- HTML
+Trois formateurs par défaut sont disponibles : sous forme de directives ou de services à provide au niveau du composant parent.
+
+#### HTML
+
+```angular2html
+<lu-rich-text-input luWithHtmlFormatter></lu-rich-text-input>
+```
 
 ```ts
 import { provideLuRichTextHTMLFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/html';
 provideLuRichTextHTMLFormatter();
 ```
 
-- Markdown
+#### Markdown
 
-Ce formateur accepte en paramètres une liste optionnelle de `Transformer` markdown pour les noeuds custom
+* Directives disponibles :
+  * `luWithMarkdownFormatter` : formateur markdown classique, avec les balises markdown standards.
+  * `luWithMarkdownTagsFormatter` : formateur markdown avec support des [tags personnalisés](#TagTool).
+```angular2html
+<lu-rich-text-input luWithMarkdownFormatter></lu-rich-text-input>
+<lu-rich-text-input luWithMarkdownTagsFormatter></lu-rich-text-input>
+```
 
+* Providers
 ```ts
 import { provideLuRichTextMarkdownFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/markdown';
 provideLuRichTextMarkdownFormatter(transformers);
 ```
 
-- Plain Text
+#### Plain Text
 
 Ce formateur accepte en paramètres une liste optionnelle de `PlainTextTransformer` pour les noeuds custom.
 
-Il peut être utilisé dans des contextes où le formatage riche n'est pas désiré, mais où l'on souhaite tout de même bénéficier d'un outil en particulier (l'outil "Tags" par exemple).
+Il peut être utilisé dans des contextes où le formatage riche n'est pas désiré, mais où l'on souhaite tout de même bénéficier d'un outil en particulier (l'outil [Tags](#TagTool) par exemple).
 
 En conséquent:
 - La plupart des outils n'auront aucun effet sur le contenu de l'éditeur.
 - Il n'intègre pas les raccourcis clavier de formatage de texte (gras, italique, listes, etc...).
 - La récupération du contenu se fait en texte brut lors du copier/coller.
 
+```angular2html
+<lu-rich-text-input luWithPlainTextTagsFormatter></lu-rich-text-input>
+```
+
 ```ts
 import { provideLuRichTextPlainTextFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/plain-text';
 provideLuRichTextPlainTextFormatter(transformers);
 ```
 
-#### Exemple d'utilisation
-
-```angular2html
-<lu-form-field label="Rich Text">
-  <lu-rich-text-input [(ngModel)]="example" placeholder="Placeholder">
-    <!-- tools -->
-  </lu-rich-text-input>
-</lu-form-field>
-```
 
 ### Barre d'outils
 
@@ -81,7 +86,9 @@ La barre d'outils du `lu-rich-text-input` est configuré directement depuis le t
 Pour plus de simplicité, une barre d'outil par défaut est mise à disposition.
 
 ```angular2html
-<lu-rich-text-input placeholder="Enter some text..." [(ngModel)]="example">
+<lu-rich-text-input luWithMarkdownFormatter 
+                    placeholder="Enter some text..." 
+                    [(ngModel)]="example">
   <lu-rich-text-input-toolbar />
 </lu-rich-text-input>
 ```
@@ -89,7 +96,9 @@ Pour plus de simplicité, une barre d'outil par défaut est mise à disposition.
 Il est aussi possible de créer une barre d'outil personnalisée en assemblant les outils existant et en y ajoutant de nouvelles fonctionnalités.
 
 ```angular2html
-<lu-rich-text-input placeholder="Enter some text..." [(ngModel)]="example">
+<lu-rich-text-input luWithMarkdownFormatter
+                    placeholder="Enter some text..." 
+                    [(ngModel)]="example">
   <div class="richTextField-toolbar-formatting">
     <div class="richTextField-toolbar-col">
       <div class="richTextField-toolbar-col-group">
@@ -119,6 +128,7 @@ Pour cacher la barre d'outil tout en gardant les fonctionnalités, il est possib
 
 ```angular2html
 <lu-rich-text-input
+  luWithMarkdownFormatter
   placeholder="Enter some text..."
   [(ngModel)]="example"
   hideToolbar
@@ -173,7 +183,7 @@ Pour cacher la barre d'outil tout en gardant les fonctionnalités, il est possib
 <lu-rich-text-plugin-clear-format />
 ```
 
-#### Tag
+#### <a id="TagTool"></a>Tag
 
 - Outil individuel
 

--- a/packages/ng/forms/rich-text-input/formatters/html/html-formatter.directive.ts
+++ b/packages/ng/forms/rich-text-input/formatters/html/html-formatter.directive.ts
@@ -1,0 +1,8 @@
+import { Directive } from '@angular/core';
+import { provideLuRichTextHTMLFormatter } from './html-formatter';
+
+@Directive({
+	selector: 'lu-rich-text-input[luWithHtmlFormatter]',
+	providers: [provideLuRichTextHTMLFormatter()],
+})
+export class HtmlFormatterDirective {}

--- a/packages/ng/forms/rich-text-input/formatters/html/public-api.ts
+++ b/packages/ng/forms/rich-text-input/formatters/html/public-api.ts
@@ -1,1 +1,2 @@
 export * from './html-formatter';
+export * from './html-formatter.directive';

--- a/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.directive.ts
+++ b/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.directive.ts
@@ -1,0 +1,15 @@
+import { Directive } from '@angular/core';
+import { DEFAULT_MARKDOWN_TRANSFORMERS, provideLuRichTextMarkdownFormatter } from './markdown-formatter';
+import { TAGS } from './transformers';
+
+@Directive({
+	selector: 'lu-rich-text-input[luWithMarkdownFormatter]',
+	providers: [provideLuRichTextMarkdownFormatter()],
+})
+export class MarkdownFormatterDirective {}
+
+@Directive({
+	selector: 'lu-rich-text-input[luWithMarkdownTagsFormatter]',
+	providers: [provideLuRichTextMarkdownFormatter([...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS])],
+})
+export class MarkdownFormatterWithTagsDirective {}

--- a/packages/ng/forms/rich-text-input/formatters/markdown/public-api.ts
+++ b/packages/ng/forms/rich-text-input/formatters/markdown/public-api.ts
@@ -1,2 +1,3 @@
 export * from './markdown-formatter';
+export * from './markdown-formatter.directive';
 export * from './transformers';

--- a/packages/ng/forms/rich-text-input/formatters/plain-text/plain-text-formatter.directive.ts
+++ b/packages/ng/forms/rich-text-input/formatters/plain-text/plain-text-formatter.directive.ts
@@ -1,0 +1,8 @@
+import { Directive } from '@angular/core';
+import { provideLuRichTextPlainTextFormatter } from './plain-text-formatter';
+
+@Directive({
+	selector: 'lu-rich-text-input[luWithPlainTextTagsFormatter]',
+	providers: [provideLuRichTextPlainTextFormatter()],
+})
+export class PlainTextFormatterWithTagsDirective {}

--- a/packages/ng/forms/rich-text-input/formatters/plain-text/public-api.ts
+++ b/packages/ng/forms/rich-text-input/formatters/plain-text/public-api.ts
@@ -1,2 +1,3 @@
 export * from './plain-text-formatter';
+export * from './plain-text-formatter.directive';
 export * from './transformers';

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -6,9 +6,9 @@ import { ButtonComponent } from '@lucca-front/ng/button';
 import { DividerComponent } from '@lucca-front/ng/divider';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { RichTextInputComponent, RichTextInputToolbarComponent, RichTextPluginTagComponent } from '@lucca-front/ng/forms/rich-text-input';
-import { provideLuRichTextHTMLFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/html';
-import { DEFAULT_MARKDOWN_TRANSFORMERS, provideLuRichTextMarkdownFormatter, TAGS } from '@lucca-front/ng/forms/rich-text-input/formatters/markdown';
-import { PLAINTEXT_TAGS, provideLuRichTextPlainTextFormatter } from '@lucca-front/ng/forms/rich-text-input/formatters/plain-text';
+import { HtmlFormatterDirective } from '@lucca-front/ng/forms/rich-text-input/formatters/html';
+import { DEFAULT_MARKDOWN_TRANSFORMERS, MarkdownFormatterDirective, MarkdownFormatterWithTagsDirective, TAGS } from '@lucca-front/ng/forms/rich-text-input/formatters/markdown';
+import { PLAINTEXT_TAGS, PlainTextFormatterWithTagsDirective } from '@lucca-front/ng/forms/rich-text-input/formatters/plain-text';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { cleanupTemplate, generateInputs } from 'stories/helpers/stories';
 import { StoryModelDisplayComponent } from 'stories/helpers/story-model-display.component';
@@ -51,7 +51,7 @@ export const Basic: StoryObj<RichTextInputComponent & { value: string; disabled:
 		return {
 			props: { value, disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithMarkdownFormatter
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="value" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
@@ -59,8 +59,7 @@ export const Basic: StoryObj<RichTextInputComponent & { value: string; disabled:
 </lu-form-field>
 <pr-story-model-display>{{ value }}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextMarkdownFormatter()],
+				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterDirective],
 			},
 		};
 	},
@@ -81,7 +80,7 @@ export const WithNoInitialValue: StoryObj<RichTextInputComponent & { value: stri
 		return {
 			props: { value, disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithMarkdownFormatter
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="value" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
@@ -89,8 +88,7 @@ export const WithNoInitialValue: StoryObj<RichTextInputComponent & { value: stri
 </lu-form-field>
 <pr-story-model-display>{{ value }}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextMarkdownFormatter()],
+				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterDirective],
 			},
 		};
 	},
@@ -111,7 +109,7 @@ export const WithHtmlFormatter: StoryObj<RichTextInputComponent & { value: strin
 		return {
 			props: { value, disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithHtmlFormatter
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="value" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
@@ -119,8 +117,7 @@ export const WithHtmlFormatter: StoryObj<RichTextInputComponent & { value: strin
 </lu-form-field>
 <pr-story-model-display>{{ value }}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextHTMLFormatter()],
+				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, HtmlFormatterDirective],
 			},
 		};
 	},
@@ -141,7 +138,7 @@ export const WithTagPlugin: StoryObj<RichTextInputComponent & { value: string; d
 		return {
 			props: { value, disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithHtmlFormatter
 	${generateInputs(inputArgs, argTypes)}
 	[(ngModel)]="value" [disabled]="disabled" [required]="required">
 		<lu-rich-text-input-toolbar />
@@ -163,8 +160,7 @@ export const WithTagPlugin: StoryObj<RichTextInputComponent & { value: string; d
 </lu-form-field>
 <pr-story-model-display>{{ value }}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextHTMLFormatter()],
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, HtmlFormatterDirective],
 			},
 		};
 	},
@@ -182,10 +178,11 @@ export const WithTagPlugin: StoryObj<RichTextInputComponent & { value: string; d
 export const WithTagPluginMarkdown: StoryObj<RichTextInputComponent & { value: string; disabled: boolean; required: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, ...inputArgs } = args;
+		const transformers = [...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS];
 		return {
-			props: { value, disabled, required },
+			props: { value, disabled, required, transformers },
 			template: cleanupTemplate(`<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithMarkdownTagsFormatter
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="value" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
@@ -207,8 +204,7 @@ export const WithTagPluginMarkdown: StoryObj<RichTextInputComponent & { value: s
 </lu-form-field>
 <pr-story-model-display>{{ value }}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextMarkdownFormatter([...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS])],
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterWithTagsDirective],
 			},
 		};
 	},
@@ -226,10 +222,12 @@ export const WithTagPluginMarkdown: StoryObj<RichTextInputComponent & { value: s
 export const WithTagPluginPlainText: StoryObj<RichTextInputComponent & { value: string; disabled: boolean; required: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, ...inputArgs } = args;
+
+		const transformers = [PLAINTEXT_TAGS];
 		return {
-			props: { value, disabled, required },
+			props: { value, disabled, required, transformers },
 			template: cleanupTemplate(`<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithPlainTextTagsFormatter
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="value" [disabled]="disabled" [required]="required">
 			<lu-rich-text-plugin-tag [tags]="[
@@ -250,8 +248,7 @@ export const WithTagPluginPlainText: StoryObj<RichTextInputComponent & { value: 
 </lu-form-field>
 <pr-story-model-display>{{ value }}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextPlainTextFormatter([PLAINTEXT_TAGS])],
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, PlainTextFormatterWithTagsDirective],
 			},
 		};
 	},
@@ -270,12 +267,13 @@ export const WithTagPluginMarkdownContentChange: StoryObj<RichTextInputComponent
 	render: (args, { argTypes }) => {
 		const { value: valueEn, valueFr, disabled, required, ...inputArgs } = args;
 		const value = valueEn;
+		const transformers = [...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS];
 		return {
-			props: { value, disabled, required },
+			props: { value, disabled, required, transformers },
 			template: cleanupTemplate(`<button luButton="outlined" size="S" (click)="value='${valueEn}';">EN</button>
 				<button luButton="outlined" size="S" (click)="value='${valueFr}';">FR</button>
 				<lu-form-field label="Label">
-	<lu-rich-text-input
+	<lu-rich-text-input luWithMarkdownTagsFormatter
 	${generateInputs(inputArgs, argTypes)}
 		[(ngModel)]="value" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
@@ -297,8 +295,7 @@ export const WithTagPluginMarkdownContentChange: StoryObj<RichTextInputComponent
 </lu-form-field>
 <pr-story-model-display>{{value}}</pr-story-model-display>`),
 			moduleMetadata: {
-				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
-				providers: [provideLuRichTextMarkdownFormatter([...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS])],
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterWithTagsDirective],
 			},
 		};
 	},


### PR DESCRIPTION
## Description

Added directives to provide formatters at input level.
* Rich Text Inputs are more straightforward to use
* Rich Text Inputs can now easily use different formatters in the same context (e.g. email objects vs email body) 

Before: 
```ts
@Component({
   ...
   providers: [provideLuRichTextMarkdownFormatter(transformers)]
})
export class MyComponent {}
```

After:
```html
<lu-rich-text-input luWithHtmlFormatter></lu-rich-text-input>
<lu-rich-text-input luWithMarkdownFormatter></lu-rich-text-input>
<lu-rich-text-input luWithMarkdownTagsFormatter></lu-rich-text-input>
<lu-rich-text-input luWithPlainTextTagsFormatter></lu-rich-text-input>
```

Note: formatter providers are not deprecated.

-----


-----
