### PR TITLE
fix(popover): HTMLElement cannot be injected

### DIFF
--- a/packages/ng/popover2/popover-focus-trap.ts
+++ b/packages/ng/popover2/popover-focus-trap.ts
@@ -1,8 +1,7 @@
 import { FocusTrap, InteractivityChecker } from '@angular/cdk/a11y';
-import { inject, Injectable, NgZone } from '@angular/core';
 import { DOCUMENT } from '@angular/common';
+import { inject, NgZone } from '@angular/core';
 
-@Injectable()
 export class PopoverFocusTrap extends FocusTrap {
 	override startAnchorListener = () => {
 		this.triggerElement.focus();


### PR DESCRIPTION
## Description

Vitest is not happy with this one.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
