### PR TITLE
fix(renovate): prevent broken lockfiles from automerging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,15 @@ name: Build, lint and test
 on:
   - push
 jobs:
+  lockfile-check:
+    name: Lockfile integrity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5.0.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version-file: 'package.json'
+      - run: npm ci --ignore-scripts
   build:
     runs-on: ubuntu-latest
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -3,8 +3,7 @@
   "extends": ["local>LuccaSA/renovate-config", ":disableMajorUpdates"],
   "baseBranchPatterns": ["$default", "rc", "/^v\\d+-lts$/"],
   "lockFileMaintenance": {
-    "enabled": true,
-    "automerge": true
+    "enabled": true
   },
   "minor": {
     "enabled": false


### PR DESCRIPTION
## Description

Two changes to prevent broken lockfiles from landing silently:

1. Disable `automerge` on `lockFileMaintenance` — Renovate's lock file maintenance was automerging directly without waiting for CI, allowing an incomplete lockfile (`readdirp@5.0.0` missing) to reach `master`.
2. Add a dedicated `lockfile-check` CI job that runs `npm ci --ignore-scripts` to detect any `package.json` / `package-lock.json` desync fast, before the full build.

**Impact**

- Prevents broken lockfiles from landing via Renovate automerge
- Surfaces lockfile desync in CI within seconds, before heavier build steps run

-----

### Closes

N/A

### How to test

N/A — configuration-only changes, no runtime behaviour affected.