### PR TITLE
fix(richtext): resolve race condition between child nodes and rte

### DIFF
--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -5,7 +5,7 @@ import {
 	Component,
 	computed,
 	contentChildren,
-	effect,
+	afterRenderEffect,
 	ElementRef,
 	forwardRef,
 	inject,
@@ -99,12 +99,12 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 	#editor?: LexicalEditor;
 
 	constructor() {
-		effect(() => {
+		afterRenderEffect(() => {
 			if (this.#formField?.presentation() && this.contentPresentation()) {
-				this.#editor?.setRootElement(this.contentPresentation()?.nativeElement);
+				this.#editor?.setRootElement(this.contentPresentation()?.nativeElement ?? null);
 				this.#editor?.setEditable(false);
 			} else if (this.content()) {
-				this.#editor?.setRootElement(this.content()?.nativeElement);
+				this.#editor?.setRootElement(this.content()?.nativeElement ?? null);
 				this.#editor?.setEditable(true);
 			}
 		});


### PR DESCRIPTION
## Description

Resolve a race condition on navigator refresh where LinkNode has no templateRef and crash

-----

`effect()` s'exécute pendant le change detection, dans l'ordre de création : le parent d'abord, les enfants ensuite
L'effect parent appelait `setRootElement()` → Lexical reconciliait l'état → `createDOM()` sur les link nodes → mais le `TemplateRef` du `LinkComponent`(content child) n'était pas encore set car son effect n'avait pas encore tourné
`afterRenderEffect()` s'exécute après la phase de rendu complète, donc après que tous les `effect()` enfants (dont celui qui set le `TemplateRef` ont tourné

-----
