### PR TITLE
chore: Upgrade Stylelint to v17.4.0.

### DIFF
--- a/.storybook/public/mockServiceWorker.js
+++ b/.storybook/public/mockServiceWorker.js
@@ -7,10 +7,10 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.7';
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82';
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.12.7'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
 addEventListener('install', function () {
   self.skipWaiting()

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
         "prettier": "^3.5.1",
         "sass": "^1.62.1",
         "storybook": "^10.1.9",
-        "stylelint": "^17.3.0",
+        "stylelint": "^17.4.0",
         "ts-node": "~10.9.1",
         "typescript": "5.9.3",
         "typescript-eslint": "^8.49.0"
@@ -14639,13 +14639,13 @@
       }
     },
     "node_modules/css-functions-list": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.2.3.tgz",
-      "integrity": "sha512-IQOkD3hbR5KrN93MtcYuad6YPuTSUhntLHDuLEbFWE+ff2/XSZNdZG+LcbbIW5AXKg/WFIfYItIzVoHngHXZzA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+      "integrity": "sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12 || >=16"
+        "node": ">=12"
       }
     },
     "node_modules/css-loader": {
@@ -32066,9 +32066,9 @@
       }
     },
     "node_modules/stylelint": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.3.0.tgz",
-      "integrity": "sha512-1POV91lcEMhj6SLVaOeA0KlS9yattS+qq+cyWqP/nYzWco7K5jznpGH1ExngvPlTM9QF1Kjd2bmuzJu9TH2OcA==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-17.4.0.tgz",
+      "integrity": "sha512-3kQ2/cHv3Zt8OBg+h2B8XCx9evEABQIrv4hh3uXahGz/ZEHrTR80zxBiK2NfXNaSoyBzxO1pjsz1Vhdzwn5XSw==",
       "dev": true,
       "funding": [
         {
@@ -32085,15 +32085,14 @@
       "dependencies": {
         "@csstools/css-calc": "^3.1.1",
         "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.27",
         "@csstools/css-tokenizer": "^4.0.0",
         "@csstools/media-query-list-parser": "^5.0.0",
         "@csstools/selector-resolve-nested": "^4.0.0",
         "@csstools/selector-specificity": "^6.0.0",
-        "balanced-match": "^3.0.1",
         "colord": "^2.9.3",
         "cosmiconfig": "^9.0.0",
-        "css-functions-list": "^3.2.3",
+        "css-functions-list": "^3.3.3",
         "css-tree": "^3.1.0",
         "debug": "^4.4.3",
         "fast-glob": "^3.3.3",
@@ -32107,7 +32106,6 @@
         "import-meta-resolve": "^4.2.0",
         "imurmurhash": "^0.1.4",
         "is-plain-object": "^5.0.0",
-        "known-css-properties": "^0.37.0",
         "mathml-tag-names": "^4.0.0",
         "meow": "^14.0.0",
         "micromatch": "^4.0.8",
@@ -32408,16 +32406,6 @@
       },
       "peerDependencies": {
         "postcss-selector-parser": "^7.1.1"
-      }
-    },
-    "node_modules/stylelint/node_modules/balanced-match": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-3.0.1.tgz",
-      "integrity": "sha512-vjtV3hiLqYDNRoiAv0zC4QaGAMPomEoq83PRmYIofPswwZurCeWR5LByXm7SyoL0Zh5+2z0+HC7jG8gSZJUh0w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/stylelint/node_modules/file-entry-cache": {
@@ -36888,7 +36876,7 @@
       "peerDependencies": {
         "@stylistic/stylelint-config": "^4.0.0",
         "@stylistic/stylelint-plugin": "^5.0.1",
-        "stylelint": "^17.3.0",
+        "stylelint": "^17.4.0",
         "stylelint-config-standard-scss": "^17.0.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "prettier": "^3.5.1",
     "sass": "^1.62.1",
     "storybook": "^10.1.9",
-    "stylelint": "^17.3.0",
+    "stylelint": "^17.4.0",
     "ts-node": "~10.9.1",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.49.0"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@stylistic/stylelint-config": "^4.0.0",
     "@stylistic/stylelint-plugin": "^5.0.1",
-    "stylelint": "^17.3.0",
+    "stylelint": "^17.4.0",
     "stylelint-config-standard-scss": "^17.0.0"
   }
 }


### PR DESCRIPTION
## Description

[Stylelint was just updated](https://github.com/stylelint/stylelint/releases/tag/17.4.0) to fix bugs, improve performance and add some options.

`npm run stylelint:fix` was run for this PR.

-----
