### PR TITLE
[navside] fix overflow wrap

### DIFF
--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -31,7 +31,7 @@
 		color: var(--components-navSide-compact-palette-text);
 		font-size: var(--components-navSide-compact-font-size);
 		padding-block: var(--pr-t-spacings-150);
-		padding-inline: var(--pr-t-spacings-100);
+		padding-inline: var(--pr-t-spacings-50);
 		flex-direction: column;
 		justify-content: center;
 		position: relative;


### PR DESCRIPTION
## Description

Smaller padding to handle words such as ‘Organigramme’ which previously did not wrap to the next line.

-----



-----


Before:
<img width="125" height="309" alt="Capture d’écran 2026-03-02 à 15 15 27" src="https://github.com/user-attachments/assets/c2c509bc-f58a-41e8-85e2-35664d15209a" />

After:
<img width="127" height="306" alt="Capture d’écran 2026-03-02 à 15 15 33" src="https://github.com/user-attachments/assets/29512adc-c83b-43fb-aff0-5c32babae313" />


