### PR TITLE
fix(user-picture): fallback to pictureHref on picture.href load error

### DIFF
--- a/packages/ng/user/picture/user-picture.component.ts
+++ b/packages/ng/user/picture/user-picture.component.ts
@@ -74,12 +74,9 @@ export class LuUserPictureComponent {
 	readonly initials = computed(() => luUserDisplay(this.user(), this.displayFormat()));
 	readonly modSize = computed(() => `mod-${this.size()}`);
 	readonly hasPicture = linkedSignal(() => isNotNilOrEmptyString(this.pictureHref()));
-	readonly pictureHref = computed(() => {
+	readonly pictureHref = linkedSignal(() => {
 		const user = this.user();
-		if (user) {
-			return user?.picture?.href || user?.pictureHref;
-		}
-		return null;
+		return user?.picture?.href || user?.pictureHref || null;
 	});
 	readonly style = linkedSignal(() => {
 		if (!this.hasPicture()) {
@@ -98,6 +95,15 @@ export class LuUserPictureComponent {
 	});
 
 	pictureError() {
+		const user = this.user();
+		const currentHref = this.pictureHref();
+		const fallbackHref = user?.pictureHref;
+
+		if (isNotNilOrEmptyString(fallbackHref) && fallbackHref !== currentHref) {
+			this.pictureHref.set(fallbackHref);
+			return;
+		}
+
 		this.hasPicture.set(false);
 		const hsl = this.#getNameHue();
 		this.style.set({ 'background-color': `hsl(${hsl}, 60%, 60%)` });


### PR DESCRIPTION
## Description

`lu-user-picture`: fall back to `pictureHref` when `picture.href` fails to load.

-----

When a user object has both `picture.href` (broken/inaccessible URL from the API model) and `pictureHref` (valid URL set by `addEmployeePictureUrl`), the component would attempt `picture.href`, fail, and immediately show initials — never trying `pictureHref`.

Now `pictureError()` checks whether `pictureHref` is available as a fallback before giving up:
1. First attempt: `picture.href`
2. On error → retry with `pictureHref`
3. On second error → show initials

`pictureHref` is changed from `computed` to `linkedSignal` so it can be overridden on image load error.