### PR TITLE
feat(dialog/drawer): max S = fromBottom + maxContent

### DIFF
--- a/packages/scss/src/components/dialog/index.scss
+++ b/packages/scss/src/components/dialog/index.scss
@@ -48,8 +48,9 @@
 				@include fromBottom;
 			}
 
-			@include media.max('XXS') {
+			@include media.max('S') {
 				@include fromBottom;
+				@include maxContent;
 			}
 		}
 


### PR DESCRIPTION
## Description

On smaller screens (max S), drawer dialogs should open from the bottom and in full page.

-----

Test it here (resize below 800px) : https://lucca-front.lucca.tech/PR-4541/storybook/iframe.html?id=documentation-overlays-dialog-drawer--drawer&viewMode=story 

https://github.com/user-attachments/assets/89aebb08-dfad-4e22-8a88-80e1d14033dd

