### PR TITLE
chore(user-popover): remove user-popover-is-activated feature flag

### DIFF
--- a/docs/user-popover.md
+++ b/docs/user-popover.md
@@ -1,16 +1,3 @@
-### Mise en place
-
-Afin de pouvoir installer la UserPopover, vous devez appeler la fonction `provideLuUserPopover` dans votre module racine.
-
-```typescript
-import { provideLuUserPopover } from '@lucca-front/ng/user-popover';
-
-@NgModule({
-  providers: [...provideLuUserPopover()],
-})
-export class AppModule {}
-```
-
 ### Utilisation
 
 Pour utiliser la UserPopover, il vous suffit d'utiliser la directive `[luUserPopover]` et de lui fournir un LuUser

--- a/packages/ng/user-popover/card/trigger/lu-user-popover.directive.ts
+++ b/packages/ng/user-popover/card/trigger/lu-user-popover.directive.ts
@@ -1,8 +1,7 @@
-import { Directive, inject, Input, input } from '@angular/core';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Directive, Input, input } from '@angular/core';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { ILuUser } from '@lucca-front/ng/user';
-import { LU_USER_POPOVER_USER, USER_POPOVER_IS_ACTIVATED } from '../../user-popover.providers';
+import { LU_USER_POPOVER_USER } from '../../user-popover.providers';
 import { LuUserPopoverComponent } from './user-popover.component';
 
 @Directive({
@@ -24,13 +23,7 @@ export class LuUserPopoverDirective extends PopoverDirective {
 
 	constructor() {
 		super();
-		// Default to disabled to avoid having it flicker or something
 		this.luPopoverDisabled = false;
-		inject(USER_POPOVER_IS_ACTIVATED)
-			.pipe(takeUntilDestroyed())
-			.subscribe((isActivated) => {
-				this.luPopoverDisabled = !isActivated;
-			});
 		this.customPositions = [
 			{ overlayX: 'start', overlayY: 'bottom', originX: 'start', originY: 'top' },
 			{ overlayX: 'start', overlayY: 'top', originX: 'start', originY: 'bottom' },

--- a/packages/ng/user-popover/user-popover.providers.ts
+++ b/packages/ng/user-popover/user-popover.providers.ts
@@ -1,23 +1,19 @@
 import { Observable, of } from 'rxjs';
-import { importProvidersFrom, inject, InjectionToken, makeEnvironmentProviders, Signal } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { catchError, map, shareReplay } from 'rxjs/operators';
-import { OverlayModule } from '@angular/cdk/overlay';
+import { InjectionToken, makeEnvironmentProviders, Signal } from '@angular/core';
 import { ILuUser } from '@lucca-front/ng/user';
 
 export const LU_USER_POPOVER_USER = new InjectionToken<Signal<ILuUser>>('user-popover-user');
 
+/**
+ * @deprecated no longer needed as popover is always activated
+ */
 export const USER_POPOVER_IS_ACTIVATED = new InjectionToken<Observable<boolean>>('user-popover-is-activated', {
-	factory: () =>
-		inject(HttpClient)
-			.get<{ key: string; status: string }>('/lucca-banner/meta/api/feature-flag-statuses/user-popover-is-activated')
-			.pipe(
-				map((flag) => flag.status === 'Enabled'),
-				catchError(() => of(false)),
-				shareReplay(1),
-			),
+	factory: () => of(true),
 });
 
+/**
+ * @deprecated no longer needed as user popover uses `luPopover2`
+ */
 export function provideLuUserPopover() {
-	return makeEnvironmentProviders([importProvidersFrom(OverlayModule)]);
+	return makeEnvironmentProviders([]);
 }

--- a/stories/documentation/listings/index-table/angular/actions.stories.ts
+++ b/stories/documentation/listings/index-table/angular/actions.stories.ts
@@ -16,7 +16,7 @@ import {
 import { PaginationComponent } from '@lucca-front/ng/pagination';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { LuUserDisplayModule } from '@lucca-front/ng/user';
-import { LuUserPopoverComponent, LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverComponent, LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { HiddenArgType } from 'stories/helpers/common-arg-types';
 
@@ -56,7 +56,7 @@ export default {
 			],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 } as Meta;

--- a/stories/documentation/listings/index-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/index-table/angular/basic.stories.ts
@@ -16,7 +16,7 @@ import {
 import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
 import { PaginationComponent } from '@lucca-front/ng/pagination';
 import { LuUserDisplayModule } from '@lucca-front/ng/user';
-import { LuUserPopoverComponent, LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverComponent, LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { HiddenArgType } from 'stories/helpers/common-arg-types';
 
@@ -130,7 +130,7 @@ export default {
 			],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 } as Meta;

--- a/stories/documentation/listings/index-table/html&css/index-table-actions-tooltipsRow.stories.ts
+++ b/stories/documentation/listings/index-table/html&css/index-table-actions-tooltipsRow.stories.ts
@@ -2,7 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { LuUserDisplayModule, LuUserPictureComponent } from '@lucca-front/ng/user';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 
 interface IndexTableActionsTooltipsRowStory {}
@@ -15,7 +15,7 @@ export default {
 			imports: [LuTooltipModule, LuUserPopoverDirective, LuUserDisplayModule, LuUserPictureComponent],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 } as Meta;

--- a/stories/documentation/listings/index-table/html&css/index-table-actions-userPopover.stories.ts
+++ b/stories/documentation/listings/index-table/html&css/index-table-actions-userPopover.stories.ts
@@ -2,7 +2,7 @@ import { bob } from '@/stories/users/user.mocks';
 import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { LuUserDisplayModule, LuUserPictureComponent } from '@lucca-front/ng/user';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 
 interface IndexTableActionsUserPopoverCellStory {}
@@ -15,7 +15,7 @@ export default {
 			imports: [LuUserPopoverDirective, LuUserDisplayModule, LuUserPictureComponent],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideLuUserPopover(), provideHttpClient()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 } as Meta;

--- a/stories/documentation/users/avatars/angular/basic.stories.ts
+++ b/stories/documentation/users/avatars/angular/basic.stories.ts
@@ -1,7 +1,7 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { LuDisplayInitials, LuUserPictureComponent } from '@lucca-front/ng/user';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { bob, georges, squidwards } from '../../user.mocks';
 
@@ -12,7 +12,7 @@ export default {
 			imports: [LuUserPictureComponent, LuUserPopoverDirective],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideHttpClient(), provideLuUserPopover()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 	render: ({ user, sizes, placeholder, displayFormat, AI }) => {

--- a/stories/documentation/users/display/with-popover.stories.ts
+++ b/stories/documentation/users/display/with-popover.stories.ts
@@ -3,7 +3,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { LuUserDisplayModule } from '@lucca-front/ng/user';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 
 export default {
@@ -13,7 +13,7 @@ export default {
 			imports: [LuUserPopoverDirective, LuUserDisplayModule, ButtonComponent],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideHttpClient(), provideLuUserPopover()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 	render: () => {

--- a/stories/documentation/users/popover/angular/popover.stories.ts
+++ b/stories/documentation/users/popover/angular/popover.stories.ts
@@ -2,7 +2,7 @@ import { provideHttpClient } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { ILuUser } from '@lucca-front/ng/user';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 
 @Component({
@@ -21,7 +21,7 @@ class UserPopoverStory {
 export default {
 	title: 'Documentation/Users/Popover/Angular',
 	component: UserPopoverStory,
-	decorators: [applicationConfig({ providers: [provideAnimations(), provideHttpClient(), provideLuUserPopover()] })],
+	decorators: [applicationConfig({ providers: [provideAnimations(), provideHttpClient()] })],
 	argsTypes: {
 		luUserPopover: { control: { type: 'object' } },
 		luUserPopoverEnterDelay: { control: { type: 'number' } },

--- a/stories/documentation/users/tile/angular/user-tile.stories.ts
+++ b/stories/documentation/users/tile/angular/user-tile.stories.ts
@@ -2,7 +2,7 @@ import { bob } from '@/stories/users/user.mocks';
 import { provideHttpClient } from '@angular/common/http';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { LuUserTileComponent } from '@lucca-front/ng/user';
-import { LuUserPopoverDirective, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+import { LuUserPopoverDirective } from '@lucca-front/ng/user-popover';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 
 export default {
@@ -12,7 +12,7 @@ export default {
 			imports: [LuUserTileComponent, LuUserPopoverDirective],
 		}),
 		applicationConfig({
-			providers: [provideAnimations(), provideHttpClient(), provideLuUserPopover()],
+			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
 	render: () => {


### PR DESCRIPTION
## Description

* Remove user-popover-is-activated feature flag (userPopover is always enabled)
* Deprecate `USER_POPOVER_IS_ACTIVATED` & `provideLuUserPopover()` as they are still in use in our codebase, but not needed anymore. Those providers now do nothing.

-----

-----
