### PR TITLE
[indexTable] fix checkbox alignement with angular wrapper

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -49,6 +49,12 @@
 			display: table-cell;
 			text-align: start;
 			font-weight: var(--pr-t-font-fontWeight-regular);
+
+			&:first-child {
+				.checkboxField {
+					--component-checkboxField-top: 0;
+				}
+			}
 		}
 
 		.indexTable-head-row-transparentCell,


### PR DESCRIPTION
## Description

Fix #4534 

-----



-----

<img width="794" height="211" alt="Capture d’écran 2026-02-23 à 17 58 20" src="https://github.com/user-attachments/assets/37c71478-04c2-4bc1-88bd-4754c800c3a6" />
