### PR TITLE
fix: Greedy selector for mod-outlined.

### DIFF
--- a/packages/stylelint-config/LFDeprecatedSelectors.mjs
+++ b/packages/stylelint-config/LFDeprecatedSelectors.mjs
@@ -9,7 +9,7 @@ export default [
 			/\.label/,
 			/\.mod-delete/,
 			/\.mod-link/,
-			/\.mod-outline/,
+			/\.mod-outline\b/,
 			/\.success/,
 			/\.u-textLight/,
 		],


### PR DESCRIPTION
## Description

* `mod-outline`also matches `mod-outlined` which is not deprecated.
* `\b` bounds the match to the word `mod-outline`.
* The [regex sandbox](https://regex101.com/r/OTnSEg) has been updated accordingly.

-----
