### PR TITLE
[timeline] fix number L mod

### DIFF
--- a/packages/scss/src/components/timeline/mods.scss
+++ b/packages/scss/src/components/timeline/mods.scss
@@ -174,8 +174,9 @@
 }
 
 @mixin numberL {
-	.timeline-step-title::after {
-		font-size: var(--pr-t-font-body-S-fontSize);
+	.timeline-step-title::after,
+	.timeline-step-title::before {
+		font-size: var(--pr-t-font-body-S-fontSize) !important;
 	}
 }
 


### PR DESCRIPTION
## Description

Fix #4447 

-----



-----

After:
<img width="910" height="63" alt="Capture d’écran 2026-03-18 à 10 23 22" src="https://github.com/user-attachments/assets/dc670e0a-6c68-4aff-afbb-76c8d58b7834" />

