### PR TITLE
security: pin GitHub Actions to commit digest

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     container:
-      image: mcr.microsoft.com/playwright:v1.57.0
+      image: mcr.microsoft.com/playwright@sha256:3bed4b1a12f2338642f3d8cba28e291deef3c66bd4a964bbeb3e57bbff511dbd # v1.57.0
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - name: Setup Node


### PR DESCRIPTION
## :pushpin: Pin GitHub Actions to commit digest

This PR pins mutable action tag references and container image tags to their current digest for supply-chain security.

### Container Images

| Workflow | Line | Before | After |
|---|---|---|---|
| `.github/workflows/e2e-test.yml` | L9 | `mcr.microsoft.com/playwright:v1.57.0` | `mcr.microsoft.com/playwright@sha256:3bed4b1a12f2…` # v1.57.0 |


---
*Automated by `audit_pin_digest.py`*