### PR TITLE
[Toasts] fix max inline size for narrow viewports

### DIFF
--- a/packages/scss/src/components/toast/vars.scss
+++ b/packages/scss/src/components/toast/vars.scss
@@ -5,7 +5,7 @@
 	--components-toasts-left: var(--pr-t-spacings-300);
 	--components-toasts-bottom: var(--pr-t-spacings-300);
 	--components-toasts-margin-bottom: var(--pr-t-spacings-50);
-	--components-toasts-maxwidth: 22.5rem;
+	--components-toasts-maxwidth: min(22.5rem, calc(100dvw - (var(--components-toasts-right) * 2)));
 	--components-toasts-inset: var(--components-toasts-top) var(--components-toasts-right) auto auto;
 	--components-toasts-footerHeight: 4.5rem;
 


### PR DESCRIPTION
## Description



-----



-----
Before:
<img width="369" height="206" alt="Capture d’écran 2026-03-13 à 12 05 16" src="https://github.com/user-attachments/assets/cbb5e0f6-7fb0-4be4-a45f-d6802a6fe894" />

After:
<img width="356" height="174" alt="Capture d’écran 2026-03-13 à 12 05 50" src="https://github.com/user-attachments/assets/88334750-1093-4c17-852c-30e22f754831" />
