### PR TITLE
[callout-popover] add disabledPopover input

### DIFF
--- a/packages/ng/callout/callout-popover/callout-popover.component.html
+++ b/packages/ng/callout/callout-popover/callout-popover.component.html
@@ -10,6 +10,7 @@
 	[luPopoverTrigger]="popoverTrigger()"
 	[luPopoverOpenDelay]="openDelay()"
 	[luPopoverCloseDelay]="closeDelay()"
+	[luPopoverDisabled]="popoverDisabled()"
 	#overlayOriginRef
 >
 	@if (calloutIcon) {

--- a/packages/ng/callout/callout-popover/callout-popover.component.ts
+++ b/packages/ng/callout/callout-popover/callout-popover.component.ts
@@ -84,6 +84,11 @@ export class CalloutPopoverComponent {
 	 */
 	readonly customPopoverPositions = input<ConnectionPositionPair[]>();
 
+	/**
+	 * Disable callout popover apparition
+	 */
+	readonly popoverDisabled = input(false, { transform: booleanAttribute });
+
 	readonly feedbackItems = contentChildren(CalloutFeedbackItemComponent, { descendants: true });
 
 	readonly contentSize = computed<'S' | 'M' | undefined>(() => {

--- a/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
+++ b/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
@@ -95,6 +95,12 @@ export default {
 			},
 			description: 'Détermine le mode d’ouverture du popover.',
 		},
+		popoverDisabled: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Désactive l’apparition du popover.',
+		},
 		size: {
 			options: [null, 'XS', 'S', 'M'],
 			control: {
@@ -125,6 +131,7 @@ export const Template: StoryObj<CalloutPopoverComponent & { items: number; custo
 		customText: '',
 		heading: '',
 		popoverTrigger: null,
+		popoverDisabled: false,
 		headingHiddenIfSingleItem: false,
 		items: 2,
 		closeDelay: 500,


### PR DESCRIPTION
## Description

This pull request introduces a new feature to the `CalloutPopoverComponent` that allows disabling the appearance of the popover via a new `popoverDisabled` input. The change is reflected in the component's template, TypeScript logic, and its Storybook documentation and examples.

-----



-----
