### PR TITLE
fix(schematics): avoid crashing on self-closing tags

### DIFF
--- a/packages/ng/schematics/lu-container/migration.ts
+++ b/packages/ng/schematics/lu-container/migration.ts
@@ -2,7 +2,7 @@ import { Tree } from '@angular-devkit/schematics';
 import type { TmplAstElement } from '@angular/compiler';
 import { applyToUpdateRecorder } from '@schematics/angular/utility/change';
 import { SourceFile } from 'typescript';
-import { extractNgTemplatesIncludingHtml, HtmlAst, insertAngularImportIfNeeded, insertTSImportIfNeeded, isInterestingNode } from '../lib';
+import { extractNgTemplatesIncludingHtml,HtmlAst,insertAngularImportIfNeeded,insertTSImportIfNeeded,isInterestingNode } from '../lib';
 
 interface ContainerInputs {
 	center?: boolean;
@@ -54,8 +54,8 @@ export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tre
 					templateUpdate.insertRight(container.nodeOffset + container.node.startSourceSpan.start.offset + 1, thingsToAdd);
 					templateUpdate.insertLeft(container.nodeOffset + container.node.endSourceSpan.start.offset + 1, '/lu-container');
 				}
-				// self closing
-				else {
+				// without content
+				else if (!container.node.isSelfClosing) {
 					const endSpanOffset = container.node.endSourceSpan?.start.offset || -1;
 					templateUpdate.remove(container.nodeOffset + container.node.startSourceSpan.end.offset, endSpanOffset - container.node.startSourceSpan.end.offset);
 					if (container.node.endSourceSpan?.start?.offset) {

--- a/packages/ng/schematics/lu-loading/migration.ts
+++ b/packages/ng/schematics/lu-loading/migration.ts
@@ -59,8 +59,8 @@ export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tre
 					templateUpdate.insertRight(loading.nodeOffset + loading.node.startSourceSpan.start.offset + 1, thingsToAdd);
 					templateUpdate.insertLeft(loading.nodeOffset + loading.node.endSourceSpan.start.offset + 1, '/lu-loading');
 				}
-				// self closing
-				else {
+				// without closing
+				else if(!loading.node.isSelfClosing) {
 					const endSpanOffset = loading.node.endSourceSpan?.start.offset || -1;
 					templateUpdate.remove(loading.nodeOffset + loading.node.startSourceSpan.end.offset, endSpanOffset - loading.node.startSourceSpan.end.offset);
 					if (loading.node.endSourceSpan?.start?.offset) {


### PR DESCRIPTION
## Description

Fix the `end should be after start` error when attempting to migrate some self closing tags with `lu-loading` and `lu-container` schematics.

Kudos to @almonais for the report!

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
