### PR TITLE
refactor(rich-text): migrate from CVA to FormValueControl

### DIFF
--- a/packages/ng/forms/rich-text-input/rich-text-input.component.html
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.html
@@ -1,15 +1,15 @@
-<div class="richTextField" [class.is-disabled]="isDisabled()" [class.mod-autoResize]="autoResize()">
+<div class="richTextField" [class.is-disabled]="disabled()" [class.mod-autoResize]="autoResize()">
 	<div
 		#content
 		luInput
 		class="richTextField-content textFlow"
 		role="textbox"
-		[attr.contenteditable]="!isDisabled()"
-		[attr.aria-disabled]="isDisabled()"
+		[attr.contenteditable]="!disabled()"
+		[attr.aria-disabled]="disabled()"
 		[attr.aria-placeholder]="currentCanShowPlaceholder() ? placeholder() : null"
 		[attr.aria-labelledby]="formFieldId() + '-label'"
 		[attr.spellcheck]="!disableSpellcheck()"
-		(blur)="touch()"
+		(blur)="touched.set(true)"
 	></div>
 	@if (currentCanShowPlaceholder()) {
 		<div aria-hidden="true" class="richTextField-content-placeholder">{{ placeholder() }}</div>

--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -1,5 +1,6 @@
 import { CommonModule } from '@angular/common';
 import {
+	afterRenderEffect,
 	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
@@ -7,10 +8,10 @@ import {
 	contentChildren,
 	effect,
 	ElementRef,
-	forwardRef,
 	inject,
 	InjectionToken,
 	input,
+	model,
 	OnDestroy,
 	OnInit,
 	Signal,
@@ -19,11 +20,11 @@ import {
 	ViewEncapsulation,
 	WritableSignal,
 } from '@angular/core';
-import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { FormValueControl } from '@angular/forms/signals';
 import { createEmptyHistoryState, registerHistory } from '@lexical/history';
 import { $canShowPlaceholderCurry, $isRootTextContentEmpty } from '@lexical/text';
 import { mergeRegister } from '@lexical/utils';
-import { isNil } from '@lucca-front/ng/core';
+import { isNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FormFieldComponent, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement, UpdateListenerPayload } from 'lexical';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from './formatters';
@@ -55,16 +56,15 @@ export const RICH_TEXT_PLUGIN_COMPONENT = new InjectionToken<RichTextPluginCompo
 	templateUrl: './rich-text-input.component.html',
 	styleUrl: './rich-text-input.component.scss',
 	encapsulation: ViewEncapsulation.None,
-	providers: [
-		{
-			provide: NG_VALUE_ACCESSOR,
-			useExisting: forwardRef(() => RichTextInputComponent),
-			multi: true,
-		},
-	],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAccessor {
+export class RichTextInputComponent implements OnInit, OnDestroy, FormValueControl<string | null> {
+	readonly value = model<string | null>(null);
+	// Writable interaction state - control updates these
+	readonly touched = model<boolean>(false);
+
+	readonly disabled = input<boolean>(false);
+
 	readonly #richTextFormatter = inject<RichTextFormatter>(RICH_TEXT_FORMATTER);
 	readonly #formField = inject(FormFieldComponent, { optional: true });
 
@@ -82,7 +82,6 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 	readonly pluginComponents = contentChildren(RICH_TEXT_PLUGIN_COMPONENT, { descendants: true });
 
 	readonly currentCanShowPlaceholder = signal(false);
-	readonly isDisabled = signal(false);
 	readonly formFieldId = computed(() => this.#formField?.id());
 
 	readonly #customNodes = computed(() =>
@@ -91,14 +90,12 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 			.flat(),
 	);
 	readonly #allPlugins = computed(() => this.#flattenPlugins(this.pluginComponents()));
-	readonly #isTouched = signal(false);
 
-	#onChange?: (markdown: string | null) => void;
-	#onTouch?: () => void;
 	#cleanup?: () => void;
 	#focusedPlugin: number = 0;
 	#editor?: LexicalEditor;
 	#isRootElementInitialized = false;
+	#lastEmittedValue: string | null = null;
 
 	constructor() {
 		effect(() => {
@@ -107,9 +104,26 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 				this.#editor?.setEditable(false);
 			} else if (this.content()) {
 				this.#editor?.setRootElement(this.content()?.nativeElement ?? null);
-				this.#editor?.setEditable(true);
+				this.#editor?.setEditable(!this.disabled());
 			}
 			this.#isRootElementInitialized = true;
+		});
+
+		ɵeffectWithDeps([this.disabled, this.pluginComponents], (isDisabled, pluginComponents) => {
+			this.#editor?.setEditable(!isDisabled);
+			pluginComponents.forEach((c) => c.setDisabledState(isDisabled));
+		});
+
+		afterRenderEffect({
+			earlyRead: () => {
+				return this.value();
+			},
+			write: (value) => {
+				const v = value();
+				if (v !== this.#lastEmittedValue) {
+					this.writeValue(v);
+				}
+			},
 		});
 	}
 
@@ -170,20 +184,6 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 		}
 	}
 
-	registerOnChange(onChange: (markdown: string | null) => void): void {
-		this.#onChange = onChange;
-	}
-
-	registerOnTouched(onTouch: () => void): void {
-		this.#onTouch = onTouch;
-	}
-
-	setDisabledState(isDisabled: boolean): void {
-		this.#editor?.setEditable(!isDisabled);
-		this.isDisabled.set(isDisabled);
-		this.pluginComponents().forEach((c) => c.setDisabledState(isDisabled));
-	}
-
 	focusSiblingPlugin(event: Event, direction: -1 | 1) {
 		event.preventDefault();
 		const plugins = this.#allPlugins();
@@ -199,11 +199,6 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 
 	focus() {
 		this.content()?.nativeElement.focus();
-	}
-
-	touch() {
-		this.#isTouched.set(true);
-		this.#onTouch?.();
 	}
 
 	#flattenPlugins(plugins: readonly RichTextPluginComponent[]): RichTextPluginComponent[] {
@@ -225,8 +220,9 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 				if (!$isRootTextContentEmpty(isComposing ?? false, false) && this.#editor) {
 					result = this.#richTextFormatter.format(this.#editor);
 				}
-				this.touch();
-				this.#onChange?.(result);
+				this.#lastEmittedValue = result;
+				this.touched.set(true);
+				this.value.set(result);
 			});
 		}
 		const currentCanShowPlaceholder = this.#editor?.getEditorState().read($canShowPlaceholderCurry(isComposing ?? false));

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -370,6 +370,52 @@ export const WithTagPluginMarkdownContentChange: StoryObj<RichTextInputComponent
 	},
 };
 
+export const DisabledToggle: StoryObj<RichTextInputComponent & { value: string; disabled: boolean; required: boolean } & FormFieldComponent> = {
+	render: (args, { argTypes }) => {
+		const { value, disabled, required, presentation, ...inputArgs } = args;
+		return {
+			props: { value, disabled, required },
+			template: cleanupTemplate(`<button luButton="outlined" size="S" (click)="disabled=!disabled">{{ disabled ? 'Enable' : 'Disable' }}</button>
+<lu-divider></lu-divider>
+<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
+	<lu-rich-text-input luWithMarkdownTagsFormatter
+	${generateInputs(inputArgs, argTypes)}
+		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+			<lu-rich-text-input-toolbar />
+			<lu-rich-text-plugin-tag [tags]="[
+																	{
+																		key: 'tag1',
+																		description: 'Tag 1',
+																	},
+																	{
+																		key: 'tag2',
+																		description: 'Tag 2',
+																	},
+																	{
+																		key: 'tag3',
+																		description: 'Tag 3',
+																	},
+																]" />
+	</lu-rich-text-input>
+</lu-form-field>
+<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+			moduleMetadata: {
+				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterWithTagsDirective],
+			},
+		};
+	},
+	args: {
+		value: 'Lorem **ipsum** dolor {{tag1}} *italic* {{tag2}} and regular text.',
+		placeholder: 'Placeholder…',
+		disabled: true,
+		required: false,
+		disableSpellcheck: false,
+		autoResize: true,
+		hideToolbar: false,
+		presentation: false,
+	},
+};
+
 export const BasicTEST = createTestStory(WithTagPluginWithNoInitialValue, async (context) => {
 	const canvas = within(context.canvasElement);
 	const editor = canvas.getByRole('textbox');


### PR DESCRIPTION
## Description

Migration form ControlValueAccessor to FormValueControl, preparing Angular 22 Signal Forms compliance.
Component : RichText

-----

---------

## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
