### PR TITLE
[dataTable] optimise sticky cols

### DIFF
--- a/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
+++ b/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
@@ -46,7 +46,8 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 	inlineSize = input<string | null>(null);
 
 	insetInlineStart = computed(() => {
-		if (!this.isStickyStart() || !this.headRef) {
+		const isFirstOrLastCol = this.position() === 0 || this.position() === (this.rowRef?.cells().length ?? 0) - 1;
+		if (isFirstOrLastCol || !this.isStickyStart() || !this.headRef) {
 			return '';
 		}
 		return (
@@ -60,7 +61,8 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 	});
 
 	insetInlineEnd = computed(() => {
-		if (!this.isStickyEnd() || !this.headRef) {
+		const isFirstOrLastCol = this.position() === 0 || this.position() === (this.rowRef?.cells().length ?? 0) - 1;
+		if (isFirstOrLastCol || !this.isStickyEnd() || !this.headRef) {
 			return '';
 		}
 		return (

--- a/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
+++ b/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
@@ -41,10 +41,14 @@ export class DataTableRowCellComponent extends BaseDataTableCell {
 	});
 
 	insetInlineStart = computed(() => {
+		const isFirstOrLastCol = this.position() === 0 || this.position() === (this.rowRef?.cells().length ?? 0) - 1;
+		if (isFirstOrLastCol) return null;
 		return this.tableRef?.header()?.cols()?.[this.position()]?.insetInlineStart();
 	});
 
 	insetInlineEnd = computed(() => {
+		const isFirstOrLastCol = this.position() === 0 || this.position() === (this.rowRef?.cells().length ?? 0) - 1;
+		if (isFirstOrLastCol) return null;
 		return this.tableRef?.header()?.cols()?.[this.position()]?.insetInlineEnd();
 	});
 }

--- a/packages/scss/src/components/dataTable/component.scss
+++ b/packages/scss/src/components/dataTable/component.scss
@@ -92,10 +92,15 @@
 
 			&:first-child {
 				inline-size: var(--components-dataTable-cellFirst-width);
+				inset-inline-start: 0;
 
 				.checkboxField {
 					--component-checkboxField-top: 0;
 				}
+			}
+
+			&:last-child {
+				inset-inline-end: 0;
 			}
 		}
 


### PR DESCRIPTION
## Description



-----

Close #4712 

The JavaScript part was suggested to me by an AI; it works and seems logical, but I’m just pointing it out.

-----

![2026-04-10 15 41 44](https://github.com/user-attachments/assets/97e80df6-374f-43e3-a5a2-442ac3ef8d15)

