### PR TITLE
fix: tooltip ellipsis not updating on content change

### DIFF
--- a/stories/documentation/overlays/tooltip/tooltip-ellipsis.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip-ellipsis.stories.ts
@@ -2,11 +2,16 @@ import { Component } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
+import { interval, map } from 'rxjs';
+import { AsyncPipe } from '@angular/common';
 
 @Component({
 	selector: 'tooltip-stories',
-	imports: [LuTooltipModule],
-	template: ` <h1>With ellipsis (should be green)</h1>
+	imports: [LuTooltipModule, AsyncPipe],
+	template: ` <h1>With ellipsis after few seconds</h1>
+		<div class="test ellipsis width400 fontSize2" luTooltip luTooltipWhenEllipsis>{{ dynamicContent$ | async }}</div>
+
+		<h1>With ellipsis (should be green)</h1>
 		<div class="test ellipsis width400 fontSize2" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
 		<div class="test ellipsis width400 paddingRight" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
 		<div class="test ellipsis width400 paddingLeft" luTooltip luTooltipWhenEllipsis>Lorem ipsum dolor sit amet consectetur adipisicing elit.</div>
@@ -94,7 +99,13 @@ import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 		`,
 	],
 })
-class TooltipStory {}
+class TooltipStory {
+	dynamicContent$ = interval(1000).pipe(
+		map((i) => {
+			return 'lorem '.repeat(i);
+		}),
+	);
+}
 
 export default {
 	title: 'Documentation/Overlays/Tooltip/Ellipsis tests',


### PR DESCRIPTION
## Description

It's not the perfect solution because we rely on Angular hook which isn't designed for this but the other, probably better approach, would be to use CDK's Observers module, which we cannot do without being breaking because a directive cannot bring in modules as imports and TooltipModule is deprecated in our public API.

-----

closes #3886

-----
