### PR TITLE
fix(select): preserve tree indentation inside option groups

### DIFF
--- a/packages/ng/styles/components/_picker.scss
+++ b/packages/ng/styles/components/_picker.scss
@@ -39,6 +39,10 @@
 		.optionItem-value {
 			--components-options-item-padding-horizontal: var(--pr-t-spacings-250) var(--pr-t-spacings-100);
 		}
+
+		lu-tree-branch .optionItem-value {
+			--components-options-item-padding-horizontal: calc(var(--pr-t-spacings-100) + var(--pr-t-spacings-100) * var(--components-treeBranch-level)) var(--pr-t-spacings-100);
+		}
 	}
 
 	.lu-picker-content-option-group-title {

--- a/packages/ng/styles/components/_picker.scss
+++ b/packages/ng/styles/components/_picker.scss
@@ -41,7 +41,7 @@
 		}
 
 		lu-tree-branch .optionItem-value {
-			--components-options-item-padding-horizontal: calc(var(--pr-t-spacings-100) + var(--pr-t-spacings-100) * var(--components-treeBranch-level)) var(--pr-t-spacings-100);
+			--components-options-item-padding-horizontal: calc(var(--pr-t-spacings-250) + var(--pr-t-spacings-100) * calc(var(--components-treeBranch-level) - 1)) var(--pr-t-spacings-100);
 		}
 	}
 


### PR DESCRIPTION
## Description

When using `lu-simple-select` with both `[treeSelect]` and `*luOptionGroup`, the option group selector `.lu-picker-content-option-group .optionItem-value` overrides `--components-options-item-padding-horizontal`, which cancels the indentation computed by `--components-treeBranch-level` in tree branches.

This adds a more specific selector for `lu-tree-branch .optionItem-value` inside option groups to restore the tree indentation.

#### Before:
<img width="324" height="375" alt="before 1" src="https://github.com/user-attachments/assets/73170382-1057-484b-93f1-50e8afbd7dcc" />

#### After:
<img width="328" height="378" alt="image" src="https://github.com/user-attachments/assets/7545acf4-fb4d-4685-a958-5ebeb8a9f72f" />

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
