### PR TITLE
chore(renovate): remove stale rc baseBranchPattern

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>LuccaSA/renovate-config", "local>LuccaSA/renovate-config//helpers/npm-frontend", ":disableMajorUpdates"],
-  "baseBranchPatterns": ["$default", "rc", "/^v\\d+-lts$/"],
+  "baseBranchPatterns": ["$default", "/^v\\d+-lts$/"],
   "lockFileMaintenance": {
     "enabled": true
   },


### PR DESCRIPTION
## Description

Remove the literal `rc` entry from `baseBranchPatterns` in `renovate.json`. This branch no longer exists on the remote, which caused Renovate to emit a "Base branch does not exist - skipping" warning on every run (see #4833).

-----

The `baseBranchPatterns` previously listed `"rc"` as an exact branch name. Since no such branch exists, Renovate skipped it with a warning. The remaining patterns (`$default` and `/^v\d+-lts$/`) are sufficient to cover all active branches.

Note: a separate issue has been opened on [LuccaSA/renovate-config#130](https://github.com/LuccaSA/renovate-config/issues/130) to address the `allowedCommands` config error (#4908), which requires a fix in the shared Renovate preset.