### PR TITLE
fix(rich-text-input): fix toolbar not appearing when switching off presentation mode

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component, effect, ElementRef, forwardRef, inject, input, OnDestroy, signal, viewChildren, ViewContainerRef } from '@angular/core';
 import { ChipComponent } from '@lucca-front/ng/chip';
 import { intlInputOptions } from '@lucca-front/ng/core';
-import { $getNodeByKey, $getRoot, $getSelection, type Klass, type LexicalEditor, type LexicalNode, type NodeKey } from 'lexical';
-import { INITIAL_UPDATE_TAG, RICH_TEXT_PLUGIN_COMPONENT, RichTextPluginComponent, SKIP_DOM_SELECTION_TAG } from '../../rich-text-input.component';
+import { $getNodeByKey, $getRoot, $getSelection, type Klass, type LexicalEditor, type LexicalNode, type NodeKey, SKIP_DOM_SELECTION_TAG } from 'lexical';
+import { INITIAL_UPDATE_TAG, RICH_TEXT_PLUGIN_COMPONENT, RichTextPluginComponent } from '../../rich-text-input.component';
 import { LU_RICH_TEXT_INPUT_TRANSLATIONS } from '../../rich-text-input.translate';
 import { $createTagNode, TagNode } from './tag-node';
 import type { Tag } from './tag.model';

--- a/packages/ng/forms/rich-text-input/rich-text-input.component.html
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.html
@@ -23,17 +23,17 @@
 		[attr.aria-labelledby]="formFieldId() + '-label'"
 		[attr.aria-controls]="formFieldId()"
 	>
-		<ng-container *ngTemplateOutlet="toolsProjection" />
+		<ng-container *cdkPortalOutlet="toolsPortal()" />
 	</div>
 </div>
 
 <ng-container *luPresentationDisplayDefault>
 	<span class="pr-u-displayNone">
-		<ng-container *ngTemplateOutlet="toolsProjection" />
+		<ng-container *cdkPortalOutlet="toolsPortal()" />
 	</span>
 	<div #contentPresentation class="textFlow"></div>
 </ng-container>
 
-<ng-template #toolsProjection>
+<span #toolsProjection>
 	<ng-content />
-</ng-template>
+</span>

--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -24,12 +24,11 @@ import { createEmptyHistoryState, registerHistory } from '@lexical/history';
 import { $canShowPlaceholderCurry, $isRootTextContentEmpty } from '@lexical/text';
 import { mergeRegister } from '@lexical/utils';
 import { FormFieldComponent, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
-import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement, UpdateListenerPayload } from 'lexical';
+import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement, SKIP_DOM_SELECTION_TAG, UpdateListenerPayload } from 'lexical';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from './formatters';
+import { CdkPortalOutlet, DomPortal } from '@angular/cdk/portal';
 
 export const INITIAL_UPDATE_TAG = 'initial-update';
-// TODO replace by lexical import when upgrade lexical
-export const SKIP_DOM_SELECTION_TAG = 'skip-dom-selection';
 
 export interface RichTextPluginComponent {
 	setEditorInstance(editor: LexicalEditor): void;
@@ -50,7 +49,7 @@ export const RICH_TEXT_PLUGIN_COMPONENT = new InjectionToken<RichTextPluginCompo
 
 @Component({
 	selector: 'lu-rich-text-input',
-	imports: [InputDirective, CommonModule, ɵPresentationDisplayDefaultDirective],
+	imports: [InputDirective, CommonModule, ɵPresentationDisplayDefaultDirective, CdkPortalOutlet],
 	templateUrl: './rich-text-input.component.html',
 	styleUrl: './rich-text-input.component.scss',
 	encapsulation: ViewEncapsulation.None,
@@ -79,10 +78,12 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 		read: ElementRef,
 	});
 	readonly pluginComponents = contentChildren(RICH_TEXT_PLUGIN_COMPONENT, { descendants: true });
+	readonly toolsProjection = viewChild.required<ElementRef<HTMLElement>>('toolsProjection');
 
 	readonly currentCanShowPlaceholder = signal(false);
 	readonly isDisabled = signal(false);
 	readonly formFieldId = computed(() => this.#formField?.id());
+	readonly toolsPortal = computed(() => new DomPortal(this.toolsProjection()));
 
 	readonly #customNodes = computed(() =>
 		this.pluginComponents()


### PR DESCRIPTION
## Description

Fixed toolbar not appearing when switching off presentation mode

-----

Fixes #4915 
<img width="957" height="307" alt="firefox_u7jddSfhwK" src="https://github.com/user-attachments/assets/aca51cec-3b2d-48a6-a378-265c9a8cdaeb" />

Cause :
* Form Field uses structural directive to display field in presentation mode or editable mode.
* RTE uses transclusion to register tools to the lexical editor. 
* Angular does not handle conditionnal positionning of the same `<ng-content />`, as it can only be projected once in the parent lifecycle.
* To circumvent that issue, `<ng-content>` was put inside a reusable `<ng-template>`, inserted in both editable & presentation views. Content is projected only when the template is used.
* After first view init, the template is inserted in the editor and content is projected. After presentation mode is switched 'on', the template is transfered to the structural div. Once it's in there, it stays there, regardless of field mode. Hypothesis: content cannot be reprojected once it's in the structural directive, hence resulting in empty toolbar div in editable mode.
* Projected content is bound to the lifecycle of the parent component, so the toolbar angular components themselves were not destroyed, and were still bound to the editor (that's why it was somewhat still functionnal, e.g. link tool).
* This bug was not reproducible with Storybook's native "presentation" input, as it destroys the whole view to change the input. 

Fix:
* As the same `ng-content` can only be projected once, it must be included unconditionally in the editor (i.e. editor root, always visible).  
* Once content is projected, it is stored in a `DomPortal`.
* That portal is then physically transferred in either presentation or editable views. It is therefore never destroyed within the editor's lifecycle.

-----
