### PR TITLE
[mainLayout] fix focus

### DIFF
--- a/packages/ng/main-layout/main-layout.component.ts
+++ b/packages/ng/main-layout/main-layout.component.ts
@@ -10,6 +10,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncaps
 		class: 'mainLayout',
 		role: 'main',
 		id: 'main-content',
+		tabindex: '-1',
 	},
 })
 export class MainLayoutComponent {

--- a/packages/scss/src/components/mainLayout/component.scss
+++ b/packages/scss/src/components/mainLayout/component.scss
@@ -8,7 +8,7 @@
 	flex-direction: var(--components-mainLayout-flexDirection);
 	block-size: 100%;
 
-	&:target {
+	&:focus-visible {
 		position: relative;
 
 		&::after {


### PR DESCRIPTION
## Description

Here, we want:
- not to see the focus on tabulation
- to see it when focus is gained via skip links
- not to keep it when the anchor is activated

-----



-----
