### PR TITLE
[core] readonly properties and update ESLint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -69,6 +69,16 @@ export default defineConfig(
 			'@angular-eslint/prefer-inject': 'off',
 			'@angular-eslint/prefer-on-push-component-change-detection': 'error',
 
+			'@angular-eslint/prefer-signals': [
+				'error',
+				{
+					preferReadonlySignalProperties: true,
+					preferInputSignals: false,
+					preferQuerySignals: false,
+					useTypeChecking: true,
+				},
+			],
+
 			'@typescript-eslint/explicit-function-return-type': 'off',
 			'@typescript-eslint/explicit-module-boundary-types': 'off', // on aimerait bien dire oui sauf pour void
 			'@typescript-eslint/naming-convention': [

--- a/packages/ng/api/select/feeder/api-feeder.component.ts
+++ b/packages/ng/api/select/feeder/api-feeder.component.ts
@@ -27,7 +27,7 @@ import { ALuApiOptionFeeder } from './api-feeder.model';
 	],
 })
 export class LuApiFeederComponent<T extends ILuApiItem = ILuApiItem> extends ALuApiOptionFeeder<T, LuApiHybridService<T>> implements ILuOptionOperator<T>, ILuOnOpenSubscriber {
-	override outOptions$ = new BehaviorSubject<T[]>([]);
+	override readonly outOptions$ = new BehaviorSubject<T[]>([]);
 	constructor(
 		@Inject(ALuApiService)
 		@Optional()

--- a/packages/ng/api/select/feeder/api-feeder.model.ts
+++ b/packages/ng/api/select/feeder/api-feeder.model.ts
@@ -9,7 +9,7 @@ export interface ILuApiFeederService<T extends ILuApiItem = ILuApiItem> {
 }
 
 export abstract class ALuApiOptionFeeder<T extends ILuApiItem = ILuApiItem, S extends ILuApiService<T> = ILuApiService<T>> implements ILuApiOptionFeeder<T> {
-	outOptions$ = new BehaviorSubject<T[]>([]);
+	readonly outOptions$ = new BehaviorSubject<T[]>([]);
 	protected _service: S;
 	constructor(service: S) {
 		this._service = service;

--- a/packages/ng/api/select/pager/api-pager.model.ts
+++ b/packages/ng/api/select/pager/api-pager.model.ts
@@ -17,13 +17,13 @@ export interface ILuApiPagerService<T extends ILuApiItem = ILuApiItem> {
 export abstract class ALuApiOptionPager<T extends ILuApiItem = ILuApiItem, S extends ILuApiService<T> = ILuApiService<T>>
 	implements ILuApiOptionPager<T>, ILuOnOpenSubscriber, ILuOnScrollBottomSubscriber
 {
-	outOptions$ = new Subject<T[]>();
+	readonly outOptions$ = new Subject<T[]>();
 	loading$: Observable<boolean>;
 
 	protected _loading = false;
 	protected _results$: Observable<{ items: T[]; strategy: Strategy }>;
 	protected _options: T[] = [];
-	protected _page$ = new Subject<number>();
+	protected readonly _page$ = new Subject<number>();
 	protected _page: number;
 	protected _initialized = false;
 	constructor(protected _service: S) {}

--- a/packages/ng/api/select/searcher/api-searcher.component.ts
+++ b/packages/ng/api/select/searcher/api-searcher.component.ts
@@ -33,7 +33,7 @@ import { ALuApiOptionPagedSearcher, ALuApiOptionSearcher } from './api-searcher.
 })
 export class LuApiSearcherComponent<T extends import('../../api.model').ILuApiItem = import('../../api.model').ILuApiItem> extends ALuApiOptionSearcher<T, LuApiHybridService<T>> implements OnInit {
 	@ViewChild('searchInput', { read: ElementRef, static: true })
-	searchInput: ElementRef<HTMLElement>;
+	readonly searchInput: ElementRef<HTMLElement>;
 
 	@Input() set standard(standard: 'v3' | 'v4') {
 		this._service.standard = standard;
@@ -118,7 +118,7 @@ export class LuApiPagedSearcherComponent<T extends import('../../api.model').ILu
 	implements OnInit
 {
 	@ViewChild('searchInput', { read: ElementRef, static: true })
-	searchInput: ElementRef<HTMLElement>;
+	readonly searchInput: ElementRef<HTMLElement>;
 	@Input() set standard(standard: 'v3' | 'v4') {
 		this._service.standard = standard;
 	}

--- a/packages/ng/api/select/searcher/api-searcher.model.ts
+++ b/packages/ng/api/select/searcher/api-searcher.model.ts
@@ -9,7 +9,7 @@ export type ILuApiOptionSearcher<T extends import('../../api.model').ILuApiItem 
 export abstract class ALuApiOptionSearcher<T extends import('../../api.model').ILuApiItem = import('../../api.model').ILuApiItem, S extends ILuApiService<T> = ILuApiService<T>>
 	implements ILuApiOptionFeeder<T>, ILuOnOpenSubscriber
 {
-	outOptions$ = new Subject<T[]>();
+	readonly outOptions$ = new Subject<T[]>();
 	loading$: Observable<boolean>;
 	empty$: Observable<boolean>;
 
@@ -53,10 +53,10 @@ export abstract class ALuApiOptionPagedSearcher<T extends import('../../api.mode
 	extends ALuApiOptionSearcher<T, S>
 	implements ILuApiOptionPagedSearcher<T>, ILuOnScrollBottomSubscriber
 {
-	override outOptions$ = new Subject<T[]>();
+	override readonly outOptions$ = new Subject<T[]>();
 	override loading$: Observable<boolean>;
 	protected _loading = false;
-	protected _page$ = new Subject<void>();
+	protected readonly _page$ = new Subject<void>();
 	protected _isLastPage: boolean;
 	protected _options: T[] = [];
 

--- a/packages/ng/clear/clear.component.ts
+++ b/packages/ng/clear/clear.component.ts
@@ -75,7 +75,7 @@ export class ClearComponent<T> extends ALuClear<T> implements ILuClear<T> {
 	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
 	@Output() override onClear = new EventEmitter<T>();
 
-	contentRef = contentChildren<ElementRef>('content');
+	readonly contentRef = contentChildren<ElementRef>('content');
 
 	constructor() {
 		super();

--- a/packages/ng/core-select/api/api-v3.directive.ts
+++ b/packages/ng/core-select/api/api-v3.directive.ts
@@ -37,10 +37,10 @@ export class LuCoreSelectApiV3Directive<T extends ILuApiItem> extends ALuCoreSel
 		this.filters$.next(value);
 	}
 
-	protected url$ = new ReplaySubject<string>(1);
-	protected fields$ = new BehaviorSubject<string>('id,name');
-	protected orderBy$ = new BehaviorSubject<string | null>('name,asc');
-	protected filters$ = new BehaviorSubject<Record<string, string | number | boolean>>({});
+	protected readonly url$ = new ReplaySubject<string>(1);
+	protected readonly fields$ = new BehaviorSubject<string>('id,name');
+	protected readonly orderBy$ = new BehaviorSubject<string | null>('name,asc');
+	protected readonly filters$ = new BehaviorSubject<Record<string, string | number | boolean>>({});
 
 	protected httpClient = inject(HttpClient);
 

--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -18,14 +18,14 @@ import { ALuCoreSelectApiDirective } from './api.directive';
 	],
 })
 export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSelectApiDirective<T> implements CoreSelectApiTotalCountProvider {
-	apiV4 = model.required<string>();
-	sort = input<string | null>('+name');
-	filters = input<Record<string, string | number | boolean>>({});
-	searchDelimiter = input<string>(' ');
+	readonly apiV4 = model.required<string>();
+	readonly sort = input<string | null>('+name');
+	readonly filters = input<Record<string, string | number | boolean>>({});
+	readonly searchDelimiter = input<string>(' ');
 
 	protected httpClient = inject(HttpClient);
 
-	protected clue = toSignal(this.clue$);
+	protected readonly clue = toSignal(this.clue$);
 
 	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {

--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -27,7 +27,7 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 
 	protected readonly clue = toSignal(this.clue$);
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const sort = this.sort();
 			const clue = this.clue();
@@ -40,7 +40,7 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 		}),
 	);
 
-	public totalCount$ = toObservable(computed(() => ({ url: this.apiV4(), filters: this.filters() }))).pipe(
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.apiV4(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -16,7 +16,7 @@ interface TestEntity {
 	selector: 'lu-simple-select[testApi]',
 })
 class TestDirective extends ALuCoreSelectApiDirective<TestEntity> {
-	protected override params$ = this.clue$.pipe(
+	protected override readonly params$ = this.clue$.pipe(
 		map((clue) => ({
 			...(clue ? { clue } : {}),
 		})),

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -7,7 +7,7 @@ export const MAGIC_DEBOUNCE_DURATION = 250;
 
 @Directive()
 export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string, string | number | boolean>> implements OnDestroy, OnInit {
-	protected destroy$ = new Subject<void>();
+	protected readonly destroy$ = new Subject<void>();
 	protected pageSize = LU_SELECT_MAGIC_PAGE_SIZE;
 	protected debounceDuration = MAGIC_DEBOUNCE_DURATION;
 

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -13,12 +13,12 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 
 	public select = inject<ALuSelectInputComponent<TOption, unknown>>(ALuSelectInputComponent);
 
-	protected page$ = this.select.nextPage$.pipe(
+	protected readonly page$ = this.select.nextPage$.pipe(
 		scan((page) => page + 1, 0),
 		startWith(0),
 	);
 
-	protected clue$ = this.select.clueChange$.pipe(debounceTime(this.debounceDuration), startWith(''));
+	protected readonly clue$ = this.select.clueChange$.pipe(debounceTime(this.debounceDuration), startWith(''));
 
 	/**
 	 * Create an object that will be used as params for the api call

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -85,7 +85,7 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 		}),
 	);
 
-	public totalCount$ = this.select.options$.pipe(
+	public readonly totalCount$ = this.select.options$.pipe(
 		filter((opts) => opts.length > 0),
 		map((opts) => {
 			return opts.map((branch) => this.flattenTree(branch)).flat().length;

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -25,12 +25,12 @@ import { NoopTreeSelectDirective } from './noop-tree-select.directive';
 export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepartment> extends ALuCoreSelectApiDirective<TreeNode<T>> implements OnInit, CoreSelectApiTotalCountProvider {
 	protected httpClient = inject(HttpClient);
 
-	url = input<string>('/organization/structure/api/departments/tree');
-	filters = input<Record<string, string | number | boolean> | null>(null);
-	operationIds = input<readonly number[] | null>(null);
-	uniqueOperationIds = input<readonly number[] | null>(null);
-	appInstanceId = input<number | null>(null);
-	searchDelimiter = input<string>(' ');
+	readonly url = input<string>('/organization/structure/api/departments/tree');
+	readonly filters = input<Record<string, string | number | boolean> | null>(null);
+	readonly operationIds = input<readonly number[] | null>(null);
+	readonly uniqueOperationIds = input<readonly number[] | null>(null);
+	readonly appInstanceId = input<number | null>(null);
+	readonly searchDelimiter = input<string>(' ');
 
 	public override ngOnInit(): void {
 		super.ngOnInit();

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -71,7 +71,7 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 			.filter(isNotNil);
 	}
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const operationIds = this.operationIds();
 			const uniqueOperationIds = this.uniqueOperationIds();

--- a/packages/ng/core-select/department/noop-tree-select.directive.ts
+++ b/packages/ng/core-select/department/noop-tree-select.directive.ts
@@ -9,9 +9,9 @@ import { ALuSelectInputComponent, TreeGenerator, TreeGroupingFn, TreeNode } from
 export class NoopTreeSelectDirective<T extends TreeNode<any>, V> implements TreeGenerator<T, T> {
 	#select = inject<ALuSelectInputComponent<T, V>>(ALuSelectInputComponent);
 
-	groupingFnInput = input<TreeGroupingFn<T>>(() => null, { alias: 'noopTreeSelect' });
+	readonly groupingFnInput = input<TreeGroupingFn<T>>(() => null, { alias: 'noopTreeSelect' });
 
-	groupingFn = linkedSignal(() => this.groupingFnInput());
+	readonly groupingFn = linkedSignal(() => this.groupingFnInput());
 
 	constructor() {
 		this.#select.treeGenerator = this;

--- a/packages/ng/core-select/establishment/establishment-grouping.service.ts
+++ b/packages/ng/core-select/establishment/establishment-grouping.service.ts
@@ -9,10 +9,10 @@ export class EstablishmentGroupingService {
 	protected legalUnitsUrl = '/organization/structure/api/legal-units';
 
 	protected countParams: HttpParams = new HttpParams().set('fields.root', 'count').set('limit', 0);
-	protected establishmentsCount$ = this.http.get<{ count: number }>(this.establishmentsUrl, { params: this.countParams }).pipe(map((res) => res.count));
-	protected legalUnitsCount$ = this.http.get<{ count: number }>(this.legalUnitsUrl, { params: this.countParams }).pipe(map((res) => res.count));
+	protected readonly establishmentsCount$ = this.http.get<{ count: number }>(this.establishmentsUrl, { params: this.countParams }).pipe(map((res) => res.count));
+	protected readonly legalUnitsCount$ = this.http.get<{ count: number }>(this.legalUnitsUrl, { params: this.countParams }).pipe(map((res) => res.count));
 
-	public useGrouping$ = combineLatest([this.legalUnitsCount$, this.establishmentsCount$]).pipe(
+	public readonly useGrouping$ = combineLatest([this.legalUnitsCount$, this.establishmentsCount$]).pipe(
 		map(([luCount, establishmentCount]) => luCount > 1 && establishmentCount > 1 && luCount !== establishmentCount),
 		shareReplay(),
 	);

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -29,14 +29,14 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 
 	protected httpClient = inject(HttpClient);
 
-	url = input<string>('/organization/structure/api/establishments');
-	filters = input<Record<string, string | number | boolean> | null>(null);
-	operationIds = input<readonly number[] | null>(null);
-	uniqueOperationIds = input<readonly number[] | null>(null);
-	appInstanceId = input<number | null>(null);
-	searchDelimiter = input<string>(' ');
+	readonly url = input<string>('/organization/structure/api/establishments');
+	readonly filters = input<Record<string, string | number | boolean> | null>(null);
+	readonly operationIds = input<readonly number[] | null>(null);
+	readonly uniqueOperationIds = input<readonly number[] | null>(null);
+	readonly appInstanceId = input<number | null>(null);
+	readonly searchDelimiter = input<string>(' ');
 
-	protected clue = toSignal(this.clue$);
+	protected readonly clue = toSignal(this.clue$);
 
 	public override ngOnInit(): void {
 		super.ngOnInit();

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -66,7 +66,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		return this.#groupingService.useGrouping$.pipe(switchMap(() => options$));
 	}
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const operationIds = this.operationIds();
 			const uniqueOperationIds = this.uniqueOperationIds();
@@ -87,7 +87,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		}),
 	);
 
-	public totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -68,7 +68,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	public readonly highlightedOption = output<TOption>();
 
 	@ViewChild('inputElement')
-	private inputElementRef: ElementRef<HTMLInputElement>;
+	private readonly inputElementRef: ElementRef<HTMLInputElement>;
 
 	readonly placeholder$ = new BehaviorSubject('');
 

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -91,15 +91,15 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		return this.#clearable();
 	}
 	#clearable = computed(() => this.#inputClearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
-	#defaultFilterPillClearable = signal<boolean | null>(null);
-	#inputClearable = signal<boolean | null>(null);
+	readonly #defaultFilterPillClearable = signal<boolean | null>(null);
+	readonly #inputClearable = signal<boolean | null>(null);
 	#defaultClearable = false;
 
 	get searchable(): boolean {
 		return this.clueChange$.observed;
 	}
 
-	#addOptionLabelInput = signal<PortalContent | null>(null);
+	readonly #addOptionLabelInput = signal<PortalContent | null>(null);
 	protected computedAddOptionLabel = computed(() => this.#addOptionLabelInput() ?? this.intl().addOption);
 
 	@Input()
@@ -188,7 +188,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	displayerTpl = computed(() => this.valueTpl() || this.optionTpl());
 
-	groupingSignal = signal<LuOptionGrouping<TOption, unknown> | undefined>(undefined);
+	readonly groupingSignal = signal<LuOptionGrouping<TOption, unknown> | undefined>(undefined);
 
 	/**
 	 * @deprecated use groupingSignal
@@ -212,7 +212,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	previousPage = output<void>();
 	addOption = output<string>();
 
-	public valueSignal = signal<TValue | null>(null);
+	public readonly valueSignal = signal<TValue | null>(null);
 	isFilterPillEmpty = computed(() => this.valueSignal() === null);
 	isFilterPillClearable = computed(() => this.#clearable());
 

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -90,7 +90,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	get clearable(): boolean {
 		return this.#clearable();
 	}
-	#clearable = computed(() => this.#inputClearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
+	readonly #clearable = computed(() => this.#inputClearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
 	readonly #defaultFilterPillClearable = signal<boolean | null>(null);
 	readonly #inputClearable = signal<boolean | null>(null);
 	#defaultClearable = false;
@@ -186,7 +186,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	panelHeaderTpl = model<TemplateRef<void> | Type<unknown> | undefined>();
 	panelFooterTpl = model<TemplateRef<void> | Type<unknown> | undefined>();
 
-	displayerTpl = computed(() => this.valueTpl() || this.optionTpl());
+	readonly displayerTpl = computed(() => this.valueTpl() || this.optionTpl());
 
 	readonly groupingSignal = signal<LuOptionGrouping<TOption, unknown> | undefined>(undefined);
 
@@ -213,8 +213,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	readonly addOption = output<string>();
 
 	public readonly valueSignal = signal<TValue | null>(null);
-	isFilterPillEmpty = computed(() => this.valueSignal() === null);
-	isFilterPillClearable = computed(() => this.#clearable());
+	readonly isFilterPillEmpty = computed(() => this.valueSignal() === null);
+	readonly isFilterPillClearable = computed(() => this.#clearable());
 
 	public get value(): TValue | null {
 		return this._value;

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -57,15 +57,15 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	protected updatePositionFn?: () => void;
 	protected filterPillMode = false;
 
-	public ignorePresentation = input(false, { transform: booleanAttribute });
+	public readonly ignorePresentation = input(false, { transform: booleanAttribute });
 
 	public selectParent$?: Subject<void>;
 	public selectChildren$?: Subject<void>;
 
-	public panelClosed = output<void>();
-	public panelOpened = output<void>();
+	public readonly panelClosed = output<void>();
+	public readonly panelOpened = output<void>();
 
-	public highlightedOption = output<TOption>();
+	public readonly highlightedOption = output<TOption>();
 
 	@ViewChild('inputElement')
 	private inputElementRef: ElementRef<HTMLInputElement>;
@@ -75,7 +75,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	readonly disabled$ = new BehaviorSubject(false);
 	filterPillDisabled = toSignal(this.disabled$, { initialValue: false });
 
-	prefix = input<PortalContent | null>(null);
+	readonly prefix = input<PortalContent | null>(null);
 
 	@Input()
 	set placeholder(value: string) {
@@ -169,12 +169,12 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	@Input() optionComparer: LuOptionComparer<TOption> = coreSelectDefaultOptionComparer;
 	@Input() optionKey: (option: TOption) => unknown = coreSelectDefaultOptionKey;
 
-	noClueIcon = input(false, { transform: booleanAttribute });
+	readonly noClueIcon = input(false, { transform: booleanAttribute });
 	inputTabindex = input<number>(0);
 
-	compact = input(false, { transform: booleanAttribute });
+	readonly compact = input(false, { transform: booleanAttribute });
 
-	colorPicker = input(false, { transform: booleanAttribute });
+	readonly colorPicker = input(false, { transform: booleanAttribute });
 
 	@HostBinding('class.mod-noClueIcon')
 	protected get isNoClueIconClass(): boolean {
@@ -209,8 +209,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	clueChange = outputFromObservable(this.clueChange$);
 	readonly nextPage$ = new Subject<void>();
 	nextPage = outputFromObservable(this.nextPage$);
-	previousPage = output<void>();
-	addOption = output<string>();
+	readonly previousPage = output<void>();
+	readonly addOption = output<string>();
 
 	public readonly valueSignal = signal<TValue | null>(null);
 	isFilterPillEmpty = computed(() => this.valueSignal() === null);

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -73,7 +73,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	readonly placeholder$ = new BehaviorSubject('');
 
 	readonly disabled$ = new BehaviorSubject(false);
-	filterPillDisabled = toSignal(this.disabled$, { initialValue: false });
+	readonly filterPillDisabled = toSignal(this.disabled$, { initialValue: false });
 
 	readonly prefix = input<PortalContent | null>(null);
 
@@ -100,7 +100,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	}
 
 	readonly #addOptionLabelInput = signal<PortalContent | null>(null);
-	protected computedAddOptionLabel = computed(() => this.#addOptionLabelInput() ?? this.intl().addOption);
+	protected readonly computedAddOptionLabel = computed(() => this.#addOptionLabelInput() ?? this.intl().addOption);
 
 	@Input()
 	set addOptionLabel(label: PortalContent) {
@@ -170,7 +170,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	@Input() optionKey: (option: TOption) => unknown = coreSelectDefaultOptionKey;
 
 	readonly noClueIcon = input(false, { transform: booleanAttribute });
-	inputTabindex = input<number>(0);
+	readonly inputTabindex = input<number>(0);
 
 	readonly compact = input(false, { transform: booleanAttribute });
 
@@ -181,10 +181,10 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		return this.noClueIcon();
 	}
 
-	optionTpl = model<TemplateRef<LuOptionContext<TOption>> | Type<unknown>>(LuSimpleSelectDefaultOptionComponent);
-	valueTpl = model<TemplateRef<LuOptionContext<TOption>> | Type<unknown> | undefined>();
-	panelHeaderTpl = model<TemplateRef<void> | Type<unknown> | undefined>();
-	panelFooterTpl = model<TemplateRef<void> | Type<unknown> | undefined>();
+	readonly optionTpl = model<TemplateRef<LuOptionContext<TOption>> | Type<unknown>>(LuSimpleSelectDefaultOptionComponent);
+	readonly valueTpl = model<TemplateRef<LuOptionContext<TOption>> | Type<unknown> | undefined>();
+	readonly panelHeaderTpl = model<TemplateRef<void> | Type<unknown> | undefined>();
+	readonly panelFooterTpl = model<TemplateRef<void> | Type<unknown> | undefined>();
 
 	readonly displayerTpl = computed(() => this.valueTpl() || this.optionTpl());
 

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -249,7 +249,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	clue: string | null = null;
 	// This is the clue stored after we selected an option to know if we should emit an empty clue on open or not
 	lastEmittedClue: string = '';
-	clue$ = defer(() => this.clueChange$.pipe(startWith(this.clue)));
+	readonly clue$ = defer(() => this.clueChange$.pipe(startWith(this.clue)));
 
 	readonly addOptionStrategy$ = new BehaviorSubject<CoreSelectAddOptionStrategy>('never');
 	shouldDisplayAddOption$ = this.addOptionStrategy$.pipe(

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -70,9 +70,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	@ViewChild('inputElement')
 	private inputElementRef: ElementRef<HTMLInputElement>;
 
-	public placeholder$ = new BehaviorSubject('');
+	readonly placeholder$ = new BehaviorSubject('');
 
-	public disabled$ = new BehaviorSubject(false);
+	readonly disabled$ = new BehaviorSubject(false);
 	filterPillDisabled = toSignal(this.disabled$, { initialValue: false });
 
 	prefix = input<PortalContent | null>(null);
@@ -132,9 +132,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		return this.isPanelOpen$.value;
 	}
 
-	public isPanelOpen$ = new BehaviorSubject(false);
+	readonly isPanelOpen$ = new BehaviorSubject(false);
 
-	public activeDescendant$ = new BehaviorSubject('');
+	readonly activeDescendant$ = new BehaviorSubject('');
 
 	get ariaControls(): string {
 		return this.overlayContainerRef.id;
@@ -205,9 +205,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	treeGenerator?: TreeGenerator<TOption, TreeNode<TOption>>;
 
-	clueChange$ = new Subject<string>();
+	readonly clueChange$ = new Subject<string>();
 	clueChange = outputFromObservable(this.clueChange$);
-	nextPage$ = new Subject<void>();
+	readonly nextPage$ = new Subject<void>();
 	nextPage = outputFromObservable(this.nextPage$);
 	previousPage = output<void>();
 	addOption = output<string>();
@@ -244,14 +244,14 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	protected _value: TValue | null = null;
 
-	options$ = new ReplaySubject<readonly TOption[]>(1);
-	loading$ = new BehaviorSubject(false);
+	readonly options$ = new ReplaySubject<readonly TOption[]>(1);
+	readonly loading$ = new BehaviorSubject(false);
 	clue: string | null = null;
 	// This is the clue stored after we selected an option to know if we should emit an empty clue on open or not
 	lastEmittedClue: string = '';
 	clue$ = defer(() => this.clueChange$.pipe(startWith(this.clue)));
 
-	addOptionStrategy$ = new BehaviorSubject<CoreSelectAddOptionStrategy>('never');
+	readonly addOptionStrategy$ = new BehaviorSubject<CoreSelectAddOptionStrategy>('never');
 	shouldDisplayAddOption$ = this.addOptionStrategy$.pipe(
 		switchMap((strategy) => {
 			switch (strategy) {
@@ -276,7 +276,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	protected _panelRef?: LuSelectPanelRef<TOption, TValue>;
 
-	protected destroyed$ = new Subject<void>();
+	protected readonly destroyed$ = new Subject<void>();
 
 	constructor() {
 		if (this.filterPillHost) {

--- a/packages/ng/core-select/input/total-count.directive.ts
+++ b/packages/ng/core-select/input/total-count.directive.ts
@@ -14,7 +14,7 @@ import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider }
 	],
 })
 export class LuCoreSelectTotalCountDirective implements CoreSelectApiTotalCountProvider {
-	totalCount = input.required<number>({ alias: 'totalCount' });
+	readonly totalCount = input.required<number>({ alias: 'totalCount' });
 
 	totalCount$ = toObservable(this.totalCount);
 }

--- a/packages/ng/core-select/input/total-count.directive.ts
+++ b/packages/ng/core-select/input/total-count.directive.ts
@@ -16,5 +16,5 @@ import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider }
 export class LuCoreSelectTotalCountDirective implements CoreSelectApiTotalCountProvider {
 	readonly totalCount = input.required<number>({ alias: 'totalCount' });
 
-	totalCount$ = toObservable(this.totalCount);
+	readonly totalCount$ = toObservable(this.totalCount);
 }

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -25,11 +25,11 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 {
 	protected httpClient = inject(HttpClient);
 
-	url = input<string>('/organization/structure/api/job-qualifications');
-	filters = input<Record<string, string | number | boolean> | null>(null);
-	searchDelimiter = input<string>(' ');
+	readonly url = input<string>('/organization/structure/api/job-qualifications');
+	readonly filters = input<Record<string, string | number | boolean> | null>(null);
+	readonly searchDelimiter = input<string>(' ');
 
-	protected clue = toSignal(this.clue$);
+	protected readonly clue = toSignal(this.clue$);
 
 	public constructor() {
 		super();

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -52,7 +52,7 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 			.pipe(map((res) => (Array.isArray(res) ? res : res?.items) ?? []));
 	}
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const filters = this.filters();
 			const clue = this.clue();
@@ -68,7 +68,7 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 		}),
 	);
 
-	public totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {

--- a/packages/ng/core-select/no-clue/no-clue.directive.spec.ts
+++ b/packages/ng/core-select/no-clue/no-clue.directive.spec.ts
@@ -14,7 +14,7 @@ import { LuCoreSelectNoClueDirective } from './no-clue.directive';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class TestV3NoClueComponent {
-	select = viewChild.required(LuSimpleSelectInputComponent);
+	readonly select = viewChild.required(LuSimpleSelectInputComponent);
 }
 
 @Component({
@@ -24,7 +24,7 @@ class TestV3NoClueComponent {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class TestV4NoClueComponent {
-	select = viewChild.required(LuSimpleSelectInputComponent);
+	readonly select = viewChild.required(LuSimpleSelectInputComponent);
 }
 
 describe('LuCoreSelectNoClueDirective', () => {

--- a/packages/ng/core-select/occupation-category/occupation-category.directive.ts
+++ b/packages/ng/core-select/occupation-category/occupation-category.directive.ts
@@ -43,7 +43,7 @@ export class LuCoreSelectOccupationCategoriesDirective<T extends LuCoreSelectOcc
 			.pipe(map((res) => (Array.isArray(res) ? res : res?.items) ?? []));
 	}
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const filters = this.filters();
 			const clue = this.clue();
@@ -59,7 +59,7 @@ export class LuCoreSelectOccupationCategoriesDirective<T extends LuCoreSelectOcc
 		}),
 	);
 
-	public totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {

--- a/packages/ng/core-select/occupation-category/occupation-category.directive.ts
+++ b/packages/ng/core-select/occupation-category/occupation-category.directive.ts
@@ -25,11 +25,11 @@ export class LuCoreSelectOccupationCategoriesDirective<T extends LuCoreSelectOcc
 {
 	protected httpClient = inject(HttpClient);
 
-	url = input<string>('/organization/structure/api/occupation-categories');
-	filters = input<Record<string, string | number | boolean> | null>(null);
-	searchDelimiter = input<string>(' ');
+	readonly url = input<string>('/organization/structure/api/occupation-categories');
+	readonly filters = input<Record<string, string | number | boolean> | null>(null);
+	readonly searchDelimiter = input<string>(' ');
 
-	protected clue = toSignal(this.clue$);
+	protected readonly clue = toSignal(this.clue$);
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
 		return this.httpClient

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -55,14 +55,14 @@ export class LuOptionComponent<T> implements AfterViewInit, OnDestroy, OnInit {
 	onlyParent = output<void>();
 	onlyChildren = output<void>();
 
-	groupIndex = input<number>();
+	readonly groupIndex = input<number>();
 
-	public optionIndex = input.required({ transform: (value: string | number) => `${value}` });
+	public readonly optionIndex = input.required({ transform: (value: string | number) => `${value}` });
 
 	@Input()
 	scrollIntoViewOptions: ScrollIntoViewOptions = {};
 
-	groupTemplateLocation = input<GroupTemplateLocation>();
+	readonly groupTemplateLocation = input<GroupTemplateLocation>();
 
 	@ViewChild(LuOptionOutletDirective, { read: LU_OPTION_CONTEXT, static: true })
 	private readonly optionContext?: ILuOptionContext<T>;

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -51,7 +51,7 @@ export class LuOptionComponent<T> implements AfterViewInit, OnDestroy, OnInit {
 	@Input() option?: T;
 	@Input() grouping?: LuOptionGrouping<T, unknown>;
 
-	hasChildren = input(false, { transform: booleanAttribute });
+	readonly hasChildren = input(false, { transform: booleanAttribute });
 	onlyParent = output<void>();
 	onlyChildren = output<void>();
 

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -65,7 +65,7 @@ export class LuOptionComponent<T> implements AfterViewInit, OnDestroy, OnInit {
 	groupTemplateLocation = input<GroupTemplateLocation>();
 
 	@ViewChild(LuOptionOutletDirective, { read: LU_OPTION_CONTEXT, static: true })
-	private optionContext?: ILuOptionContext<T>;
+	private readonly optionContext?: ILuOptionContext<T>;
 
 	private cdr = inject(ChangeDetectorRef);
 	private subscription?: Subscription;

--- a/packages/ng/core-select/panel/key-manager.ts
+++ b/packages/ng/core-select/panel/key-manager.ts
@@ -22,6 +22,7 @@ export class CoreSelectKeyManager<T> {
 	#options?: CoreSelectKeyManagerOptions<T>;
 	#injector = inject(Injector);
 
+	// eslint-disable-next-line @angular-eslint/prefer-signals
 	#queryList: Signal<CoreSelectPanelElement<T>[]>;
 	#queryList$: Observable<CoreSelectPanelElement<T>[]>;
 

--- a/packages/ng/core-select/panel/selectable-item.ts
+++ b/packages/ng/core-select/panel/selectable-item.ts
@@ -24,7 +24,7 @@ export class CoreSelectPanelElement<T> implements Highlightable, OnDestroy {
 
 	elementId = input<string>('');
 
-	idAttribute = computed(() => this.id() || this.elementId());
+	readonly idAttribute = computed(() => this.id() || this.elementId());
 
 	isSelected = model(false);
 

--- a/packages/ng/core-select/panel/selectable-item.ts
+++ b/packages/ng/core-select/panel/selectable-item.ts
@@ -30,7 +30,7 @@ export class CoreSelectPanelElement<T> implements Highlightable, OnDestroy {
 
 	option = input<T>();
 
-	isHighlighted = signal(false);
+	readonly isHighlighted = signal(false);
 
 	selected = output<void>();
 

--- a/packages/ng/core-select/panel/selectable-item.ts
+++ b/packages/ng/core-select/panel/selectable-item.ts
@@ -20,15 +20,15 @@ export class CoreSelectPanelElement<T> implements Highlightable, OnDestroy {
 
 	readonly #selectRef = inject<ALuSelectInputComponent<T, T>>(ALuSelectInputComponent);
 
-	id = signal<string>('');
+	readonly id = signal<string>('');
 
-	elementId = input<string>('');
+	readonly elementId = input<string>('');
 
 	readonly idAttribute = computed(() => this.id() || this.elementId());
 
-	isSelected = model(false);
+	readonly isSelected = model(false);
 
-	option = input<T>();
+	readonly option = input<T>();
 
 	readonly isHighlighted = signal(false);
 

--- a/packages/ng/core-select/user/user-option.component.ts
+++ b/packages/ng/core-select/user/user-option.component.ts
@@ -46,7 +46,7 @@ export class LuUserOptionComponent {
 	protected context = inject<ILuOptionContext<LuCoreSelectWithAdditionnalInformation<LuCoreSelectUser>>>(LU_OPTION_CONTEXT);
 	protected userDirective = inject(LuCoreSelectUsersDirective);
 	readonly intl = input(...intlInputOptions(LU_CORE_SELECT_USER_TRANSLATIONS));
-	protected hasEmptyClue$ = this.userDirective.select.clueChange$.pipe(
+	protected readonly hasEmptyClue$ = this.userDirective.select.clueChange$.pipe(
 		startWith(this.userDirective.select.clue),
 		map((clue) => !clue),
 	);

--- a/packages/ng/core-select/user/user-option.component.ts
+++ b/packages/ng/core-select/user/user-option.component.ts
@@ -50,5 +50,5 @@ export class LuUserOptionComponent {
 		startWith(this.userDirective.select.clue),
 		map((clue) => !clue),
 	);
-	protected customUserOptionTpl = this.userDirective.customUserOptionTpl;
+	protected readonly customUserOptionTpl = this.userDirective.customUserOptionTpl;
 }

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -31,8 +31,8 @@ class TestUsersDirective extends LuCoreSelectUsersDirective {
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class LuUsersDirectiveHostComponent {
-	simpleSelect = viewChild.required<LuSimpleSelectInputComponent<LuCoreSelectUser>>(LuSimpleSelectInputComponent);
-	usersDirective = viewChild.required<TestUsersDirective>(TestUsersDirective);
+	readonly simpleSelect = viewChild.required<LuSimpleSelectInputComponent<LuCoreSelectUser>>(LuSimpleSelectInputComponent);
+	readonly usersDirective = viewChild.required<TestUsersDirective>(TestUsersDirective);
 }
 
 const CURRENT_USER_ID = 12;

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -133,7 +133,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		}),
 	);
 
-	protected me$ = this.meParams$.pipe(
+	protected readonly me$ = this.meParams$.pipe(
 		switchMap((params) =>
 			this.httpClient
 				.get<

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -58,20 +58,20 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	protected httpClient = inject(HttpClient);
 	public currentUserId = inject(LU_CORE_SELECT_CURRENT_USER_ID);
 
-	displayFormat = input<LuDisplayFormat>(LuDisplayFullname.lastfirst);
+	readonly displayFormat = input<LuDisplayFormat>(LuDisplayFullname.lastfirst);
 
-	filters = input<Record<string, string | number | boolean>>({});
-	url = input<string | null>(null);
-	orderBy = input<string | null>(null);
-	operationIds = input<readonly number[] | null>(null);
-	uniqueOperationIds = input<readonly number[] | null>(null);
-	appInstanceId = input<number | null>(null);
+	readonly filters = input<Record<string, string | number | boolean>>({});
+	readonly url = input<string | null>(null);
+	readonly orderBy = input<string | null>(null);
+	readonly operationIds = input<readonly number[] | null>(null);
+	readonly uniqueOperationIds = input<readonly number[] | null>(null);
+	readonly appInstanceId = input<number | null>(null);
 	readonly enableFormerEmployees = input(false, { transform: booleanAttribute });
 	readonly displayMeOption = input(true);
-	customUserOptionTpl = model<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
+	readonly customUserOptionTpl = model<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
 
 	readonly includeFormerEmployees = signal(false);
-	searchDelimiter = input<string>(' ');
+	readonly searchDelimiter = input<string>(' ');
 
 	constructor() {
 		super();
@@ -88,10 +88,10 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		});
 	}
 
-	protected defaultUrl = computed(() => (this.uniqueOperationIds()?.length || (this.appInstanceId() && this.operationIds()?.length) ? this.#defaultScopedSearchUrl : this.#defaultSearchUrl));
-	protected urlOrDefault = computed(() => this.url() ?? this.defaultUrl());
+	protected readonly defaultUrl = computed(() => (this.uniqueOperationIds()?.length || (this.appInstanceId() && this.operationIds()?.length) ? this.#defaultScopedSearchUrl : this.#defaultSearchUrl));
+	protected readonly urlOrDefault = computed(() => this.url() ?? this.defaultUrl());
 
-	protected clue = toSignal(this.clue$);
+	protected readonly clue = toSignal(this.clue$);
 
 	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -70,7 +70,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	displayMeOption = input(true);
 	customUserOptionTpl = model<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
 
-	includeFormerEmployees = signal(false);
+	readonly includeFormerEmployees = signal(false);
 	searchDelimiter = input<string>(' ');
 
 	constructor() {

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -66,8 +66,8 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	operationIds = input<readonly number[] | null>(null);
 	uniqueOperationIds = input<readonly number[] | null>(null);
 	appInstanceId = input<number | null>(null);
-	enableFormerEmployees = input(false, { transform: booleanAttribute });
-	displayMeOption = input(true);
+	readonly enableFormerEmployees = input(false, { transform: booleanAttribute });
+	readonly displayMeOption = input(true);
 	customUserOptionTpl = model<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
 
 	readonly includeFormerEmployees = signal(false);

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -93,7 +93,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 
 	protected readonly clue = toSignal(this.clue$);
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const orderBy = this.orderBy();
 			const clue = this.clue();
@@ -116,7 +116,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		}),
 	);
 
-	protected meParams$ = toObservable(
+	protected readonly meParams$ = toObservable(
 		computed(() => {
 			const uniqueOperationIds = this.uniqueOperationIds();
 			const operationIds = this.operationIds();
@@ -148,7 +148,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 		shareReplay(1),
 	);
 
-	public totalCount$ = toObservable(computed(() => ({ url: this.urlOrDefault(), filters: this.filters() }))).pipe(
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.urlOrDefault(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
 			this.httpClient.get<{ count: number }>(url, {

--- a/packages/ng/core/portal/portal.directive.spec.ts
+++ b/packages/ng/core/portal/portal.directive.spec.ts
@@ -15,11 +15,11 @@ import { PortalDirective } from './portal.directive';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class PortalTestComponent {
-	context = input<PortalDirective['luPortalContext'] | null>(null);
-	content = input<PortalContent | null>(null);
-	displayed = input(true);
+	readonly context = input<PortalDirective['luPortalContext'] | null>(null);
+	readonly content = input<PortalContent | null>(null);
+	readonly displayed = input(true);
 
-	contentTpl = viewChild.required<TemplateRef<unknown>>('tpl');
+	readonly contentTpl = viewChild.required<TemplateRef<unknown>>('tpl');
 }
 
 @Component({

--- a/packages/ng/core/portal/portal.directive.ts
+++ b/packages/ng/core/portal/portal.directive.ts
@@ -10,9 +10,9 @@ export class PortalDirective<T extends object = object> implements OnDestroy {
 	private templateRef = inject(TemplateRef);
 	private injector = inject(Injector);
 
-	luPortal = input.required<PortalContent<T>>();
+	readonly luPortal = input.required<PortalContent<T>>();
 
-	luPortalContext = input<T | null>(null);
+	readonly luPortalContext = input<T | null>(null);
 
 	private createdTextElement: Text | null = null;
 	private embeddedViewRef?: EmbeddedViewRef<T>;

--- a/packages/ng/data-table/base-data-table-cell.ts
+++ b/packages/ng/data-table/base-data-table-cell.ts
@@ -19,7 +19,7 @@ export abstract class BaseDataTableCell {
 	rowRef = inject(LU_DATA_TABLE_ROW_INSTANCE, { optional: true });
 
 	readonly editable = input(false, { transform: booleanAttribute });
-	align = input<null | 'start' | 'center' | 'end'>(null);
+	readonly align = input<null | 'start' | 'center' | 'end'>(null);
 
 	readonly isStickyStart = computed(() => {
 		const position = this.position();

--- a/packages/ng/data-table/base-data-table-cell.ts
+++ b/packages/ng/data-table/base-data-table-cell.ts
@@ -18,7 +18,7 @@ export abstract class BaseDataTableCell {
 	footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });
 	rowRef = inject(LU_DATA_TABLE_ROW_INSTANCE, { optional: true });
 
-	editable = input(false, { transform: booleanAttribute });
+	readonly editable = input(false, { transform: booleanAttribute });
 	align = input<null | 'start' | 'center' | 'end'>(null);
 
 	isStickyStart = computed(() => {

--- a/packages/ng/data-table/base-data-table-cell.ts
+++ b/packages/ng/data-table/base-data-table-cell.ts
@@ -12,11 +12,11 @@ import { LU_DATA_TABLE_INSTANCE } from './data-table.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export abstract class BaseDataTableCell {
-	tableRef = inject(LU_DATA_TABLE_INSTANCE, { optional: true });
-	bodyRef = inject(LU_DATA_TABLE_BODY_INSTANCE, { optional: true });
-	headRef = inject(LU_DATA_TABLE_HEAD_INSTANCE, { optional: true });
-	footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });
-	rowRef = inject(LU_DATA_TABLE_ROW_INSTANCE, { optional: true });
+	readonly tableRef = inject(LU_DATA_TABLE_INSTANCE, { optional: true });
+	readonly bodyRef = inject(LU_DATA_TABLE_BODY_INSTANCE, { optional: true });
+	readonly headRef = inject(LU_DATA_TABLE_HEAD_INSTANCE, { optional: true });
+	readonly footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });
+	readonly rowRef = inject(LU_DATA_TABLE_ROW_INSTANCE, { optional: true });
 
 	readonly editable = input(false, { transform: booleanAttribute });
 	readonly align = input<null | 'start' | 'center' | 'end'>(null);

--- a/packages/ng/data-table/base-data-table-cell.ts
+++ b/packages/ng/data-table/base-data-table-cell.ts
@@ -21,17 +21,17 @@ export abstract class BaseDataTableCell {
 	readonly editable = input(false, { transform: booleanAttribute });
 	align = input<null | 'start' | 'center' | 'end'>(null);
 
-	isStickyStart = computed(() => {
+	readonly isStickyStart = computed(() => {
 		const position = this.position();
 		return isNotNil(position) && isNotNil(this.tableRef) ? position <= this.tableRef.stickyColsStart() - 1 : undefined;
 	});
 
-	isStickyEnd = computed(() => {
+	readonly isStickyEnd = computed(() => {
 		const position = this.position();
 		return isNotNil(position) && isNotNil(this.tableRef) && isNotNil(this.rowRef) ? position >= this.rowRef.cells().length - this.tableRef.stickyColsEnd() : undefined;
 	});
 
-	position = computed(() => {
+	readonly position = computed(() => {
 		return this.rowRef?.cells().indexOf(this);
 	});
 }

--- a/packages/ng/data-table/data-table-body/data-table-body.component.ts
+++ b/packages/ng/data-table/data-table-body/data-table-body.component.ts
@@ -34,7 +34,7 @@ export class DataTableBodyComponent {
 
 	protected tableRef = inject(LU_DATA_TABLE_INSTANCE, { optional: true });
 
-	colspan = computed(() => {
+	readonly colspan = computed(() => {
 		if (!this.tableRef) {
 			return 0;
 		}

--- a/packages/ng/data-table/data-table-body/data-table-body.component.ts
+++ b/packages/ng/data-table/data-table-body/data-table-body.component.ts
@@ -23,10 +23,10 @@ import { LU_DATA_TABLE_BODY_INSTANCE } from './data-table-body.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableBodyComponent {
-	group = input<PortalContent | null>(null);
-	groupButtonAlt = input<string | null>(null);
+	readonly group = input<PortalContent | null>(null);
+	readonly groupButtonAlt = input<string | null>(null);
 
-	expanded = model(false);
+	readonly expanded = model(false);
 
 	expandedToggle() {
 		this.expanded.set(!this.expanded());

--- a/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
+++ b/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
@@ -73,7 +73,7 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 		);
 	});
 
-	#inlineSizePx$ = new ReplaySubject<number>();
+	readonly #inlineSizePx$ = new ReplaySubject<number>();
 
 	readonly inlineSizePx = toSignal(this.#inlineSizePx$);
 

--- a/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
+++ b/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
@@ -39,7 +39,7 @@ import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableRowCellHeaderComponent extends BaseDataTableCell implements AfterContentInit {
-	elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
+	readonly elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
 
 	readonly sort = model<null | 'none' | 'ascending' | 'descending'>(null);
 	readonly fixedWidth = input<string | null>(null);

--- a/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
+++ b/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
@@ -45,7 +45,7 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 	fixedWidth = input<string | null>(null);
 	inlineSize = input<string | null>(null);
 
-	insetInlineStart = computed(() => {
+	readonly insetInlineStart = computed(() => {
 		if (!this.isStickyStart() || !this.headRef) {
 			return '';
 		}
@@ -59,7 +59,7 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 		);
 	});
 
-	insetInlineEnd = computed(() => {
+	readonly insetInlineEnd = computed(() => {
 		if (!this.isStickyEnd() || !this.headRef) {
 			return '';
 		}

--- a/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
+++ b/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
@@ -41,9 +41,9 @@ import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
 export class DataTableRowCellHeaderComponent extends BaseDataTableCell implements AfterContentInit {
 	elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
 
-	sort = model<null | 'none' | 'ascending' | 'descending'>(null);
-	fixedWidth = input<string | null>(null);
-	inlineSize = input<string | null>(null);
+	readonly sort = model<null | 'none' | 'ascending' | 'descending'>(null);
+	readonly fixedWidth = input<string | null>(null);
+	readonly inlineSize = input<string | null>(null);
 
 	readonly insetInlineStart = computed(() => {
 		if (!this.isStickyStart() || !this.headRef) {
@@ -75,7 +75,7 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 
 	#inlineSizePx$ = new ReplaySubject<number>();
 
-	inlineSizePx = toSignal(this.#inlineSizePx$);
+	readonly inlineSizePx = toSignal(this.#inlineSizePx$);
 
 	ngAfterContentInit(): void {
 		new ResizeObserver(() => {

--- a/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
+++ b/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
@@ -30,7 +30,7 @@ import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableRowCellComponent extends BaseDataTableCell {
-	actions = input(false, { transform: booleanAttribute });
+	readonly actions = input(false, { transform: booleanAttribute });
 
 	isSticky = computed(() => {
 		return this.isStickyStart() || this.isStickyEnd();

--- a/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
+++ b/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
@@ -32,23 +32,23 @@ import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
 export class DataTableRowCellComponent extends BaseDataTableCell {
 	readonly actions = input(false, { transform: booleanAttribute });
 
-	isSticky = computed(() => {
+	readonly isSticky = computed(() => {
 		return this.isStickyStart() || this.isStickyEnd();
 	});
 
-	alignCol = computed(() => {
+	readonly alignCol = computed(() => {
 		const cols = this.tableRef?.header()?.cols?.();
 		const position = this.position();
 		return position !== undefined ? cols?.[position]?.align?.() : undefined;
 	});
 
-	insetInlineStart = computed(() => {
+	readonly insetInlineStart = computed(() => {
 		const cols = this.tableRef?.header()?.cols?.();
 		const position = this.position();
 		return position !== undefined ? cols?.[position]?.insetInlineStart?.() : undefined;
 	});
 
-	insetInlineEnd = computed(() => {
+	readonly insetInlineEnd = computed(() => {
 		const cols = this.tableRef?.header()?.cols?.();
 		const position = this.position();
 		return position !== undefined ? cols?.[position]?.insetInlineEnd?.() : undefined;

--- a/packages/ng/data-table/data-table-head/data-table-head.component.ts
+++ b/packages/ng/data-table/data-table-head/data-table-head.component.ts
@@ -26,5 +26,5 @@ export class DataTableHeadComponent {
 	readonly sticky = input(false, { transform: booleanAttribute });
 	readonly isFirstVisible = signal(false);
 
-	cols = contentChildren(DataTableRowCellHeaderComponent, { descendants: true });
+	readonly cols = contentChildren(DataTableRowCellHeaderComponent, { descendants: true });
 }

--- a/packages/ng/data-table/data-table-row/data-table-row.component.ts
+++ b/packages/ng/data-table/data-table-row/data-table-row.component.ts
@@ -36,7 +36,7 @@ import { LU_DATA_TABLE_ROW_INSTANCE } from './data-table-row.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableRowComponent {
-	intl = input(...intlInputOptions(LU_DATA_TABLE_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_DATA_TABLE_TRANSLATIONS));
 	bodyRef = inject(LU_DATA_TABLE_BODY_INSTANCE, { optional: true });
 	headRef = inject(LU_DATA_TABLE_HEAD_INSTANCE, { optional: true });
 	footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });

--- a/packages/ng/data-table/data-table-row/data-table-row.component.ts
+++ b/packages/ng/data-table/data-table-row/data-table-row.component.ts
@@ -37,11 +37,11 @@ import { LU_DATA_TABLE_ROW_INSTANCE } from './data-table-row.token';
 })
 export class DataTableRowComponent {
 	readonly intl = input(...intlInputOptions(LU_DATA_TABLE_TRANSLATIONS));
-	bodyRef = inject(LU_DATA_TABLE_BODY_INSTANCE, { optional: true });
-	headRef = inject(LU_DATA_TABLE_HEAD_INSTANCE, { optional: true });
-	footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });
+	readonly bodyRef = inject(LU_DATA_TABLE_BODY_INSTANCE, { optional: true });
+	readonly headRef = inject(LU_DATA_TABLE_HEAD_INSTANCE, { optional: true });
+	readonly footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });
 
-	elementRef = inject<ElementRef<Element>>(ElementRef);
+	readonly elementRef = inject<ElementRef<Element>>(ElementRef);
 
 	public readonly cells = contentChildren(LU_DATA_TABLE_CELL_INSTANCE);
 

--- a/packages/ng/data-table/data-table-row/data-table-row.component.ts
+++ b/packages/ng/data-table/data-table-row/data-table-row.component.ts
@@ -47,7 +47,7 @@ export class DataTableRowComponent {
 
 	protected tableRef = inject(LU_DATA_TABLE_INSTANCE, { optional: true });
 
-	selected = model<boolean>(false);
+	readonly selected = model<boolean>(false);
 	readonly selectedLabel = input<string | null>(null);
 	readonly disabled = input(false, { transform: booleanAttribute });
 }

--- a/packages/ng/data-table/data-table.component.ts
+++ b/packages/ng/data-table/data-table.component.ts
@@ -42,7 +42,7 @@ import { LU_DATA_TABLE_INSTANCE } from './data-table.token';
 })
 export class DataTableComponent implements OnInit {
 	#elementRef = inject<ElementRef<Element>>(ElementRef);
-	tableRef = viewChild<ElementRef<Element>>('tableRef');
+	readonly tableRef = viewChild<ElementRef<Element>>('tableRef');
 
 	readonly hover = input(false, { transform: booleanAttribute });
 	readonly selectable = input(false, { transform: booleanAttribute });

--- a/packages/ng/data-table/data-table.component.ts
+++ b/packages/ng/data-table/data-table.component.ts
@@ -64,14 +64,14 @@ export class DataTableComponent implements OnInit {
 	readonly stickyColsStart = input(0, { transform: numberAttribute });
 	readonly stickyColsEnd = input(0, { transform: numberAttribute });
 
-	firstColumnVisibleAfterColsStart = signal(true);
-	lastColumnVisibleBeforeColsEnd = signal(false);
+	readonly firstColumnVisibleAfterColsStart = signal(true);
+	readonly lastColumnVisibleBeforeColsEnd = signal(false);
 
-	firstColumnVisible = signal(true);
-	lastColumnVisible = signal(false);
+	readonly firstColumnVisible = signal(true);
+	readonly lastColumnVisible = signal(false);
 
-	firstRowVisible = signal(true);
-	lastRowVisible = signal(false);
+	readonly firstRowVisible = signal(true);
+	readonly lastRowVisible = signal(false);
 
 	readonly cols = computed(() => this.header()?.cols());
 

--- a/packages/ng/date/calendar/calendar-input.component.ts
+++ b/packages/ng/date/calendar/calendar-input.component.ts
@@ -28,7 +28,7 @@ import { ICalendarItem } from './calendar-item.interface';
 	],
 })
 export class LuCalendarInputComponent<D> extends ALuInput<D> implements ControlValueAccessor, OnInit, Validator {
-	intl = input(...intlInputOptions(LU_CALENDARINPUT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_CALENDARINPUT_TRANSLATIONS));
 
 	@Input() min?: D;
 	@Input() max?: D;

--- a/packages/ng/date/input/date-input.directive.ts
+++ b/packages/ng/date/input/date-input.directive.ts
@@ -28,7 +28,7 @@ export class LuDateInputDirective<D> extends ALuInput<D, HTMLInputElement> imple
 	@Input() override set placeholder(p: string) {
 		this._elementRef.nativeElement.placeholder = p;
 	}
-	public intl = input(...intlInputOptions(LU_DATE_INPUT_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_DATE_INPUT_TRANSLATIONS));
 	constructor(
 		_changeDetectorRef: ChangeDetectorRef,
 		_elementRef: ElementRef<HTMLInputElement>,

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -19,7 +19,7 @@ export abstract class AbstractDateComponent {
 	// Contains the current date format (like dd/mm/yy etc) based on current locale
 	protected dateFormat = getDateFormat(this.locale);
 	protected separator = getSeparator(this.locale);
-	protected dateFormatWithMode = computed(() => getDateFormat(this.locale, this.mode()));
+	protected readonly dateFormatWithMode = computed(() => getDateFormat(this.locale, this.mode()));
 	intlDateTimeFormat = new Intl.DateTimeFormat(this.locale);
 
 	intlDateTimeFormatMonth = new Intl.DateTimeFormat(this.locale, { month: 'numeric', year: 'numeric' });
@@ -28,10 +28,10 @@ export abstract class AbstractDateComponent {
 	readonly intl = input(...intlInputOptions(LU_DATE2_TRANSLATIONS));
 
 	onTouched?: () => void;
-	disabled = signal<boolean>(false);
+	readonly disabled = signal<boolean>(false);
 
 	readonly format = input<DateFormat>(DATE_FORMAT.DATE);
-	protected inDateISOFormat = computed(() => this.format() === DATE_FORMAT.DATE_ISO);
+	protected readonly inDateISOFormat = computed(() => this.format() === DATE_FORMAT.DATE_ISO);
 
 	readonly ranges = input([], { transform: (v: readonly DateRange[] | readonly DateRangeInput[]) => v.map(transformDateRangeInputToDateRange) });
 	readonly hideToday = input(false, { transform: booleanAttribute });
@@ -54,7 +54,7 @@ export abstract class AbstractDateComponent {
 		transform: transformDateInputToDate,
 	});
 
-	calendarMode = model<CalendarMode | null>(null);
+	readonly calendarMode = model<CalendarMode | null>(null);
 
 	readonly panelOpened = output<void>();
 

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -25,7 +25,7 @@ export abstract class AbstractDateComponent {
 	intlDateTimeFormatMonth = new Intl.DateTimeFormat(this.locale, { month: 'numeric', year: 'numeric' });
 	intlDateTimeFormatYear = new Intl.DateTimeFormat(this.locale, { year: 'numeric' });
 
-	intl = input(...intlInputOptions(LU_DATE2_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_DATE2_TRANSLATIONS));
 
 	onTouched?: () => void;
 	disabled = signal<boolean>(false);

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -62,9 +62,9 @@ export abstract class AbstractDateComponent {
 
 	readonly dateFormatLocalized = computed(() => getLocalizedDateFormat(this.locale, this.mode()));
 
-	protected currentDate = signal(new Date());
+	protected readonly currentDate = signal(new Date());
 
-	protected tabbableDate = signal<Date | null>(null);
+	protected readonly tabbableDate = signal<Date | null>(null);
 
 	protected constructor() {
 		effect(() => {

--- a/packages/ng/date2/calendar2/calendar2-cell.directive.ts
+++ b/packages/ng/date2/calendar2/calendar2-cell.directive.ts
@@ -18,15 +18,15 @@ const modeToDurationKey: Record<CalendarMode, keyof Duration> = {
 export class Calendar2CellDirective {
 	#host = inject<ElementRef<HTMLButtonElement>>(ElementRef);
 
-	#tabbableDate = inject(CALENDAR_TABBABLE_DATE);
+	readonly #tabbableDate = inject(CALENDAR_TABBABLE_DATE);
 	#weekInfo = inject(WEEK_INFO);
 
 	// Index of this day in the current week display row, not depending on locale, 0 is first day of week and 6 is last
-	luCalendar2Cell = input.required<number>();
+	readonly luCalendar2Cell = input.required<number>();
 
-	luCalendar2Mode = input.required<CalendarMode>();
+	readonly luCalendar2Mode = input.required<CalendarMode>();
 
-	luCalendar2Date = input.required<Date>();
+	readonly luCalendar2Date = input.required<Date>();
 
 	@HostBinding('tabindex')
 	get tabindex(): 0 | -1 {

--- a/packages/ng/date2/calendar2/calendar2-cell.directive.ts
+++ b/packages/ng/date2/calendar2/calendar2-cell.directive.ts
@@ -1,6 +1,6 @@
 import { computed, Directive, ElementRef, HostBinding, HostListener, inject, input } from '@angular/core';
-import { add, addMonths, addYears, endOfWeek, startOfWeek, sub, subMonths, subYears } from 'date-fns';
 import type { Duration } from 'date-fns';
+import { add, addMonths, addYears, endOfWeek, startOfWeek, sub, subMonths, subYears } from 'date-fns';
 import { WEEK_INFO } from '../calendar.token';
 import { comparePeriods, getJSFirstDayOfWeek } from '../utils';
 import { CalendarMode } from './calendar-mode';
@@ -33,7 +33,7 @@ export class Calendar2CellDirective {
 		return this.isTabbableDate() ? 0 : -1;
 	}
 
-	isTabbableDate = computed(() => {
+	readonly isTabbableDate = computed(() => {
 		return comparePeriods(this.luCalendar2Mode(), this.luCalendar2Date(), this.#tabbableDate());
 	});
 

--- a/packages/ng/date2/calendar2/calendar2.component.ts
+++ b/packages/ng/date2/calendar2/calendar2.component.ts
@@ -94,17 +94,17 @@ export class Calendar2Component implements OnInit {
 	readonly disableModeChange = input(false, { transform: booleanAttribute });
 
 	// Date used to init the component and as internal focus model
-	date = model.required<Date>();
+	readonly date = model.required<Date>();
 
-	tabbableDate = model<Date | null>(null);
+	readonly tabbableDate = model<Date | null>(null);
 
-	mode = model<CalendarMode>('day');
+	readonly mode = model<CalendarMode>('day');
 
-	displayMode = model<CalendarMode | null>(null);
+	readonly displayMode = model<CalendarMode | null>(null);
 
-	ranges = input<readonly DateRange[]>([]);
+	readonly ranges = input<readonly DateRange[]>([]);
 
-	getCellInfo = input<(date: Date, displayMode: CalendarMode | null) => CellStatus>((_date: Date) => ({
+	readonly getCellInfo = input<(date: Date, displayMode: CalendarMode | null) => CellStatus>((_date: Date) => ({
 		classes: [],
 		disabled: false,
 	}));
@@ -125,7 +125,7 @@ export class Calendar2Component implements OnInit {
 
 	dateClicked = output<Date>();
 
-	dateHovered = model<Date | null>(null);
+	readonly dateHovered = model<Date | null>(null);
 
 	todayLabel = this.#intlRelativeDay.format(0, 'day');
 	thisMonthLabel = this.#intlRelativeDay.format(0, 'month');

--- a/packages/ng/date2/calendar2/calendar2.component.ts
+++ b/packages/ng/date2/calendar2/calendar2.component.ts
@@ -77,21 +77,21 @@ export class Calendar2Component implements OnInit {
 
 	#weekOptions: WeekOptions = { weekStartsOn: getJSFirstDayOfWeek(this.#weekInfo) };
 
-	intl = input(...intlInputOptions(LU_DATE2_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_DATE2_TRANSLATIONS));
 
-	showOverflow = input(false, { transform: booleanAttribute });
+	readonly showOverflow = input(false, { transform: booleanAttribute });
 
-	enableOverflow = input(false, { transform: booleanAttribute });
+	readonly enableOverflow = input(false, { transform: booleanAttribute });
 
-	removeYearOverflow = input(false, { transform: booleanAttribute });
+	readonly removeYearOverflow = input(false, { transform: booleanAttribute });
 
-	hideToday = input(false, { transform: booleanAttribute });
+	readonly hideToday = input(false, { transform: booleanAttribute });
 
-	hasTodayButton = input(false, { transform: booleanAttribute });
+	readonly hasTodayButton = input(false, { transform: booleanAttribute });
 
-	hideWeekend = input(false, { transform: booleanAttribute });
+	readonly hideWeekend = input(false, { transform: booleanAttribute });
 
-	disableModeChange = input(false, { transform: booleanAttribute });
+	readonly disableModeChange = input(false, { transform: booleanAttribute });
 
 	// Date used to init the component and as internal focus model
 	date = model.required<Date>();
@@ -119,9 +119,9 @@ export class Calendar2Component implements OnInit {
 
 	nextMonth = computed(() => addMonths(this.month(), 1));
 
-	nextPage = output();
+	readonly nextPage = output();
 
-	previousPage = output();
+	readonly previousPage = output();
 
 	dateClicked = output<Date>();
 

--- a/packages/ng/date2/calendar2/calendar2.component.ts
+++ b/packages/ng/date2/calendar2/calendar2.component.ts
@@ -131,7 +131,7 @@ export class Calendar2Component implements OnInit {
 	thisMonthLabel = this.#intlRelativeDay.format(0, 'month');
 	thisYearLabel = this.#intlRelativeDay.format(0, 'year');
 
-	calendar2CellInstances = viewChildren(Calendar2CellDirective);
+	readonly calendar2CellInstances = viewChildren(Calendar2CellDirective);
 
 	daysOfWeek = eachDayOfInterval({
 		start: startOfWeek(new Date(), this.#weekOptions),

--- a/packages/ng/date2/calendar2/calendar2.component.ts
+++ b/packages/ng/date2/calendar2/calendar2.component.ts
@@ -109,15 +109,15 @@ export class Calendar2Component implements OnInit {
 		disabled: false,
 	}));
 
-	month = computed(() => startOfMonth(this.date()));
+	readonly month = computed(() => startOfMonth(this.date()));
 
-	year = computed(() => startOfYear(this.date()));
+	readonly year = computed(() => startOfYear(this.date()));
 
-	decade = computed(() => startOfDecade(this.date()));
+	readonly decade = computed(() => startOfDecade(this.date()));
 
-	previousMonth = computed(() => subMonths(this.month(), 1));
+	readonly previousMonth = computed(() => subMonths(this.month(), 1));
 
-	nextMonth = computed(() => addMonths(this.month(), 1));
+	readonly nextMonth = computed(() => addMonths(this.month(), 1));
 
 	readonly nextPage = output();
 
@@ -141,7 +141,7 @@ export class Calendar2Component implements OnInit {
 		short: this.#intlDaysShort.format(day),
 	}));
 
-	monthGridDisplay = computed(() => {
+	readonly monthGridDisplay = computed(() => {
 		const daysOfMonth: CalendarCellInfo[] = eachDayOfInterval({
 			start: this.month(),
 			end: endOfMonth(this.month()),
@@ -190,7 +190,7 @@ export class Calendar2Component implements OnInit {
 			.map((weekStart) => daysByWeek[+weekStart]);
 	});
 
-	yearGridDisplay = computed(() => {
+	readonly yearGridDisplay = computed(() => {
 		const monthsOfYear: Date[] = eachMonthOfInterval({
 			start: this.year(),
 			end: endOfYear(this.year()),
@@ -211,7 +211,7 @@ export class Calendar2Component implements OnInit {
 			}, []);
 	});
 
-	decadeGridDisplay = computed(() => {
+	readonly decadeGridDisplay = computed(() => {
 		const yearsOfDecade: Date[] = eachYearOfInterval({
 			start: this.removeYearOverflow() ? this.decade() : subYears(this.decade(), 1),
 			end: this.removeYearOverflow() ? endOfDecade(this.decade()) : addYears(endOfDecade(this.decade()), 1),
@@ -231,15 +231,15 @@ export class Calendar2Component implements OnInit {
 			}, []);
 	});
 
-	currentMonthLabel = computed(() => {
+	readonly currentMonthLabel = computed(() => {
 		return this.#intlDateFormat.format(this.date());
 	});
 
-	currentYearLabel = computed(() => {
+	readonly currentYearLabel = computed(() => {
 		return this.#intlDateYear.format(this.date());
 	});
 
-	currentDecadeLabel = computed(() => {
+	readonly currentDecadeLabel = computed(() => {
 		return `${this.#intlDateYear.format(startOfDecade(this.decade()))} – ${this.#intlDateYear.format(endOfDecade(this.decade()))}`;
 	});
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -111,7 +111,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 
 	inputRef = viewChild<ElementRef<HTMLInputElement>>('date');
 
-	displayValue = computed(() => {
+	readonly displayValue = computed(() => {
 		const textInput = this.userTextInput();
 		if (textInput !== 'ɵ') {
 			const parsedInput = parse(textInput, this.dateFormatWithMode(), startOfDay(new Date()));
@@ -168,8 +168,8 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		return this.widthAuto();
 	}
 
-	isFilterPillEmpty = computed(() => !this.selectedDate());
-	isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
+	readonly isFilterPillEmpty = computed(() => !this.selectedDate());
+	readonly isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
 	#defaultClearable = false;
 	#defaultFilterPillClearable = signal<boolean | null>(null);
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -81,9 +81,9 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 
 	placeholder = input<string>();
 
-	disableOverflow = input(false, { transform: booleanAttribute });
-	hideOverflow = input(false, { transform: booleanAttribute });
-	widthAuto = input(false, { transform: booleanAttribute });
+	readonly disableOverflow = input(false, { transform: booleanAttribute });
+	readonly hideOverflow = input(false, { transform: booleanAttribute });
+	readonly widthAuto = input(false, { transform: booleanAttribute });
 
 	readonly filterPillDisabled = signal(false);
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -77,9 +77,9 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 
 	#luClass = inject(LuClass);
 
-	autocomplete = input<AutoFill>('off');
+	readonly autocomplete = input<AutoFill>('off');
 
-	placeholder = input<string>();
+	readonly placeholder = input<string>();
 
 	readonly disableOverflow = input(false, { transform: booleanAttribute });
 	readonly hideOverflow = input(false, { transform: booleanAttribute });
@@ -143,7 +143,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 	});
 
 	// We need to use a "magic key" here to avoid sending a null value change on initialization
-	userTextInput = signal<string>('ɵ');
+	readonly userTextInput = signal<string>('ɵ');
 
 	combinedGetCellInfo = (date: Date, mode: CalendarMode): CellStatus => {
 		const infoFromInput = this.getCellInfo()?.(date, mode);
@@ -156,9 +156,9 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		};
 	};
 
-	previousButton = viewChild<ElementRef<Element>>('previousButtonRef');
+	readonly previousButton = viewChild<ElementRef<Element>>('previousButtonRef');
 
-	nextButton = viewChild<ElementRef<Element>>('nextButtonRef');
+	readonly nextButton = viewChild<ElementRef<Element>>('nextButtonRef');
 
 	@HostBinding('class.mod-filterPill')
 	isFilterPill = false;
@@ -171,7 +171,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 	readonly isFilterPillEmpty = computed(() => !this.selectedDate());
 	readonly isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
 	#defaultClearable = false;
-	#defaultFilterPillClearable = signal<boolean | null>(null);
+	readonly #defaultFilterPillClearable = signal<boolean | null>(null);
 
 	filterPillPopoverCloseFn?: () => void;
 

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -107,9 +107,9 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 	readonly initialValue = signal<Date | null | undefined>(undefined);
 	readonly dateFromWriteValue = signal<Date | null>(null);
 
-	calendar = viewChild(Calendar2Component);
+	readonly calendar = viewChild(Calendar2Component);
 
-	inputRef = viewChild<ElementRef<HTMLInputElement>>('date');
+	readonly inputRef = viewChild<ElementRef<HTMLInputElement>>('date');
 
 	readonly displayValue = computed(() => {
 		const textInput = this.userTextInput();

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -85,7 +85,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 	hideOverflow = input(false, { transform: booleanAttribute });
 	widthAuto = input(false, { transform: booleanAttribute });
 
-	filterPillDisabled = signal(false);
+	readonly filterPillDisabled = signal(false);
 
 	popoverPositions: ConnectionPositionPair[] = [
 		new ConnectionPositionPair({ originX: 'start', originY: 'bottom' }, { overlayX: 'start', overlayY: 'top' }, -8, 0),
@@ -100,12 +100,12 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		),
 	];
 
-	inputFocused = signal(false);
+	readonly inputFocused = signal(false);
 
-	selectedDate = signal<Date | null>(null);
+	readonly selectedDate = signal<Date | null>(null);
 
-	initialValue = signal<Date | null | undefined>(undefined);
-	dateFromWriteValue = signal<Date | null>(null);
+	readonly initialValue = signal<Date | null | undefined>(undefined);
+	readonly dateFromWriteValue = signal<Date | null>(null);
 
 	calendar = viewChild(Calendar2Component);
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -164,7 +164,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		}
 	});
 
-	calendars = viewChildren(Calendar2Component);
+	readonly calendars = viewChildren(Calendar2Component);
 
 	combinedGetCellInfo = (date: Date, mode: CalendarMode): CellStatus => {
 		const infoFromInput = this.getCellInfo()?.(date, mode);

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -91,14 +91,14 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	#breakpointObserver = inject(BreakpointObserver);
 
-	hasTwoCalendars = toSignal(this.#breakpointObserver.observe('(min-width: 40em)').pipe(map((state) => state.matches)));
+	readonly hasTwoCalendars = toSignal(this.#breakpointObserver.observe('(min-width: 40em)').pipe(map((state) => state.matches)));
 
 	idSuffix = nextId++;
 
-	startTextInputRef = viewChild<ElementRef<HTMLInputElement>>('start');
+	readonly startTextInputRef = viewChild<ElementRef<HTMLInputElement>>('start');
 	readonly startUserTextInput = signal('ɵ');
 
-	endTextInputRef = viewChild<ElementRef<HTMLInputElement>>('end');
+	readonly endTextInputRef = viewChild<ElementRef<HTMLInputElement>>('end');
 	readonly endUserTextInput = signal('ɵ');
 
 	// CVA stuff
@@ -109,7 +109,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	readonly dateHovered = signal<Date | null>(null);
 
-	placeholder = input<string>();
+	readonly placeholder = input<string>();
 
 	readonly widthAuto = input(false, { transform: booleanAttribute });
 
@@ -134,15 +134,15 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	readonly highlightedField = signal<-1 | 0 | 1>(-1);
 
-	shortcuts = input<readonly CalendarShortcut[]>();
+	readonly shortcuts = input<readonly CalendarShortcut[]>();
 
-	autocomplete = input<AutoFill>('off');
+	readonly autocomplete = input<AutoFill>('off');
 
-	protected currentRightDate = computed(() => {
+	protected readonly currentRightDate = computed(() => {
 		return this.hasTwoCalendars() ? this.getNextCalendarDate(this.currentDate()) : this.currentDate();
 	});
 
-	protected currentStartDisplayDate = computed(() => {
+	protected readonly currentStartDisplayDate = computed(() => {
 		switch (this.mode()) {
 			case 'day':
 				return startOfMonth(this.currentDate());
@@ -153,7 +153,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		}
 	});
 
-	protected currentEndDisplayDate = computed(() => {
+	protected readonly currentEndDisplayDate = computed(() => {
 		switch (this.mode()) {
 			case 'day':
 				return endOfMonth(this.currentRightDate());
@@ -207,9 +207,9 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		return '';
 	});
 
-	previousButton = viewChild<ElementRef<Element>>('previousButtonRef');
+	readonly previousButton = viewChild<ElementRef<Element>>('previousButtonRef');
 
-	nextButton = viewChild<ElementRef<Element>>('nextButtonRef');
+	readonly nextButton = viewChild<ElementRef<Element>>('nextButtonRef');
 
 	// Which calendar is currently being focused in, used for tabbable date logic
 	readonly focusedCalendarIndex = signal(0);
@@ -227,7 +227,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 	readonly isFilterPillEmpty = computed(() => this.selectedRange() === null);
 	readonly isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
 	#defaultClearable = false;
-	#defaultFilterPillClearable = signal<boolean | null>(null);
+	readonly #defaultFilterPillClearable = signal<boolean | null>(null);
 
 	filterPillPopoverCloseFn?: () => void;
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -96,24 +96,24 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 	idSuffix = nextId++;
 
 	startTextInputRef = viewChild<ElementRef<HTMLInputElement>>('start');
-	startUserTextInput = signal('ɵ');
+	readonly startUserTextInput = signal('ɵ');
 
 	endTextInputRef = viewChild<ElementRef<HTMLInputElement>>('end');
-	endUserTextInput = signal('ɵ');
+	readonly endUserTextInput = signal('ɵ');
 
 	// CVA stuff
 	#onChange?: (value: DateRange | null) => void;
 
-	initialValue = signal<DateRange | null | undefined>(undefined);
-	selectedRange = signal<DateRange | null>(null);
+	readonly initialValue = signal<DateRange | null | undefined>(undefined);
+	readonly selectedRange = signal<DateRange | null>(null);
 
-	dateHovered = signal<Date | null>(null);
+	readonly dateHovered = signal<Date | null>(null);
 
 	placeholder = input<string>();
 
 	widthAuto = input(false, { transform: booleanAttribute });
 
-	label: Signal<PortalContent | undefined> = signal('');
+	readonly label: Signal<PortalContent | undefined> = signal('');
 
 	popoverPositions: ConnectionPositionPair[] = [
 		new ConnectionPositionPair({ originX: 'start', originY: 'bottom' }, { overlayX: 'start', overlayY: 'top' }, -8, 0),
@@ -128,11 +128,11 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		),
 	];
 
-	inputFocused = signal(false);
+	readonly inputFocused = signal(false);
 
-	editedField = signal<-1 | 0 | 1>(-1);
+	readonly editedField = signal<-1 | 0 | 1>(-1);
 
-	highlightedField = signal<-1 | 0 | 1>(-1);
+	readonly highlightedField = signal<-1 | 0 | 1>(-1);
 
 	shortcuts = input<readonly CalendarShortcut[]>();
 
@@ -212,7 +212,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 	nextButton = viewChild<ElementRef<Element>>('nextButtonRef');
 
 	// Which calendar is currently being focused in, used for tabbable date logic
-	focusedCalendarIndex = signal(0);
+	readonly focusedCalendarIndex = signal(0);
 
 	focusedCalendar = computed(() => this.calendars()[this.focusedCalendarIndex()]);
 
@@ -231,7 +231,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	filterPillPopoverCloseFn?: () => void;
 
-	filterPillDisabled = signal(false);
+	readonly filterPillDisabled = signal(false);
 
 	get isNavigationButtonFocused(): boolean {
 		return [this.previousButton()?.nativeElement, this.nextButton()?.nativeElement].includes(document.activeElement ?? undefined);

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -111,7 +111,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	placeholder = input<string>();
 
-	widthAuto = input(false, { transform: booleanAttribute });
+	readonly widthAuto = input(false, { transform: booleanAttribute });
 
 	readonly label: Signal<PortalContent | undefined> = signal('');
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -176,14 +176,14 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		};
 	};
 
-	calendarRanges = computed(() => {
+	readonly calendarRanges = computed(() => {
 		if (this.selectedRange()) {
 			return [this.selectedRange(), ...this.ranges()];
 		}
 		return this.ranges();
 	});
 
-	startLabel = computed(() => {
+	readonly startLabel = computed(() => {
 		const inputValue = this.startUserTextInput();
 		if (inputValue !== 'ɵ') {
 			return inputValue;
@@ -195,7 +195,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		return '';
 	});
 
-	endLabel = computed(() => {
+	readonly endLabel = computed(() => {
 		const inputValue = this.endUserTextInput();
 		if (inputValue !== 'ɵ') {
 			return inputValue;
@@ -214,7 +214,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 	// Which calendar is currently being focused in, used for tabbable date logic
 	readonly focusedCalendarIndex = signal(0);
 
-	focusedCalendar = computed(() => this.calendars()[this.focusedCalendarIndex()]);
+	readonly focusedCalendar = computed(() => this.calendars()[this.focusedCalendarIndex()]);
 
 	@HostBinding('class.mod-filterPill')
 	isFilterPill = false;
@@ -224,8 +224,8 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 		return this.widthAuto();
 	}
 
-	isFilterPillEmpty = computed(() => this.selectedRange() === null);
-	isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
+	readonly isFilterPillEmpty = computed(() => this.selectedRange() === null);
+	readonly isFilterPillClearable = computed(() => this.clearable() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
 	#defaultClearable = false;
 	#defaultFilterPillClearable = signal<boolean | null>(null);
 

--- a/packages/ng/department/select/feeder/department-feeder.component.ts
+++ b/packages/ng/department/select/feeder/department-feeder.component.ts
@@ -32,7 +32,7 @@ import { ALuDepartmentService, LuDepartmentV4Service } from '../../service/index
 export class LuDepartmentFeederComponent extends ALuTreeOptionOperator<ILuDepartment> implements ILuTreeOptionOperator<ILuDepartment>, ILuOnOpenSubscriber {
 	inOptions$: Observable<ILuTree<ILuDepartment>[]>;
 	outOptions$: Observable<ILuTree<ILuDepartment>[]>;
-	protected _out$ = new Subject<ILuTree<ILuDepartment>[]>();
+	protected readonly _out$ = new Subject<ILuTree<ILuDepartment>[]>();
 	protected _service: LuDepartmentV4Service;
 	@Input() set appInstanceId(appInstanceId: number | string) {
 		this._service.appInstanceId = appInstanceId;

--- a/packages/ng/department/select/input/department-select-input.component.ts
+++ b/packages/ng/department/select/input/department-select-input.component.ts
@@ -61,7 +61,7 @@ export class LuDepartmentSelectInputComponent<
 	@Input() filters: string[] = [];
 	@Input() uniqueOperation: number;
 
-	public intl = input(...intlInputOptions(LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_DEPARTMENT_SELECT_INPUT_TRANSLATIONS));
 
 	constructor(
 		protected override _changeDetectorRef: ChangeDetectorRef,

--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -28,7 +28,7 @@ export class DialogHeaderAction {}
 export class DialogHeaderComponent implements OnInit {
 	#ref = inject(LuDialogRef);
 
-	intl = input(...intlInputOptions(LU_DIALOG_HEADER_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_DIALOG_HEADER_TRANSLATIONS));
 
 	dismissible = !this.#ref.config.alert;
 

--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -40,7 +40,7 @@ export class DialogHeaderComponent implements OnInit {
 		this.#ref.dismiss();
 	}
 
-	optionalAction = contentChild(DialogHeaderAction);
+	readonly optionalAction = contentChild(DialogHeaderAction);
 
 	ngOnInit(): void {
 		// Using setTimeout here to make sure this will be handled in the next Cd cycle, not the current one.

--- a/packages/ng/divider/divider.component.ts
+++ b/packages/ng/divider/divider.component.ts
@@ -17,7 +17,7 @@ import { LuClass } from '@lucca-front/ng/core';
 export class DividerComponent implements OnChanges {
 	#luClass = inject(LuClass);
 
-	@ViewChild('content') content: ElementRef;
+	@ViewChild('content') readonly content: ElementRef;
 
 	/**
 	 * Allows rendering the Divider as a native separator

--- a/packages/ng/establishment/select/input/establishment-select-input.component.ts
+++ b/packages/ng/establishment/select/input/establishment-select-input.component.ts
@@ -74,7 +74,7 @@ export class LuEstablishmentSelectInputComponent<
 		return this.isSearching ? 'name' : 'legalunit.name,name';
 	}
 
-	public intl = input(...intlInputOptions(LU_ESTABLISHMENT_SELECT_INPUT_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_ESTABLISHMENT_SELECT_INPUT_TRANSLATIONS));
 
 	constructor(
 		protected override _changeDetectorRef: ChangeDetectorRef,

--- a/packages/ng/establishment/select/legal-unit-selector/legal-unit-selector.directive.ts
+++ b/packages/ng/establishment/select/legal-unit-selector/legal-unit-selector.directive.ts
@@ -21,7 +21,7 @@ import { DEFAULT_ESTABLISHMENT_SERVICE } from '../establishment-select.token';
 })
 export class LuLegalUnitSelectorDirective implements ILuOptionSelector<ILuEstablishment>, OnDestroy {
 	multiple = true;
-	onSelectValue = new Subject<ILuEstablishment[]>();
+	readonly onSelectValue = new Subject<ILuEstablishment[]>();
 	private _values: ILuEstablishment[];
 	private _service: LuEstablishmentService;
 	private _subs = new Subscription();

--- a/packages/ng/establishment/select/searcher/establishment-searcher.component.ts
+++ b/packages/ng/establishment/select/searcher/establishment-searcher.component.ts
@@ -78,14 +78,14 @@ export class LuEstablishmentSearcherComponent implements ILuOnOpenSubscriber, IL
 
 	loading = false;
 
-	private _nextPage$ = new Subject<void>();
-	private _page$: Observable<number> = this._nextPage$.pipe(
+	private readonly _nextPage$ = new Subject<void>();
+	private readonly _page$: Observable<number> = this._nextPage$.pipe(
 		scan((acc) => acc + 1, 0),
 		startWith(0),
 	);
 	private _resetOutOptions = new Subject<void>();
 
-	outOptions$ = this._resetOutOptions.pipe(
+	readonly outOptions$ = this._resetOutOptions.pipe(
 		startWith(undefined),
 		switchMap(() =>
 			this.clueControl.valueChanges.pipe(
@@ -112,7 +112,7 @@ export class LuEstablishmentSearcherComponent implements ILuOnOpenSubscriber, IL
 		share(),
 	);
 
-	displayPlaceholder$ = this.outOptions$.pipe(map((o) => o?.length === 0 && this._isSearching));
+	readonly displayPlaceholder$ = this.outOptions$.pipe(map((o) => o?.length === 0 && this._isSearching));
 
 	constructor(
 		@Inject(ALuEstablishmentService)

--- a/packages/ng/establishment/select/searcher/establishment-searcher.component.ts
+++ b/packages/ng/establishment/select/searcher/establishment-searcher.component.ts
@@ -68,7 +68,7 @@ export class LuEstablishmentSearcherComponent implements ILuOnOpenSubscriber, IL
 
 	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef, static: true })
-	searchInput: ElementRef<HTMLElement>;
+	readonly searchInput: ElementRef<HTMLElement>;
 
 	@Output()
 	isSearching = new EventEmitter<boolean>();

--- a/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
+++ b/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
@@ -20,21 +20,21 @@ export abstract class BaseFileUploadComponent {
 
 	filePicked = output<File>();
 
-	accept = input<
+	readonly accept = input<
 		Array<{
 			format: string;
 			name?: string;
 		}>
 	>([]);
 
-	protected defaultAccept = computed(() => [
+	protected readonly defaultAccept = computed(() => [
 		{
 			format: '*',
 			name: this.intl().all,
 		},
 	]);
 
-	protected resolvedAccept = computed(() => {
+	protected readonly resolvedAccept = computed(() => {
 		const acceptValue = this.accept();
 		return acceptValue.length > 0 ? acceptValue : this.defaultAccept();
 	});
@@ -53,15 +53,15 @@ export abstract class BaseFileUploadComponent {
 
 	readonly structure = input(false, { transform: booleanAttribute });
 
-	fileMaxSize = input<number>(80 * MEGA_BYTE);
+	readonly fileMaxSize = input<number>(80 * MEGA_BYTE);
 
 	readonly maxSizeDisplay = computed(() => formatFileSize(this.locale, this.fileMaxSize()));
 
-	size = input<'S' | null>(null);
+	readonly size = input<'S' | null>(null);
 
 	readonly password = input(false, { transform: booleanAttribute });
 
-	illustration = input<
+	readonly illustration = input<
 		/** @deprecated use 'invoice' instead */
 		'paper' | 'picture' | 'invoice'
 	>('invoice');

--- a/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
+++ b/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
@@ -39,15 +39,15 @@ export abstract class BaseFileUploadComponent {
 		return acceptValue.length > 0 ? acceptValue : this.defaultAccept();
 	});
 
-	acceptNames = computed(() =>
+	readonly acceptNames = computed(() =>
 		this.resolvedAccept()
 			.filter((e) => e.name)
 			.map((e) => e.name),
 	);
 
-	acceptAttribute = computed(() => this.resolvedAccept().map((e) => e.format));
+	readonly acceptAttribute = computed(() => this.resolvedAccept().map((e) => e.format));
 
-	acceptAll = computed(() => {
+	readonly acceptAll = computed(() => {
 		return this.acceptAttribute().some((str) => str.includes('*'));
 	});
 
@@ -55,7 +55,7 @@ export abstract class BaseFileUploadComponent {
 
 	fileMaxSize = input<number>(80 * MEGA_BYTE);
 
-	maxSizeDisplay = computed(() => formatFileSize(this.locale, this.fileMaxSize()));
+	readonly maxSizeDisplay = computed(() => formatFileSize(this.locale, this.fileMaxSize()));
 
 	size = input<'S' | null>(null);
 
@@ -66,7 +66,7 @@ export abstract class BaseFileUploadComponent {
 		'paper' | 'picture' | 'invoice'
 	>('invoice');
 
-	illus = computed(() => {
+	readonly illus = computed(() => {
 		switch (this.illustration()) {
 			case 'paper':
 			case 'invoice':

--- a/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
+++ b/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
@@ -14,7 +14,7 @@ export abstract class BaseFileUploadComponent {
 
 	protected droppable = false;
 
-	intl = input(...intlInputOptions(LU_FILE_UPLOAD_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_FILE_UPLOAD_TRANSLATIONS));
 
 	protected formFieldRef = inject(FORM_FIELD_INSTANCE, { optional: true });
 
@@ -51,7 +51,7 @@ export abstract class BaseFileUploadComponent {
 		return this.acceptAttribute().some((str) => str.includes('*'));
 	});
 
-	structure = input(false, { transform: booleanAttribute });
+	readonly structure = input(false, { transform: booleanAttribute });
 
 	fileMaxSize = input<number>(80 * MEGA_BYTE);
 
@@ -59,7 +59,7 @@ export abstract class BaseFileUploadComponent {
 
 	size = input<'S' | null>(null);
 
-	password = input(false, { transform: booleanAttribute });
+	readonly password = input(false, { transform: booleanAttribute });
 
 	illustration = input<
 		/** @deprecated use 'invoice' instead */
@@ -76,7 +76,7 @@ export abstract class BaseFileUploadComponent {
 		}
 	});
 
-	required = input(false, { transform: booleanAttribute });
+	readonly required = input(false, { transform: booleanAttribute });
 
 	readonly buttonFilled = input(false, { transform: booleanAttribute });
 

--- a/packages/ng/file-upload/file-entry/file-entry.component.ts
+++ b/packages/ng/file-upload/file-entry/file-entry.component.ts
@@ -45,7 +45,7 @@ export class FileEntryComponent {
 	readonly downloadURL = input('');
 
 	readonly password = input('');
-	passwordChange$ = new Subject<string>();
+	readonly passwordChange$ = new Subject<string>();
 	passwordChange = outputFromObservable(this.passwordChange$);
 
 	get withPassword() {
@@ -54,7 +54,7 @@ export class FileEntryComponent {
 
 	readonly media = input(false, { transform: booleanAttribute });
 
-	deleteFile$ = new Subject<void>();
+	readonly deleteFile$ = new Subject<void>();
 
 	deleteFile = outputFromObservable(this.deleteFile$);
 

--- a/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
+++ b/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
@@ -26,8 +26,8 @@ import { LU_FILTER_PILLS_TRANSLATIONS } from '../filter-pills.translate';
 export class FilterBarComponent {
 	readonly intl = input(...intlInputOptions(LU_FILTER_PILLS_TRANSLATIONS));
 
-	addonBefore = signal<TemplateRef<unknown> | null>(null);
-	addonAfter = signal<TemplateRef<unknown> | null>(null);
+	readonly addonBefore = signal<TemplateRef<unknown> | null>(null);
+	readonly addonAfter = signal<TemplateRef<unknown> | null>(null);
 
 	popoverPositions: ConnectionPositionPair[] = [
 		new ConnectionPositionPair(

--- a/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
+++ b/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
@@ -52,5 +52,5 @@ export class FilterBarComponent {
 
 	pills = contentChildren(FilterPillComponent, { descendants: true });
 
-	optionalPills = computed(() => this.pills().filter((pill) => pill.optional()));
+	readonly optionalPills = computed(() => this.pills().filter((pill) => pill.optional()));
 }

--- a/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
+++ b/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
@@ -24,7 +24,7 @@ import { LU_FILTER_PILLS_TRANSLATIONS } from '../filter-pills.translate';
 	},
 })
 export class FilterBarComponent {
-	intl = input(...intlInputOptions(LU_FILTER_PILLS_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_FILTER_PILLS_TRANSLATIONS));
 
 	addonBefore = signal<TemplateRef<unknown> | null>(null);
 	addonAfter = signal<TemplateRef<unknown> | null>(null);

--- a/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
+++ b/packages/ng/filter-pills/filter-bar/filter-bar.component.ts
@@ -50,7 +50,7 @@ export class FilterBarComponent {
 		),
 	];
 
-	pills = contentChildren(FilterPillComponent, { descendants: true });
+	readonly pills = contentChildren(FilterPillComponent, { descendants: true });
 
 	readonly optionalPills = computed(() => this.pills().filter((pill) => pill.optional()));
 }

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -62,7 +62,7 @@ export class FilterPillComponent {
 	readonly layout = computed(() => this.inputComponentRef()?.filterPillLayout?.() || 'default');
 
 	// The easy way to grab input component, will work in most cases
-	childInputComponentRef = contentChild(FILTER_PILL_INPUT_COMPONENT);
+	readonly childInputComponentRef = contentChild(FILTER_PILL_INPUT_COMPONENT);
 
 	// The harder way, because child has to register itself to the host, might become the default approach if this is required too much
 	// (like when child isn't created when component inits or it's too deep)
@@ -70,13 +70,13 @@ export class FilterPillComponent {
 
 	readonly inputComponentRef = computed(() => this.registeredInputComponentRef() || this.childInputComponentRef());
 
-	popoverRef = viewChild(PopoverDirective);
+	readonly popoverRef = viewChild(PopoverDirective);
 
 	pillTpl: TemplateRef<unknown>;
 
 	readonly labelTpl = computed(() => this.customLabelTpl() || this.defaultLabelTpl());
 
-	defaultLabelTpl = viewChild<TemplateRef<unknown>>('defaultLabel');
+	readonly defaultLabelTpl = viewChild<TemplateRef<unknown>>('defaultLabel');
 
 	customLabelTpl = signal<TemplateRef<unknown> | null>(null);
 

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -59,7 +59,7 @@ export class FilterPillComponent {
 
 	id = `filterPill-combobox-${nextId++}`;
 
-	layout = computed(() => this.inputComponentRef()?.filterPillLayout?.() || 'default');
+	readonly layout = computed(() => this.inputComponentRef()?.filterPillLayout?.() || 'default');
 
 	// The easy way to grab input component, will work in most cases
 	childInputComponentRef = contentChild(FILTER_PILL_INPUT_COMPONENT);
@@ -68,13 +68,13 @@ export class FilterPillComponent {
 	// (like when child isn't created when component inits or it's too deep)
 	registeredInputComponentRef = signal<FilterPillInputComponent | null>(null);
 
-	inputComponentRef = computed(() => this.registeredInputComponentRef() || this.childInputComponentRef());
+	readonly inputComponentRef = computed(() => this.registeredInputComponentRef() || this.childInputComponentRef());
 
 	popoverRef = viewChild(PopoverDirective);
 
 	pillTpl: TemplateRef<unknown>;
 
-	labelTpl = computed(() => this.customLabelTpl() || this.defaultLabelTpl());
+	readonly labelTpl = computed(() => this.customLabelTpl() || this.defaultLabelTpl());
 
 	defaultLabelTpl = viewChild<TemplateRef<unknown>>('defaultLabel');
 
@@ -84,7 +84,7 @@ export class FilterPillComponent {
 
 	readonly optional = input(false, { transform: booleanAttribute });
 
-	disabled = computed(() => this.inputComponentRef()?.filterPillDisabled?.() || false);
+	readonly disabled = computed(() => this.inputComponentRef()?.filterPillDisabled?.() || false);
 
 	@HostBinding('class.is-hidden')
 	get isHiddenClass() {
@@ -118,23 +118,23 @@ export class FilterPillComponent {
 
 	label = input.required<string>();
 
-	placeholder = computed(() => this.placeholderOverride() ?? this.intl().placeholder);
+	readonly placeholder = computed(() => this.placeholderOverride() ?? this.intl().placeholder);
 	placeholderOverride = input<string | null>(null, { alias: 'placeholder' });
 
 	icon = input<LuccaIcon>();
 
-	defaultIcon = computed<LuccaIcon>(() => this.inputComponentRef()?.getDefaultFilterPillIcon?.() ?? 'arrowChevronBottom');
+	readonly defaultIcon = computed<LuccaIcon>(() => this.inputComponentRef()?.getDefaultFilterPillIcon?.() ?? 'arrowChevronBottom');
 
-	displayedIcon = computed(() => this.icon() || this.defaultIcon());
+	readonly displayedIcon = computed(() => this.icon() || this.defaultIcon());
 
-	shouldHideCombobox = computed(() => this.inputComponentRef()?.hideCombobox?.() ?? false);
+	readonly shouldHideCombobox = computed(() => this.inputComponentRef()?.hideCombobox?.() ?? false);
 
-	inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty() ?? true);
-	inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable() ?? false);
+	readonly inputIsEmpty = computed(() => this.inputComponentRef()?.isFilterPillEmpty() ?? true);
+	readonly inputIsClearable = computed(() => this.inputComponentRef()?.isFilterPillClearable() ?? false);
 
-	shouldShowColon = computed(() => this.inputComponentRef()?.showColon?.() || !this.inputIsEmpty());
+	readonly shouldShowColon = computed(() => this.inputComponentRef()?.showColon?.() || !this.inputIsEmpty());
 
-	colonDisplay = computed(() => {
+	readonly colonDisplay = computed(() => {
 		if (!this.shouldShowColon()) {
 			return '';
 		}
@@ -144,7 +144,7 @@ export class FilterPillComponent {
 		return ':';
 	});
 
-	modCheckbox = computed(() => this.layout() === 'checkable');
+	readonly modCheckbox = computed(() => this.layout() === 'checkable');
 
 	@HostBinding('class.mod-checkbox')
 	get isModCheckbox() {

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -66,7 +66,7 @@ export class FilterPillComponent {
 
 	// The harder way, because child has to register itself to the host, might become the default approach if this is required too much
 	// (like when child isn't created when component inits or it's too deep)
-	registeredInputComponentRef = signal<FilterPillInputComponent | null>(null);
+	readonly registeredInputComponentRef = signal<FilterPillInputComponent | null>(null);
 
 	readonly inputComponentRef = computed(() => this.registeredInputComponentRef() || this.childInputComponentRef());
 
@@ -78,9 +78,9 @@ export class FilterPillComponent {
 
 	readonly defaultLabelTpl = viewChild<TemplateRef<unknown>>('defaultLabel');
 
-	customLabelTpl = signal<TemplateRef<unknown> | null>(null);
+	readonly customLabelTpl = signal<TemplateRef<unknown> | null>(null);
 
-	name = input<string>();
+	readonly name = input<string>();
 
 	readonly optional = input(false, { transform: booleanAttribute });
 
@@ -91,9 +91,9 @@ export class FilterPillComponent {
 		return this.isHidden();
 	}
 
-	displayed = model(false);
+	readonly displayed = model(false);
 
-	protected isHidden = computed(() => this.optional() && !this.displayed());
+	protected readonly isHidden = computed(() => this.optional() && !this.displayed());
 
 	popoverPositions: ConnectionPositionPair[] = [
 		new ConnectionPositionPair(
@@ -116,12 +116,12 @@ export class FilterPillComponent {
 		),
 	];
 
-	label = input.required<string>();
+	readonly label = input.required<string>();
 
 	readonly placeholder = computed(() => this.placeholderOverride() ?? this.intl().placeholder);
-	placeholderOverride = input<string | null>(null, { alias: 'placeholder' });
+	readonly placeholderOverride = input<string | null>(null, { alias: 'placeholder' });
 
-	icon = input<LuccaIcon>();
+	readonly icon = input<LuccaIcon>();
 
 	readonly defaultIcon = computed<LuccaIcon>(() => this.inputComponentRef()?.getDefaultFilterPillIcon?.() ?? 'arrowChevronBottom');
 

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -55,7 +55,7 @@ export class FilterPillComponent {
 
 	#locale = inject(LOCALE_ID);
 
-	elementRef = inject(ElementRef);
+	readonly elementRef = inject(ElementRef);
 
 	id = `filterPill-combobox-${nextId++}`;
 

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -51,7 +51,7 @@ let nextId = 0;
 	},
 })
 export class FilterPillComponent {
-	intl = input(...intlInputOptions(LU_FILTER_PILLS_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_FILTER_PILLS_TRANSLATIONS));
 
 	#locale = inject(LOCALE_ID);
 
@@ -82,7 +82,7 @@ export class FilterPillComponent {
 
 	name = input<string>();
 
-	optional = input(false, { transform: booleanAttribute });
+	readonly optional = input(false, { transform: booleanAttribute });
 
 	disabled = computed(() => this.inputComponentRef()?.filterPillDisabled?.() || false);
 

--- a/packages/ng/form-field/form-field.component.spec.ts
+++ b/packages/ng/form-field/form-field.component.spec.ts
@@ -15,10 +15,10 @@ import { FormFieldComponent } from './form-field.component';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FormFieldComponentTestComponent {
-	formControlToUse = input<'normal' | 'required'>('normal');
-	formField = viewChild(FormFieldComponent);
+	readonly formControlToUse = input<'normal' | 'required'>('normal');
+	readonly formField = viewChild(FormFieldComponent);
 
-	formControl = computed(() => (this.formControlToUse() === 'normal' ? this.normalFormControl : this.requiredFormControl));
+	readonly formControl = computed(() => (this.formControlToUse() === 'normal' ? this.normalFormControl : this.requiredFormControl));
 
 	requiredFormControl = new FormControl('', { validators: Validators.required });
 	normalFormControl = new FormControl('');

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -91,7 +91,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	rolePresentationLabel = model(false);
 
-	labelIsPresentation = computed(() => this.rolePresentationLabel() || this.presentation());
+	readonly labelIsPresentation = computed(() => this.rolePresentationLabel() || this.presentation());
 
 	readonly inline = input(false, { transform: booleanAttribute });
 

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -166,7 +166,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	id = signal<string>('');
 
-	ready$ = new BehaviorSubject<boolean>(false);
+	readonly ready$ = new BehaviorSubject<boolean>(false);
 
 	public get ready(): boolean {
 		return this.ready$.value;

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -89,7 +89,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	 */
 	readonly hiddenLabel = input(false, { transform: booleanAttribute });
 
-	rolePresentationLabel = model(false);
+	readonly rolePresentationLabel = model(false);
 
 	readonly labelIsPresentation = computed(() => this.rolePresentationLabel() || this.presentation());
 
@@ -112,7 +112,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	readonly #invalidStatus = signal(false);
 	invalidStatus = this.#invalidStatus.asReadonly();
 
-	invalid = input<boolean | null, boolean>(null, { transform: booleanAttribute });
+	readonly invalid = input<boolean | null, boolean>(null, { transform: booleanAttribute });
 
 	readonly inlineMessage = input<PortalContent | null>(null);
 
@@ -164,7 +164,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 		return this.#inputs;
 	}
 
-	id = signal<string>('');
+	readonly id = signal<string>('');
 
 	readonly ready$ = new BehaviorSubject<boolean>(false);
 

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -78,8 +78,8 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	readonly ownRequiredValidators = computed(() => this.requiredValidators().filter((c) => !this.ignoredRequiredValidators().has(c)));
 	readonly ownControls = computed(() => this.ngControls().filter((c) => !this.ignoredControls().has(c)));
 
-	#hasInputRequired = signal(false);
-	forceInputRequired = signal(false);
+	readonly #hasInputRequired = signal(false);
+	readonly forceInputRequired = signal(false);
 	readonly isInputRequired = computed(() => this.forceInputRequired() || this.#hasInputRequired());
 
 	readonly label = input.required<PortalContent>();
@@ -109,7 +109,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 		transform: numberAttribute as (value: FormFieldWidth | `${FormFieldWidth}`) => FormFieldWidth,
 	});
 
-	#invalidStatus = signal(false);
+	readonly #invalidStatus = signal(false);
 	invalidStatus = this.#invalidStatus.asReadonly();
 
 	invalid = input<boolean | null, boolean>(null, { transform: booleanAttribute });

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -65,7 +65,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	#renderer = inject(Renderer2);
 	protected parentForm = inject(LU_FORM_INSTANCE, { optional: true });
 
-	framed = inject(INPUT_FRAMED_INSTANCE, { optional: true }) !== null;
+	readonly framed = inject(INPUT_FRAMED_INSTANCE, { optional: true }) !== null;
 
 	readonly formFieldChildren = contentChildren(FormFieldComponent, { descendants: true });
 

--- a/packages/ng/form-field/value-presentation/presentation-display.directive.ts
+++ b/packages/ng/form-field/value-presentation/presentation-display.directive.ts
@@ -11,7 +11,7 @@ export class PresentationDisplayDirective implements OnInit {
 
 	#vcr = inject(ViewContainerRef);
 
-	defaultDisplay = signal(false);
+	readonly defaultDisplay = signal(false);
 
 	ngOnInit() {
 		if (this.#formFieldRef) {

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -1,12 +1,12 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, input, signal, Signal, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { getIntl } from '@lucca-front/ng/core';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent, FilterPillLabelDirective, FilterPillLayout } from '@lucca-front/ng/filter-pills';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, INPUT_FRAMED_INSTANCE, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
 import { CHECKBOX_INPUT_TRANSLATIONS } from './checkbox-input.translate';
-import { getIntl } from '@lucca-front/ng/core';
 
 let nextId = 0;
 
@@ -45,11 +45,11 @@ export class CheckboxInputComponent implements FilterPillInputComponent {
 	isFilterPill = signal<boolean>(false);
 	filterPillInputId = `lu-checkbox-pill-input-${nextId++}`;
 
-	filterPillLayout: Signal<FilterPillLayout> = signal('checkable');
-	isFilterPillEmpty: Signal<boolean> = signal(true);
-	isFilterPillClearable: Signal<boolean> = signal(false);
-	hideCombobox: Signal<boolean> = signal(true);
-	showColon: Signal<boolean> = signal(false);
+	readonly filterPillLayout: Signal<FilterPillLayout> = signal('checkable');
+	readonly isFilterPillEmpty: Signal<boolean> = signal(true);
+	readonly isFilterPillClearable: Signal<boolean> = signal(false);
+	readonly hideCombobox: Signal<boolean> = signal(true);
+	readonly showColon: Signal<boolean> = signal(false);
 
 	ngControl = injectNgControl();
 

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -42,7 +42,7 @@ export class CheckboxInputComponent implements FilterPillInputComponent {
 	 */
 	readonly mixed = input(false, { transform: booleanAttribute });
 
-	isFilterPill = signal<boolean>(false);
+	readonly isFilterPill = signal<boolean>(false);
 	filterPillInputId = `lu-checkbox-pill-input-${nextId++}`;
 
 	readonly filterPillLayout: Signal<FilterPillLayout> = signal('checkable');

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -30,10 +30,10 @@ let nextId = 0;
 	},
 })
 export class CheckboxInputComponent implements FilterPillInputComponent {
-	framed = inject(INPUT_FRAMED_INSTANCE, { optional: true }) !== null;
-	parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
-	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
-	intl = getIntl(CHECKBOX_INPUT_TRANSLATIONS);
+	readonly framed = inject(INPUT_FRAMED_INSTANCE, { optional: true }) !== null;
+	readonly parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
+	readonly formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
+	readonly intl = getIntl(CHECKBOX_INPUT_TRANSLATIONS);
 
 	readonly checklist = input(false, { transform: booleanAttribute });
 

--- a/packages/ng/forms/color-input/color-input.component.ts
+++ b/packages/ng/forms/color-input/color-input.component.ts
@@ -24,18 +24,18 @@ import { LU_COLOR_TRANSLATIONS } from './color.translate';
 export class ColorInputComponent {
 	readonly intl = input(...intlInputOptions(LU_COLOR_TRANSLATIONS));
 
-	mouseHighlighted = signal<string>('');
-	keyboardHighlighted = signal<string>('');
+	readonly mouseHighlighted = signal<string>('');
+	readonly keyboardHighlighted = signal<string>('');
 	readonly highlighted = computed(() => this.mouseHighlighted() || this.keyboardHighlighted());
 
-	clue = signal<string>('');
-	colors = input.required<ColorOption[]>();
+	readonly clue = signal<string>('');
+	readonly colors = input.required<ColorOption[]>();
 	readonly clearable = input(false, { transform: booleanAttribute });
 	readonly compact = input(false, { transform: booleanAttribute });
 
 	ngControl = injectNgControl();
 
-	currentColorPresentation: Signal<ColorOption | null>;
+	readonly currentColorPresentation: Signal<ColorOption | null>;
 
 	constructor() {
 		if (this.ngControl && this.ngControl.valueChanges) {

--- a/packages/ng/forms/color-input/color-input.component.ts
+++ b/packages/ng/forms/color-input/color-input.component.ts
@@ -26,7 +26,7 @@ export class ColorInputComponent {
 
 	mouseHighlighted = signal<string>('');
 	keyboardHighlighted = signal<string>('');
-	highlighted = computed(() => this.mouseHighlighted() || this.keyboardHighlighted());
+	readonly highlighted = computed(() => this.mouseHighlighted() || this.keyboardHighlighted());
 
 	clue = signal<string>('');
 	colors = input.required<ColorOption[]>();
@@ -46,7 +46,7 @@ export class ColorInputComponent {
 		}
 	}
 
-	filteredColors = computed(() => {
+	readonly filteredColors = computed(() => {
 		if (this.clue()) {
 			return this.colors().filter((color) => color.name.toLowerCase().includes(this.clue().toLowerCase()));
 		}

--- a/packages/ng/forms/color-input/color-input.component.ts
+++ b/packages/ng/forms/color-input/color-input.component.ts
@@ -22,7 +22,7 @@ import { LU_COLOR_TRANSLATIONS } from './color.translate';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ColorInputComponent {
-	intl = input(...intlInputOptions(LU_COLOR_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_COLOR_TRANSLATIONS));
 
 	mouseHighlighted = signal<string>('');
 	keyboardHighlighted = signal<string>('');
@@ -30,8 +30,8 @@ export class ColorInputComponent {
 
 	clue = signal<string>('');
 	colors = input.required<ColorOption[]>();
-	clearable = input(false, { transform: booleanAttribute });
-	compact = input(false, { transform: booleanAttribute });
+	readonly clearable = input(false, { transform: booleanAttribute });
+	readonly compact = input(false, { transform: booleanAttribute });
 
 	ngControl = injectNgControl();
 

--- a/packages/ng/forms/fieldset/fieldset.component.ts
+++ b/packages/ng/forms/fieldset/fieldset.component.ts
@@ -21,7 +21,7 @@ export class FieldsetComponent {
 	readonly horizontal = input(false, { transform: booleanAttribute });
 	readonly expandable = input(false, { transform: booleanAttribute });
 
-	expanded = model(false);
+	readonly expanded = model(false);
 
 	id = `fieldsetTitleContent${nextId++}`;
 }

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -61,15 +61,15 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	model: WritableSignal<MultilanguageTranslation[]> = signal([] as MultilanguageTranslation[]);
 
-	invariant = computed(() => {
+	readonly invariant = computed(() => {
 		return this.model().find((row) => row.cultureCode === INVARIANT_CULTURE_CODE) || { value: '' };
 	});
 
-	panelInputs = computed(() => {
+	readonly panelInputs = computed(() => {
 		return this.model().filter((row) => row.cultureCode !== INVARIANT_CULTURE_CODE);
 	});
 
-	presentationValue = computed(() => {
+	readonly presentationValue = computed(() => {
 		return this.model().find((row) => row.cultureCode === this.#localeId)?.value || this.invariant()?.value;
 	});
 

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -40,7 +40,7 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	#intlDisplay = new Intl.DisplayNames([this.#localeId], { type: 'language' });
 
-	intl = input(...intlInputOptions(LU_MULTILANGUAGE_INPUT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_MULTILANGUAGE_INPUT_TRANSLATIONS));
 
 	#formFieldRef = inject(FORM_FIELD_INSTANCE);
 
@@ -50,9 +50,9 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	protected onChange = (_value: MultilanguageTranslation[]) => {};
 
-	placeholder = input('');
+	readonly placeholder = input('');
 
-	openOnFocus = input(false, { transform: booleanAttribute });
+	readonly openOnFocus = input(false, { transform: booleanAttribute });
 
 	autocomplete = input<AutoFill>('off');
 

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -57,7 +57,7 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 	autocomplete = input<AutoFill>('off');
 
 	// Suffixed with Internal to avoid conflict with NgModel's disabled attribute
-	disabledInternal = signal(false);
+	readonly disabledInternal = signal(false);
 
 	model: WritableSignal<MultilanguageTranslation[]> = signal([] as MultilanguageTranslation[]);
 

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -44,7 +44,7 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	#formFieldRef = inject(FORM_FIELD_INSTANCE);
 
-	formFieldSize = this.#formFieldRef.size;
+	readonly formFieldSize = this.#formFieldRef.size;
 
 	protected onTouched = () => {};
 
@@ -54,12 +54,12 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	readonly openOnFocus = input(false, { transform: booleanAttribute });
 
-	autocomplete = input<AutoFill>('off');
+	readonly autocomplete = input<AutoFill>('off');
 
 	// Suffixed with Internal to avoid conflict with NgModel's disabled attribute
 	readonly disabledInternal = signal(false);
 
-	model: WritableSignal<MultilanguageTranslation[]> = signal([] as MultilanguageTranslation[]);
+	readonly model: WritableSignal<MultilanguageTranslation[]> = signal([] as MultilanguageTranslation[]);
 
 	readonly invariant = computed(() => {
 		return this.model().find((row) => row.cultureCode === INVARIANT_CULTURE_CODE) || { value: '' };

--- a/packages/ng/forms/number-format-input/number-format-input.component.ts
+++ b/packages/ng/forms/number-format-input/number-format-input.component.ts
@@ -57,7 +57,7 @@ export class NumberFormatInputComponent implements AfterViewInit {
 
 	readonly valueAlignRight = input(false, { transform: booleanAttribute });
 
-	inputElementRef = viewChild<ElementRef<HTMLInputElement>>('inputElement');
+	readonly inputElementRef = viewChild<ElementRef<HTMLInputElement>>('inputElement');
 
 	readonly #suffixPrefixValue = signal(1);
 

--- a/packages/ng/forms/number-format-input/number-format-input.component.ts
+++ b/packages/ng/forms/number-format-input/number-format-input.component.ts
@@ -103,7 +103,7 @@ export class NumberFormatInputComponent implements AfterViewInit {
 			}) satisfies NumberFormatOptions,
 	);
 
-	formattedValue = computed(() => this.#numberFormat().getBlurFormat(this.#suffixPrefixValue()));
+	readonly formattedValue = computed(() => this.#numberFormat().getBlurFormat(this.#suffixPrefixValue()));
 
 	readonly intl = input(...intlInputOptions(LU_NUMBERFORMATFIELD_TRANSLATIONS));
 

--- a/packages/ng/forms/number-format-input/number-format-input.component.ts
+++ b/packages/ng/forms/number-format-input/number-format-input.component.ts
@@ -59,7 +59,7 @@ export class NumberFormatInputComponent implements AfterViewInit {
 
 	inputElementRef = viewChild<ElementRef<HTMLInputElement>>('inputElement');
 
-	#suffixPrefixValue = signal(1);
+	readonly #suffixPrefixValue = signal(1);
 
 	readonly #numberFormat = computed(() => new NumberFormat(this.formatOptions()));
 	readonly prefixAddon = computed(() => {

--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -105,7 +105,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 		return this.prefixEntries.filter((e) => whitelist.includes(e.country));
 	});
 
-	query = signal('');
+	readonly query = signal('');
 
 	protected prefixesDisplay = computed(() => {
 		const query = this.query();

--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -107,7 +107,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 
 	readonly query = signal('');
 
-	protected prefixesDisplay = computed(() => {
+	protected readonly prefixesDisplay = computed(() => {
 		const query = this.query();
 		if (query === '') {
 			return this.#prefixEntries();
@@ -117,7 +117,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 		});
 	});
 
-	countryCodeSelected = signal<CountryCode | undefined>(undefined);
+	readonly countryCodeSelected = signal<CountryCode | undefined>(undefined);
 
 	readonly countryCode = computed(() => this.countryCodeSelected() ?? this.defaultCountryCode());
 
@@ -127,7 +127,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 		return exampleNumber?.formatNational() ?? '';
 	});
 
-	displayedNumber = signal<string | undefined>(undefined);
+	readonly displayedNumber = signal<string | undefined>(undefined);
 
 	readonly prefixEntry = computed(() => this.#prefixEntries().find((p) => p.country === this.countryCode()));
 

--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -119,9 +119,9 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 
 	countryCodeSelected = signal<CountryCode | undefined>(undefined);
 
-	countryCode = computed(() => this.countryCodeSelected() ?? this.defaultCountryCode());
+	readonly countryCode = computed(() => this.countryCodeSelected() ?? this.defaultCountryCode());
 
-	placeholder = computed(() => {
+	readonly placeholder = computed(() => {
 		const countryCode = this.countryCode();
 		const exampleNumber = this.noAutoPlaceholder() === false && countryCode ? getExampleNumber(countryCode, examples) : undefined;
 		return exampleNumber?.formatNational() ?? '';

--- a/packages/ng/forms/radio-group-input/radio-group-input.component.ts
+++ b/packages/ng/forms/radio-group-input/radio-group-input.component.ts
@@ -26,7 +26,7 @@ let nextId = 0;
 	],
 })
 export class RadioGroupInputComponent {
-	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
+	readonly formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
 
 	ngControl = injectNgControl();
 

--- a/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.ts
@@ -17,7 +17,7 @@ export class LinkDialogComponent {
 	public readonly dialogData = injectDialogData<string>();
 	public readonly dialogRef = injectDialogRef<string | undefined>();
 
-	intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
 
 	public readonly formGroup = new FormGroup({
 		href: new FormControl<string>(this.dialogData, Validators.required),

--- a/packages/ng/forms/rich-text-input/plugins/list-format/list-format.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/list-format/list-format.component.ts
@@ -31,9 +31,9 @@ export class ListFormatComponent implements OnDestroy, RichTextPluginComponent {
 
 	public element = viewChild('element', { read: ElementRef<HTMLButtonElement> });
 
-	public tabindex = signal<number>(-1);
-	public active = signal(false);
-	public isDisabled = signal(false);
+	public readonly tabindex = signal<number>(-1);
+	public readonly active = signal(false);
+	public readonly isDisabled = signal(false);
 
 	#editor?: LexicalEditor;
 

--- a/packages/ng/forms/rich-text-input/plugins/list-format/list-format.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/list-format/list-format.component.ts
@@ -25,11 +25,11 @@ import { FORMAT_LIST, registerListsSelectionChange } from './list-format.command
 	],
 })
 export class ListFormatComponent implements OnDestroy, RichTextPluginComponent {
-	public format = input.required<ListType>();
-	public icon = input.required<LuccaIcon>();
-	public tooltip = input.required<string>();
+	public readonly format = input.required<ListType>();
+	public readonly icon = input.required<LuccaIcon>();
+	public readonly tooltip = input.required<string>();
 
-	public element = viewChild('element', { read: ElementRef<HTMLButtonElement> });
+	public readonly element = viewChild('element', { read: ElementRef<HTMLButtonElement> });
 
 	public readonly tabindex = signal<number>(-1);
 	public readonly active = signal(false);

--- a/packages/ng/forms/rich-text-input/plugins/list-format/list-style-toolbar.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/list-format/list-style-toolbar.component.ts
@@ -30,7 +30,7 @@ export class ListStyleToolbarComponent implements OnDestroy, RichTextPluginCompo
 
 	pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
 
-	intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
 
 	setEditorInstance(editor: LexicalEditor): void {
 		this.pluginComponents().forEach((plugin) => plugin.setEditorInstance(editor));

--- a/packages/ng/forms/rich-text-input/plugins/list-format/list-style-toolbar.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/list-format/list-style-toolbar.component.ts
@@ -28,7 +28,7 @@ import { ListFormatComponent } from './list-format.component';
 export class ListStyleToolbarComponent implements OnDestroy, RichTextPluginComponent {
 	#registeredCommands: () => void = () => {};
 
-	pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
+	readonly pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
 
 	readonly intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
 

--- a/packages/ng/forms/rich-text-input/plugins/text-style/text-style-toolbar.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/text-style/text-style-toolbar.component.ts
@@ -21,7 +21,7 @@ import { TextStyleComponent } from './text-style.component';
 	],
 })
 export class TextStyleToolbarComponent implements RichTextPluginComponent {
-	pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
+	readonly pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
 
 	readonly intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
 

--- a/packages/ng/forms/rich-text-input/plugins/text-style/text-style-toolbar.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/text-style/text-style-toolbar.component.ts
@@ -23,7 +23,7 @@ import { TextStyleComponent } from './text-style.component';
 export class TextStyleToolbarComponent implements RichTextPluginComponent {
 	pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
 
-	intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
 
 	setEditorInstance(editor: LexicalEditor): void {
 		this.pluginComponents().forEach((plugin) => plugin.setEditorInstance(editor));

--- a/packages/ng/forms/rich-text-input/plugins/text-style/text-style.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/text-style/text-style.component.ts
@@ -24,15 +24,15 @@ import { registerFormatSelectionChange } from './text-style.command';
 	],
 })
 export class TextStyleComponent implements OnDestroy, RichTextPluginComponent {
-	public format = input.required<TextFormatType>();
-	public icon = input.required<LuccaIcon>();
-	public tooltip = input.required<string>();
+	public readonly format = input.required<TextFormatType>();
+	public readonly icon = input.required<LuccaIcon>();
+	public readonly tooltip = input.required<string>();
 
 	public readonly tabindex = signal<number>(-1);
 	public readonly active = signal(false);
 	public readonly isDisabled = signal(false);
 
-	public element = viewChild('element', { read: ElementRef<HTMLButtonElement> });
+	public readonly element = viewChild('element', { read: ElementRef<HTMLButtonElement> });
 
 	#editor?: LexicalEditor;
 

--- a/packages/ng/forms/rich-text-input/plugins/text-style/text-style.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/text-style/text-style.component.ts
@@ -28,9 +28,9 @@ export class TextStyleComponent implements OnDestroy, RichTextPluginComponent {
 	public icon = input.required<LuccaIcon>();
 	public tooltip = input.required<string>();
 
-	public tabindex = signal<number>(-1);
-	public active = signal(false);
-	public isDisabled = signal(false);
+	public readonly tabindex = signal<number>(-1);
+	public readonly active = signal(false);
+	public readonly isDisabled = signal(false);
 
 	public element = viewChild('element', { read: ElementRef<HTMLButtonElement> });
 

--- a/packages/ng/forms/rich-text-input/plugins/toolbar/toolbar.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/toolbar/toolbar.component.ts
@@ -23,7 +23,7 @@ import { TextStyleToolbarComponent } from '../text-style';
 	],
 })
 export class RichTextInputToolbarComponent implements RichTextPluginComponent {
-	pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
+	readonly pluginComponents = viewChildren(RICH_TEXT_PLUGIN_COMPONENT);
 
 	setEditorInstance(editor: LexicalEditor): void {
 		this.pluginComponents().forEach((plugin) => plugin.setEditorInstance(editor));

--- a/packages/ng/forms/switch-input/switch-input.component.ts
+++ b/packages/ng/forms/switch-input/switch-input.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { getIntl } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
+import { CHECKBOX_INPUT_TRANSLATIONS } from '../checkbox-input/checkbox-input.translate';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
-import { getIntl } from '@lucca-front/ng/core';
-import { CHECKBOX_INPUT_TRANSLATIONS } from '../checkbox-input/checkbox-input.translate';
 
 @Component({
 	selector: 'lu-switch-input',
@@ -19,11 +19,11 @@ import { CHECKBOX_INPUT_TRANSLATIONS } from '../checkbox-input/checkbox-input.tr
 	},
 })
 export class SwitchInputComponent {
-	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
+	readonly formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
 
 	ngControl = injectNgControl();
 
-	intl = getIntl(CHECKBOX_INPUT_TRANSLATIONS);
+	readonly intl = getIntl(CHECKBOX_INPUT_TRANSLATIONS);
 
 	constructor() {
 		if (this.formField) {

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -55,11 +55,11 @@ export class TextInputComponent {
 	// eslint-disable-next-line @angular-eslint/no-output-native
 	readonly blur = output<FocusEvent>();
 
-	protected showPassword = signal<boolean>(false);
+	protected readonly showPassword = signal<boolean>(false);
 
-	protected typeRef = computed(() => (this.showPassword() ? 'text' : this.type()));
+	protected readonly typeRef = computed(() => (this.showPassword() ? 'text' : this.type()));
 
-	protected hasTogglePasswordVisibilityIcon = computed(() => this.type() === 'password');
+	protected readonly hasTogglePasswordVisibilityIcon = computed(() => this.type() === 'password');
 
 	clearValue(): void {
 		this.ngControl.reset();

--- a/packages/ng/index-table/base-index-table-cell.ts
+++ b/packages/ng/index-table/base-index-table-cell.ts
@@ -20,11 +20,11 @@ export abstract class BaseIndexTableCell {
 
 	align = input<null | 'start' | 'center' | 'end'>(null);
 
-	alignCol = computed(() => {
+	readonly alignCol = computed(() => {
 		return this.tableRef.header()?.cols()[this.position()].align();
 	});
 
-	position = computed(() => {
+	readonly position = computed(() => {
 		return this.rowRef.cells().indexOf(this);
 	});
 }

--- a/packages/ng/index-table/base-index-table-cell.ts
+++ b/packages/ng/index-table/base-index-table-cell.ts
@@ -12,11 +12,11 @@ import { LU_INDEX_TABLE_INSTANCE } from './index-table.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export abstract class BaseIndexTableCell {
-	tableRef = inject(LU_INDEX_TABLE_INSTANCE);
-	bodyRef = inject(LU_INDEX_TABLE_BODY_INSTANCE, { optional: true });
-	headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
-	footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
-	rowRef = inject(LU_INDEX_TABLE_ROW_INSTANCE);
+	readonly tableRef = inject(LU_INDEX_TABLE_INSTANCE);
+	readonly bodyRef = inject(LU_INDEX_TABLE_BODY_INSTANCE, { optional: true });
+	readonly headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
+	readonly footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
+	readonly rowRef = inject(LU_INDEX_TABLE_ROW_INSTANCE);
 
 	readonly align = input<null | 'start' | 'center' | 'end'>(null);
 

--- a/packages/ng/index-table/base-index-table-cell.ts
+++ b/packages/ng/index-table/base-index-table-cell.ts
@@ -18,7 +18,7 @@ export abstract class BaseIndexTableCell {
 	footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
 	rowRef = inject(LU_INDEX_TABLE_ROW_INSTANCE);
 
-	align = input<null | 'start' | 'center' | 'end'>(null);
+	readonly align = input<null | 'start' | 'center' | 'end'>(null);
 
 	readonly alignCol = computed(() => {
 		return this.tableRef.header()?.cols()[this.position()].align();

--- a/packages/ng/index-table/index-table-body/index-table-body.component.ts
+++ b/packages/ng/index-table/index-table-body/index-table-body.component.ts
@@ -24,10 +24,10 @@ import { LU_INDEX_TABLE_BODY_INSTANCE } from './index-table-body.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableBodyComponent {
-	group = input<PortalContent | null>(null);
-	groupButtonAlt = input<string | null>(null);
+	readonly group = input<PortalContent | null>(null);
+	readonly groupButtonAlt = input<string | null>(null);
 
-	expanded = model(false);
+	readonly expanded = model(false);
 
 	expandedToggle() {
 		this.expanded.set(!this.expanded());

--- a/packages/ng/index-table/index-table-body/index-table-body.component.ts
+++ b/packages/ng/index-table/index-table-body/index-table-body.component.ts
@@ -35,5 +35,5 @@ export class IndexTableBodyComponent {
 
 	protected tableRef = inject(LU_INDEX_TABLE_INSTANCE);
 
-	colspan = computed(() => (this.tableRef.cols()?.length ?? 0) + (this.tableRef.selectable() ? 1 : 0));
+	readonly colspan = computed(() => (this.tableRef.cols()?.length ?? 0) + (this.tableRef.selectable() ? 1 : 0));
 }

--- a/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
+++ b/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
@@ -41,10 +41,10 @@ export class IndexTableRowCellHeaderComponent extends BaseIndexTableCell {
 	elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
 
 	sort = model<null | 'none' | 'ascending' | 'descending'>(null);
-	selectable = input(false, { transform: booleanAttribute });
-	hiddenLabel = input(false, { transform: booleanAttribute });
-	actions = input(false, { transform: booleanAttribute });
-	inlineSize = input(0, { transform: numberAttribute });
+	readonly selectable = input(false, { transform: booleanAttribute });
+	readonly hiddenLabel = input(false, { transform: booleanAttribute });
+	readonly actions = input(false, { transform: booleanAttribute });
+	readonly inlineSize = input(0, { transform: numberAttribute });
 
 	toggleSort(): void {
 		if (this.sort()) {

--- a/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
+++ b/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
@@ -40,7 +40,7 @@ const SORT_VALUES = ['none', 'ascending', 'descending'] as const;
 export class IndexTableRowCellHeaderComponent extends BaseIndexTableCell {
 	elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
 
-	sort = model<null | 'none' | 'ascending' | 'descending'>(null);
+	readonly sort = model<null | 'none' | 'ascending' | 'descending'>(null);
 	readonly selectable = input(false, { transform: booleanAttribute });
 	readonly hiddenLabel = input(false, { transform: booleanAttribute });
 	readonly actions = input(false, { transform: booleanAttribute });

--- a/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
+++ b/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
@@ -38,7 +38,7 @@ const SORT_VALUES = ['none', 'ascending', 'descending'] as const;
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableRowCellHeaderComponent extends BaseIndexTableCell {
-	elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
+	readonly elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
 
 	readonly sort = model<null | 'none' | 'ascending' | 'descending'>(null);
 	readonly selectable = input(false, { transform: booleanAttribute });

--- a/packages/ng/index-table/index-table-cell/index-table-cell.component.ts
+++ b/packages/ng/index-table/index-table-cell/index-table-cell.component.ts
@@ -32,7 +32,7 @@ export class IndexTableRowCellComponent extends BaseIndexTableCell {
 	readonly allowTextSelection = input(false, { transform: booleanAttribute });
 	readonly tfoot = input(false, { transform: booleanAttribute });
 
-	actions = computed(() => {
+	readonly actions = computed(() => {
 		return this.tableRef.header()?.cols()[this.position()].actions();
 	});
 }

--- a/packages/ng/index-table/index-table-cell/index-table-cell.component.ts
+++ b/packages/ng/index-table/index-table-cell/index-table-cell.component.ts
@@ -29,8 +29,8 @@ import { LU_INDEX_TABLE_CELL_INSTANCE } from '../index-table-cell.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableRowCellComponent extends BaseIndexTableCell {
-	allowTextSelection = input(false, { transform: booleanAttribute });
-	tfoot = input(false, { transform: booleanAttribute });
+	readonly allowTextSelection = input(false, { transform: booleanAttribute });
+	readonly tfoot = input(false, { transform: booleanAttribute });
 
 	actions = computed(() => {
 		return this.tableRef.header()?.cols()[this.position()].actions();

--- a/packages/ng/index-table/index-table-head/index-table-head.component.ts
+++ b/packages/ng/index-table/index-table-head/index-table-head.component.ts
@@ -23,7 +23,7 @@ import { LU_INDEX_TABLE_HEAD_INSTANCE } from './index-table-head.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableHeadComponent {
-	cols = contentChildren(IndexTableRowCellHeaderComponent, { descendants: true });
+	readonly cols = contentChildren(IndexTableRowCellHeaderComponent, { descendants: true });
 
 	tableRef = inject(LU_INDEX_TABLE_INSTANCE);
 }

--- a/packages/ng/index-table/index-table-head/index-table-head.component.ts
+++ b/packages/ng/index-table/index-table-head/index-table-head.component.ts
@@ -25,5 +25,5 @@ import { LU_INDEX_TABLE_HEAD_INSTANCE } from './index-table-head.token';
 export class IndexTableHeadComponent {
 	readonly cols = contentChildren(IndexTableRowCellHeaderComponent, { descendants: true });
 
-	tableRef = inject(LU_INDEX_TABLE_INSTANCE);
+	readonly tableRef = inject(LU_INDEX_TABLE_INSTANCE);
 }

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -34,9 +34,9 @@ import { LU_INDEX_TABLE_ROW_INSTANCE } from './index-table-row.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableRowComponent {
-	bodyRef = inject(LU_INDEX_TABLE_BODY_INSTANCE, { optional: true });
-	headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
-	footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
+	readonly bodyRef = inject(LU_INDEX_TABLE_BODY_INSTANCE, { optional: true });
+	readonly headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
+	readonly footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
 
 	public readonly cells = contentChildren(LU_INDEX_TABLE_CELL_INSTANCE);
 

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -42,8 +42,8 @@ export class IndexTableRowComponent {
 
 	protected tableRef = inject(LU_INDEX_TABLE_INSTANCE);
 
-	selected = model<boolean>(false);
-	selectedLabel = input<string | null>(null);
+	readonly selected = model<boolean>(false);
+	readonly selectedLabel = input<string | null>(null);
 	readonly disabled = input(false, { transform: booleanAttribute });
 	readonly stack = input(1, { transform: numberAttribute });
 }

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -44,6 +44,6 @@ export class IndexTableRowComponent {
 
 	selected = model<boolean>(false);
 	selectedLabel = input<string | null>(null);
-	disabled = input(false, { transform: booleanAttribute });
-	stack = input(1, { transform: numberAttribute });
+	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly stack = input(1, { transform: numberAttribute });
 }

--- a/packages/ng/index-table/index-table.component.ts
+++ b/packages/ng/index-table/index-table.component.ts
@@ -34,9 +34,9 @@ export class IndexTableComponent {
 	rows = contentChildren(IndexTableRowComponent, { descendants: true });
 	header = contentChild(IndexTableHeadComponent, { descendants: true });
 
-	cols = computed(() => this.header()?.cols());
+	readonly cols = computed(() => this.header()?.cols());
 
-	classMods = computed(() => {
+	readonly classMods = computed(() => {
 		return {
 			indexTable: true,
 			['mod-selectable']: this.selectable(),

--- a/packages/ng/index-table/index-table.component.ts
+++ b/packages/ng/index-table/index-table.component.ts
@@ -31,8 +31,8 @@ export class IndexTableComponent {
 
 	responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
 
-	rows = contentChildren(IndexTableRowComponent, { descendants: true });
-	header = contentChild(IndexTableHeadComponent, { descendants: true });
+	readonly rows = contentChildren(IndexTableRowComponent, { descendants: true });
+	readonly header = contentChild(IndexTableHeadComponent, { descendants: true });
 
 	readonly cols = computed(() => this.header()?.cols());
 

--- a/packages/ng/index-table/index-table.component.ts
+++ b/packages/ng/index-table/index-table.component.ts
@@ -23,13 +23,13 @@ import { LU_INDEX_TABLE_INSTANCE } from './index-table.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableComponent {
-	tableRef = viewChild<ElementRef<Element>>('tableRef');
+	readonly tableRef = viewChild<ElementRef<Element>>('tableRef');
 
 	readonly selectable = input(false, { transform: booleanAttribute });
 	readonly layoutFixed = input(false, { transform: booleanAttribute });
 	readonly empty = input(false, { transform: booleanAttribute });
 
-	responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
+	readonly responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
 
 	readonly rows = contentChildren(IndexTableRowComponent, { descendants: true });
 	readonly header = contentChild(IndexTableHeadComponent, { descendants: true });

--- a/packages/ng/index-table/index-table.component.ts
+++ b/packages/ng/index-table/index-table.component.ts
@@ -25,9 +25,9 @@ import { LU_INDEX_TABLE_INSTANCE } from './index-table.token';
 export class IndexTableComponent {
 	tableRef = viewChild<ElementRef<Element>>('tableRef');
 
-	selectable = input(false, { transform: booleanAttribute });
-	layoutFixed = input(false, { transform: booleanAttribute });
-	empty = input(false, { transform: booleanAttribute });
+	readonly selectable = input(false, { transform: booleanAttribute });
+	readonly layoutFixed = input(false, { transform: booleanAttribute });
+	readonly empty = input(false, { transform: booleanAttribute });
 
 	responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
 

--- a/packages/ng/input/clearer/clearer.component.ts
+++ b/packages/ng/input/clearer/clearer.component.ts
@@ -20,7 +20,7 @@ import { LU_CLEARER_TRANSLATIONS } from './clearer.translate';
 	],
 })
 export class LuInputClearerComponent<T> extends ALuClearer<T> implements ILuClearer<T> {
-	intl = input(...intlInputOptions(LU_CLEARER_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_CLEARER_TRANSLATIONS));
 
 	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
 	@Output() override onClear = new EventEmitter<T>();

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -32,7 +32,7 @@ import { LuRouterLink } from './lu-router-link';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LinkComponent {
-	intl = input(...intlInputOptions(LU_LINK_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_LINK_TRANSLATIONS));
 	routerLink = inject(LuRouterLink);
 	#injector = inject(Injector);
 	router = inject(Router);

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -33,10 +33,10 @@ import { LuRouterLink } from './lu-router-link';
 })
 export class LinkComponent {
 	readonly intl = input(...intlInputOptions(LU_LINK_TRANSLATIONS));
-	routerLink = inject(LuRouterLink);
+	readonly routerLink = inject(LuRouterLink);
 	#injector = inject(Injector);
-	router = inject(Router);
-	location = inject(Location);
+	readonly router = inject(Router);
+	readonly location = inject(Location);
 
 	/**
 	 * Target page address. Use only for external links or pages not recognized by the router.

--- a/packages/ng/mobile-push/mobile-push.component.ts
+++ b/packages/ng/mobile-push/mobile-push.component.ts
@@ -14,7 +14,7 @@ import { LU_MOBILE_PUSH_TRANSLATIONS } from './mobile-push.translate';
 	encapsulation: ViewEncapsulation.None,
 })
 export class MobilePushComponent {
-	intl = input(...intlInputOptions(LU_MOBILE_PUSH_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_MOBILE_PUSH_TRANSLATIONS));
 
 	/**
 	 * Emit event when appStoreLink is clicked

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
@@ -41,9 +41,9 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 	ref = injectDialogRef<LuModalContentResult<C> | undefined>();
 
 	submitClass = signal('');
-	error$ = new Subject();
+	readonly error$ = new Subject();
 
-	protected doCheck$ = new ReplaySubject<void>(1);
+	protected readonly doCheck$ = new ReplaySubject<void>(1);
 
 	public intl = getIntl(LU_MODAL_TRANSLATIONS);
 	protected title$ = this.observeValue(() => this.#contentComponentInstance.title);

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
@@ -46,13 +46,13 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 	protected readonly doCheck$ = new ReplaySubject<void>(1);
 
 	public intl = getIntl(LU_MODAL_TRANSLATIONS);
-	protected title$ = this.observeValue(() => this.#contentComponentInstance.title);
-	protected submitLabel$ = this.observeValue(() => this.#contentComponentInstance.submitLabel || this.intl.submit);
-	protected cancelLabel$ = this.observeValue(() => this.#contentComponentInstance.cancelLabel || this.intl.cancel);
-	protected submitCounter$ = this.observeValue(() => this.#contentComponentInstance.submitCounter);
-	protected submitDisabled$ = this.observeValue(() => this.#contentComponentInstance.submitDisabled);
-	protected hasSubmitCounter$ = this.submitCounter$.pipe(map(Boolean));
-	protected hasSubmit$ = this.observeValue(() => this.#contentComponentInstance.submitAction).pipe(map(Boolean));
+	protected readonly title$ = this.observeValue(() => this.#contentComponentInstance.title);
+	protected readonly submitLabel$ = this.observeValue(() => this.#contentComponentInstance.submitLabel || this.intl.submit);
+	protected readonly cancelLabel$ = this.observeValue(() => this.#contentComponentInstance.cancelLabel || this.intl.cancel);
+	protected readonly submitCounter$ = this.observeValue(() => this.#contentComponentInstance.submitCounter);
+	protected readonly submitDisabled$ = this.observeValue(() => this.#contentComponentInstance.submitDisabled);
+	protected readonly hasSubmitCounter$ = this.submitCounter$.pipe(map(Boolean));
+	protected readonly hasSubmit$ = this.observeValue(() => this.#contentComponentInstance.submitAction).pipe(map(Boolean));
 
 	get submitPalette() {
 		return (this.#contentComponentInstance.submitPalette || 'product') as Palette;

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
@@ -40,7 +40,7 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 
 	ref = injectDialogRef<LuModalContentResult<C> | undefined>();
 
-	submitClass = signal('');
+	readonly submitClass = signal('');
 	readonly error$ = new Subject();
 
 	protected readonly doCheck$ = new ReplaySubject<void>(1);

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
@@ -30,7 +30,7 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 	#destroyRef = inject(DestroyRef);
 
 	@ViewChild('contentProjectionRef', { read: ViewContainerRef, static: true })
-	contentProjectionRef: ViewContainerRef;
+	readonly contentProjectionRef: ViewContainerRef;
 
 	#contentComponentInstance: C;
 

--- a/packages/ng/modal/modal-panel.component.ts
+++ b/packages/ng/modal/modal-panel.component.ts
@@ -17,7 +17,7 @@ export abstract class ALuModalPanelComponent<T extends ILuModalContent> implemen
 	@ViewChild('container', { read: ViewContainerRef, static: true })
 	protected _containerRef: ViewContainerRef;
 	protected _componentInstance: ILuModalContent;
-	protected doCheck$ = new ReplaySubject<void>(1);
+	protected readonly doCheck$ = new ReplaySubject<void>(1);
 
 	public intl = getIntl(LU_MODAL_TRANSLATIONS);
 	protected title$ = this.listenComponentValue(() => this._componentInstance.title);
@@ -36,8 +36,8 @@ export abstract class ALuModalPanelComponent<T extends ILuModalContent> implemen
 		return this._componentInstance.submitPalette || 'product';
 	}
 
-	submitClass$ = new Subject();
-	error$ = new Subject();
+	readonly submitClass$ = new Subject();
+	readonly error$ = new Subject();
 
 	public readonly modalId = modalId++;
 

--- a/packages/ng/modal/modal-panel.component.ts
+++ b/packages/ng/modal/modal-panel.component.ts
@@ -20,12 +20,12 @@ export abstract class ALuModalPanelComponent<T extends ILuModalContent> implemen
 	protected readonly doCheck$ = new ReplaySubject<void>(1);
 
 	public intl = getIntl(LU_MODAL_TRANSLATIONS);
-	protected title$ = this.listenComponentValue(() => this._componentInstance.title);
-	protected submitLabel$ = this.listenComponentValue(() => this._componentInstance.submitLabel || this.intl.submit);
-	protected cancelLabel$ = this.listenComponentValue(() => this._componentInstance.cancelLabel || this.intl.cancel);
-	protected submitCounter$ = this.listenComponentValue(() => this._componentInstance.submitCounter);
-	protected submitDisabled$ = this.listenComponentValue(() => this._componentInstance.submitDisabled);
-	protected hasSubmitCounter$ = this.submitCounter$.pipe(map(Boolean));
+	protected readonly title$ = this.listenComponentValue(() => this._componentInstance.title);
+	protected readonly submitLabel$ = this.listenComponentValue(() => this._componentInstance.submitLabel || this.intl.submit);
+	protected readonly cancelLabel$ = this.listenComponentValue(() => this._componentInstance.cancelLabel || this.intl.cancel);
+	protected readonly submitCounter$ = this.listenComponentValue(() => this._componentInstance.submitCounter);
+	protected readonly submitDisabled$ = this.listenComponentValue(() => this._componentInstance.submitDisabled);
+	protected readonly hasSubmitCounter$ = this.submitCounter$.pipe(map(Boolean));
 
 	protected closeLabel = this.intl.close;
 

--- a/packages/ng/modal/modal-panel.component.ts
+++ b/packages/ng/modal/modal-panel.component.ts
@@ -15,7 +15,7 @@ let modalId = 0;
 @Directive()
 export abstract class ALuModalPanelComponent<T extends ILuModalContent> implements OnDestroy, DoCheck {
 	@ViewChild('container', { read: ViewContainerRef, static: true })
-	protected _containerRef: ViewContainerRef;
+	protected readonly _containerRef: ViewContainerRef;
 	protected _componentInstance: ILuModalContent;
 	protected readonly doCheck$ = new ReplaySubject<void>(1);
 

--- a/packages/ng/multi-select/displayer/content-displayer/content-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/content-displayer/content-displayer.component.ts
@@ -17,5 +17,5 @@ import { LuMultiSelectDisplayerInputDirective } from '../displayer-input.directi
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LuMultiSelectContentDisplayerComponent<T> {
-	select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
+	readonly select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
 }

--- a/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
@@ -33,8 +33,8 @@ import { LuMultiSelectDisplayerInputDirective } from '../displayer-input.directi
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LuMultiSelectCounterDisplayerComponent<T> implements OnInit {
-	select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
-	context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
+	readonly select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
+	readonly context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
 
 	protected destroyRef = inject(DestroyRef);
 

--- a/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
@@ -39,7 +39,7 @@ export class LuMultiSelectCounterDisplayerComponent<T> implements OnInit {
 	protected destroyRef = inject(DestroyRef);
 
 	@ViewChild('inputElement')
-	inputElementRef: ElementRef<HTMLInputElement>;
+	readonly inputElementRef: ElementRef<HTMLInputElement>;
 
 	get value(): T[] {
 		return this.select.value || [];

--- a/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/counter-displayer/counter-displayer.component.ts
@@ -45,7 +45,7 @@ export class LuMultiSelectCounterDisplayerComponent<T> implements OnInit {
 		return this.select.value || [];
 	}
 
-	selectedOptions$ = new BehaviorSubject<T[]>([]);
+	readonly selectedOptions$ = new BehaviorSubject<T[]>([]);
 
 	@Input()
 	set selected(options: T[]) {

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -32,7 +32,7 @@ import { LuMultiSelectDisplayerInputDirective } from './displayer-input.directiv
 })
 export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 	select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
-	intl = input(...intlInputOptions(LU_MULTI_SELECT_DISPLAYER_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_MULTI_SELECT_DISPLAYER_TRANSLATIONS));
 
 	protected destroyRef = inject(DestroyRef);
 

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -45,7 +45,7 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 
 	readonly context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
 
-	displayedOptions$ = this.context.option$.pipe(
+	readonly displayedOptions$ = this.context.option$.pipe(
 		map((options) => {
 			if (this.select.maxValuesShown) {
 				return (options || []).slice(0, this.select.maxValuesShown);
@@ -54,7 +54,7 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 		}),
 	);
 
-	overflowOptions$ = this.context.option$.pipe(
+	readonly overflowOptions$ = this.context.option$.pipe(
 		map((options) => {
 			return Math.max(0, (options || []).length - this.select.maxValuesShown);
 		}),

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -37,7 +37,7 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 	protected destroyRef = inject(DestroyRef);
 
 	@ViewChild('inputElement')
-	inputElementRef: ElementRef<HTMLInputElement>;
+	readonly inputElementRef: ElementRef<HTMLInputElement>;
 
 	get value(): T[] {
 		return this.select.value || [];

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -31,7 +31,7 @@ import { LuMultiSelectDisplayerInputDirective } from './displayer-input.directiv
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
-	select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
+	readonly select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
 	readonly intl = input(...intlInputOptions(LU_MULTI_SELECT_DISPLAYER_TRANSLATIONS));
 
 	protected destroyRef = inject(DestroyRef);
@@ -43,7 +43,7 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 		return this.select.value || [];
 	}
 
-	context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
+	readonly context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
 
 	displayedOptions$ = this.context.option$.pipe(
 		map((options) => {

--- a/packages/ng/multi-select/displayer/displayer-input.directive.ts
+++ b/packages/ng/multi-select/displayer/displayer-input.directive.ts
@@ -65,10 +65,10 @@ export class LuMultiSelectDisplayerInputDirective<T> implements OnInit {
 		this.select.clueChanged(this.elementRef.nativeElement.value);
 	}
 
-	#panelOpen = toSignal(this.select.isPanelOpen$);
-	#activeDescendant = toSignal(this.select.activeDescendant$);
-	#disabled = toSignal(this.select.disabled$);
-	#placeholder = toSignal(
+	readonly #panelOpen = toSignal(this.select.isPanelOpen$);
+	readonly #activeDescendant = toSignal(this.select.activeDescendant$);
+	readonly #disabled = toSignal(this.select.disabled$);
+	readonly #placeholder = toSignal(
 		this.context.option$.pipe(
 			startWith([]),
 			switchMap((options) => {

--- a/packages/ng/multi-select/displayer/displayer-input.directive.ts
+++ b/packages/ng/multi-select/displayer/displayer-input.directive.ts
@@ -20,15 +20,15 @@ import { LuMultiSelectContentDisplayerComponent } from './content-displayer/cont
 	hostDirectives: [InputDirective],
 })
 export class LuMultiSelectDisplayerInputDirective<T> implements OnInit {
-	select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
+	readonly select = inject<LuMultiSelectInputComponent<T>>(LuMultiSelectInputComponent);
 	readonly selectAllContext = inject(MULTI_SELECT_WITH_SELECT_ALL_CONTEXT, { optional: true });
-	contentDisplayer = inject(LuMultiSelectContentDisplayerComponent, { optional: true });
+	readonly contentDisplayer = inject(LuMultiSelectContentDisplayerComponent, { optional: true });
 
-	context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
+	readonly context = inject<ILuOptionContext<T[]>>(LU_OPTION_CONTEXT);
 
-	elementRef = inject<ElementRef<HTMLInputElement>>(ElementRef);
+	readonly elementRef = inject<ElementRef<HTMLInputElement>>(ElementRef);
 
-	destroyRef = inject(DestroyRef);
+	readonly destroyRef = inject(DestroyRef);
 
 	@HostBinding('attr.aria-expanded')
 	get panelOpen() {

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -97,7 +97,7 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 		return this.filterPillMode;
 	}
 
-	hideCombobox = computed(() => (this.valueSignal()?.length ?? 0) > 1);
+	readonly hideCombobox = computed(() => (this.valueSignal()?.length ?? 0) > 1);
 
 	filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -99,7 +99,7 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 
 	readonly hideCombobox = computed(() => (this.valueSignal()?.length ?? 0) > 1);
 
-	filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
+	readonly filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 
 	override isFilterPillEmpty = computed(() => {
 		const valueSignal = this.valueSignal();

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -74,7 +74,7 @@ import { LuMultiSelectPanelRef } from './panel.model';
 	encapsulation: ViewEncapsulation.None,
 })
 export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T[]> implements ControlValueAccessor, OnDestroy, OnInit {
-	intl = input(...intlInputOptions(LU_CORE_SELECT_TRANSLATIONS, LU_MULTI_SELECT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_CORE_SELECT_TRANSLATIONS, LU_MULTI_SELECT_TRANSLATIONS));
 
 	showColon: false;
 

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -89,8 +89,8 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 	@Input()
 	filterPillLabelPlural: string;
 
-	override selectParent$ = new Subject<void>();
-	override selectChildren$ = new Subject<void>();
+	override readonly selectParent$ = new Subject<void>();
+	override readonly selectChildren$ = new Subject<void>();
 
 	@HostBinding('class.mod-filterPill')
 	public get filterPillClass() {

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -78,7 +78,7 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 
 	showColon: false;
 
-	valuesTpl = model<TemplateRef<LuOptionContext<T[]>> | Type<unknown>>(LuMultiSelectDefaultDisplayerComponent);
+	readonly valuesTpl = model<TemplateRef<LuOptionContext<T[]>> | Type<unknown>>(LuMultiSelectDefaultDisplayerComponent);
 
 	@Input({ transform: numberAttribute })
 	maxValuesShown = 500;
@@ -101,12 +101,15 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 
 	readonly filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 
+	// eslint-disable-next-line @angular-eslint/prefer-signals
 	override isFilterPillEmpty = computed(() => {
 		const valueSignal = this.valueSignal();
 		return !valueSignal || valueSignal.length === 0;
 	});
 
+	// eslint-disable-next-line @angular-eslint/prefer-signals
 	public valueLength = computed(() => this.valueSignal()?.length ?? 0);
+	// eslint-disable-next-line @angular-eslint/prefer-signals
 	public useSingleOptionDisplayer: Signal<boolean> = signal(true);
 	override _value: T[] = [];
 

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -60,10 +60,10 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	readonly panelRef = inject<LuMultiSelectPanelRef<T>>(LuMultiSelectPanelRef);
 	readonly selectId = inject(SELECT_ID);
 
-	options$ = this.selectInput.options$;
+	readonly options$ = this.selectInput.options$;
 	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
-	loading$ = this.selectInput.loading$;
+	readonly loading$ = this.selectInput.loading$;
 	searchable = this.selectInput.searchable;
 	optionComparer = this.selectInput.optionComparer;
 	optionKey = this.selectInput.optionKey;
@@ -91,10 +91,10 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	});
 
 	readonly hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
-	public clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));
-	public shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
+	public readonly clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));
+	public readonly shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
 
-	groupTemplateLocation$ = ɵgetGroupTemplateLocation(this.hasGrouping$, this.clueChange$, this.options$, this.searchable);
+	readonly groupTemplateLocation$ = ɵgetGroupTemplateLocation(this.hasGrouping$, this.clueChange$, this.options$, this.searchable);
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -90,7 +90,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		};
 	});
 
-	hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
+	readonly hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
 	public clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));
 	public shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
 

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -56,9 +56,9 @@ import { LuOptionsGroupContextPipe } from './option-group-context.pipe';
 	],
 })
 export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanelInstance {
-	protected selectInput = inject<LuMultiSelectInputComponent<T>>(MULTI_SELECT_INPUT);
-	panelRef = inject<LuMultiSelectPanelRef<T>>(LuMultiSelectPanelRef);
-	selectId = inject(SELECT_ID);
+	protected readonly selectInput = inject<LuMultiSelectInputComponent<T>>(MULTI_SELECT_INPUT);
+	readonly panelRef = inject<LuMultiSelectPanelRef<T>>(LuMultiSelectPanelRef);
+	readonly selectId = inject(SELECT_ID);
 
 	options$ = this.selectInput.options$;
 	readonly grouping = this.selectInput.groupingSignal;

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -61,7 +61,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	selectId = inject(SELECT_ID);
 
 	options$ = this.selectInput.options$;
-	grouping = this.selectInput.groupingSignal;
+	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
 	loading$ = this.selectInput.loading$;
 	searchable = this.selectInput.searchable;
@@ -74,9 +74,9 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	trackBranchesBy: TrackByFunction<TreeNode<T>> = (_, option) => this.optionKey(option.node);
 
 	selectedOptions: T[] = this.selectInput.value || [];
-	optionTpl = this.selectInput.optionTpl;
+	readonly optionTpl = this.selectInput.optionTpl;
 
-	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
+	readonly options = signal<ɵCoreSelectPanelElement<T>[]>([]);
 	keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 
 	readonly someGroupOptionEnabled = computed(() => {

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -79,7 +79,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
 	keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 
-	someGroupOptionEnabled = computed(() => {
+	readonly someGroupOptionEnabled = computed(() => {
 		return (groupOptions: T[]) => {
 			const disabledOptionIds = this.options()
 				.filter((o) => o.disabled)

--- a/packages/ng/number-format/number-format.directive.ts
+++ b/packages/ng/number-format/number-format.directive.ts
@@ -25,7 +25,7 @@ export class NumberFormatDirective implements ControlValueAccessor {
 	#isFocused = signal<boolean>(false);
 
 	formatOptions = input.required<NumberFormatOptions>();
-	#numberFormat = computed(() => {
+	readonly #numberFormat = computed(() => {
 		return new NumberFormat(this.formatOptions());
 	});
 

--- a/packages/ng/number-format/number-format.directive.ts
+++ b/packages/ng/number-format/number-format.directive.ts
@@ -21,10 +21,10 @@ export class NumberFormatDirective implements ControlValueAccessor {
 	readonly #inputElement = inject<ElementRef<HTMLInputElement>>(ElementRef<HTMLInputElement>).nativeElement;
 	readonly #renderer = inject(Renderer2);
 
-	#value = signal<number | undefined | null>(null);
-	#isFocused = signal<boolean>(false);
+	readonly #value = signal<number | undefined | null>(null);
+	readonly #isFocused = signal<boolean>(false);
 
-	formatOptions = input.required<NumberFormatOptions>();
+	readonly formatOptions = input.required<NumberFormatOptions>();
 	readonly #numberFormat = computed(() => {
 		return new NumberFormat(this.formatOptions());
 	});

--- a/packages/ng/option/item/option-item.component.ts
+++ b/packages/ng/option/item/option-item.component.ts
@@ -55,7 +55,7 @@ export class LuOptionItemComponent<T> extends ALuOptionItem<T> implements ILuOpt
 		this._disabled = d;
 	}
 
-	@ViewChild('element', { read: ElementRef, static: true }) element: ElementRef;
+	@ViewChild('element', { read: ElementRef, static: true }) readonly element: ElementRef;
 	constructor(private _cdr: ChangeDetectorRef) {
 		super();
 	}

--- a/packages/ng/option/item/tree-option-item.component.ts
+++ b/packages/ng/option/item/tree-option-item.component.ts
@@ -100,7 +100,7 @@ export class LuTreeOptionItemComponent<T> extends ALuTreeOptionItem<T> implement
 		this._displayer = displayer;
 	}
 
-	public intl = input(...intlInputOptions(LU_TREE_OPTION_ITEM_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_TREE_OPTION_ITEM_TRANSLATIONS));
 
 	constructor(private _cdr: ChangeDetectorRef) {
 		super();

--- a/packages/ng/option/item/tree-option-item.component.ts
+++ b/packages/ng/option/item/tree-option-item.component.ts
@@ -27,10 +27,10 @@ export class LuTreeOptionItemComponent<T> extends ALuTreeOptionItem<T> implement
 	protected _tree: ILuTree<T>;
 	protected _displayer: ILuInputDisplayer<T>;
 	@ViewChild('value', { static: true, read: ViewContainerRef })
-	protected _valueVCR: ViewContainerRef;
+	protected readonly _valueVCR: ViewContainerRef;
 	@ViewChild('children', { static: true, read: ViewContainerRef })
-	protected _childrenVCR: ViewContainerRef;
-	@ViewChild('element', { read: ElementRef, static: true }) element: ElementRef;
+	protected readonly _childrenVCR: ViewContainerRef;
+	@ViewChild('element', { read: ElementRef, static: true }) readonly element: ElementRef;
 
 	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
 	@Output() onSelect = new EventEmitter<this>();

--- a/packages/ng/option/operator/feeder/option-feeder.component.ts
+++ b/packages/ng/option/operator/feeder/option-feeder.component.ts
@@ -15,7 +15,7 @@ import { ALuOptionOperator, ILuOptionOperator } from '../option-operator.model';
 	],
 })
 export class LuOptionFeederComponent<T> implements ILuOptionOperator<T> {
-	outOptions$ = new BehaviorSubject<T[]>([]);
+	readonly outOptions$ = new BehaviorSubject<T[]>([]);
 	@Input() set options(options: T[]) {
 		this.outOptions$.next(options);
 	}

--- a/packages/ng/option/operator/feeder/tree-option-feeder.component.ts
+++ b/packages/ng/option/operator/feeder/tree-option-feeder.component.ts
@@ -18,7 +18,7 @@ import { ALuTreeOptionOperator, ILuTreeOptionOperator } from '../tree-option-ope
 	],
 })
 export class LuTreeOptionFeederComponent<T> implements ILuTreeOptionOperator<T> {
-	outOptions$ = new BehaviorSubject<ILuTree<T>[]>([]);
+	readonly outOptions$ = new BehaviorSubject<ILuTree<T>[]>([]);
 	@Input() set options(options: ILuTree<T>[]) {
 		this.outOptions$.next(options);
 	}

--- a/packages/ng/option/operator/pager/option-pager.component.ts
+++ b/packages/ng/option/operator/pager/option-pager.component.ts
@@ -30,7 +30,7 @@ export class LuOptionPagerComponent<T> extends ALuOptionOperator<T> implements I
 			}),
 		);
 	}
-	paging$ = new BehaviorSubject<number>(MAGIC_STEP);
+	readonly paging$ = new BehaviorSubject<number>(MAGIC_STEP);
 	next() {
 		this.paging$.next(this.paging$.value + MAGIC_STEP);
 	}

--- a/packages/ng/option/operator/pager/tree-option-pager.component.ts
+++ b/packages/ng/option/operator/pager/tree-option-pager.component.ts
@@ -34,7 +34,7 @@ export class LuTreeOptionPagerComponent<T> extends ALuTreeOptionOperator<T> impl
 			}),
 		);
 	}
-	paging$ = new BehaviorSubject<number>(MAGIC_STEP);
+	readonly paging$ = new BehaviorSubject<number>(MAGIC_STEP);
 	next() {
 		this.paging$.next(this.paging$.value + MAGIC_STEP);
 	}

--- a/packages/ng/option/operator/searcher/option-searcher.component.ts
+++ b/packages/ng/option/operator/searcher/option-searcher.component.ts
@@ -31,7 +31,7 @@ export class LuOptionSearcherComponent<T> extends ALuOptionOperator<T> implement
 	clue$ = merge(of(''), this.searchControl.valueChanges) as Observable<string>;
 	empty$: Observable<boolean>;
 	@ViewChild('searchInput', { read: ElementRef, static: true })
-	searchInput: ElementRef<HTMLElement>;
+	readonly searchInput: ElementRef<HTMLElement>;
 	outOptions$: Observable<T[]>;
 	set inOptions$(in$: Observable<T[]>) {
 		this.outOptions$ = combineLatest([in$, this.clue$]).pipe(

--- a/packages/ng/option/operator/searcher/option-searcher.component.ts
+++ b/packages/ng/option/operator/searcher/option-searcher.component.ts
@@ -28,7 +28,7 @@ import { ALuOptionOperator, ILuOptionOperator } from '../option-operator.model';
 })
 export class LuOptionSearcherComponent<T> extends ALuOptionOperator<T> implements ILuOptionOperator<T>, ILuOnOpenSubscriber {
 	searchControl = new FormControl();
-	clue$ = merge(of(''), this.searchControl.valueChanges) as Observable<string>;
+	readonly clue$ = merge(of(''), this.searchControl.valueChanges) as Observable<string>;
 	empty$: Observable<boolean>;
 	@ViewChild('searchInput', { read: ElementRef, static: true })
 	readonly searchInput: ElementRef<HTMLElement>;

--- a/packages/ng/option/operator/searcher/tree-option-searcher.component.ts
+++ b/packages/ng/option/operator/searcher/tree-option-searcher.component.ts
@@ -34,7 +34,7 @@ export class LuTreeOptionSearcherComponent<T> extends ALuTreeOptionOperator<T> i
 	clue$ = merge(of(''), this.searchControl.valueChanges) as Observable<string>;
 	empty$: Observable<boolean>;
 	@ViewChild('searchInput', { read: ElementRef, static: true })
-	searchInput: ElementRef<HTMLElement>;
+	readonly searchInput: ElementRef<HTMLElement>;
 	outOptions$: Observable<ILuTree<T>[]>;
 	set inOptions$(in$: Observable<ILuTree<T>[]>) {
 		this.outOptions$ = combineLatest([in$, this.clue$]).pipe(

--- a/packages/ng/option/picker/tree-option-picker.component.ts
+++ b/packages/ng/option/picker/tree-option-picker.component.ts
@@ -36,7 +36,7 @@ export abstract class ALuTreeOptionPickerComponent<T, O extends import('../item/
 		descendants: true,
 		read: ViewContainerRef,
 	})
-	optionsQLVR: QueryList<ViewContainerRef>;
+	readonly optionsQLVR: QueryList<ViewContainerRef>;
 
 	protected override set _options$(optionItems$: Observable<O[]>) {
 		// reapply selected when the options change

--- a/packages/ng/option/placeholder/option-placeholder.component.ts
+++ b/packages/ng/option/placeholder/option-placeholder.component.ts
@@ -15,7 +15,7 @@ export class LuOptionPlaceholderComponent {
 	// eslint-disable-next-line @angular-eslint/no-output-on-prefix
 	@Output() onClear = new EventEmitter();
 
-	public intl = input(...intlInputOptions(LU_OPTION_PLACEHOLDER_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_OPTION_PLACEHOLDER_TRANSLATIONS));
 
 	clear() {
 		this.onClear.emit();

--- a/packages/ng/option/selector/all/select-all.component.ts
+++ b/packages/ng/option/selector/all/select-all.component.ts
@@ -39,7 +39,7 @@ export class LuOptionSelectAllComponent<T> extends ALuOptionOperator<T> implemen
 		this.outOptions$ = in$.pipe(tap((options) => (this.options = options)));
 	}
 
-	public intl = input(...intlInputOptions(LU_OPTION_SELECT_ALL_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_OPTION_SELECT_ALL_TRANSLATIONS));
 
 	selectAll() {
 		if (!this.options) {

--- a/packages/ng/option/selector/all/select-all.component.ts
+++ b/packages/ng/option/selector/all/select-all.component.ts
@@ -29,7 +29,7 @@ import { LU_OPTION_SELECT_ALL_TRANSLATIONS } from './select-all.translate';
 })
 export class LuOptionSelectAllComponent<T> extends ALuOptionOperator<T> implements ILuOptionSelector<T> {
 	multiple = true;
-	onSelectValue = new Subject<T | T[]>();
+	readonly onSelectValue = new Subject<T | T[]>();
 	private _values: T[];
 
 	@HostBinding('class.position-fixed') fixed = true;

--- a/packages/ng/option/selector/all/tree-select-all.component.ts
+++ b/packages/ng/option/selector/all/tree-select-all.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, forwardRef, HostBinding, input } from '@angular/core';
-import { intlInputOptions, ILuTree } from '@lucca-front/ng/core';
+import { ILuTree, intlInputOptions } from '@lucca-front/ng/core';
 import { Observable, Subject } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { ALuTreeOptionOperator } from '../../operator/index';
@@ -29,7 +29,7 @@ import { LU_OPTION_SELECT_ALL_TRANSLATIONS } from './select-all.translate';
 })
 export class LuTreeOptionSelectAllComponent<T> extends ALuTreeOptionOperator<T> implements ILuTreeOptionSelector<T> {
 	multiple = true;
-	onSelectValue = new Subject<T | T[]>();
+	readonly onSelectValue = new Subject<T | T[]>();
 	private _values: T[];
 
 	@HostBinding('class.position-fixed') fixed = true;

--- a/packages/ng/option/selector/all/tree-select-all.component.ts
+++ b/packages/ng/option/selector/all/tree-select-all.component.ts
@@ -39,7 +39,7 @@ export class LuTreeOptionSelectAllComponent<T> extends ALuTreeOptionOperator<T> 
 		this.outOptions$ = in$.pipe(tap((options) => (this.flatOptions = this.flattenTree(options))));
 	}
 
-	public intl = input(...intlInputOptions(LU_OPTION_SELECT_ALL_TRANSLATIONS));
+	public readonly intl = input(...intlInputOptions(LU_OPTION_SELECT_ALL_TRANSLATIONS));
 
 	selectAll() {
 		if (!this.flatOptions) {

--- a/packages/ng/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/popover/trigger/popover-trigger.model.ts
@@ -63,7 +63,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 
 	protected _mouseoverTimer: unknown;
 
-	protected _hovered$ = new Subject();
+	protected readonly _hovered$ = new Subject();
 	protected _hoveredSubscription: Subscription;
 	protected _panelEventsSubscriptions: Subscription;
 	protected _overlayDetachmentsSubscription: Subscription;

--- a/packages/ng/popover2/content/popover-content/popover-content.component.ts
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.ts
@@ -33,18 +33,18 @@ export class PopoverContentComponent implements AfterViewInit, OnDestroy {
 
 	#focusManager = new PopoverFocusTrap(this.#elementRef.nativeElement, this.config.triggerElement);
 
-	closed$ = new Subject<void>();
+	readonly closed$ = new Subject<void>();
 
 	contentChangedDebounceTime = 100;
 
-	mouseEnter$ = new Subject<void>();
+	readonly mouseEnter$ = new Subject<void>();
 
 	@HostListener('mouseenter')
 	mouseEnter(): void {
 		this.mouseEnter$.next();
 	}
 
-	mouseLeave$ = new Subject<void>();
+	readonly mouseLeave$ = new Subject<void>();
 
 	@HostListener('mouseleave')
 	mouseLeave(): void {

--- a/packages/ng/popover2/content/popover-content/popover-content.component.ts
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.ts
@@ -22,9 +22,9 @@ export class PopoverContentComponent implements AfterViewInit, OnDestroy {
 
 	#elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
-	config = inject(POPOVER_CONFIG);
+	readonly config = inject(POPOVER_CONFIG);
 
-	destroyRef = inject(DestroyRef);
+	readonly destroyRef = inject(DestroyRef);
 
 	@HostBinding('attr.id')
 	contentId = this.config.contentId;

--- a/packages/ng/popover2/content/popover-content/popover-content.component.ts
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.ts
@@ -18,7 +18,7 @@ import { LU_POPOVER2_TRANSLATIONS } from '../../popover.translate';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class PopoverContentComponent implements AfterViewInit, OnDestroy {
-	intl = input(...intlInputOptions(LU_POPOVER2_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_POPOVER2_TRANSLATIONS));
 
 	#elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -128,9 +128,9 @@ export class PopoverDirective implements OnDestroy {
 
 	readonly close$ = new Subject<void>();
 
-	luPopoverClosed = output<void>();
+	readonly luPopoverClosed = output<void>();
 
-	luPopoverOpened = output<void>();
+	readonly luPopoverOpened = output<void>();
 
 	#listenToMouseLeave = false;
 	#listenToMouseEnter = true;

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -124,9 +124,9 @@ export class PopoverDirective implements OnDestroy {
 
 	luPopoverPositionRef = linkedSignal(() => this.luPopoverPosition() || 'above');
 
-	open$ = new Subject<'focus' | 'click' | 'hover'>();
+	readonly open$ = new Subject<'focus' | 'click' | 'hover'>();
 
-	close$ = new Subject<void>();
+	readonly close$ = new Subject<void>();
 
 	luPopoverClosed = output<void>();
 

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -73,9 +73,9 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	exportAs: 'luPopover2',
 })
 export class PopoverDirective implements OnDestroy {
-	overlay = inject(Overlay);
+	readonly overlay = inject(Overlay);
 
-	elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+	readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	#vcr = inject(ViewContainerRef);
 

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -90,7 +90,7 @@ export class PopoverDirective implements OnDestroy {
 	})
 	content: TemplateRef<unknown> | Type<unknown>;
 
-	luPopoverPosition = input<PopoverPosition | null>(null);
+	readonly luPopoverPosition = input<PopoverPosition | null>(null);
 
 	@Input()
 	overlayScrollStrategy: 'reposition' | 'block' | 'close' = 'reposition';
@@ -100,7 +100,7 @@ export class PopoverDirective implements OnDestroy {
 	})
 	luPopoverDisabled = false;
 
-	luPopoverTrigger = model<'click' | 'click+hover' | 'hover+focus'>('click');
+	readonly luPopoverTrigger = model<'click' | 'click+hover' | 'hover+focus'>('click');
 
 	@Input()
 	customPositions?: ConnectionPositionPair[];
@@ -115,14 +115,14 @@ export class PopoverDirective implements OnDestroy {
 	 * Allows to anchor the popover to another element instead of the trigger one
 	 * for placement purpose
 	 */
-	luPopoverAnchor = input<FlexibleConnectedPositionStrategyOrigin>(this.elementRef);
+	readonly luPopoverAnchor = input<FlexibleConnectedPositionStrategyOrigin>(this.elementRef);
 
 	// We have to type these two for Compodoc to find the right type and tell Storybook these aren't strings
-	luPopoverOpenDelay: InputSignal<number> = input<number>(300);
+	readonly luPopoverOpenDelay: InputSignal<number> = input<number>(300);
 
-	luPopoverCloseDelay: InputSignal<number> = input<number>(100);
+	readonly luPopoverCloseDelay: InputSignal<number> = input<number>(100);
 
-	luPopoverPositionRef = linkedSignal(() => this.luPopoverPosition() || 'above');
+	readonly luPopoverPositionRef = linkedSignal(() => this.luPopoverPosition() || 'above');
 
 	readonly open$ = new Subject<'focus' | 'click' | 'hover'>();
 

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -83,7 +83,7 @@ export class PopoverDirective implements OnDestroy {
 
 	#renderer = inject(Renderer2);
 
-	intl = input(...intlInputOptions(LU_POPOVER2_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_POPOVER2_TRANSLATIONS));
 
 	@Input({
 		alias: 'luPopover2',

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -142,7 +142,7 @@ export class PopoverDirective implements OnDestroy {
 
 	positionPairs: Record<PopoverPosition, ConnectionPositionPair> = defaultPositionPairs;
 
-	opened = signal(false);
+	readonly opened = signal(false);
 
 	@HostBinding('attr.aria-controls')
 	ariaControls = `popover-content-${nextId++}`;

--- a/packages/ng/popup/popup-ref.model.ts
+++ b/packages/ng/popup/popup-ref.model.ts
@@ -20,10 +20,10 @@ export interface ILuPopupRefFactory<TComponent = unknown, TConfig extends ILuPop
 }
 
 export abstract class ALuPopupRef<T = unknown, D = unknown, R = unknown, C extends ILuPopupConfig = ILuPopupConfig> implements ILuPopupRef<D, R> {
-	onOpen = new Subject<D | undefined>();
-	onClose = new Subject<R | undefined>();
-	onDismiss = new Subject<void>();
-	onBackdropClick = new Subject<void>();
+	readonly onOpen = new Subject<D | undefined>();
+	readonly onClose = new Subject<R | undefined>();
+	readonly onDismiss = new Subject<void>();
+	readonly onBackdropClick = new Subject<void>();
 
 	protected _overlayRef: OverlayRef;
 	protected _componentRef: ComponentRef<T>;

--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -20,7 +20,7 @@ import { LU_READMORE_TRANSLATIONS } from './read-more.translate';
 	},
 })
 export class ReadMoreComponent {
-	intl = input(...intlInputOptions(LU_READMORE_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_READMORE_TRANSLATIONS));
 
 	/**
 	 * Change the number of lines displayed when collapsed

--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -47,10 +47,10 @@ export class ReadMoreComponent {
 	 */
 	readonly innerContent = input<null | string>(null);
 
-	labelReadMore = computed(() => this.intl().readMore);
-	labelReadLess = computed(() => this.intl().readLess);
+	readonly labelReadMore = computed(() => this.intl().readMore);
+	readonly labelReadLess = computed(() => this.intl().readLess);
 
-	label = computed(() => (this.expanded() ? this.labelReadLess() : this.labelReadMore()));
+	readonly label = computed(() => (this.expanded() ? this.labelReadLess() : this.labelReadMore()));
 
 	readonly contentRef = viewChild<ElementRef<HTMLDivElement>>('content');
 

--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -54,8 +54,8 @@ export class ReadMoreComponent {
 
 	readonly contentRef = viewChild<ElementRef<HTMLDivElement>>('content');
 
-	expanded = signal(false);
-	isClamped = signal(false);
+	readonly expanded = signal(false);
+	readonly isClamped = signal(false);
 
 	readonly backgroundColor = computed(() => {
 		if (this.surface() === 'sunken' || this.surface() === 'default' || this.surface() === null) {

--- a/packages/ng/scroll-box/scroll-box.component.ts
+++ b/packages/ng/scroll-box/scroll-box.component.ts
@@ -22,8 +22,8 @@ export class ScrollBoxComponent implements OnInit {
 	 */
 	vertical = input(false, { transform: booleanAttribute });
 
-	isFirstVisible = signal(true);
-	isLastVisible = signal(false);
+	readonly isFirstVisible = signal(true);
+	readonly isLastVisible = signal(false);
 
 	scroll() {
 		if (this.vertical()) {

--- a/packages/ng/scroll-box/scroll-box.component.ts
+++ b/packages/ng/scroll-box/scroll-box.component.ts
@@ -20,7 +20,7 @@ export class ScrollBoxComponent implements OnInit {
 	/**
 	 * Scroll box content vertically
 	 */
-	vertical = input(false, { transform: booleanAttribute });
+	readonly vertical = input(false, { transform: booleanAttribute });
 
 	readonly isFirstVisible = signal(true);
 	readonly isLastVisible = signal(false);

--- a/packages/ng/scroll/scroll.directive.ts
+++ b/packages/ng/scroll/scroll.directive.ts
@@ -23,7 +23,7 @@ export class LuScrollDirective implements ILuScrollable, OnInit {
 	readonly onScrollRight = output<Event>();
 
 	#scrollSubject = new Subject<Event>();
-	#scroll$ = this.#scrollSubject.asObservable().pipe(debounceTime(this.debounceTime()));
+	readonly #scroll$ = this.#scrollSubject.asObservable().pipe(debounceTime(this.debounceTime()));
 
 	scroll(event: Event) {
 		this.#scrollSubject.next(event);

--- a/packages/ng/segmented-control-tabs/segmented-control-tabs.component.ts
+++ b/packages/ng/segmented-control-tabs/segmented-control-tabs.component.ts
@@ -46,7 +46,7 @@ export class SegmentedControlTabsComponent<T = unknown> implements AfterContentI
 	 */
 	readonly vertical = input(false, { transform: booleanAttribute });
 
-	active = model<T | null>(null);
+	readonly active = model<T | null>(null);
 
 	readonly id = `segmentedControl${nextId++}`;
 

--- a/packages/ng/select/input/select-input.component.ts
+++ b/packages/ng/select/input/select-input.component.ts
@@ -94,16 +94,16 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 	/**
 	 * popover trigger class extension
 	 */
-	@ContentChild(ALuPickerPanel, { static: true }) ccPicker: TPicker;
-	@ViewChild(ALuPickerPanel, { static: true }) vcPicker: TPicker;
+	@ContentChild(ALuPickerPanel, { static: true }) readonly ccPicker: TPicker;
+	@ViewChild(ALuPickerPanel, { static: true }) readonly vcPicker: TPicker;
 
 	@ContentChild(ALuInputDisplayer, { static: true })
-	ccDisplayer: ILuInputDisplayer<T>;
+	readonly ccDisplayer: ILuInputDisplayer<T>;
 	@ViewChild(ALuInputDisplayer, { static: true })
-	vcDisplayer: ILuInputDisplayer<T>;
+	readonly vcDisplayer: ILuInputDisplayer<T>;
 
-	@ContentChild(ALuClear, { static: true }) ccClearer: ILuClear<T>;
-	@ViewChild(ALuClear, { static: true }) vcClearer: ILuClear<T>;
+	@ContentChild(ALuClear, { static: true }) readonly ccClearer: ILuClear<T>;
+	@ViewChild(ALuClear, { static: true }) readonly vcClearer: ILuClear<T>;
 
 	@HostListener('click')
 	override onClick() {
@@ -222,9 +222,9 @@ export class LuSelectInputComponent<T> extends ALuSelectInputComponent<T> implem
 
 	// display clearer
 	@ContentChild(ALuClear, { read: ElementRef, static: false })
-	clearerEltRef: ElementRef<HTMLElement>;
+	readonly clearerEltRef: ElementRef<HTMLElement>;
 	@ViewChild('suffix', { read: ElementRef, static: true })
-	suffixEltRef: ElementRef<HTMLElement>;
+	readonly suffixEltRef: ElementRef<HTMLElement>;
 
 	displayClearer() {
 		if (this.clearerEltRef) {

--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -58,7 +58,7 @@ export class LuSimpleSelectInputComponent<T> extends ALuSelectInputComponent<T, 
 		return this.filterPillMode;
 	}
 
-	autocomplete = input<AutoFill>('off');
+	readonly autocomplete = input<AutoFill>('off');
 
 	readonly filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 

--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -60,7 +60,7 @@ export class LuSimpleSelectInputComponent<T> extends ALuSelectInputComponent<T, 
 
 	autocomplete = input<AutoFill>('off');
 
-	filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
+	readonly filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 
 	protected panelRefFactory = inject(LuSimpleSelectPanelRefFactory);
 

--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -51,7 +51,7 @@ import { LuSimpleSelectPanelRefFactory } from './panel-ref.factory';
 	encapsulation: ViewEncapsulation.None,
 })
 export class LuSimpleSelectInputComponent<T> extends ALuSelectInputComponent<T, T> implements ControlValueAccessor {
-	intl = input(...intlInputOptions(LU_CORE_SELECT_TRANSLATIONS, LU_SIMPLE_SELECT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_CORE_SELECT_TRANSLATIONS, LU_SIMPLE_SELECT_TRANSLATIONS));
 
 	@HostBinding('class.mod-filterPill')
 	public get filterPillClass() {

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -84,7 +84,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 
 	public readonly selected = computed(() => this.selectInput.valueSignal());
 
-	hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
+	readonly hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
 	public clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));
 	public shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
 	public groupTemplateLocation$ = ɵgetGroupTemplateLocation(this.hasGrouping$, this.clueChange$, this.options$, this.searchable);

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -63,7 +63,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	public intl = this.selectInput.intl;
 
 	options$ = this.selectInput.options$;
-	grouping = this.selectInput.groupingSignal;
+	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
 	loading$ = this.selectInput.loading$;
 	searchable = this.selectInput.searchable;
@@ -76,13 +76,13 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	trackBranchesBy: TrackByFunction<TreeNode<T>> = (_, option) => this.optionKey(option.node);
 
 	initialValue: T | null = this.selectInput.value;
-	optionTpl = this.selectInput.optionTpl;
+	readonly optionTpl = this.selectInput.optionTpl;
 
-	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
+	readonly options = signal<ɵCoreSelectPanelElement<T>[]>([]);
 
 	public keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 
-	public selected = computed(() => this.selectInput.valueSignal());
+	public readonly selected = computed(() => this.selectInput.valueSignal());
 
 	hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
 	public clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -62,10 +62,10 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	public selectId = inject(SELECT_ID);
 	public intl = this.selectInput.intl;
 
-	options$ = this.selectInput.options$;
+	readonly options$ = this.selectInput.options$;
 	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
-	loading$ = this.selectInput.loading$;
+	readonly loading$ = this.selectInput.loading$;
 	searchable = this.selectInput.searchable;
 	optionComparer = this.selectInput.optionComparer;
 	optionKey = this.selectInput.optionKey;

--- a/packages/ng/skeleton/skeleton-resource-card/skeleton-resource-card.component.ts
+++ b/packages/ng/skeleton/skeleton-resource-card/skeleton-resource-card.component.ts
@@ -10,7 +10,7 @@ export class SkeletonResourceCardComponent {
 	/**
 	 * Defines the number of description lines in resource card
 	 */
-	descriptionLines = input(0, { transform: numberAttribute });
+	readonly descriptionLines = input(0, { transform: numberAttribute });
 
 	readonly lines = computed(() => Array.from({ length: this.descriptionLines() }));
 

--- a/packages/ng/sortable-list/sortable-list-item/sortable-list-item.component.ts
+++ b/packages/ng/sortable-list/sortable-list-item/sortable-list-item.component.ts
@@ -23,12 +23,12 @@ export class SortableListItemComponent {
 	/**
 	 * Changes the text displayed by the sortable list item
 	 */
-	label = input.required<string>();
+	readonly label = input.required<string>();
 
 	/**
 	 * Adds descriptive help text below the label
 	 */
-	helperMessage = input<string>();
+	readonly helperMessage = input<string>();
 
 	/**
 	 * Sortable list item can be clickable

--- a/packages/ng/sortable-list/sortable-list-item/sortable-list-item.component.ts
+++ b/packages/ng/sortable-list/sortable-list-item/sortable-list-item.component.ts
@@ -33,22 +33,22 @@ export class SortableListItemComponent {
 	/**
 	 * Sortable list item can be clickable
 	 */
-	clickable = input(false, { transform: booleanAttribute });
+	readonly clickable = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Disabled the possibility to clear the sortable list item
 	 */
-	unclearable = input(false, { transform: booleanAttribute });
+	readonly unclearable = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Sortable list item can be draggable
 	 */
-	drag = input(false, { transform: booleanAttribute });
+	readonly drag = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Applies small size to segmented control tabs
 	 */
-	small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Emit event when click on clear

--- a/packages/ng/sortable-list/sortable-list.component.ts
+++ b/packages/ng/sortable-list/sortable-list.component.ts
@@ -15,5 +15,5 @@ export class SortableListComponent {
 	 */
 	readonly small = input(false, { transform: booleanAttribute });
 
-	sortableListItems = contentChildren(SortableListItemComponent, { descendants: true });
+	readonly sortableListItems = contentChildren(SortableListItemComponent, { descendants: true });
 }

--- a/packages/ng/sortable-list/sortable-list.component.ts
+++ b/packages/ng/sortable-list/sortable-list.component.ts
@@ -13,7 +13,7 @@ export class SortableListComponent {
 	/**
 	 * Applies small size to sortable list
 	 */
-	small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: booleanAttribute });
 
 	sortableListItems = contentChildren(SortableListItemComponent, { descendants: true });
 }

--- a/packages/ng/time/core/base-picker.component.ts
+++ b/packages/ng/time/core/base-picker.component.ts
@@ -11,18 +11,18 @@ export abstract class BasePickerComponent implements ControlValueAccessor {
 	onChange: (value: ISO8601Time | ISO8601Duration) => void;
 	onTouched: () => void;
 
-	step = input<ISO8601Duration | null>(null);
+	readonly step = input<ISO8601Duration | null>(null);
 
-	disabled = model(false);
+	readonly disabled = model(false);
 
-	size = input<'S' | 'M'>();
+	readonly size = input<'S' | 'M'>();
 
-	hoursPart = viewChild<TimePickerPartComponent>('hoursPart');
+	readonly hoursPart = viewChild<TimePickerPartComponent>('hoursPart');
 
-	minutesPart = viewChild<TimePickerPartComponent>('minutesPart');
+	readonly minutesPart = viewChild<TimePickerPartComponent>('minutesPart');
 
-	protected hoursIncrement = computed(() => this.getHoursIncrement());
-	protected minutesIncrement = computed(() => this.getMinutesIncrement());
+	protected readonly hoursIncrement = computed(() => this.getHoursIncrement());
+	protected readonly minutesIncrement = computed(() => this.getMinutesIncrement());
 
 	registerOnChange(fn: () => void): void {
 		this.onChange = fn;

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -65,7 +65,7 @@ export class TimePickerPartComponent {
 
 	@ViewChild('timePickerInput') timePickerInput?: ElementRef<HTMLInputElement>;
 
-	valueLabel = computed(() => {
+	readonly valueLabel = computed(() => {
 		if (this.hideValue()) {
 			return '  ';
 		}

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -19,7 +19,7 @@ export class TimePickerPartComponent {
 
 	readonly decimalConf = input('2.0-0');
 
-	value: ModelSignal<number | '––'> = model('––');
+	readonly value: ModelSignal<number | '––'> = model('––');
 
 	readonly display = input<number | '––'>();
 
@@ -55,8 +55,8 @@ export class TimePickerPartComponent {
 
 	readonly showZero = input(false, { transform: booleanAttribute });
 
-	digitNumber = model(2);
-	isValueSet = model<boolean>(false);
+	readonly digitNumber = model(2);
+	readonly isValueSet = model<boolean>(false);
 
 	prevRequest = output<void>();
 	nextRequest = output<void>();

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -63,7 +63,7 @@ export class TimePickerPartComponent {
 	inputControlClick = output<PickerControlDirection>();
 	touched = output<void>();
 
-	@ViewChild('timePickerInput') timePickerInput?: ElementRef<HTMLInputElement>;
+	@ViewChild('timePickerInput') readonly timePickerInput?: ElementRef<HTMLInputElement>;
 
 	readonly valueLabel = computed(() => {
 		if (this.hideValue()) {

--- a/packages/ng/time/duration-picker/duration-picker.component.ts
+++ b/packages/ng/time/duration-picker/duration-picker.component.ts
@@ -29,7 +29,7 @@ import { LU_DURATION_PICKER_TRANSLATIONS } from './duration-picker.translate';
 export class DurationPickerComponent extends BasePickerComponent {
 	readonly intl = input(...intlInputOptions(LU_DURATION_PICKER_TRANSLATIONS));
 
-	value = model<ISO8601Duration>('PT0S');
+	readonly value = model<ISO8601Duration>('PT0S');
 	readonly max = input<ISO8601Duration>('PT99H');
 
 	readonly displayArrows = input(false, { transform: booleanAttribute });
@@ -65,7 +65,7 @@ export class DurationPickerComponent extends BasePickerComponent {
 			'pr-u-visibilityHidden': this.shouldHideValue(),
 		};
 	});
-	protected separator = computed(() => this.intl().timePickerTimeSeparator);
+	protected readonly separator = computed(() => this.intl().timePickerTimeSeparator);
 
 	protected hoursDecimalConf = DEFAULT_TIME_DECIMAL_PIPE_FORMAT;
 

--- a/packages/ng/time/time-picker/time-picker.component.ts
+++ b/packages/ng/time/time-picker/time-picker.component.ts
@@ -48,7 +48,7 @@ export class TimePickerComponent extends BasePickerComponent {
 
 	readonly postMeridiemRef = viewChild<ElementRef<HTMLInputElement>>('postMeridiemRef');
 
-	value = model<ISO8601Time>('--:--:--');
+	readonly value = model<ISO8601Time>('--:--:--');
 	readonly max = input<ISO8601Time>(MAX_TIME);
 
 	readonly displayArrows = input(false, { transform: booleanAttribute });
@@ -85,7 +85,7 @@ export class TimePickerComponent extends BasePickerComponent {
 			[`mod-${this.size()}`]: Boolean(this.size()),
 		};
 	});
-	protected separator = computed(() => this.intl().timePickerTimeSeparator);
+	protected readonly separator = computed(() => this.intl().timePickerTimeSeparator);
 
 	protected hoursDecimalConf = DEFAULT_TIME_DECIMAL_PIPE_FORMAT;
 

--- a/packages/ng/title/title.service.ts
+++ b/packages/ng/title/title.service.ts
@@ -12,8 +12,8 @@ import { PageTitle, TitleSeparator } from './title.model';
 @Injectable()
 export class LuTitleService {
 	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>(['Lucca']);
-	titleParts$ = this.titlePartsSubject.asObservable();
-	title$ = this.titleParts$.pipe(
+	readonly titleParts$ = this.titlePartsSubject.asObservable();
+	readonly title$ = this.titleParts$.pipe(
 		switchMap((titleParts) => combineLatest(titleParts.map((part) => (typeof part === 'string' ? of(part) : part)))),
 		map((parts) => parts.join(TitleSeparator)),
 	);

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -24,11 +24,11 @@ export class LuTitleStrategy extends TitleStrategy {
 	private appTitle = inject(ɵAPP_TITLE);
 	private namingStrategy = inject(ɵNAMING_STRATEGY);
 
-	private luccaTitle$ = isObservable(this.appTitle) ? this.appTitle.pipe(map((title) => this.#luccaTitle(title))) : of(this.#luccaTitle(this.appTitle));
+	private readonly luccaTitle$ = isObservable(this.appTitle) ? this.appTitle.pipe(map((title) => this.#luccaTitle(title))) : of(this.#luccaTitle(this.appTitle));
 
 	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>([Lucca]);
-	titleParts$ = this.titlePartsSubject.asObservable();
-	title$ = this.titleParts$.pipe(
+	readonly titleParts$ = this.titlePartsSubject.asObservable();
+	readonly title$ = this.titleParts$.pipe(
 		switchMap((titleParts) => combineLatest(titleParts.map((part) => (typeof part === 'string' ? of(part) : part)))),
 		map((parts) => parts.join(TitleSeparator)),
 		distinctUntilChanged(),

--- a/packages/ng/toast/toasts.service.ts
+++ b/packages/ng/toast/toasts.service.ts
@@ -4,7 +4,7 @@ import { defaultToastDuration, LuToast, LuToastInput } from './toasts.model';
 
 @Injectable({ providedIn: 'root' })
 export class LuToastsService {
-	public toasts$ = new BehaviorSubject<LuToast[]>([]);
+	public readonly toasts$ = new BehaviorSubject<LuToast[]>([]);
 
 	public addToast(toastInput: LuToastInput): LuToast {
 		const toast = this.getToast(toastInput);

--- a/packages/ng/tree-select/tree-branch/tree-branch.component.ts
+++ b/packages/ng/tree-select/tree-branch/tree-branch.component.ts
@@ -31,9 +31,9 @@ export class TreeBranchComponent<T> {
 
 	unselectMany = output<T[]>();
 
-	simpleMode = input(false, { transform: booleanAttribute });
+	readonly simpleMode = input(false, { transform: booleanAttribute });
 
-	depth = input(1);
+	readonly depth = input(1);
 
 	constructor() {
 		if (this.selectInputComponent.selectChildren$) {

--- a/packages/ng/tree-select/tree-branch/tree-branch.component.ts
+++ b/packages/ng/tree-select/tree-branch/tree-branch.component.ts
@@ -11,7 +11,7 @@ import { ALuSelectInputComponent, LuIsOptionSelectedPipe, LuOptionComparer, LuOp
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TreeBranchComponent<T> {
-	selectInputComponent = inject(ALuSelectInputComponent);
+	readonly selectInputComponent = inject(ALuSelectInputComponent);
 
 	readonly rootOptionRef = viewChild<ɵCoreSelectPanelElement<T>>('rootOption');
 

--- a/packages/ng/tree-select/tree-branch/tree-branch.component.ts
+++ b/packages/ng/tree-select/tree-branch/tree-branch.component.ts
@@ -13,17 +13,17 @@ import { ALuSelectInputComponent, LuIsOptionSelectedPipe, LuOptionComparer, LuOp
 export class TreeBranchComponent<T> {
 	selectInputComponent = inject(ALuSelectInputComponent);
 
-	rootOptionRef = viewChild<ɵCoreSelectPanelElement<T>>('rootOption');
+	readonly rootOptionRef = viewChild<ɵCoreSelectPanelElement<T>>('rootOption');
 
-	branch = input.required<TreeNode<T>>();
+	readonly branch = input.required<TreeNode<T>>();
 
-	optionTpl = input.required<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
+	readonly optionTpl = input.required<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
 
-	optionIndex = input.required({ transform: (value: string | number) => `${value}` });
+	readonly optionIndex = input.required({ transform: (value: string | number) => `${value}` });
 
-	optionComparer = input.required<LuOptionComparer<T>>();
+	readonly optionComparer = input.required<LuOptionComparer<T>>();
 
-	selectedOptions = input<T[]>([]);
+	readonly selectedOptions = input<T[]>([]);
 
 	toggleOne = output<T>();
 

--- a/packages/ng/tree-select/tree-select.directive.ts
+++ b/packages/ng/tree-select/tree-select.directive.ts
@@ -8,9 +8,9 @@ import { ALuSelectInputComponent, TreeGenerator, TreeGroupingFn, TreeNode } from
 export class TreeSelectDirective<T, V> implements TreeGenerator<T, TreeNode<T>> {
 	#select = inject<ALuSelectInputComponent<T, V>>(ALuSelectInputComponent);
 
-	groupingFnInput = input.required<TreeGroupingFn<T>>({ alias: 'treeSelect' });
+	readonly groupingFnInput = input.required<TreeGroupingFn<T>>({ alias: 'treeSelect' });
 
-	groupingFn = linkedSignal(() => this.groupingFnInput());
+	readonly groupingFn = linkedSignal(() => this.groupingFnInput());
 
 	constructor() {
 		this.#select.treeGenerator = this;

--- a/packages/ng/user-popover/card/pipe/leave-ends-display.pipe.ts
+++ b/packages/ng/user-popover/card/pipe/leave-ends-display.pipe.ts
@@ -8,8 +8,8 @@ import { LU_POPUP_EMPLOYEE_TRANSLATIONS } from '../../popup-employee.translate';
 	name: 'leaveEndsDisplay',
 })
 export class LeaveEndsDisplayPipe implements PipeTransform {
-	intl = getIntl(LU_POPUP_EMPLOYEE_TRANSLATIONS);
-	locale = inject(LOCALE_ID);
+	readonly intl = getIntl(LU_POPUP_EMPLOYEE_TRANSLATIONS);
+	readonly locale = inject(LOCALE_ID);
 	public transform(leaveEndsOn: Date, leaveEndIsFirstHalfDay: boolean): string {
 		if (isToday(leaveEndsOn)) {
 			if (leaveEndIsFirstHalfDay) {

--- a/packages/ng/user-popover/card/trigger/lu-user-popover.directive.ts
+++ b/packages/ng/user-popover/card/trigger/lu-user-popover.directive.ts
@@ -12,7 +12,7 @@ import { LuUserPopoverComponent } from './user-popover.component';
 	exportAs: 'LuUserPopoverDirective',
 })
 export class LuUserPopoverDirective extends PopoverDirective {
-	luUserPopover = input.required<ILuUser>();
+	readonly luUserPopover = input.required<ILuUser>();
 
 	@Input()
 	set luUserPopoverDisabled(disabled: boolean) {

--- a/packages/ng/user-popover/card/trigger/user-popover.component.ts
+++ b/packages/ng/user-popover/card/trigger/user-popover.component.ts
@@ -34,7 +34,7 @@ export class LuUserPopoverComponent {
 
 	skeletonWidths = [this.getRandomPercent(), this.getRandomPercent(), this.getRandomPercent(), this.getRandomPercent()];
 
-	public employee$: Observable<LuUserPopover> = toObservable(this.luUser).pipe(
+	public readonly employee$: Observable<LuUserPopover> = toObservable(this.luUser).pipe(
 		switchMap((user) =>
 			this.#service.get(user.id).pipe(
 				catchError(() =>

--- a/packages/ng/user-popover/card/trigger/user-popover.component.ts
+++ b/packages/ng/user-popover/card/trigger/user-popover.component.ts
@@ -30,7 +30,7 @@ export class LuUserPopoverComponent {
 
 	readonly intl = input(...intlInputOptions(LU_POPUP_EMPLOYEE_TRANSLATIONS));
 
-	#errorImage$ = new BehaviorSubject<boolean>(false);
+	readonly #errorImage$ = new BehaviorSubject<boolean>(false);
 
 	skeletonWidths = [this.getRandomPercent(), this.getRandomPercent(), this.getRandomPercent(), this.getRandomPercent()];
 
@@ -51,7 +51,7 @@ export class LuUserPopoverComponent {
 		shareReplay(1),
 	);
 
-	public userPictureDisplay$ = combineLatest([this.employee$, this.#errorImage$]).pipe(
+	public readonly userPictureDisplay$ = combineLatest([this.employee$, this.#errorImage$]).pipe(
 		map(([employee, isError]) => {
 			if (employee.pictureHref && !isError) {
 				return 'img';
@@ -61,9 +61,9 @@ export class LuUserPopoverComponent {
 		}),
 	);
 
-	public userPictureHref$ = this.employee$.pipe(map((employee) => employee.pictureHref));
+	public readonly userPictureHref$ = this.employee$.pipe(map((employee) => employee.pictureHref));
 
-	public userInitials$ = this.employee$.pipe(
+	public readonly userInitials$ = this.employee$.pipe(
 		map((employee) => {
 			const initials = `${employee.firstName[0]}${employee.lastName[0]}`;
 

--- a/packages/ng/user-popover/card/trigger/user-popover.component.ts
+++ b/packages/ng/user-popover/card/trigger/user-popover.component.ts
@@ -28,7 +28,7 @@ export class LuUserPopoverComponent {
 
 	#service = inject(LuUserPopoverStore);
 
-	intl = input(...intlInputOptions(LU_POPUP_EMPLOYEE_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_POPUP_EMPLOYEE_TRANSLATIONS));
 
 	#errorImage$ = new BehaviorSubject<boolean>(false);
 

--- a/packages/ng/user/select/input/user-select-input.component.ts
+++ b/packages/ng/user/select/input/user-select-input.component.ts
@@ -66,7 +66,7 @@ export class LuUserSelectInputComponent<U extends import('../../user.model').ILu
 
 	byId: LuOptionComparer<U> = (option1: U, option2: U) => option1 && option2 && option1.id === option2.id;
 
-	intl = input(...intlInputOptions(LU_USER_SELECT_INPUT_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_USER_SELECT_INPUT_TRANSLATIONS));
 
 	constructor(
 		protected override _changeDetectorRef: ChangeDetectorRef,

--- a/packages/ng/user/select/me/me-option.directive.ts
+++ b/packages/ng/user/select/me/me-option.directive.ts
@@ -68,7 +68,7 @@ export class LuUserMeOptionDirective<U extends ILuUser = ILuUser> implements ILu
 	}
 
 	me: U | undefined = undefined;
-	private meDisplayed$ = new BehaviorSubject(false);
+	private readonly meDisplayed$ = new BehaviorSubject(false);
 	onOpen() {
 		this._service.getMe().subscribe((me) => {
 			this.me = me;

--- a/packages/ng/user/select/searcher/user-searcher.component.ts
+++ b/packages/ng/user/select/searcher/user-searcher.component.ts
@@ -1,7 +1,7 @@
 import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ElementRef, forwardRef, HostBinding, Inject, input, Input, OnDestroy, OnInit, Optional, Output, Self, SkipSelf, ViewChild } from '@angular/core';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { ALuOnCloseSubscriber, ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber, intlInputOptions, ILuOnCloseSubscriber, ILuOnOpenSubscriber, ILuOnScrollBottomSubscriber } from '@lucca-front/ng/core';
+import { ALuOnCloseSubscriber, ALuOnOpenSubscriber, ALuOnScrollBottomSubscriber, ILuOnCloseSubscriber, ILuOnOpenSubscriber, ILuOnScrollBottomSubscriber, intlInputOptions } from '@lucca-front/ng/core';
 import { ALuOptionOperator, LuOptionPlaceholderComponent } from '@lucca-front/ng/option';
 import { BehaviorSubject, combineLatest, merge, Observable, of, Subject, Subscription } from 'rxjs';
 import { catchError, debounceTime, filter, map, scan, share, startWith, switchMap } from 'rxjs/operators';
@@ -76,7 +76,7 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser> implement
 
 	form: FormGroup;
 	// page$: Subject<number>;
-	outOptions$ = new Subject<U[]>();
+	readonly outOptions$ = new Subject<U[]>();
 	loading$: Observable<boolean>;
 	empty$: Observable<boolean>;
 	private _loading = false;

--- a/packages/ng/user/select/searcher/user-searcher.component.ts
+++ b/packages/ng/user/select/searcher/user-searcher.component.ts
@@ -53,7 +53,7 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser> implement
 
 	@HostBinding('class.position-fixed') fixed = true;
 	@ViewChild('searchInput', { read: ElementRef, static: true })
-	searchInput: ElementRef<HTMLInputElement>;
+	readonly searchInput: ElementRef<HTMLInputElement>;
 
 	@Input() set fields(fields: string) {
 		this._service.fields = fields;

--- a/packages/ng/user/select/searcher/user-searcher.component.ts
+++ b/packages/ng/user/select/searcher/user-searcher.component.ts
@@ -80,8 +80,8 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser> implement
 	loading$: Observable<boolean>;
 	empty$: Observable<boolean>;
 	private _loading = false;
-	private _isOpened$ = new BehaviorSubject(false);
-	private _page$ = new Subject<void>();
+	private readonly _isOpened$ = new BehaviorSubject(false);
+	private readonly _page$ = new Subject<void>();
 	private _isLastPage: boolean;
 	private _options: U[] = [];
 

--- a/packages/ng/user/select/searcher/user-searcher.component.ts
+++ b/packages/ng/user/select/searcher/user-searcher.component.ts
@@ -85,7 +85,7 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser> implement
 	private _isLastPage: boolean;
 	private _options: U[] = [];
 
-	intl = input(...intlInputOptions(LU_USER_SEARCHER_TRANSLATIONS));
+	readonly intl = input(...intlInputOptions(LU_USER_SEARCHER_TRANSLATIONS));
 
 	constructor(@Inject(ALuUserService) @Optional() @SkipSelf() hostService: LuUserV3Service<U>, @Inject(ALuUserService) @Self() selfService: LuUserV3Service<U>) {
 		this._service = hostService || selfService;


### PR DESCRIPTION
## Description

This pull request focuses on improving code safety and clarity throughout the codebase by marking class properties as `readonly` where appropriate. This change ensures that these properties cannot be reassigned after initialization, which helps prevent accidental mutations and makes the code easier to reason about. Additionally, the ESLint configuration is updated to enforce Angular's signals best practices.

**ESLint configuration update:**

* Added the `@angular-eslint/prefer-signals` rule to the ESLint config with strict settings to encourage the use of Angular signals and readonly signal properties, with type checking enabled.

These changes collectively enhance immutability and code robustness, and help enforce modern Angular best practices across the codebase.

-----



-----
