### PR TITLE
feat(indexTable): sticky pagination

### DIFF
--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -257,6 +257,8 @@
 			}
 
 			.pagination {
+				position: sticky;
+				inset-inline-end: 0;
 				align-self: flex-end;
 				padding-block: var(--pr-t-spacings-50) 0;
 				padding-inline: 0;
@@ -265,6 +267,13 @@
 		}
 
 		.indexTableWrapper-pagination {
+			display: flex;
+			justify-content: flex-end;
+
+			lu-pagination {
+				display: contents;
+			}
+
 			&:empty {
 				display: none;
 			}

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -257,8 +257,6 @@
 			}
 
 			.pagination {
-				position: sticky;
-				inset-inline-end: 0;
 				align-self: flex-end;
 				padding-block: var(--pr-t-spacings-50) 0;
 				padding-inline: 0;
@@ -267,12 +265,9 @@
 		}
 
 		.indexTableWrapper-pagination {
-			display: flex;
-			justify-content: flex-end;
-
-			lu-pagination {
-				display: contents;
-			}
+			position: sticky;
+			inset-inline-end: 0;
+			align-self: flex-end;
 
 			&:empty {
 				display: none;


### PR DESCRIPTION
## Description

Allow pagination to be sticky on the Index Table. #4711 
It's the default behavior like the Data Table does, regardless what is used (or not) around the table to manage the scroll.

### Default
<img width="997" height="274" alt="Capture d’écran 2026-04-29 à 11 21 01" src="https://github.com/user-attachments/assets/13ba83af-7fcf-4048-9607-da4711e9ee56" />

### With an horizontal scroll
<img width="997" height="288" alt="Capture d’écran 2026-04-29 à 11 24 58" src="https://github.com/user-attachments/assets/52951030-f3a7-47e8-b5f3-c02b978214ef" />

### Test
I tried on the basic story, by adding an attribute `style="width:1200px""` on the `<lu-index-table>` element. And also with the use of the `<lu-scroll-box>` around.

-----
