### PR TITLE
feat(file-entry): make file size and type optional

### DIFF
--- a/packages/ng/file-upload/file-entry/file-entry.component.html
+++ b/packages/ng/file-upload/file-entry/file-entry.component.html
@@ -9,10 +9,12 @@
 			</dd>
 		} @else {
 			<dd class="fileEntry-description">
-				<span class="fileEntry-description-format" luTooltip luTooltipWhenEllipsis>{{ fileTypeDisplay() }}</span
-				><span class="pr-u-mask"> – </span>
-				<lu-divider vertical />
-				<span class="fileEntry-description-size">{{ fileSizeDisplay() }}</span>
+				<span class="fileEntry-description-format" luTooltip luTooltipWhenEllipsis>{{ fileTypeDisplay() }}</span>
+				@if (fileSizeDisplay(); as fileSizeDisplay) {
+					<span class="pr-u-mask"> – </span>
+					<lu-divider vertical />
+					<span class="fileEntry-description-size">{{ fileSizeDisplay }}</span>
+				}
 			</dd>
 		}
 	}

--- a/packages/ng/file-upload/file-upload-entry.ts
+++ b/packages/ng/file-upload/file-upload-entry.ts
@@ -1,6 +1,6 @@
 export interface FileEntry {
 	name: string;
-	size: number;
-	type: string;
+	size?: number;
+	type?: string;
 	preview?: string;
 }

--- a/packages/ng/file-upload/multi/multi-file-upload.component.ts
+++ b/packages/ng/file-upload/multi/multi-file-upload.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/
 import { BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration';
 import { IntlParamsPipe } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
-import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.component';
 
 @Component({
@@ -13,7 +12,7 @@ import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.co
 	host: {
 		'[class.mod-structure]': 'structure()',
 	},
-	imports: [InputDirective, LuTooltipModule, IntlParamsPipe, BubbleIllustrationComponent],
+	imports: [InputDirective, IntlParamsPipe, BubbleIllustrationComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MultiFileUploadComponent extends BaseFileUploadComponent {}

--- a/packages/ng/file-upload/single/single-file-upload.component.ts
+++ b/packages/ng/file-upload/single/single-file-upload.component.ts
@@ -2,7 +2,6 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, output, Vi
 import { BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration';
 import { IntlParamsPipe } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
-import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.component';
 import { FileEntryComponent } from '../file-entry/file-entry.component';
 import { FileEntry } from '../file-upload-entry';
@@ -15,7 +14,7 @@ import { FileEntry } from '../file-upload-entry';
 	host: {
 		'[class.mod-structure]': 'structure()',
 	},
-	imports: [InputDirective, LuTooltipModule, FileEntryComponent, IntlParamsPipe, BubbleIllustrationComponent],
+	imports: [InputDirective, FileEntryComponent, IntlParamsPipe, BubbleIllustrationComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SingleFileUploadComponent extends BaseFileUploadComponent {

--- a/stories/documentation/forms/file-entry/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-entry/angular/basic.stories.ts
@@ -24,6 +24,20 @@ export default {
 		displayFileName: {
 			if: { arg: 'media', truthy: true },
 		},
+		withFileType: {
+			control: 'boolean',
+		},
+		fileType: {
+			control: 'text',
+			if: { arg: 'withFileType' },
+		},
+		withFileSize: {
+			control: 'boolean',
+		},
+		fileSize: {
+			control: 'number',
+			if: { arg: 'withFileSize' },
+		},
 	},
 	decorators: [
 		moduleMetadata({
@@ -41,7 +55,7 @@ export default {
 			template: `<lu-file-entry ${deletableParam} ${withPasswordParam} [entry]="{
 			name: '${fileName}',
 			size: ${fileSize},
-			type: '${fileType}',
+			type: ${fileType && `'${fileType}'`},
 		}"  ${generateInputs(otherArgs, argTypes)} />`,
 		};
 	},
@@ -53,7 +67,9 @@ export const Basic = {
 		displayFileName: false,
 		size: null,
 		fileSize: 28420,
+		withFileSize: true,
 		fileType: 'image/png',
+		withFileType: true,
 		fileName: 'dummyimage.png',
 		iconOverride: '',
 		previewUrl: 'https://dummyimage.com/500',


### PR DESCRIPTION
## Description

Allow use of file entry without file metadata like type and size. 
* If size is not provided, do not display it, and remove it from tooltip in small mode
* If type is not provided, fallback to file name extension.

-----

<img width="1200" height="106" alt="firefox_oOYMBrSeLC" src="https://github.com/user-attachments/assets/75f644f2-1f50-4d8f-95a2-0e5c1e374a1d" />


-----
