### PR TITLE
Fix(simple-select/multi-select): panel loading

### DIFF
--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -10,7 +10,7 @@
 	<div class="lu-picker-panel lu-option-picker-panel mod-multiple" data-testid="dialog-panel">
 		<div
 			class="lu-picker-content"
-			[class.is-loading]="loading$ | async"
+			[class.is-loading]="loading()"
 			[class.is-filled]="ctx.options.length > 0"
 			tabindex="0"
 			role="listbox"
@@ -97,13 +97,13 @@
 						}
 					}
 				</ng-template>
-				@if (ctx.options.length === 0 && (loading$ | async) === false) {
+				@if (ctx.options.length === 0 && (loading()) === false) {
 					<div class="lu-picker-content-option-emptyState">
 						{{ ctx.clueChange.length ? intl().emptyResults : intl().emptyOptions }}
 					</div>
 				}
 			</div>
-			@if (loading$ | async) {
+			@if (loading()) {
 				<div class="lu-picker-content-loading">
 					<div class="loading">{{ intl().loading }}</div>
 				</div>

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -97,7 +97,7 @@
 						}
 					}
 				</ng-template>
-				@if (ctx.options.length === 0 && (loading()) === false) {
+				@if (ctx.options.length === 0 && !loading()) {
 					<div class="lu-picker-content-option-emptyState">
 						{{ ctx.clueChange.length ? intl().emptyResults : intl().emptyOptions }}
 					</div>

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,7 +1,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
 import {
@@ -63,6 +63,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	options$ = this.selectInput.options$;
 	grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
+	loading = toSignal(this.selectInput.loading$);
 	loading$ = this.selectInput.loading$;
 	searchable = this.selectInput.searchable;
 	optionComparer = this.selectInput.optionComparer;

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -67,7 +67,7 @@
 						}
 					}
 				</ng-template>
-				@if (ctx.options.length === 0 && (loading()) === false) {
+				@if (ctx.options.length === 0 && !loading()) {
 					<div class="lu-picker-content-option-emptyState">
 						{{ ctx.clueChange.length ? intl().emptyResults : intl().emptyOptions }}
 					</div>

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -8,7 +8,7 @@
 	as ctx
 ) {
 	<div class="lu-picker-panel lu-option-picker-panel" cdkTrapFocus>
-		<div class="lu-picker-content" [class.is-loading]="loading$ | async" (scroll)="onScroll($event)">
+		<div class="lu-picker-content" [class.is-loading]="loading()" (scroll)="onScroll($event)">
 			@if (selectInput.panelHeaderTpl(); as tpl) {
 				<div>
 					<ng-container *luPortal="tpl" />
@@ -67,13 +67,13 @@
 						}
 					}
 				</ng-template>
-				@if (ctx.options.length === 0 && (loading$ | async) === false) {
+				@if (ctx.options.length === 0 && (loading()) === false) {
 					<div class="lu-picker-content-option-emptyState">
 						{{ ctx.clueChange.length ? intl().emptyResults : intl().emptyOptions }}
 					</div>
 				}
 			</div>
-			@if (loading$ | async) {
+			@if (loading()) {
 				<div class="lu-picker-content-loading">
 					<div class="loading">{{ intl().loading }}</div>
 				</div>

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -1,7 +1,7 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
 import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
-import { toObservable } from '@angular/core/rxjs-interop';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
 import {
@@ -65,6 +65,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	options$ = this.selectInput.options$;
 	grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
+	loading = toSignal(this.selectInput.loading$);
 	loading$ = this.selectInput.loading$;
 	searchable = this.selectInput.searchable;
 	optionComparer = this.selectInput.optionComparer;


### PR DESCRIPTION
## Description

Updated `LuMultiSelectPanelComponent` and `LuSelectPanelComponent` to use `toSignal` for the `loading` state instead of an behavior subject, and updated all template bindings to use the new signal-based approach

-----

SelectInputComponent exposes a BehaviorSubject through an @Input setter.
XPanelComponent uses this BehaviorSubject to determine whether the panel is loading or not.
However, Angular does not detect changes from the BehaviorSubject because they are not triggered within the same component.

We could force change detection using changeDetectorRef.detectChanges() inside a .pipe(tap()), but using signals would be a cleaner and more robust approach.

-----
