### PR TITLE
fix(rich-text-input): remove delete button in link popover for autolinks

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.html
+++ b/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.html
@@ -6,9 +6,9 @@
 			</lu-form-field>
 		</lu-dialog-content>
 		<lu-dialog-footer>
-			@if (dialogData) {
+			@if (dialogData.url && dialogData.canDelete) {
 				<div class="footer-content">
-					<button type="button" luButton="ghost" delete (click)="deleteLink()">{{ intl().linksDelete }}</button>
+					<button type="button" luButton="ghost" critical (click)="deleteLink()">{{ intl().linksDelete }}</button>
 				</div>
 			}
 			<div class="footer-actions">

--- a/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.ts
@@ -14,13 +14,13 @@ import { LU_RICH_TEXT_INPUT_TRANSLATIONS } from '../../../rich-text-input.transl
 	imports: [DialogComponent, DialogContentComponent, DialogFooterComponent, FormFieldComponent, TextInputComponent, ReactiveFormsModule, ButtonComponent, DialogDismissDirective],
 })
 export class LinkDialogComponent {
-	public readonly dialogData = injectDialogData<string>();
+	public readonly dialogData = injectDialogData<{ url: string; canDelete: boolean }>();
 	public readonly dialogRef = injectDialogRef<string | undefined>();
 
 	intl = input(...intlInputOptions(LU_RICH_TEXT_INPUT_TRANSLATIONS));
 
 	public readonly formGroup = new FormGroup({
-		href: new FormControl<string>(this.dialogData, Validators.required),
+		href: new FormControl<string>(this.dialogData.url, Validators.required),
 	});
 
 	public save() {

--- a/packages/ng/forms/rich-text-input/plugins/link/link-template-context.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/link-template-context.ts
@@ -1,0 +1,6 @@
+export interface LinkTemplateContext {
+	href: string;
+	title?: string | null;
+	target?: string | null;
+	isAutoLink: boolean;
+}

--- a/packages/ng/forms/rich-text-input/plugins/link/link.component.html
+++ b/packages/ng/forms/rich-text-input/plugins/link/link.component.html
@@ -14,8 +14,8 @@
 	<lu-icon icon="formatLink" [alt]="intl().linksLabel" />
 </button>
 
-<ng-template #linkNodeTemplate let-href="href" let-title="title" let-target="target">
-	<a [href]="href" [title]="title" [target]="target" [luPopover2]="popover" #trigger="luPopover2"></a>
+<ng-template #linkNodeTemplate let-href="href" let-title="title" let-target="target" let-isAutoLink="isAutoLink">
+	<a [href]="href" [attr.title]="title" [attr.target]="target" [luPopover2]="popover" rel="noopener noreferrer" #trigger="luPopover2"></a>
 	<ng-template #popover>
 		<div class="popover-contentOptional linkPopover">
 			<a [href]="href" luLink external class="pr-u-ellipsis">{{ href }}</a>
@@ -29,16 +29,18 @@
 			>
 				<lu-icon icon="officePen" [alt]="intl().linksLabel" />
 			</button>
-			<button
-				type="button"
-				luButton="ghost"
-				size="XS"
-				(click)="trigger.close(); deleteLink()"
-				[luTooltip]="intl().linksDelete"
-				luTooltipOnlyForDisplay
-			>
-				<lu-icon icon="trashDelete" [alt]="intl().linksDelete" />
-			</button>
+			@if (!isAutoLink) {
+				<button
+					type="button"
+					luButton="ghost"
+					size="XS"
+					(click)="trigger.close(); deleteLink()"
+					[luTooltip]="intl().linksDelete"
+					luTooltipOnlyForDisplay
+				>
+					<lu-icon icon="trashDelete" [alt]="intl().linksDelete" />
+				</button>
+			}
 		</div>
 	</ng-template>
 </ng-template>

--- a/packages/ng/forms/rich-text-input/plugins/link/link.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/link.component.ts
@@ -15,7 +15,7 @@ import { getSelectedNode } from '../../utils';
 import { LinkDialogComponent } from './link-dialog';
 import { FORMAT_LINK, registerLink, registerLinkSelectionChange } from './link.command';
 import { $createPopoverLinkNode, PopoverLinkNode } from './popover-link-node';
-import { $createPopoverAutoLinkNode, PopoverAutoLinkNode } from './popover-autolink-node';
+import { $createPopoverAutoLinkNode, $isPopoverAutoLinkNode, PopoverAutoLinkNode } from './popover-autolink-node';
 
 const URL_REGEX = /https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?!&/=;,[\]]*)/;
 const EMAIL_REGEX = /(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))/;
@@ -104,12 +104,14 @@ export class LinkComponent implements OnDestroy, RichTextPluginComponent {
 	dispatchCommand() {
 		this.#editor?.read(() => {
 			let url = '';
+			let canDelete = false;
 			const selection = $getSelection();
 			if ($isRangeSelection(selection)) {
 				const node = getSelectedNode(selection);
 				const parent = $getNearestNodeOfType(node, LinkNode);
 				if (parent) {
 					url = parent.getURL();
+					canDelete = !$isPopoverAutoLinkNode(parent);
 				}
 			}
 
@@ -117,7 +119,10 @@ export class LinkComponent implements OnDestroy, RichTextPluginComponent {
 				.open({
 					content: LinkDialogComponent,
 					size: 'S',
-					data: url,
+					data: {
+						url,
+						canDelete,
+					},
 				})
 				.result$.subscribe((href) => {
 					let newHref = href;

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
@@ -1,26 +1,27 @@
 import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
 import { AutoLinkNode, LinkAttributes, LinkNode, SerializedAutoLinkNode } from '@lexical/link';
 import { DOMExportOutput, EditorConfig, LexicalEditor, type NodeKey } from 'lexical';
+import { LinkTemplateContext } from './link-template-context';
 
 export class PopoverAutoLinkNode extends AutoLinkNode {
 	#viewContainerRef?: ViewContainerRef;
-	#templateRef?: TemplateRef<{ href?: string; title?: string; target?: string }>;
-	#view?: EmbeddedViewRef<{ href?: string; title?: string; target?: string }>;
+	#templateRef?: TemplateRef<LinkTemplateContext>;
+	#view?: EmbeddedViewRef<LinkTemplateContext>;
 
 	setViewContainerRef(vcr: ViewContainerRef): this {
 		const self = this.getWritable();
 		self.#viewContainerRef = vcr;
 		return self;
 	}
-	getViewContainerRef(): ViewContainerRef {
+	getViewContainerRef(): ViewContainerRef | undefined {
 		return this.#viewContainerRef;
 	}
-	setTemplateRef(vcr: TemplateRef<{ href?: string; title?: string; target?: string }>): this {
+	setTemplateRef(vcr: TemplateRef<LinkTemplateContext>): this {
 		const self = this.getWritable();
 		self.#templateRef = vcr;
 		return self;
 	}
-	getTemplateRef(): TemplateRef<{ href?: string; title?: string; target?: string }> {
+	getTemplateRef(): TemplateRef<LinkTemplateContext> | undefined {
 		return this.#templateRef;
 	}
 
@@ -28,7 +29,7 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 		return 'popoverautolink';
 	}
 
-	constructor(url?: string, attributes?: LinkAttributes & { viewContainerRef: ViewContainerRef; templateRef: TemplateRef<{ href?: string; title?: string; target?: string }> }, key?: NodeKey) {
+	constructor(url?: string, attributes?: LinkAttributes & { viewContainerRef?: ViewContainerRef; templateRef?: TemplateRef<LinkTemplateContext> }, key?: NodeKey) {
 		super(url, attributes, key);
 		this.#viewContainerRef = attributes?.viewContainerRef;
 		this.#templateRef = attributes?.templateRef;
@@ -94,12 +95,12 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 
 export function $createPopoverAutoLinkNode(
 	url?: string,
-	attributes?: LinkAttributes & { viewContainerRef: ViewContainerRef; templateRef: TemplateRef<{ href?: string; title?: string; target?: string }> },
+	attributes?: LinkAttributes & { viewContainerRef?: ViewContainerRef; templateRef?: TemplateRef<LinkTemplateContext> },
 	key?: NodeKey,
 ): PopoverAutoLinkNode {
 	return new PopoverAutoLinkNode(url, attributes, key);
 }
 
-export function $isPopoverLinkNode(node: LinkNode | null | undefined): node is PopoverAutoLinkNode {
+export function $isPopoverAutoLinkNode(node: LinkNode | null | undefined): node is PopoverAutoLinkNode {
 	return node instanceof PopoverAutoLinkNode;
 }

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
@@ -41,6 +41,7 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 				title: this.__title,
 				target: this.__target,
 				key: this.__key,
+				isAutoLink: true,
 			};
 			if (this.#view) {
 				this.#view.context = context;

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
@@ -44,13 +44,12 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 				key: this.__key,
 				isAutoLink: true,
 			};
+			// if view already exists, destroy it. Can't reuse it since Lexical injects HTML content inside afterward (link text).
 			if (this.#view) {
-				this.#view.context = context;
-				this.#view.markForCheck();
-			} else {
-				// Create the view
-				this.#view = this.#viewContainerRef.createEmbeddedView(this.#templateRef, context);
+				this.#view.destroy();
 			}
+			// Create the view
+			this.#view = this.#viewContainerRef.createEmbeddedView(this.#templateRef, context);
 
 			// Return the template DOM element
 			return this.#view.rootNodes[0] as HTMLElement;

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
@@ -16,9 +16,9 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 	getViewContainerRef(): ViewContainerRef | undefined {
 		return this.#viewContainerRef;
 	}
-	setTemplateRef(vcr: TemplateRef<LinkTemplateContext>): this {
+	setTemplateRef(templateRef: TemplateRef<LinkTemplateContext>): this {
 		const self = this.getWritable();
-		self.#templateRef = vcr;
+		self.#templateRef = templateRef;
 		return self;
 	}
 	getTemplateRef(): TemplateRef<LinkTemplateContext> | undefined {

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
@@ -16,9 +16,9 @@ export class PopoverLinkNode extends LinkNode {
 	getViewContainerRef(): ViewContainerRef | undefined {
 		return this.#viewContainerRef;
 	}
-	setTemplateRef(vcr: TemplateRef<LinkTemplateContext>): this {
+	setTemplateRef(templateRef: TemplateRef<LinkTemplateContext>): this {
 		const self = this.getWritable();
-		self.#templateRef = vcr;
+		self.#templateRef = templateRef;
 		return self;
 	}
 	getTemplateRef(): TemplateRef<LinkTemplateContext> | undefined {

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
@@ -1,26 +1,27 @@
 import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
 import { LinkAttributes, LinkNode, SerializedLinkNode } from '@lexical/link';
 import { DOMExportOutput, EditorConfig, LexicalEditor, type NodeKey } from 'lexical';
+import { LinkTemplateContext } from './link-template-context';
 
 export class PopoverLinkNode extends LinkNode {
 	#viewContainerRef?: ViewContainerRef;
-	#templateRef?: TemplateRef<{ href?: string; title?: string; target?: string }>;
-	#view?: EmbeddedViewRef<{ href?: string; title?: string; target?: string }>;
+	#templateRef?: TemplateRef<LinkTemplateContext>;
+	#view?: EmbeddedViewRef<LinkTemplateContext>;
 
 	setViewContainerRef(vcr: ViewContainerRef): this {
 		const self = this.getWritable();
 		self.#viewContainerRef = vcr;
 		return self;
 	}
-	getViewContainerRef(): ViewContainerRef {
+	getViewContainerRef(): ViewContainerRef | undefined {
 		return this.#viewContainerRef;
 	}
-	setTemplateRef(vcr: TemplateRef<{ href?: string; title?: string; target?: string }>): this {
+	setTemplateRef(vcr: TemplateRef<LinkTemplateContext>): this {
 		const self = this.getWritable();
 		self.#templateRef = vcr;
 		return self;
 	}
-	getTemplateRef(): TemplateRef<{ href?: string; title?: string; target?: string }> {
+	getTemplateRef(): TemplateRef<LinkTemplateContext> | undefined {
 		return this.#templateRef;
 	}
 
@@ -28,7 +29,7 @@ export class PopoverLinkNode extends LinkNode {
 		return 'popoverlink';
 	}
 
-	constructor(url?: string, attributes?: LinkAttributes & { viewContainerRef: ViewContainerRef; templateRef: TemplateRef<{ href?: string; title?: string; target?: string }> }, key?: NodeKey) {
+	constructor(url?: string, attributes?: LinkAttributes & { viewContainerRef?: ViewContainerRef; templateRef?: TemplateRef<LinkTemplateContext> }, key?: NodeKey) {
 		super(url, attributes, key);
 		this.#viewContainerRef = attributes?.viewContainerRef;
 		this.#templateRef = attributes?.templateRef;
@@ -84,13 +85,13 @@ export class PopoverLinkNode extends LinkNode {
 	}
 
 	static override clone(node: PopoverLinkNode): PopoverLinkNode {
-		return new PopoverLinkNode(node.__url, { target: node.__target, rel: node.__rel, title: node.__title, templateRef: node.#templateRef, viewContainerRef: node.#viewContainerRef }, node.__key);
+		return $createPopoverLinkNode(node.__url, { target: node.__target, rel: node.__rel, title: node.__title, templateRef: node.#templateRef, viewContainerRef: node.#viewContainerRef }, node.__key);
 	}
 }
 
 export function $createPopoverLinkNode(
 	url?: string,
-	attributes?: LinkAttributes & { viewContainerRef: ViewContainerRef; templateRef: TemplateRef<{ href?: string; title?: string; target?: string }> },
+	attributes?: LinkAttributes & { viewContainerRef?: ViewContainerRef; templateRef?: TemplateRef<LinkTemplateContext> },
 	key?: NodeKey,
 ): PopoverLinkNode {
 	return new PopoverLinkNode(url, attributes, key);

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
@@ -41,6 +41,7 @@ export class PopoverLinkNode extends LinkNode {
 				title: this.__title,
 				target: this.__target,
 				key: this.__key,
+				isAutoLink: false,
 			};
 			if (this.#view) {
 				this.#view.context = context;

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
@@ -44,13 +44,12 @@ export class PopoverLinkNode extends LinkNode {
 				key: this.__key,
 				isAutoLink: false,
 			};
+			// if view already exists, destroy it. Can't reuse it since Lexical injects HTML content inside afterward (link text).
 			if (this.#view) {
-				this.#view.context = context;
-				this.#view.markForCheck();
-			} else {
-				// Create the view
-				this.#view = this.#viewContainerRef.createEmbeddedView(this.#templateRef, context);
+				this.#view.destroy();
 			}
+			// Create the view
+			this.#view = this.#viewContainerRef.createEmbeddedView(this.#templateRef, context);
 
 			// Return the template DOM element
 			return this.#view.rootNodes[0] as HTMLElement;


### PR DESCRIPTION
## Description

* Remove delete button in link popover & popup for autolinks (fixes #4619)
* Fixes visual duplication of link text when splitting list or when using undo/redo (#4686)
* Also fixes "null" title on links in presentation mode & added `rel` for security reasons.

-----

<img width="1125" height="470" alt="firefox_7M8txEzUFH" src="https://github.com/user-attachments/assets/f808bcf4-18b6-4aa1-b2e2-093a0c7e54e5" />

-----
