### PR TITLE
fix(rich-text-input): do not sanitize markdown input (#4789)

### DIFF
--- a/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.ts
+++ b/packages/ng/forms/rich-text-input/formatters/markdown/markdown-formatter.ts
@@ -20,7 +20,6 @@ import {
 import { registerRichText } from '@lexical/rich-text';
 import { mergeRegister } from '@lexical/utils';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from '@lucca-front/ng/forms/rich-text-input';
-import DOMPurify from 'isomorphic-dompurify';
 import { LexicalEditor } from 'lexical';
 
 export const DEFAULT_MARKDOWN_TRANSFORMERS: Transformer[] = [
@@ -54,14 +53,14 @@ export class MarkdownFormatter extends RichTextFormatter {
 
 	override parse(editor: LexicalEditor, markdown?: string | null): void {
 		editor.update(() => {
-			$convertFromMarkdownString(DOMPurify.sanitize(markdown ?? ''), this.#transformers, undefined, true);
+			$convertFromMarkdownString(markdown ?? '', this.#transformers, undefined, true);
 		});
 	}
 
 	override format(editor: LexicalEditor): string {
 		let result = '';
 		editor.getEditorState().read(() => (result = $convertToMarkdownString(this.#transformers, undefined, true)));
-		return DOMPurify.sanitize(result);
+		return result;
 	}
 }
 


### PR DESCRIPTION
## Description

Do not sanitize markdown input (#4789)

-----

### Analysis of `$convertFromMarkdownString`

The `createMarkdownImport` code (line 666) shows that Markdown is processed in a **purely textual** manner:

1. **Split by lines** (`markdownString.split('\n')`) — line 670
2. **Each line** is processed by transformers (element, multiline, text-format, text-match) that use **regex** to recognize Markdown syntax
3. Content is inserted via `$createTextNode(lineText)` (line 795) — this is a **Lexical TextNode**, not raw HTML
4. **No `innerHTML`**, no `DOMParser`, no HTML parsing is performed

### Verdict: **no XSS risk in `$convertFromMarkdownString`**

Markdown like `<script>alert(1)</script>` passed to this function will simply be created as a **TextNode** containing the literal string `<script>alert(1)</script>`. Lexical renders TextNodes via `document.createTextNode()` in the DOM, which **automatically escapes** all HTML.

The flow is:

```
Markdown string → split by lines → regex matching → $createTextNode() → DOM via createTextNode()
```

There is **no point** at which the content is interpreted as HTML.

### Conclusion

Your current code **without DOMPurify and without `stripHtmlFromMarkdown`** is safe on the Lexical side. You can leave it as is. Sanitization is only needed if this Markdown is later rendered as HTML **elsewhere** (another component, back-end, etc.).

-----
