### PR TITLE
fix(date2): sync tabbableDate in DateInputComponent writeValue and reset

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -355,6 +355,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 			this.dateFromWriteValue.set(start);
 			this.selectedDate.set(start);
 			this.currentDate.set(start);
+			this.tabbableDate.set(start);
 		} else {
 			this.reset();
 		}
@@ -375,6 +376,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		const newValue = this.clearBehavior() === 'reset' ? this.initialValue() : null;
 		this.dateFromWriteValue.set(newValue);
 		this.selectedDate.set(newValue);
+		this.tabbableDate.set(newValue);
 		return newValue;
 	}
 


### PR DESCRIPTION
## Description

`DateInputComponent.writeValue()` updates `currentDate`, `selectedDate`, and `dateFromWriteValue` but does **not** update `tabbableDate`.

`tabbableDate` is initialized to `null` in `AbstractDateComponent`, then set to `new Date()` by `Calendar2Component`'s initialization effect. After that, `writeValue()` never updates it. This causes a desync between `currentDate` and `tabbableDate` when the written value is in a different year than `new Date()`.

On the first `move()` call (prev/next navigation), both signals are shifted by the same delta, but `tabbableDate` ends up in a different period than `currentDate`. The `_effectWithDeps([calendarMode, tabbableDate])` effect then detects the mismatch and snaps `currentDate` to `startOfPeriod(calendarMode, tabbableDate)`, making the calendar jump to the wrong year.

-----

**Example (mode `month`, today = 2026-03-10):**
1. `writeValue('2025-01-01')` → `currentDate` = Jan 2025, `tabbableDate` = Mar 2026
2. Click next → `move(1, 'month')` → `currentDate` = Jan 2026, `tabbableDate` = Mar 2027
3. Effect detects `isSameYear(2027, 2026) === false` → snaps `currentDate` to `startOfYear(2027)` = Jan 2027
4. Calendar skips 2026 entirely

**Fix:** Set `tabbableDate` in `writeValue()` alongside `currentDate`.

## How to test

1. Use a `DateInputComponent` with `mode="month"` bound via `ngModel` to a date in a **different year** than today (e.g., `2025-01-01` while today is in 2026)
2. Open the calendar — it should display 2025
3. Click the "next" arrow once — should display **2026** (not 2027)
4. Click "prev" — should go back to 2025
5. Repeat with a future year (e.g., `2027-06-01`), click "prev" — should display **2026** (not 2025)
6. Verify that a date in the **same year** as today still navigates correctly

-----
