### PR TITLE
fix(user-display): do not crash when no first or last name

### DIFF
--- a/packages/ng/user/display/user-display.pipe.spec.ts
+++ b/packages/ng/user/display/user-display.pipe.spec.ts
@@ -1,6 +1,6 @@
 import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
-import { luUserDisplay, LuUserDisplayPipe } from './user-display.pipe';
+import { luUserDisplay, LuUserDisplayInput, LuUserDisplayPipe } from './user-display.pipe';
 
 describe(LuUserDisplayPipe.name, () => {
 	const users = [
@@ -11,10 +11,10 @@ describe(LuUserDisplayPipe.name, () => {
 	const user = users[0];
 	const userFirst = { firstName: user.firstName, lastName: '' };
 	const userLast = { firstName: '', lastName: user.lastName };
-	const userWithNullLastName = { firstName: 'John', lastName: null } as unknown as { firstName: string; lastName: string };
-	const userWithNullFirstName = { firstName: null, lastName: 'Doe' } as unknown as { firstName: string; lastName: string };
-	const userWithNoLastName = { firstName: 'John' } as unknown as { firstName: string; lastName: string };
-	const userWithNoFirstName = { lastName: 'Doe' } as unknown as { firstName: string; lastName: string };
+	const userWithNullLastName = { firstName: 'John', lastName: null } as unknown as LuUserDisplayInput;
+	const userWithNullFirstName = { firstName: null, lastName: 'Doe' } as unknown as LuUserDisplayInput;
+	const userWithNoLastName = { firstName: 'John' } as unknown as LuUserDisplayInput;
+	const userWithNoFirstName = { lastName: 'Doe' } as unknown as LuUserDisplayInput;
 
 	describe('luUserDisplay()', () => {
 		describe('fallback when lastName is missing', () => {

--- a/packages/ng/user/display/user-display.pipe.spec.ts
+++ b/packages/ng/user/display/user-display.pipe.spec.ts
@@ -11,8 +11,60 @@ describe(LuUserDisplayPipe.name, () => {
 	const user = users[0];
 	const userFirst = { firstName: user.firstName, lastName: '' };
 	const userLast = { firstName: '', lastName: user.lastName };
+	const userWithNullLastName = { firstName: 'John', lastName: null } as unknown as { firstName: string; lastName: string };
+	const userWithNullFirstName = { firstName: null, lastName: 'Doe' } as unknown as { firstName: string; lastName: string };
+	const userWithNoLastName = { firstName: 'John' } as unknown as { firstName: string; lastName: string };
+	const userWithNoFirstName = { lastName: 'Doe' } as unknown as { firstName: string; lastName: string };
 
 	describe('luUserDisplay()', () => {
+		describe('fallback when lastName is missing', () => {
+			it('should fallback to first name (full) for fullname formats', () => {
+				expect(luUserDisplay(userWithNullLastName, LuDisplayFullname.lastfirst)).toBe('John');
+				expect(luUserDisplay(userWithNoLastName, LuDisplayFullname.firstlast)).toBe('John');
+				expect(luUserDisplay(userWithNullLastName, LuDisplayFullname.last)).toBe('John');
+			});
+
+			it('should fallback to first name (initial) for initials formats', () => {
+				expect(luUserDisplay(userWithNullLastName, LuDisplayInitials.lastfirst)).toBe('J');
+				expect(luUserDisplay(userWithNoLastName, LuDisplayInitials.firstlast)).toBe('J');
+				expect(luUserDisplay(userWithNullLastName, LuDisplayInitials.last)).toBe('J');
+			});
+
+			it('should fallback to first name (full) for hybrid formats containing f', () => {
+				expect(luUserDisplay(userWithNullLastName, LuDisplayHybrid.lastIfirstFull)).toBe('John');
+				expect(luUserDisplay(userWithNoLastName, LuDisplayHybrid.firstFulllastI)).toBe('John');
+			});
+
+			it('should fallback to first name (initial) for hybrid formats without f', () => {
+				expect(luUserDisplay(userWithNullLastName, LuDisplayHybrid.firstIlastFull)).toBe('J');
+				expect(luUserDisplay(userWithNoLastName, LuDisplayHybrid.lastFullfirstI)).toBe('J');
+			});
+		});
+
+		describe('fallback when firstName is missing', () => {
+			it('should fallback to last name (full) for fullname formats', () => {
+				expect(luUserDisplay(userWithNullFirstName, LuDisplayFullname.lastfirst)).toBe('Doe');
+				expect(luUserDisplay(userWithNoFirstName, LuDisplayFullname.firstlast)).toBe('Doe');
+				expect(luUserDisplay(userWithNullFirstName, LuDisplayFullname.first)).toBe('Doe');
+			});
+
+			it('should fallback to last name (initial) for initials formats', () => {
+				expect(luUserDisplay(userWithNullFirstName, LuDisplayInitials.lastfirst)).toBe('D');
+				expect(luUserDisplay(userWithNoFirstName, LuDisplayInitials.firstlast)).toBe('D');
+				expect(luUserDisplay(userWithNullFirstName, LuDisplayInitials.first)).toBe('D');
+			});
+
+			it('should fallback to last name (full) for hybrid formats containing l', () => {
+				expect(luUserDisplay(userWithNullFirstName, LuDisplayHybrid.firstIlastFull)).toBe('Doe');
+				expect(luUserDisplay(userWithNoFirstName, LuDisplayHybrid.lastFullfirstI)).toBe('Doe');
+			});
+
+			it('should fallback to last name (initial) for hybrid formats without l', () => {
+				expect(luUserDisplay(userWithNullFirstName, LuDisplayHybrid.lastIfirstFull)).toBe('D');
+				expect(luUserDisplay(userWithNoFirstName, LuDisplayHybrid.firstFulllastI)).toBe('D');
+			});
+		});
+
 		it("should return the right value with 'lf' format", () => {
 			expect(luUserDisplay(user, LuDisplayFullname.lastfirst)).toBe('Doe John');
 			expect(luUserDisplay(userFirst, LuDisplayFullname.lastfirst)).toBe('John');

--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -44,22 +44,12 @@ export function luUserDisplay(user?: LuUserDisplayInput, format: LuDisplayFormat
 	}
 
 	if (isNil(user?.lastName)) {
-		if (format.includes('f')) {
-			return formatUser[LuDisplayFullname.first](user);
-		} else if (format.includes('F')) {
-			return formatUser[LuDisplayInitials.first](user);
-		} else {
-			return formatUser[format === format.toLowerCase() ? LuDisplayFullname.first : LuDisplayInitials.first](user);
-		}
+		const useFull = format.includes('f') || format === format.toLowerCase();
+		return formatUser[useFull ? LuDisplayFullname.first : LuDisplayInitials.first](user);
 	}
 	if (isNil(user?.firstName)) {
-		if (format.includes('l')) {
-			return formatUser[LuDisplayFullname.last](user);
-		} else if (format.includes('L')) {
-			return formatUser[LuDisplayInitials.last](user);
-		} else {
-			return formatUser[format === format.toLowerCase() ? LuDisplayFullname.last : LuDisplayInitials.last](user);
-		}
+		const useFull = format.includes('l') || format === format.toLowerCase();
+		return formatUser[useFull ? LuDisplayFullname.last : LuDisplayInitials.last](user);
 	}
 	return formatUser[format](user);
 }

--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -1,4 +1,5 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
+import { isNil } from '@lucca-front/ng/core';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
 
 function getFirstCharacter([firstCharacter]: string): string {
@@ -34,7 +35,7 @@ const formatUser: Record<LuDisplayFormat, (user: LuUserDisplayInput) => string> 
  * F for first initial, l for last name, L for last initial.
  */
 export function luUserDisplay(user?: LuUserDisplayInput, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
-	if (!user) {
+	if (isNil(user)) {
 		return '';
 	}
 	return formatUser[format](user);

--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -1,13 +1,13 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
-import { isNil } from '@lucca-front/ng/core';
+import { isNil, isNotNil } from '@lucca-front/ng/core';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
 
-function getFirstCharacter([firstCharacter]: string): string {
-	return firstCharacter ?? '';
+function getFirstCharacter(value: string | null | undefined): string {
+	return value?.at(0) ?? '';
 }
 
-function isNotEmptyString(value: string): boolean {
-	return value?.length > 0;
+function isNotNilAndEmptyString(value: string | null | undefined): boolean {
+	return isNotNil(value) && value.length > 0;
 }
 
 export interface LuUserDisplayInput {
@@ -16,18 +16,22 @@ export interface LuUserDisplayInput {
 }
 
 const formatUser: Record<LuDisplayFormat, (user: LuUserDisplayInput) => string> = {
-	[LuDisplayFullname.lastfirst]: ({ firstName, lastName }) => [lastName, firstName].filter(isNotEmptyString).join(' '),
-	[LuDisplayFullname.firstlast]: ({ firstName, lastName }) => [firstName, lastName].filter(isNotEmptyString).join(' '),
-	[LuDisplayFullname.first]: ({ firstName }) => firstName,
-	[LuDisplayFullname.last]: ({ lastName }) => lastName,
-	[LuDisplayInitials.lastfirst]: ({ firstName, lastName }) => [getFirstCharacter(lastName), getFirstCharacter(firstName)].filter(isNotEmptyString).join(''),
-	[LuDisplayInitials.firstlast]: ({ firstName, lastName }) => [getFirstCharacter(firstName), getFirstCharacter(lastName)].filter(isNotEmptyString).join(''),
-	[LuDisplayInitials.first]: ({ firstName }) => getFirstCharacter(firstName),
-	[LuDisplayInitials.last]: ({ lastName }) => getFirstCharacter(lastName),
-	[LuDisplayHybrid.lastIfirstFull]: ({ firstName, lastName }) => [isNotEmptyString(lastName) ? getFirstCharacter(lastName) + '.' : '', firstName].filter(isNotEmptyString).join(' '),
-	[LuDisplayHybrid.firstIlastFull]: ({ firstName, lastName }) => [isNotEmptyString(firstName) ? getFirstCharacter(firstName) + '.' : '', lastName].filter(isNotEmptyString).join(' '),
-	[LuDisplayHybrid.lastFullfirstI]: ({ firstName, lastName }) => [lastName, firstName ? getFirstCharacter(firstName) + '.' : ''].filter(isNotEmptyString).join(' '),
-	[LuDisplayHybrid.firstFulllastI]: ({ firstName, lastName }) => [firstName, lastName ? getFirstCharacter(lastName) + '.' : ''].filter(isNotEmptyString).join(' '),
+	[LuDisplayFullname.lastfirst]: ({ firstName, lastName }) => [lastName, firstName].filter(isNotNilAndEmptyString).join(' '),
+	[LuDisplayFullname.firstlast]: ({ firstName, lastName }) => [firstName, lastName].filter(isNotNilAndEmptyString).join(' '),
+	[LuDisplayFullname.first]: ({ firstName }) => (isNotNilAndEmptyString(firstName) ? firstName : ''),
+	[LuDisplayFullname.last]: ({ lastName }) => (isNotNilAndEmptyString(lastName) ? lastName : ''),
+	[LuDisplayInitials.lastfirst]: ({ firstName, lastName }) => [getFirstCharacter(lastName), getFirstCharacter(firstName)].filter(isNotNilAndEmptyString).join(''),
+	[LuDisplayInitials.firstlast]: ({ firstName, lastName }) => [getFirstCharacter(firstName), getFirstCharacter(lastName)].filter(isNotNilAndEmptyString).join(''),
+	[LuDisplayInitials.first]: ({ firstName }) => (isNotNilAndEmptyString(firstName) ? getFirstCharacter(firstName) : ''),
+	[LuDisplayInitials.last]: ({ lastName }) => (isNotNilAndEmptyString(lastName) ? getFirstCharacter(lastName) : ''),
+	[LuDisplayHybrid.lastIfirstFull]: ({ firstName, lastName }) =>
+		[isNotNilAndEmptyString(lastName) ? getFirstCharacter(lastName) + '.' : '', isNotNilAndEmptyString(firstName) ? firstName : ''].filter(isNotNilAndEmptyString).join(' '),
+	[LuDisplayHybrid.firstIlastFull]: ({ firstName, lastName }) =>
+		[isNotNilAndEmptyString(firstName) ? getFirstCharacter(firstName) + '.' : '', isNotNilAndEmptyString(lastName) ? lastName : ''].filter(isNotNilAndEmptyString).join(' '),
+	[LuDisplayHybrid.lastFullfirstI]: ({ firstName, lastName }) =>
+		[isNotNilAndEmptyString(lastName) ? lastName : '', isNotNilAndEmptyString(firstName) ? getFirstCharacter(firstName) + '.' : ''].filter(isNotNilAndEmptyString).join(' '),
+	[LuDisplayHybrid.firstFulllastI]: ({ firstName, lastName }) =>
+		[isNotNilAndEmptyString(firstName) ? firstName : '', isNotNilAndEmptyString(lastName) ? getFirstCharacter(lastName) + '.' : ''].filter(isNotNilAndEmptyString).join(' '),
 };
 
 /**
@@ -37,6 +41,25 @@ const formatUser: Record<LuDisplayFormat, (user: LuUserDisplayInput) => string> 
 export function luUserDisplay(user?: LuUserDisplayInput, format: LuDisplayFormat = LuDisplayFullname.lastfirst): string {
 	if (isNil(user)) {
 		return '';
+	}
+
+	if (isNil(user?.lastName)) {
+		if (format.includes('f')) {
+			return formatUser[LuDisplayFullname.first](user);
+		} else if (format.includes('F')) {
+			return formatUser[LuDisplayInitials.first](user);
+		} else {
+			return formatUser[format === format.toLowerCase() ? LuDisplayFullname.first : LuDisplayInitials.first](user);
+		}
+	}
+	if (isNil(user?.firstName)) {
+		if (format.includes('l')) {
+			return formatUser[LuDisplayFullname.last](user);
+		} else if (format.includes('L')) {
+			return formatUser[LuDisplayInitials.last](user);
+		} else {
+			return formatUser[format === format.toLowerCase() ? LuDisplayFullname.last : LuDisplayInitials.last](user);
+		}
 	}
 	return formatUser[format](user);
 }


### PR DESCRIPTION
## Description

Fallback to the `userDisplayFormat` adapted depending on whether a first name or last name is present.
Avoid the component to crash.
Add fallback test.

-----


-----
