### PR TITLE
fix: Deprecated selectors

### DIFF
--- a/packages/stylelint-config/LFDeprecatedSelectors.mjs
+++ b/packages/stylelint-config/LFDeprecatedSelectors.mjs
@@ -68,8 +68,9 @@ export default [
 		versionDeprecated: '18.2.0',
 		versionDeleted: '20.1.0',
 	},
+	// SEE https://regex101.com/r/1EfDam
 	{
-		objectPattern: [/\.table-head-row-cell-sortableButton/, /\.indexTable-head-row-cell-sortableButton/],
+		objectPattern: [/\.(indexT|t)able-head-row-cell-sortableButton/],
 		versionDeprecated: '18.2.0',
 		versionDeleted: '20.1.0',
 	},


### PR DESCRIPTION
## Description

* Some selectors were missing the period making them class selectors.
* String patterns only match full selector, not part of it, which won’t work for combined selectors. We broaden the scope to lint combinations of selectors.
-----
