### PR TITLE
[dialog] fix dialog stacked

### DIFF
--- a/packages/ng/dialog/dialog/dialog.component.ts
+++ b/packages/ng/dialog/dialog/dialog.component.ts
@@ -28,7 +28,7 @@ export class DialogComponent implements AfterViewInit {
 
 	ngAfterViewInit(): void {
 		if (this.stacked()) {
-			this.dialogRef.cdkRef.overlayRef.addPanelClass('mod-stacked');
+			this.dialogRef.cdkRef.overlayRef.backdropElement?.parentElement?.classList.add('mod-stacked');
 		}
 
 		if (this.dialogRef.config.autoFocus === 'first-input' && !this.dialogRef.config.cdkConfigOverride?.autoFocus) {

--- a/packages/ng/styles/components/cdk/_global.scss
+++ b/packages/ng/styles/components/cdk/_global.scss
@@ -3,18 +3,16 @@
 
 @mixin stacked($level) {
   $selector: '';
-  $string: '~ .cdk-global-overlay-wrapper';
+  $string: '~ .cdk-global-overlay-wrapper.mod-stacked';
 
 	@for $i from 1 through $level {
     $selector: $selector + $string;
   }
 
   &:has(#{$selector}) {
-      .dialog {
-				&.mod-stacked {
-					--components-dialog-level: #{$level};
-				}
-			}
+		.dialog {
+			--components-dialog-level: #{$level};
+		}
   }
 }
 
@@ -28,8 +26,10 @@
 	position: absolute;
 	z-index: 1000;
 
-	@for $i from 1 through 3 {
-		@include stacked($i);
+	&.mod-stacked {
+		@for $i from 1 through 3 {
+			@include stacked($i);
+		}
 	}
 }
 

--- a/packages/scss/src/components/dialog/index.scss
+++ b/packages/scss/src/components/dialog/index.scss
@@ -64,9 +64,5 @@
 		&:has(.dialog-inside-header-actionOptional:not(:empty)) {
 			@include withAction;
 		}
-
-		&.mod-stacked {
-			@include stacked;
-		}
 	}
 }

--- a/packages/scss/src/components/dialog/mods.scss
+++ b/packages/scss/src/components/dialog/mods.scss
@@ -94,7 +94,3 @@
 	--components-dialog-insideHeaderAreas: 'container action close';
 	--components-dialog-insideHeaderColumns: 1fr auto auto;
 }
-
-@mixin stacked {
-
-}


### PR DESCRIPTION
## Description

The mod-stacked element has been moved from the dialogs to their overlays so that its absence can be detected using CSS.

-----



-----

![2026-03-17 10 37 03](https://github.com/user-attachments/assets/e5d336c7-3588-42ff-9359-ceeaa15ff95e)
