### PR TITLE
fix: handle local files for illustrations

### DIFF
--- a/packages/ng/bubble-illustration/bubble-illustration.component.ts
+++ b/packages/ng/bubble-illustration/bubble-illustration.component.ts
@@ -23,7 +23,7 @@ export class BubbleIllustrationComponent {
 	readonly action = input(false, { transform: booleanAttribute });
 
 	readonly illustrationUrl = computed(() => {
-		if (this.illustration().startsWith('https://')) {
+		if (this.illustration().startsWith('https://') || this.illustration().startsWith('/')) {
 			return this.illustration();
 		}
 		return `${this.domain}${this.path}${this.illustration()}${this.extension}`;


### PR DESCRIPTION
## Description

When using project static files, we should not use `https://domain` but `/project/static/file.svg` directly.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
