### PR TITLE
fix(index-table): hide empty pagination wrapper

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -263,11 +263,11 @@
 				margin-inline-end: var(--pr-t-spacings-100);
 			}
 		}
-	}
 
-	.indexTableWrapper-pagination {
-		&:empty {
-			display: none;
+		.indexTableWrapper-pagination {
+			&:empty {
+				display: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
## Description

Le wrapper de la pagination n'est pas vraiment caché si vide car le sélecteur n'est pas bon, `.indexTableWrapper-pagination` est adjacent de `.indexTable`et pas son enfant.

```css
.indexTable .indexTableWrapper-pagination:empty {
	display: none;
}
```

## Correction
Je remonte le sélecteur dans la règle `@at-root`, ce qui donne :

```css
.indexTableWrapper-pagination:empty {
	display: none;
}
```

-----
