### PR TITLE
fix(dateInput): Validation issue error & value not triggered

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.spec.ts
+++ b/packages/ng/date2/date-input/date-input.component.spec.ts
@@ -13,78 +13,76 @@ describe('DateInputComponent', () => {
 		providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 	});
 
-	describe('CVA value update on clear', () => {
-		it('should emit null when user clear the input', () => {
-			const valueChanges = jest.fn();
+	it('should emit null when user clear the input', () => {
+		const valueChanges = jest.fn();
 
-			const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
-			formControl.valueChanges.subscribe((value) => {
-				valueChanges(value);
-			});
-
-			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-				hostProps: { formControl },
-			});
-
-			const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
-			expect(input).toBeTruthy();
-
-			spectator.typeInElement('', input);
-
-			expect(formControl.value).toBeNull();
+		const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
+		formControl.valueChanges.subscribe((value) => {
+			valueChanges(value);
 		});
 
-		it('should emit error when user enter a invalid date', () => {
-			const valueChanges = jest.fn();
-
-			const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
-			formControl.valueChanges.subscribe((value) => {
-				valueChanges(value);
-			});
-
-			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-				hostProps: { formControl },
-			});
-
-			const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
-			expect(input).toBeTruthy();
-
-			spectator.typeInElement('12', input);
-
-			expect(valueChanges).toHaveBeenCalledTimes(1);
-			expect(formControl.errors).toEqual({ date: true });
+		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+			hostProps: { formControl },
 		});
 
-		it('should not emit value at init if null value', fakeAsync(() => {
-			const valueChanges = jest.fn();
+		const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
 
-			const formControl = new FormControl(null);
-			formControl.valueChanges.subscribe((value) => {
-				valueChanges(value);
-			});
+		spectator.typeInElement('', input);
 
-			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-				hostProps: { formControl },
-			});
-
-			spectator.tick();
-			expect(valueChanges).toHaveBeenCalledTimes(0);
-		}));
-
-		it('should not emit value at init if there is a value', fakeAsync(() => {
-			const valueChanges = jest.fn();
-
-			const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
-			formControl.valueChanges.subscribe((value) => {
-				valueChanges(value);
-			});
-
-			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-				hostProps: { formControl },
-			});
-
-			spectator.tick();
-			expect(valueChanges).toHaveBeenCalledTimes(0);
-		}));
+		expect(formControl.value).toBeNull();
 	});
+
+	it('should emit error when user enter a invalid date', () => {
+		const valueChanges = jest.fn();
+
+		const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
+		formControl.valueChanges.subscribe((value) => {
+			valueChanges(value);
+		});
+
+		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+			hostProps: { formControl },
+		});
+
+		const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
+		expect(input).toBeTruthy();
+
+		spectator.typeInElement('12', input);
+
+		expect(valueChanges).toHaveBeenCalledTimes(1);
+		expect(formControl.errors).toEqual({ date: true });
+	});
+
+	it('should not emit value at init if null value', fakeAsync(() => {
+		const valueChanges = jest.fn();
+
+		const formControl = new FormControl(null);
+		formControl.valueChanges.subscribe((value) => {
+			valueChanges(value);
+		});
+
+		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+			hostProps: { formControl },
+		});
+
+		spectator.tick();
+		expect(valueChanges).toHaveBeenCalledTimes(0);
+	}));
+
+	it('should not emit value at init if there is a value', fakeAsync(() => {
+		const valueChanges = jest.fn();
+
+		const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
+		formControl.valueChanges.subscribe((value) => {
+			valueChanges(value);
+		});
+
+		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+			hostProps: { formControl },
+		});
+
+		spectator.tick();
+		expect(valueChanges).toHaveBeenCalledTimes(0);
+	}));
 });

--- a/packages/ng/date2/date-input/date-input.component.spec.ts
+++ b/packages/ng/date2/date-input/date-input.component.spec.ts
@@ -1,0 +1,90 @@
+import { LOCALE_ID } from '@angular/core';
+import { fakeAsync } from '@angular/core/testing';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
+import { DateInputComponent } from './date-input.component';
+
+describe('DateInputComponent', () => {
+	let spectator: SpectatorHost<DateInputComponent>;
+
+	const createHost = createHostFactory({
+		component: DateInputComponent,
+		imports: [FormsModule, ReactiveFormsModule],
+		providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
+	});
+
+	describe('CVA value update on clear', () => {
+		it('should emit null when user clear the input', () => {
+			const valueChanges = jest.fn();
+
+			const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
+			formControl.valueChanges.subscribe((value) => {
+				valueChanges(value);
+			});
+
+			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+				hostProps: { formControl },
+			});
+
+			const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
+			expect(input).toBeTruthy();
+
+			spectator.typeInElement('', input);
+
+			expect(formControl.value).toBeNull();
+		});
+
+		it('should emit error when user enter a invalid date', () => {
+			const valueChanges = jest.fn();
+
+			const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
+			formControl.valueChanges.subscribe((value) => {
+				valueChanges(value);
+			});
+
+			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+				hostProps: { formControl },
+			});
+
+			const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
+			expect(input).toBeTruthy();
+
+			spectator.typeInElement('12', input);
+
+			expect(valueChanges).toHaveBeenCalledTimes(1);
+			expect(formControl.errors).toEqual({ date: true });
+		});
+
+		it('should not emit value at init if null value', fakeAsync(() => {
+			const valueChanges = jest.fn();
+
+			const formControl = new FormControl(null);
+			formControl.valueChanges.subscribe((value) => {
+				valueChanges(value);
+			});
+
+			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+				hostProps: { formControl },
+			});
+
+			spectator.tick();
+			expect(valueChanges).toHaveBeenCalledTimes(0);
+		}));
+
+		it('should not emit value at init if there is a value', fakeAsync(() => {
+			const valueChanges = jest.fn();
+
+			const formControl = new FormControl(new Date('2024-01-01T00:00:00.000Z'));
+			formControl.valueChanges.subscribe((value) => {
+				valueChanges(value);
+			});
+
+			spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
+				hostProps: { formControl },
+			});
+
+			spectator.tick();
+			expect(valueChanges).toHaveBeenCalledTimes(0);
+		}));
+	});
+});

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -222,7 +222,7 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		effect(() => {
 			if (!this.#safeCompareDate(untracked(this.dateFromWriteValue), this.selectedDate())) {
 				this.#onChange?.(this.selectedDate());
-				this.dateFromWriteValue.set(null);
+				this.dateFromWriteValue.set(this.selectedDate());
 			}
 		});
 


### PR DESCRIPTION
## Description

This pull request adds new unit tests for the `DateInputComponent` and makes a small fix to its value update logic.

**Testing improvements:**

* Added a comprehensive test suite for `DateInputComponent` in `date-input.component.spec.ts`, including tests for clearing the input, handling invalid dates, and ensuring no unnecessary emissions on initialization.

**Component logic fix:**

* Updated the internal effect in `DateInputComponent` to set `dateFromWriteValue` to the current selected date instead of `null` after emitting a value change, ensuring internal state stays in sync with user actions.

-----

https://github.com/LuccaSA/lucca-front/issues/4870

-----
