### PR TITLE
chore(renovate): disable major and minor updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>LuccaSA/renovate-config"
-  ]
+  "extends": ["local>LuccaSA/renovate-config", ":disableMajorUpdates"],
+  "baseBranches": ["$default", "rc"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+  "minor": {
+    "enabled": false
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>LuccaSA/renovate-config", ":disableMajorUpdates"],
-  "baseBranches": ["$default", "rc"],
+  "baseBranchPatterns": ["$default", "rc", "/^v\\d+-lts$/"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true


### PR DESCRIPTION
## Description

Two improvements to the Renovate configuration:

1. Disable minor dependency updates — only patch updates and lock file maintenance (with automerge) remain active.
2. Migrate deprecated `baseBranches` to `baseBranchPatterns` and add regex support for `vX-lts` branches.

**Impact**

- Reduces dependency PR noise by limiting updates to patch-level only
- All `vX-lts` branches (e.g. `v18-lts`, `v20-lts`) are now automatically covered without listing them explicitly
- Lock file maintenance keeps transitive deps fresh with automerge

-----

### Closes

N/A

### How to test

N/A — configuration-only change, no runtime behaviour affected.