### PR TITLE
fix(date-range): label not being considered as filled when not static

### DIFF
--- a/packages/ng/date2/date-range-input/date-range-input.component.html
+++ b/packages/ng/date2/date-range-input/date-range-input.component.html
@@ -1,7 +1,7 @@
 <fieldset class="dateRangeField-fieldset">
 	<legend>
 		<span class="pr-u-mask">
-			<ng-container *luPortal="label" />
+			<ng-container *luPortal="label()" />
 		</span>
 	</legend>
 	<div class="dateRangeField-fieldset-textField textField" #popoverAnchor>

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -14,6 +14,7 @@ import {
 	Injector,
 	input,
 	OnInit,
+	Signal,
 	signal,
 	viewChild,
 	viewChildren,
@@ -112,7 +113,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	widthAuto = input(false, { transform: booleanAttribute });
 
-	label: PortalContent;
+	label: Signal<PortalContent | undefined> = signal('');
 
 	popoverPositions: ConnectionPositionPair[] = [
 		new ConnectionPositionPair({ originX: 'start', originY: 'bottom' }, { overlayX: 'start', overlayY: 'top' }, -8, 0),
@@ -239,7 +240,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 		if (this.#formFieldRef) {
 			this.#formFieldRef.rolePresentationLabel.set(true);
-			this.label = this.#formFieldRef.label();
+			this.label = computed(() => this.#formFieldRef?.label());
 		}
 
 		effect(() => {


### PR DESCRIPTION
## Description

Label was causing a crash because we were trying to read it inside the constructor. With this reading operation being done on a `required` input, it was crashing when the value wasn't there before the constructor, which can only happen if the value is static.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
