### PR TITLE
fix(rich-text-input): fix caret position when adding tag in last position

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
@@ -128,7 +128,7 @@ export class TagNode extends DecoratorNode<string> {
 	}
 
 	override updateDOM(prevNode: TagNode, _dom: HTMLElement, _config: EditorConfig): boolean {
-		return this.#tagDescription !== prevNode.#tagDescription || this.#tagKey !== prevNode.#tagKey || this.#disabled !== prevNode.#disabled || this.#componentRef !== prevNode.#componentRef;
+		return this.#tagDescription !== prevNode.#tagDescription || this.#tagKey !== prevNode.#tagKey || this.#disabled !== prevNode.#disabled;
 	}
 
 	override remove(preserveEmptyParent?: boolean): void {


### PR DESCRIPTION
## Description

Fix caret position when adding tag in last position

-----

I think we forgot to clean all the amendments we made when debugging presentation mode, as `#componentRef` is not part of tag node metadata and its changes should not be listened to. 

-----

![firefox_rzHPLxxqOr](https://github.com/user-attachments/assets/95aba953-ffc2-4419-876b-5f9ef8b758a0)
![firefox_lYKyERfanp](https://github.com/user-attachments/assets/1e5e8a96-1967-4bc2-9b38-4919fbc77ef9)

