### PR TITLE
fix(time): show minutes, adding unit test and qa part in storybook

### DIFF
--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -1,9 +1,7 @@
 import { formatNumber } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ElementRef, Inject, LOCALE_ID, ModelSignal, ViewChild, booleanAttribute, computed, input, model, numberAttribute, output } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
 import { ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
-import { skip, take, tap } from 'rxjs';
 import { PickerControlDirection } from './misc.utils';
 import { RepeatOnHoldDirective } from './repeat-on-hold.directive';
 
@@ -100,13 +98,6 @@ export class TimePickerPartComponent {
 				}
 			}
 		});
-		toObservable(this.value)
-			.pipe(
-				skip(1),
-				tap(() => this.isValueSet.set(true)),
-				take(1),
-			)
-			.subscribe();
 	}
 
 	arrowKeyPressed(event: KeyboardEvent, isUpArrow: boolean): void {

--- a/packages/ng/time/duration-picker/duration-picker.component.spec.ts
+++ b/packages/ng/time/duration-picker/duration-picker.component.spec.ts
@@ -1,0 +1,117 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { DurationPickerComponent } from './duration-picker.component';
+
+@Component({
+	selector: 'lu-duration-picker-ngmodel-test',
+	imports: [DurationPickerComponent, FormFieldComponent, FormsModule],
+	template: `
+		<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+			<lu-duration-picker [(ngModel)]="value" />
+		</lu-form-field>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DurationPickerNgModelTestComponent {
+	value: string | null = null;
+}
+
+@Component({
+	selector: 'lu-duration-picker-formcontrol-test',
+	imports: [DurationPickerComponent, FormFieldComponent, ReactiveFormsModule],
+	template: `
+		<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+			<lu-duration-picker [formControl]="control" />
+		</lu-form-field>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DurationPickerFormControlTestComponent {
+	control = new FormControl<string | null>(null);
+}
+
+@Component({
+	selector: 'lu-duration-picker-formcontrol-max-test',
+	imports: [DurationPickerComponent, FormFieldComponent, ReactiveFormsModule],
+	template: `
+		<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+			<lu-duration-picker [formControl]="control" max="PT9999H" />
+		</lu-form-field>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DurationPickerFormControlMaxTestComponent {
+	control = new FormControl<string | null>(null);
+}
+
+const classSpan = '.timePicker-fieldset-group-textfield-display';
+
+function getDisplayTexts(fixture: ComponentFixture<unknown>): { hours: string; minutes: string } {
+	const inputs = (fixture.nativeElement as HTMLElement).querySelectorAll(classSpan);
+	expect(inputs.length).toBeGreaterThanOrEqual(2);
+	return {
+		hours: inputs[0].textContent ?? '',
+		minutes: inputs[1].textContent ?? '',
+	};
+}
+
+describe('DurationPickerComponent', () => {
+	it('should render with empty ngModel (null)', async () => {
+		const fixture = TestBed.createComponent(DurationPickerNgModelTestComponent);
+		fixture.componentInstance.value = null;
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('');
+		expect(minutes).toBe('');
+	});
+
+	it('should render with filled ngModel', async () => {
+		const fixture = TestBed.createComponent(DurationPickerNgModelTestComponent);
+		fixture.componentInstance.value = 'PT1H';
+		fixture.detectChanges();
+		await fixture.whenStable();
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('1');
+		expect(minutes).toBe('00');
+	});
+
+	it('should render with empty formControl (null)', async () => {
+		const fixture = TestBed.createComponent(DurationPickerFormControlTestComponent);
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('');
+		expect(minutes).toBe('');
+	});
+
+	it('should render with filled formControl', async () => {
+		const fixture = TestBed.createComponent(DurationPickerFormControlTestComponent);
+		fixture.componentInstance.control = new FormControl('PT1H');
+		fixture.detectChanges();
+		await fixture.whenStable();
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('1');
+		expect(minutes).toBe('00');
+	});
+
+	it('should render with 1000 hours when max allows it', async () => {
+		const fixture = TestBed.createComponent(DurationPickerFormControlMaxTestComponent);
+		fixture.componentInstance.control = new FormControl('PT1000H');
+		fixture.detectChanges();
+		await fixture.whenStable();
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('1000');
+		expect(minutes).toBe('00');
+	});
+});

--- a/packages/ng/time/duration-picker/duration-picker.component.ts
+++ b/packages/ng/time/duration-picker/duration-picker.component.ts
@@ -71,6 +71,10 @@ export class DurationPickerComponent extends BasePickerComponent {
 
 	writeValue(value: ISO8601Duration): void {
 		this.value.set(value || 'PT0S');
+		if (value) {
+			this.hoursPart()?.isValueSet.set(true);
+			this.minutesPart()?.isValueSet.set(true);
+		}
 	}
 
 	setDisabledState?(isDisabled: boolean): void {
@@ -165,8 +169,8 @@ export class DurationPickerComponent extends BasePickerComponent {
 		let hoursPart = getHoursPartFromDuration(protoEvent.value);
 		const minutesPart = getMinutesPartFromDuration(protoEvent.value);
 
-		this.hoursPart().isValueSet.set(true);
-		this.minutesPart().isValueSet.set(true);
+		this.hoursPart()?.isValueSet.set(true);
+		this.minutesPart()?.isValueSet.set(true);
 
 		if (hoursPart < 0) {
 			if (hoursPart === -1) {

--- a/packages/ng/time/time-picker/time-picker.component.spec.ts
+++ b/packages/ng/time/time-picker/time-picker.component.spec.ts
@@ -1,0 +1,106 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { TimePickerComponent } from './time-picker.component';
+
+@Component({
+	selector: 'lu-time-picker-ngmodel-test',
+	imports: [TimePickerComponent, FormFieldComponent, FormsModule],
+	template: `
+		<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+			<lu-time-picker [(ngModel)]="value" />
+		</lu-form-field>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TimePickerNgModelTestComponent {
+	value: string | null = null;
+}
+
+@Component({
+	selector: 'lu-time-picker-formcontrol-test',
+	imports: [TimePickerComponent, FormFieldComponent, ReactiveFormsModule],
+	template: `
+		<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+			<lu-time-picker [formControl]="control" />
+		</lu-form-field>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TimePickerFormControlTestComponent {
+	control = new FormControl<string | null>(null);
+}
+
+const classSpan = '.timePicker-fieldset-group-textfield-display';
+
+function getDisplayTexts(fixture: ComponentFixture<unknown>): { hours: string; minutes: string } {
+	const inputs = (fixture.nativeElement as HTMLElement).querySelectorAll(classSpan);
+	expect(inputs.length).toBeGreaterThanOrEqual(2);
+	return {
+		hours: inputs[0].textContent ?? '',
+		minutes: inputs[1].textContent ?? '',
+	};
+}
+
+describe('TimePickerComponent', () => {
+	it('should render with empty ngModel (null)', async () => {
+		const fixture = TestBed.createComponent(TimePickerNgModelTestComponent);
+		fixture.componentInstance.value = null;
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('––');
+		expect(minutes).toBe('––');
+	});
+
+	it('should render with filled ngModel', async () => {
+		const fixture = TestBed.createComponent(TimePickerNgModelTestComponent);
+		fixture.componentInstance.value = '12:30:00';
+		fixture.detectChanges();
+		await fixture.whenStable();
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('12');
+		expect(minutes).toBe('30');
+	});
+
+	it('should render with empty formControl (null)', async () => {
+		const fixture = TestBed.createComponent(TimePickerFormControlTestComponent);
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('––');
+		expect(minutes).toBe('––');
+	});
+
+	it('should render with filled formControl', async () => {
+		const fixture = TestBed.createComponent(TimePickerFormControlTestComponent);
+		fixture.componentInstance.control = new FormControl('12:30:00');
+		fixture.detectChanges();
+		await fixture.whenStable();
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('12');
+		expect(minutes).toBe('30');
+	});
+
+	it('should display 00 for minutes after typing hours', async () => {
+		const fixture = TestBed.createComponent(TimePickerNgModelTestComponent);
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		const hoursInput = (fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset-group-textfield-input') as HTMLInputElement;
+		hoursInput.value = '5';
+		hoursInput.dispatchEvent(new InputEvent('input', { data: '5', inputType: 'insertText', bubbles: true }));
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		expect(hours).toBe('5');
+		expect(minutes).toBe('00');
+	});
+});

--- a/packages/ng/time/time-picker/time-picker.component.ts
+++ b/packages/ng/time/time-picker/time-picker.component.ts
@@ -111,6 +111,10 @@ export class TimePickerComponent extends BasePickerComponent {
 
 	writeValue(value: ISO8601Time): void {
 		this.value.set(value || '––:––:––');
+		if (value) {
+			this.hoursPart()?.isValueSet.set(true);
+			this.minutesPart()?.isValueSet.set(true);
+		}
 	}
 
 	setDisabledState?(isDisabled: boolean): void {
@@ -196,6 +200,9 @@ export class TimePickerComponent extends BasePickerComponent {
 	private setTime(protoEvent: TimeChangeEvent): void {
 		const hoursPart = getHoursPartFromIsoTime(protoEvent.value);
 		const minutesPart = getMinutesPartFromIsoTime(protoEvent.value);
+
+		this.hoursPart()?.isValueSet.set(true);
+		this.minutesPart()?.isValueSet.set(true);
 
 		const max = isoTimeToSeconds(this.max());
 

--- a/stories/qa/time/time.stories.html
+++ b/stories/qa/time/time.stories.html
@@ -1,0 +1,96 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">lu-duration-picker</div>
+			</td>
+		</tr>
+		<tr>
+			<td>ngModel empty</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-duration-picker [(ngModel)]="emptyDuration" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>ngModel filled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-duration-picker [(ngModel)]="filledDuration" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>formControl empty</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-duration-picker [formControl]="emptyDurationControl" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>formControl filled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-duration-picker [formControl]="filledDurationControl" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>formControl filled 1000h</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-duration-picker [formControl]="filledDuration1000hControl" max="PT9999H" />
+				</lu-form-field>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">lu-time-picker</div>
+			</td>
+		</tr>
+		<tr>
+			<td>ngModel empty</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-time-picker [(ngModel)]="emptyTime" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>ngModel filled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-time-picker [(ngModel)]="filledTime" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>formControl empty</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-time-picker [formControl]="emptyTimeControl" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>formControl filled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-time-picker [formControl]="filledTimeControl" />
+				</lu-form-field>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/time/time.stories.ts
+++ b/stories/qa/time/time.stories.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { Meta } from '@storybook/angular';
+import { DurationPickerComponent, TimePickerComponent } from '@lucca-front/ng/time';
+
+@Component({
+	selector: 'time-stories',
+	templateUrl: './time.stories.html',
+	imports: [DurationPickerComponent, FormFieldComponent, FormsModule, ReactiveFormsModule, TimePickerComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TimeStory {
+	emptyDuration = null;
+	filledDuration = 'PT1H';
+	emptyDurationControl = new FormControl(null);
+	filledDurationControl = new FormControl('PT1H');
+	filledDuration1000hControl = new FormControl('PT1000H');
+	emptyTime = null;
+	filledTime = '12:30:00';
+	emptyTimeControl = new FormControl(null);
+	filledTimeControl = new FormControl('12:30:00');
+}
+
+export default {
+	title: 'QA/Time',
+	component: TimeStory,
+} as Meta;
+
+export const Basic = {};


### PR DESCRIPTION
## Description

Cette PR corrige l'absence des minutes lorsqu'on a un champ `lu-duration-picker` ou `lu-time-picker` pré-rempli.
Elle ajoute des tests unitaires et une section dans la QA avec différents exemples.

<img width="1395" height="1012" alt="image" src="https://github.com/user-attachments/assets/0a2225d1-42c1-4be7-9933-6de4ad62d1af" />

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
