### PR TITLE
fix(time-picker-part): Fix current value input 

### DIFF
--- a/packages/ng/time/core/time-picker-part.component.html
+++ b/packages/ng/time/core/time-picker-part.component.html
@@ -11,7 +11,7 @@
 			class="timePicker-fieldset-group-textfield-input"
 			[attr.aria-labelledby]="inputId + '-label'"
 			autocomplete="off"
-			[value]="hideValue() ? null : value()"
+			[value]="currentValue()"
 			(input)="keysInputHandler($event)"
 			(click)="clickHandler($event)"
 			(keydown)="keydownHandler($event)"

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -85,6 +85,8 @@ export class TimePickerPartComponent {
 		return this.showZero() ? label : label.replace(/^0/, '');
 	});
 
+	readonly currentValue = computed(() => (this.hideValue() || !this.isValueSet() ? null : this.value()));
+
 	protected inputId = `time-picker-part-${nextId++}`;
 
 	constructor(@Inject(LOCALE_ID) private locale: string) {


### PR DESCRIPTION
## Description

`hidevalue()` puts "0" in the DOM input even when `isValueSet()` is false (the field appears empty visually via the overlay span). When focus + select() doesn't reliably work, typing 1 appends to the hidden 0 create 10.
don't put value in the DOM input when the field isn't set yet.

-----



-----
