### PR TITLE
chore(renovate): add in-range-only strategy for npm dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,13 @@
   },
   "minor": {
     "enabled": false
-  }
+  },
+  "packageRules": [
+    {
+      "description": "Disable pinning for npm dependencies (override best-practices)",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["*"],
+      "rangeStrategy": "in-range-only"
+    }
+  ]
 }


### PR DESCRIPTION
## Description

Adds a `packageRules` entry to disable version pinning for npm dependencies, overriding the `best-practices` preset default. Uses `in-range-only` range strategy to keep existing SemVer ranges without bumping to exact versions.

**Impact**

- Prevents Renovate from pinning npm dependency versions to exact numbers
- Preserves SemVer range expressions already in `package.json`

-----

### Closes

N/A

### How to test

N/A — configuration-only change, no runtime behaviour affected.