### PR TITLE
[segmentedControl] add home/end support for tabs

### DIFF
--- a/packages/ng/segmented-control-tabs/segmented-control-tabs.component.html
+++ b/packages/ng/segmented-control-tabs/segmented-control-tabs.component.html
@@ -15,6 +15,8 @@
 				(keydown.arrowup)="$event.preventDefault(); previous()"
 				(keydown.arrowright)="$event.preventDefault(); next()"
 				(keydown.arrowdown)="$event.preventDefault(); next()"
+				(keydown.home)="$event.preventDefault(); first()"
+				(keydown.end)="$event.preventDefault(); last()"
 			>
 				<ng-container *luPortal="panel.label()" />
 			</button>

--- a/packages/ng/segmented-control-tabs/segmented-control-tabs.component.ts
+++ b/packages/ng/segmented-control-tabs/segmented-control-tabs.component.ts
@@ -71,6 +71,14 @@ export class SegmentedControlTabsComponent<T = unknown> implements AfterContentI
 		this.setActiveTab(newIndex);
 	}
 
+	first() {
+		this.setActiveTab(0);
+	}
+
+	last() {
+		this.setActiveTab(this.tabs().length - 1);
+	}
+
 	setActiveTab(index: number) {
 		this.active.set(this.tabs()[index].value());
 		this.tabButtons()[index].nativeElement.focus();


### PR DESCRIPTION
## Description

Improved keyboard navigation support to better comply with ARIA guidelines.

-----



-----

<img width="713" height="258" alt="2026-04-16 17 48 32" src="https://github.com/user-attachments/assets/0add696b-541f-4666-a7fe-2a059621c3a1" />

<img width="695" height="173" alt="Capture d’écran 2026-06-05 à 11 01 31" src="https://github.com/user-attachments/assets/b7cd7245-4a12-4cde-9845-79b901b0a0a3" />


