### PR TITLE
[schematics] handle breaking api cases & groups

### DIFF
--- a/packages/ng/schematics/lib/html-ast.ts
+++ b/packages/ng/schematics/lib/html-ast.ts
@@ -89,7 +89,7 @@ export class HtmlAstVisitor<TNode extends TemplateNode> {
 				}
 			} else if (node instanceof currentSchematicContext.angularCompiler.TmplAstSwitchBlock) {
 				if ('groups' in node) {
-					(node.groups as unknown[]).forEach((groupNode) => {
+					(node.groups as unknown[]).forEach((groupNode) => {
 						this.visit(cb, (groupNode as { children: TemplateNode[]}).children , node);
 					});
 				}


### PR DESCRIPTION
## Description

Since there is an API change on the Angular schematics side, we handle both types depending on the Angular version used. 

Therefore, there is no breaking change on our side, but we should remember to remove the cases line in the next breaking change.

-----



-----
