### PR TITLE
fix(callout): margin remains visible after removal

### DIFF
--- a/packages/ng/callout/callout/callout.component.scss
+++ b/packages/ng/callout/callout/callout.component.scss
@@ -3,5 +3,9 @@
 @layer base {
 	lu-callout {
 		display: block;
+
+		&[hidden] {
+			display: none;
+		}
 	}
 }

--- a/packages/ng/callout/callout/callout.component.ts
+++ b/packages/ng/callout/callout/callout.component.ts
@@ -13,7 +13,7 @@ import { getCalloutPalette } from '../callout.utils';
 	templateUrl: './callout.component.html',
 	styleUrl: './callout.component.scss',
 	host: {
-		'[attr.hidden]': 'removed() ? "hidden" : null',
+		'[attr.hidden]': 'removedRef() ? "hidden" : null',
 	},
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,

--- a/packages/ng/callout/callout/callout.component.ts
+++ b/packages/ng/callout/callout/callout.component.ts
@@ -14,7 +14,7 @@ import { getCalloutPalette } from '../callout.utils';
 	templateUrl: './callout.component.html',
 	styleUrl: './callout.component.scss',
 	host: {
-		'[attr.hidden]': 'removed() ? "hidden" : null',
+		'[attr.hidden]': 'removedRef() ? "hidden" : null',
 	},
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	encapsulation: ViewEncapsulation.None,


### PR DESCRIPTION
## Description

- When a `margin` is applied on `<lu-callout [removable]="true">`, the margin remains visible after clicking the remove button
- Fix host binding reading `removed()` (parent input) instead of `removedRef()` (internal signal), so `[hidden]` was never applied on user click
- Add `&[hidden] { display: none }` to prevent `display: block` from overriding the native hidden attribute

https://github.com/user-attachments/assets/d42a960d-1ec1-41d0-8a2d-03a2760a2f8a

https://github.com/user-attachments/assets/88fe765c-8a39-47db-b13d-56d5f8c1e8ef


-----
