### PR TITLE
fix(lu-box): add (killed) output for [killable]

### DIFF
--- a/packages/ng/box/box.component.html
+++ b/packages/ng/box/box.component.html
@@ -1,6 +1,6 @@
 @if (killable()) {
 	<div class="box-close">
-		<button luButton="ghost" type="button">
+		<button luButton="ghost" type="button" (click)="killed.emit()">
 			<lu-icon icon="signClose" alt="Close" />
 		</button>
 	</div>

--- a/packages/ng/box/box.component.ts
+++ b/packages/ng/box/box.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { IconComponent } from '@lucca-front/ng/icon';
 
@@ -24,4 +24,6 @@ export class BoxComponent {
 	readonly killable = input(false, { transform: booleanAttribute });
 
 	readonly withArrow = input(false, { transform: booleanAttribute });
+
+	readonly killed = output();
 }


### PR DESCRIPTION
## Description

`lu-box` has a nice `killable` input that allows the user to "kill" the box. But it's not plugged into anything. 

Until now.

-----

