### PR TITLE
[activity-feed] Fix date formatting literal for Safari simplify date return

### DIFF
--- a/packages/ng/activity-feed/activity-feed-step/activity-feed-step.component.ts
+++ b/packages/ng/activity-feed/activity-feed-step/activity-feed-step.component.ts
@@ -56,8 +56,20 @@ export class ActivityFeedStepComponent {
 		if (!date) {
 			return null;
 		}
-		const formatted = this.#intlDateTimeFormat.format(date);
-		const parts = formatted.split(', ');
-		return `${parts[0].charAt(0).toUpperCase() + parts[0].slice(1)} ${this.intl().at} ${parts[1]}`;
+		// Use formatToParts for reliable cross-browser parsing (especially Safari)
+		const parts = this.#intlDateTimeFormat.formatToParts(date);
+		const datePart = parts
+			.filter(({ type }) => ['weekday', 'day', 'month', 'year'].includes(type))
+			.map(({ value }) => value)
+			.join(' ');
+		const timePart = parts
+			.filter(({ type }) => ['hour', 'minute'].includes(type))
+			.map(({ value }) => value)
+			.join(':');
+		if (timePart) {
+			return `${datePart.charAt(0).toUpperCase() + datePart.slice(1)} ${this.intl().at} ${timePart}`;
+		} else {
+			return datePart.charAt(0).toUpperCase() + datePart.slice(1);
+		}
 	});
 }

--- a/packages/ng/activity-feed/activity-feed-step/activity-feed-step.component.ts
+++ b/packages/ng/activity-feed/activity-feed-step/activity-feed-step.component.ts
@@ -56,20 +56,6 @@ export class ActivityFeedStepComponent {
 		if (!date) {
 			return null;
 		}
-		// Use formatToParts for reliable cross-browser parsing (especially Safari)
-		const parts = this.#intlDateTimeFormat.formatToParts(date);
-		const datePart = parts
-			.filter(({ type }) => ['weekday', 'day', 'month', 'year'].includes(type))
-			.map(({ value }) => value)
-			.join(' ');
-		const timePart = parts
-			.filter(({ type }) => ['hour', 'minute'].includes(type))
-			.map(({ value }) => value)
-			.join(':');
-		if (timePart) {
-			return `${datePart.charAt(0).toUpperCase() + datePart.slice(1)} ${this.intl().at} ${timePart}`;
-		} else {
-			return datePart.charAt(0).toUpperCase() + datePart.slice(1);
-		}
+		return this.#intlDateTimeFormat.format(date);
 	});
 }

--- a/packages/ng/activity-feed/activity-feed.translate.ts
+++ b/packages/ng/activity-feed/activity-feed.translate.ts
@@ -8,7 +8,6 @@ export const LU_ACTIVITY_FEED_TRANSLATIONS = new InjectionToken('luActivityFeedT
 
 export interface ActivityFeedTranslate {
 	replaceByAlt: string;
-	at: string;
 }
 
 export const luActivityFeedTranslations: LuTranslation<ActivityFeedTranslate> = Translations;

--- a/packages/ng/activity-feed/translations.ts
+++ b/packages/ng/activity-feed/translations.ts
@@ -1,34 +1,26 @@
 ﻿export const Translations = {
 	'nl-BE': {
 		replaceByAlt: 'is vervangen door',
-		at: 'tot',
 	},
 	fr: {
 		replaceByAlt: 'à été remplacé par',
-		at: 'à',
 	},
 	de: {
 		replaceByAlt: 'wurde ersetzt durch',
-		at: 'in',
 	},
 	en: {
 		replaceByAlt: 'has been replaced by',
-		at: 'to',
 	},
 	es: {
 		replaceByAlt: 'ha sido sustituido por',
-		at: 'a',
 	},
 	it: {
 		replaceByAlt: 'è stato sostituito da',
-		at: 'a',
 	},
 	nl: {
 		replaceByAlt: 'is vervangen door',
-		at: 'tot',
 	},
 	pt: {
 		replaceByAlt: 'foi substituído por',
-		at: 'à',
 	},
 };


### PR DESCRIPTION
## Description

This pull request simplifies the date formatting logic in the `ActivityFeedStepComponent` by removing custom string manipulation and returning the formatted date directly.

- Simplified date formatting in `ActivityFeedStepComponent` by returning the result of `#intlDateTimeFormat.format(date)` directly, instead of splitting and reconstructing the formatted string.

-----


-----
