### PR TITLE
Fix miss-spelled attribute:

### DIFF
--- a/packages/ng/resource-card/resource-card.component.html
+++ b/packages/ng/resource-card/resource-card.component.html
@@ -16,7 +16,7 @@
 		<div class="resourceCard-layout-before-illustration"><ng-content select="[resourceCardIllustration]" /></div>
 	</div>
 	<header class="resourceCard-layout-header">
-		<div class="resourceCard-layout-header-title" role="heading" [attr.level]="headingLevel()"><ng-content /></div>
+		<div class="resourceCard-layout-header-title" role="heading" [attr.aria-level]="headingLevel()"><ng-content /></div>
 		<div class="resourceCard-layout-header-infos"><ng-content select="[resourceCardInfos]" /></div>
 	</header>
 	<div class="resourceCard-layout-after"><ng-content select="[resourceCardAction]" /></div>


### PR DESCRIPTION
## Description

While implementing resource cards, I noticed the document outline was not matching what was requested in the `headingLevel` directive.

The [combination](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/heading_role) is `role="heading"` and `aria-level="[1-6]"`.

-----
