### PR TITLE
[fancyBox] Move mod-S in layer

### DIFF
--- a/packages/scss/src/components/fancyBox/index.scss
+++ b/packages/scss/src/components/fancyBox/index.scss
@@ -11,9 +11,9 @@
 		@include media.max('XS') {
 			@include narrow;
 		}
-	}
 
-	&.mod-S {
-		@include S;
+		&.mod-S {
+			@include S;
+		}
 	}
 }


### PR DESCRIPTION
## Description

We can’t use `@layer product` currently.

Moving the mod within `@layer mods` should allow that, and avoid having to use `!important`.

-----
