### PR TITLE
fix: Use consistent widths for mod-form:

### DIFF
--- a/packages/scss/src/components/grid/mods.scss
+++ b/packages/scss/src/components/grid/mods.scss
@@ -14,7 +14,7 @@
 
 @mixin form {
 	--grid-columns: 4;
-	--grid-maxWidth: 40rem;
+	--grid-maxWidth: 50rem;
 }
 
 @mixin dense {


### PR DESCRIPTION
## Description

- Our Design System mentions forms should be `800px` max.
- LF is using `40rem`.
- We change to `50rem` (`800px` with a `16px` equivalence).

-----

See https://prisme.lucca.io/94310e217/p/53a634-conception-dun-formulaire#:~:text=La%20largeur%20maximum%20du%20formulaire%20est%20de%20800px%2E.

-----
