### PR TITLE
fix(department): prevent infinite loading when API returns multiple of pageSize items

### DIFF
--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -4,7 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, TreeNode } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { ILuDepartment } from '@lucca-front/ng/department';
-import { combineLatest, map, Observable } from 'rxjs';
+import { combineLatest, map, Observable, of } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { NoopTreeSelectDirective } from './noop-tree-select.directive';
 
@@ -41,6 +41,14 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 				return this.trim(data, clue);
 			}),
 		);
+	}
+
+	protected override getOptionsPage(params: Record<string, string | number | boolean> | null, page: number): Observable<{ items: TreeNode<T>[]; isLastPage: boolean }> {
+		if (page > 0) {
+			return of({ items: [], isLastPage: true });
+		}
+
+		return super.getOptionsPage(params, page).pipe(map((result) => ({ ...result, isLastPage: true })));
 	}
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null): Observable<TreeNode<T>[]> {


### PR DESCRIPTION
## Description

When the department tree API returns a number of items that is an exact multiple of the page size (20), the base class `ALuCoreSelectApiDirective.getOptionsPage` considers it not the last page (`items.length < pageSize` → false), triggering infinite pagination requests.

Fix: override `getOptionsPage` in `LuCoreSelectDepartmentsDirective` to always mark page 0 as the last page (tree endpoint returns everything at once), and short-circuit any subsequent page requests.

-----
