### PR TITLE
feat(LuTitleStrategy): add `readTitleByLiveAnnouncer` option

### DIFF
--- a/packages/ng/title/title.strategy.spec.ts
+++ b/packages/ng/title/title.strategy.spec.ts
@@ -1,3 +1,4 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { Location } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
@@ -82,11 +83,13 @@ export class OverrideTitlePartComponent implements OnInit {
 describe('TitleStrategy', () => {
 	let spectator: SpectatorRouting<AppComponent>;
 	let pageTitleService: LuTitleStrategy;
+	let liveAnnouncer: LiveAnnouncer;
 
 	const createComponent = createRoutingFactory({
 		component: AppComponent,
 		providers: [
 			mockProvider(Title),
+			mockProvider(LiveAnnouncer),
 			provideLuTitleStrategy({
 				appTitle: () => 'BU',
 				translateService: () => new TranslateService(),
@@ -152,6 +155,7 @@ describe('TitleStrategy', () => {
 
 	beforeEach(() => {
 		spectator = createComponent();
+		liveAnnouncer = spectator.inject(LiveAnnouncer);
 		pageTitleService = spectator.inject(TitleStrategy) as unknown as LuTitleStrategy;
 	});
 
@@ -220,5 +224,98 @@ describe('TitleStrategy', () => {
 		spectator.click('.link-7');
 		await spectator.fixture.whenStable();
 		expect(resultTitle).toEqual(`Stubs' child Name 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
+	});
+
+	it('should not announce title via LiveAnnouncer when not enabled', async () => {
+		await spectator.fixture.whenStable();
+		expect(liveAnnouncer.announce).not.toHaveBeenCalled();
+	});
+});
+
+describe('TitleStrategy readTitleByLiveAnnouncer enabled', () => {
+	let spectator: SpectatorRouting<AppComponent>;
+	let liveAnnouncer: LiveAnnouncer;
+
+	const createComponent = createRoutingFactory({
+		component: AppComponent,
+		providers: [
+			mockProvider(Title),
+			mockProvider(LiveAnnouncer),
+			provideLuTitleStrategy({
+				appTitle: () => 'BU',
+				translateService: () => new TranslateService(),
+				readTitleByLiveAnnouncer: true,
+			}),
+		],
+		stubsEnabled: false,
+		routes: [
+			{
+				path: '',
+				title: 'Stub',
+				component: StubComponent,
+				children: [
+					{
+						path: 'first',
+						component: StubComponent,
+						children: [
+							{
+								path: ':id',
+								title: `Stubs' child {{id}}`,
+								component: StubComponent,
+							},
+						],
+					},
+				],
+			},
+		],
+	});
+
+	beforeEach(() => {
+		spectator = createComponent();
+		liveAnnouncer = spectator.inject(LiveAnnouncer);
+	});
+
+	it('should announce the title via LiveAnnouncer on navigation', async () => {
+		await spectator.fixture.whenStable();
+		expect(liveAnnouncer.announce).toHaveBeenCalledWith(`Stub${TitleSeparator}Lucca BU`, 'polite');
+	});
+
+	it('should announce updated title on subsequent navigation', async () => {
+		await spectator.fixture.whenStable();
+		jest.clearAllMocks();
+
+		spectator.click('.link-3');
+		await spectator.fixture.whenStable();
+		expect(liveAnnouncer.announce).toHaveBeenCalledWith(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`, 'polite');
+	});
+});
+
+describe('TitleStrategy readTitleByLiveAnnouncer disabled', () => {
+	let spectator: SpectatorRouting<AppComponent>;
+	let liveAnnouncer: LiveAnnouncer;
+
+	const createComponent = createRoutingFactory({
+		component: AppComponent,
+		providers: [
+			mockProvider(Title),
+			mockProvider(LiveAnnouncer),
+			provideLuTitleStrategy({
+				appTitle: () => 'BU',
+				translateService: () => new TranslateService(),
+				readTitleByLiveAnnouncer: false,
+			}),
+		],
+		stubsEnabled: false,
+		routes: [{ path: '', title: 'Stub', component: StubComponent }],
+	});
+
+	beforeEach(() => {
+		spectator = createComponent();
+		liveAnnouncer = spectator.inject(LiveAnnouncer);
+	});
+
+	it('should not announce title via LiveAnnouncer when disabled', async () => {
+		await spectator.fixture.whenStable();
+		expect(liveAnnouncer.announce).not.toHaveBeenCalled();
 	});
 });

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -1,6 +1,8 @@
+import { LiveAnnouncer } from '@angular/cdk/a11y';
 import { inject, Injectable, InjectionToken, Provider } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { isNotNil } from '@lucca-front/ng/core';
 import { BehaviorSubject, combineLatest, isObservable, Observable, ObservableInput, of } from 'rxjs';
 import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
@@ -9,6 +11,7 @@ import { PageTitle, TitleSeparator } from './title.model';
 export const ɵAPP_TITLE = new InjectionToken<string | Observable<string>>('APP_TITLE');
 export type LuTitleNamingStrategy = 'product' | 'other';
 export const ɵNAMING_STRATEGY = new InjectionToken<LuTitleNamingStrategy>('NAMING_STRATEGY', { factory: () => 'product' });
+export const ɵREAD_TITLE_BY_LIVE_ANNOUNCER = new InjectionToken<boolean>('READ_TITLE_BY_LIVE_ANNOUNCEMENT', { factory: () => false });
 
 /**
  * @deprecated Use `provideLuTitleStrategy` instead.
@@ -23,6 +26,8 @@ export class LuTitleStrategy extends TitleStrategy {
 	private translateService = inject<ILuTitleTranslateService>(LU_TITLE_TRANSLATE_SERVICE, { optional: true });
 	private appTitle = inject(ɵAPP_TITLE);
 	private namingStrategy = inject(ɵNAMING_STRATEGY);
+	private readTitleByLiveAnnouncer = inject(ɵREAD_TITLE_BY_LIVE_ANNOUNCER);
+	private liveAnnouncer = inject(LiveAnnouncer);
 
 	private luccaTitle$ = isObservable(this.appTitle) ? this.appTitle.pipe(map((title) => this.#luccaTitle(title))) : of(this.#luccaTitle(this.appTitle));
 
@@ -35,7 +40,16 @@ export class LuTitleStrategy extends TitleStrategy {
 	);
 	constructor() {
 		super();
-		this.title$.pipe(tap((title) => this.title.setTitle(title))).subscribe();
+		this.title$
+			.pipe(
+				tap((title) => {
+					this.title.setTitle(title);
+					if (this.readTitleByLiveAnnouncer) {
+						void this.liveAnnouncer.announce(title, 'polite');
+					}
+				}),
+			)
+			.subscribe();
 	}
 
 	override updateTitle(routerState: RouterStateSnapshot) {
@@ -84,6 +98,7 @@ export interface LuTitleStrategyOptions {
 	appTitle?: () => string | Observable<string>;
 	translateService?: () => ILuTitleTranslateService;
 	namingStrategy?: LuTitleNamingStrategy;
+	readTitleByLiveAnnouncer?: boolean;
 }
 
 export function provideLuTitleStrategy(options: LuTitleStrategyOptions): Provider[] {
@@ -97,6 +112,9 @@ export function provideLuTitleStrategy(options: LuTitleStrategyOptions): Provide
 	}
 	if (options.namingStrategy) {
 		providers.push({ provide: ɵNAMING_STRATEGY, useValue: options.namingStrategy });
+	}
+	if (isNotNil(options.readTitleByLiveAnnouncer)) {
+		providers.push({ provide: ɵREAD_TITLE_BY_LIVE_ANNOUNCER, useValue: options.readTitleByLiveAnnouncer });
 	}
 
 	return providers;


### PR DESCRIPTION
## Description

Add `readTitleByLiveAnnouncer` option to announce page title changes by [LiveAnnouncer](https://material.angular.dev/cdk/a11y/overview#liveannouncer)

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
