### PR TITLE
fix(text-input): fix password visibility toggle

### DIFF
--- a/packages/ng/forms/text-input/text-input.component.html
+++ b/packages/ng/forms/text-input/text-input.component.html
@@ -30,7 +30,7 @@
 	<div class="textField-input">
 		<input
 			luInput
-			[type]="type()"
+			[type]="typeRef()"
 			[attr.autocomplete]="autocomplete() ? autocomplete() : null"
 			class="textField-input-value"
 			[placeholder]="placeholder()"

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -1,9 +1,9 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, input, linkedSignal, output, signal, viewChild, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, input, output, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { intlInputOptions } from '@lucca-front/ng/core';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 import { FormFieldIdDirective } from '../form-field-id.directive';
@@ -52,20 +52,14 @@ export class TextInputComponent {
 
 	readonly type = input<TextFieldType>('text');
 
-	readonly typeRef = linkedSignal(() => this.type());
-
 	// eslint-disable-next-line @angular-eslint/no-output-native
 	readonly blur = output<FocusEvent>();
 
 	protected showPassword = signal<boolean>(false);
 
-	protected hasTogglePasswordVisibilityIcon() {
-		return this.typeRef() === 'password';
-	}
+	protected typeRef = computed(() => (this.showPassword() ? 'text' : this.type()));
 
-	constructor() {
-		ɵeffectWithDeps([this.showPassword], (showPassword) => this.typeRef.set(showPassword ? 'text' : this.type()));
-	}
+	protected hasTogglePasswordVisibilityIcon = computed(() => this.type() === 'password');
 
 	clearValue(): void {
 		this.ngControl.reset();


### PR DESCRIPTION
## Description

Cette PR corrige trois problèmes actuels sur le composant TextInputComponent :
- Il y avait un problème de performance/réactivité dû au fait que la fonction `hasTogglePasswordVisibilityIcon()` était appelée directement depuis le template. Elle a été remplacée par un computed afin d’éviter des recalculs inutiles.
- `hasTogglePasswordVisibilityIcon` se basait sur `this.typeRef`, qui est mis à jour dynamiquement, ce qui cassait le comportement du bouton. La logique est désormais basée sur le signal Input `type`, qui reste la source de vérité.
- L’attribut `[type]` dans le template utilisait le signal input `type()` au lieu du signal `typeRef()` pour mettre à jour dynamiquement le type de l’input. Il utilise maintenant correctement `typeRef()`.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
