### PR TITLE
[popover] fix trigger with non-interative elements

### DIFF
--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -69,8 +69,8 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	selector: '[luPopover2]',
 	host: {
 		'[attr.aria-expanded]': 'opened()',
-		'[attr.tabindex]': 'tabIndexAttr',
-		'[attr.role]': 'roleAttr',
+		'[attr.tabindex]': 'luPopoverDisabled ? null : tabIndexAttr',
+		'[attr.role]': 'luPopoverDisabled ? null : roleAttr',
 	},
 	exportAs: 'luPopover2',
 })

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -70,6 +70,7 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	host: {
 		'[attr.aria-expanded]': 'opened()',
 		'[attr.tabindex]': 'tabIndexAttr',
+		'[attr.role]': 'roleAttr',
 	},
 	exportAs: 'luPopover2',
 })
@@ -151,6 +152,7 @@ export class PopoverDirective implements OnDestroy {
 	#screenReaderDescription?: HTMLSpanElement;
 
 	readonly tabIndexAttr = this.#shouldSetTabIndex(this.elementRef.nativeElement) ? '0' : null;
+	readonly roleAttr = this.#shouldSetRole(this.elementRef.nativeElement) ? 'button' : null;
 
 	// For when we need to extend this popover and add some extra providers to the panel
 	protected additionalProviders: Provider[] = [];
@@ -357,6 +359,14 @@ export class PopoverDirective implements OnDestroy {
 		}
 
 		return !this.#isNativelyFocusable(element);
+	}
+
+	#shouldSetRole(element: HTMLElement): boolean {
+		if (element.hasAttribute('role')) {
+			return false;
+		}
+
+		return this.#shouldSetTabIndex(element);
 	}
 
 	#isNativelyFocusable(element: HTMLElement): boolean {

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -71,6 +71,9 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 		'[attr.aria-expanded]': 'opened()',
 		'[attr.tabindex]': 'luPopoverDisabled ? null : tabIndexAttr',
 		'[attr.role]': 'luPopoverDisabled ? null : roleAttr',
+		'(keydown.enter)': 'onEnterKeyDown()',
+		'(keydown.space)': 'onSpaceKeyDown($event)',
+		'(keyup.space)': 'onSpaceKeyUp($event)',
 	},
 	exportAs: 'luPopover2',
 })
@@ -227,7 +230,6 @@ export class PopoverDirective implements OnDestroy {
 		this.#togglePopoverFromTrigger();
 	}
 
-	@HostListener('keydown.enter')
 	onEnterKeyDown(): void {
 		if (!this.#isUsingSyntheticTabIndex()) {
 			return;
@@ -236,7 +238,6 @@ export class PopoverDirective implements OnDestroy {
 		this.#togglePopoverFromTrigger();
 	}
 
-	@HostListener('keydown.space', ['$event'])
 	onSpaceKeyDown(event: Event): void {
 		if (!this.#isUsingSyntheticTabIndex()) {
 			return;
@@ -245,7 +246,6 @@ export class PopoverDirective implements OnDestroy {
 		event.preventDefault();
 	}
 
-	@HostListener('keyup.space', ['$event'])
 	onSpaceKeyUp(event: Event): void {
 		if (!this.#isUsingSyntheticTabIndex()) {
 			return;

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -154,7 +154,7 @@ export class PopoverDirective implements OnDestroy {
 
 	#screenReaderDescription?: HTMLSpanElement;
 
-	readonly tabIndexAttr = this.#shouldSetTabIndex(this.elementRef.nativeElement) ? '0' : null;
+	readonly tabIndexAttr = this.#shouldSetTabIndex(this.elementRef.nativeElement) ? 0 : null;
 	readonly roleAttr = this.#shouldSetRole(this.elementRef.nativeElement) ? 'button' : null;
 
 	// For when we need to extend this popover and add some extra providers to the panel
@@ -350,7 +350,7 @@ export class PopoverDirective implements OnDestroy {
 	}
 
 	#isUsingSyntheticTabIndex(): boolean {
-		return this.tabIndexAttr === '0';
+		return this.tabIndexAttr === 0;
 	}
 
 	#shouldSetTabIndex(element: HTMLElement): boolean {
@@ -376,19 +376,18 @@ export class PopoverDirective implements OnDestroy {
 			return true;
 		}
 
-		if (tag === 'a') {
-			return element.hasAttribute('href');
+		switch (tag) {
+			case 'a':
+				return element.hasAttribute('href');
+			case 'button':
+			case 'select':
+			case 'textarea':
+				return !element.hasAttribute('disabled');
+			case 'input':
+				return !element.hasAttribute('disabled') && (element as HTMLInputElement).type !== 'hidden';
+			default:
+				return false;
 		}
-
-		if (tag === 'button' || tag === 'select' || tag === 'textarea') {
-			return !element.hasAttribute('disabled');
-		}
-
-		if (tag === 'input') {
-			return !element.hasAttribute('disabled') && (element as HTMLInputElement).type !== 'hidden';
-		}
-
-		return false;
 	}
 
 	#buildPositions(): ConnectedPosition[] {

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -69,6 +69,7 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	selector: '[luPopover2]',
 	host: {
 		'[attr.aria-expanded]': 'opened()',
+		'[attr.tabindex]': 'tabIndexAttr',
 	},
 	exportAs: 'luPopover2',
 })
@@ -149,6 +150,8 @@ export class PopoverDirective implements OnDestroy {
 
 	#screenReaderDescription?: HTMLSpanElement;
 
+	readonly tabIndexAttr = this.#shouldSetTabIndex(this.elementRef.nativeElement) ? '0' : null;
+
 	// For when we need to extend this popover and add some extra providers to the panel
 	protected additionalProviders: Provider[] = [];
 
@@ -219,6 +222,38 @@ export class PopoverDirective implements OnDestroy {
 
 	@HostListener('click')
 	click(): void {
+		this.#togglePopoverFromTrigger();
+	}
+
+	@HostListener('keydown.enter')
+	onEnterKeyDown(): void {
+		if (!this.#isUsingSyntheticTabIndex()) {
+			return;
+		}
+
+		this.#togglePopoverFromTrigger();
+	}
+
+	@HostListener('keydown.space', ['$event'])
+	onSpaceKeyDown(event: Event): void {
+		if (!this.#isUsingSyntheticTabIndex()) {
+			return;
+		}
+
+		event.preventDefault();
+	}
+
+	@HostListener('keyup.space', ['$event'])
+	onSpaceKeyUp(event: Event): void {
+		if (!this.#isUsingSyntheticTabIndex()) {
+			return;
+		}
+
+		event.preventDefault();
+		this.#togglePopoverFromTrigger();
+	}
+
+	#togglePopoverFromTrigger(): void {
 		if (this.opened()) {
 			this.#componentRef?.close();
 			this.#listenToMouseLeave = true;
@@ -310,6 +345,40 @@ export class PopoverDirective implements OnDestroy {
 
 	updatePosition() {
 		this.#overlayRef?.updatePosition();
+	}
+
+	#isUsingSyntheticTabIndex(): boolean {
+		return this.tabIndexAttr === '0';
+	}
+
+	#shouldSetTabIndex(element: HTMLElement): boolean {
+		if (element.hasAttribute('tabindex')) {
+			return false;
+		}
+
+		return !this.#isNativelyFocusable(element);
+	}
+
+	#isNativelyFocusable(element: HTMLElement): boolean {
+		const tag = element.tagName.toLowerCase();
+
+		if (element.isContentEditable) {
+			return true;
+		}
+
+		if (tag === 'a') {
+			return element.hasAttribute('href');
+		}
+
+		if (tag === 'button' || tag === 'select' || tag === 'textarea') {
+			return !element.hasAttribute('disabled');
+		}
+
+		if (tag === 'input') {
+			return !element.hasAttribute('disabled') && (element as HTMLInputElement).type !== 'hidden';
+		}
+
+		return false;
 	}
 
 	#buildPositions(): ConnectedPosition[] {

--- a/stories/documentation/overlays/popover2/popover2.stories.ts
+++ b/stories/documentation/overlays/popover2/popover2.stories.ts
@@ -96,6 +96,51 @@ export const Basic: StoryObj<PopoverDirective> = {
 		luPopoverNoCloseButton: false,
 	},
 };
+
+export const NeutralElement: StoryObj<PopoverDirective> = {
+	render: (args, { argTypes }) => {
+		const action = args.luPopoverTrigger === 'click' ? 'Cliquez-moi' : 'Cliquez ou survolez-moi';
+		let openDelay = '';
+		if (args.luPopoverTrigger !== 'click') {
+			openDelay = ' ' + args.luPopoverOpenDelay + 'ms';
+		}
+		return {
+			template: `<div class="demo">
+	<div class="pr-u-focusVisible pr-u-borderRadiusSmall" luButton [luPopover2]="contentRef" ${generateInputs(args, argTypes)}>${action}${openDelay} !</div>
+	<ng-template #contentRef>
+		<div class="popover-contentOptional">
+			<h3>Title</h3>
+			<lu-divider />
+			<lu-listing checklist palette="success">
+				<lu-listing-item>item item item item item item item item item item item</lu-listing-item>
+				<lu-listing-item>item</lu-listing-item>
+				<lu-listing-item>item</lu-listing-item>
+			</lu-listing>
+		</div>
+	</ng-template>
+</div>
+`,
+			styles: [
+				`
+	.demo {
+		display: flex;
+		min-block-size: 20rem;
+		align-items: center;
+		justify-content: center;
+	}`,
+			],
+		};
+	},
+	args: {
+		luPopoverTrigger: 'click',
+		luPopoverCloseDelay: 300,
+		luPopoverOpenDelay: 300,
+		luPopoverDisabled: false,
+		luPopoverPosition: 'above',
+		luPopoverNoCloseButton: false,
+	},
+};
+
 export const CustomPosition: StoryObj<PopoverDirective> = {
 	render: (_args, { argTypes }) => {
 		const { luPopoverPosition, ...args } = _args;


### PR DESCRIPTION
## Description

Handles the ability to trigger a popover on an element that is non-interactive by default.
A button role and a tabindex are added.

-----

Another option: https://github.com/LuccaSA/lucca-front/pull/4984

-----

<img width="1490" height="418" alt="2026-05-29 15 24 01" src="https://github.com/user-attachments/assets/6cd4120a-5c7f-40c8-80db-43732be2bf51" />

