### PR TITLE
fix: add custom `boolean` and `number` transforms for typing issue

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -2,9 +2,9 @@
 
 English is the main language used to debate, provide feedback and discuss features, please use it by default.
 
- - [Naming](#naming)
- - [Architecture](#architecture)
- - [Developer eXperience](#dx)
+- [Naming](#naming)
+- [Architecture](#architecture)
+- [Developer eXperience](#dx)
 
 ## <a name="naming"></a> Naming
 
@@ -17,7 +17,6 @@ We're using Angular's standard for naming, which includes:
 - Component inputs must never collide with an existing native input on their host.
 
 You can read a very detailed version of that here: https://google.github.io/styleguide/tsguide.html
-
 
 ## <a name="architecture"></a> Architecture
 
@@ -44,10 +43,10 @@ For a component to be used, it must be easy to use. Always prefer keeping the ha
 
 This includes, but not only:
 
-- Using `booleanAttribute` transform, it makes components easier to use overall.
+- Always use `luBooleanAttribute`/`luOptionalBooleanAttribute` transform when creating an input that should take boolean, to make it easier to use for everyone.
 - Using meaningful input names, common names such as `config`, `param`, etc must be avoided and they're too generic, consumers need to know what your input does!
 - Properly typings inputs, using union strings when necessary, to provide code completion, this can also be done with a trailing `| string` that will make it become a list of suggestions instead.
-- Always use `numberAttribute` transform when creating an input that should take numbers, to make it easier to use for everyone.
+- Always use `luNumberAttribute`/`luOptionalNumberAttribute` transform when creating an input that should take numbers, to make it easier to use for everyone.
 
 Overall, ask yourself: would I want to use this component, that input? Before deciding on it, because if you don't want to use it due to how it's exposed, neither will the consumers.
 

--- a/packages/ng/app-layout/app-layout.component.ts
+++ b/packages/ng/app-layout/app-layout.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-app-layout',
@@ -12,5 +13,5 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncaps
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppLayoutComponent {
-	readonly mobileNavSideBottom = input(false, { transform: booleanAttribute });
+	readonly mobileNavSideBottom = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/box/box.component.ts
+++ b/packages/ng/box/box.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LU_BOX_TRANSLATIONS } from './box.translate';
 
@@ -21,13 +21,13 @@ import { LU_BOX_TRANSLATIONS } from './box.translate';
 export class BoxComponent {
 	readonly intl = input(...intlInputOptions(LU_BOX_TRANSLATIONS));
 
-	readonly toggle = input(false, { transform: booleanAttribute });
+	readonly toggle = input(false, { transform: luBooleanAttribute });
 
-	readonly neutral = input(false, { transform: booleanAttribute });
+	readonly neutral = input(false, { transform: luBooleanAttribute });
 
-	readonly killable = input(false, { transform: booleanAttribute });
+	readonly killable = input(false, { transform: luBooleanAttribute });
 
-	readonly withArrow = input(false, { transform: booleanAttribute });
+	readonly withArrow = input(false, { transform: luBooleanAttribute });
 
 	readonly killed = output();
 }

--- a/packages/ng/breadcrumbs/breadcrumbs.component.ts
+++ b/packages/ng/breadcrumbs/breadcrumbs.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChildren, input, ViewEncapsulation } from '@angular/core';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, contentChildren, input, ViewEncapsulation } from '@angular/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { BreadcrumbsLinkDirective } from './breadcrumbs-link.directive';
 import { LU_BREADCRUMBS_TRANSLATIONS } from './breadcrumbs.translate';
 
@@ -23,7 +23,7 @@ let nextId = 0;
 export class BreadcrumbsComponent {
 	readonly intl = input(...intlInputOptions(LU_BREADCRUMBS_TRANSLATIONS));
 
-	readonly disableCompact = input(false, { transform: booleanAttribute });
+	readonly disableCompact = input(false, { transform: luBooleanAttribute });
 
 	readonly links = contentChildren(BreadcrumbsLinkDirective);
 

--- a/packages/ng/bubble-illustration/bubble-illustration.component.ts
+++ b/packages/ng/bubble-illustration/bubble-illustration.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
-import { DecorativePalette, Palette } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { DecorativePalette, luBooleanAttribute, Palette } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
 import { BubbleIllustration } from './bubble-illustration';
 import { BubbleIllustrationSize } from './bubble-illustration.type';
@@ -23,7 +23,7 @@ export class BubbleIllustrationComponent {
 
 	readonly size = input<BubbleIllustrationSize>('M');
 
-	readonly action = input(false, { transform: booleanAttribute });
+	readonly action = input(false, { transform: luBooleanAttribute });
 
 	readonly illustrationUrl = computed(() => {
 		if (this.illustration().startsWith('https://') || this.illustration().startsWith('/')) {

--- a/packages/ng/callout/callout-actions/callout-actions.component.ts
+++ b/packages/ng/callout/callout-actions/callout-actions.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-callout-actions',
@@ -11,5 +12,5 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncaps
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CalloutActionsComponent {
-	readonly inline = input(false, { transform: booleanAttribute });
+	readonly inline = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/callout/callout-disclosure/callout-disclosure.component.ts
+++ b/packages/ng/callout/callout-disclosure/callout-disclosure.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation, booleanAttribute, computed, input, output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, output, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
-import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { luBooleanAttribute, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { CalloutIconPipe } from '../callout-icon.pipe';
 import { CalloutSize, CalloutState } from '../callout.type';
@@ -49,7 +49,7 @@ export class CalloutDisclosureComponent {
 	/**
 	 * Is the disclosure callout is open by default
 	 */
-	readonly open = input(false, { transform: booleanAttribute });
+	readonly open = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Emit boolean event when toggle disclosure callout opened

--- a/packages/ng/callout/callout-popover/callout-popover.component.ts
+++ b/packages/ng/callout/callout-popover/callout-popover.component.ts
@@ -1,7 +1,7 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChildren, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, contentChildren, input, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
-import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { luBooleanAttribute, luNumberAttribute, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { PopoverDirective, PopoverPosition } from '@lucca-front/ng/popover2';
 import { CalloutFeedbackItemComponent } from '../callout-feedback-item/callout-feedback-item.component';
@@ -21,12 +21,12 @@ export class CalloutPopoverComponent {
 	/**
 	 * Debounce for the popover to open (mouse will have to be on the element fox openDelay milliseconds for popover to show)
 	 */
-	readonly openDelay = input(50, { transform: numberAttribute });
+	readonly openDelay = input(50, { transform: luNumberAttribute });
 
 	/**
 	 * Debounce for the popover to close (mouse will have to be out of both popover and trigger for closeDelay milliseconds for it to close)
 	 */
-	readonly closeDelay = input(500, { transform: numberAttribute });
+	readonly closeDelay = input(500, { transform: luNumberAttribute });
 
 	/**
 	 * Label (visual only) to put inside the button, often used to show just a number
@@ -41,7 +41,7 @@ export class CalloutPopoverComponent {
 	/**
 	 * Hide callout popover title if there is only one item
 	 */
-	readonly headingHiddenIfSingleItem = input(false, { transform: booleanAttribute });
+	readonly headingHiddenIfSingleItem = input(false, { transform: luBooleanAttribute });
 
 	readonly popoverTrigger = input<'click' | 'click+hover' | 'hover+focus'>('click+hover');
 
@@ -87,7 +87,7 @@ export class CalloutPopoverComponent {
 	/**
 	 * Disable callout popover apparition
 	 */
-	readonly popoverDisabled = input(false, { transform: booleanAttribute });
+	readonly popoverDisabled = input(false, { transform: luBooleanAttribute });
 
 	readonly feedbackItems = contentChildren(CalloutFeedbackItemComponent, { descendants: true });
 

--- a/packages/ng/callout/callout/callout.component.ts
+++ b/packages/ng/callout/callout/callout.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, linkedSignal, numberAttribute, output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, linkedSignal, output, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
-import { intlInputOptions, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, luNumberAttribute, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { CalloutIconPipe } from '../callout-icon.pipe';
 import { LU_CALLOUT_TRANSLATIONS } from '../callout.translate';
@@ -29,7 +29,7 @@ export class CalloutComponent {
 	/**
 	 * Define the aria level of the title
 	 */
-	readonly hx = input(null, { transform: numberAttribute as (value: CalloutHx | `${CalloutHx}`) => CalloutHx });
+	readonly hx = input(null, { transform: luNumberAttribute<CalloutHx> });
 
 	/**
 	 * Which palette should be used for the entire callout.
@@ -60,12 +60,12 @@ export class CalloutComponent {
 	/**
 	 * Should we display the remove icon?
 	 */
-	readonly removable = input(false, { transform: booleanAttribute });
+	readonly removable = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Is the callout removed? Works with two way binding too.
 	 */
-	readonly removed = input(false, { transform: booleanAttribute });
+	readonly removed = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Defines the icon’s alt attribute used for accessibility
@@ -75,7 +75,7 @@ export class CalloutComponent {
 	/**
 	 * Displayed in AI mode
 	 */
-	readonly AI = input(false, { transform: booleanAttribute });
+	readonly AI = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Emit event when button removed is click

--- a/packages/ng/chip/chip.component.ts
+++ b/packages/ng/chip/chip.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, output, ViewEncapsulation } from '@angular/core';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, input, output, ViewEncapsulation } from '@angular/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 
 import { LuccaIcon } from '@lucca-front/icons';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -30,12 +30,12 @@ export class ChipComponent {
 	/**
 	 * Add an ellipsis if the text is too long
 	 */
-	readonly withEllipsis = input(false, { transform: booleanAttribute });
+	readonly withEllipsis = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Makes the chip non-removable
 	 */
-	readonly unkillable = input(false, { transform: booleanAttribute });
+	readonly unkillable = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Which palette should be used for the entire chip.
@@ -46,7 +46,7 @@ export class ChipComponent {
 	/**
 	 * Disabled the chip
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Which size should the chip be? Defaults or small

--- a/packages/ng/clear/clear.component.ts
+++ b/packages/ng/clear/clear.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, effect, ElementRef, EventEmitter, forwardRef, inject, input, untracked, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, effect, ElementRef, EventEmitter, forwardRef, inject, input, untracked, ViewEncapsulation } from '@angular/core';
 import { outputFromObservable } from '@angular/core/rxjs-interop';
-import { intlInputOptions, LuClass, Palette } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, LuClass, Palette } from '@lucca-front/ng/core';
 import { ClearSize } from './clear.type';
 import { ALuClear, ILuClear } from './clear.model';
 import { LU_CLEAR_TRANSLATIONS } from './clear.translate';
@@ -45,7 +45,7 @@ export class ClearComponent<T> extends ALuClear<T> implements ILuClear<T> {
 	/**
 	 * Disabled the clear
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Which palette should be used for the entire clear
@@ -55,7 +55,7 @@ export class ClearComponent<T> extends ALuClear<T> implements ILuClear<T> {
 	/**
 	 * Change the clear colors for use on a dark background
 	 */
-	readonly inverted = input(false, { transform: booleanAttribute });
+	readonly inverted = input(false, { transform: luBooleanAttribute });
 
 	override readonly onClear = new EventEmitter<T>();
 

--- a/packages/ng/code/code.component.ts
+++ b/packages/ng/code/code.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-code',
@@ -8,5 +9,5 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncaps
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class CodeComponent {
-	readonly block = input(false, { transform: booleanAttribute });
+	readonly block = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/color/color.component.ts
+++ b/packages/ng/color/color.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { ColorSize } from './color.type';
 
 @Component({
@@ -17,5 +18,5 @@ export class ColorComponent {
 	readonly value = input<string | null>(null);
 	readonly borderColor = input<string | null>(null);
 	readonly size = input<ColorSize | null>(null);
-	readonly hiddenName = input(false, { transform: booleanAttribute });
+	readonly hiddenName = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/comment/comment-block/comment-block.component.ts
+++ b/packages/ng/comment/comment-block/comment-block.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChildren, forwardRef, inject, input, TemplateRef, ViewEncapsulation } from '@angular/core';
-import { PortalContent } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, contentChildren, forwardRef, inject, input, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, PortalContent } from '@lucca-front/ng/core';
 import { CommentBlockSize } from '../comment.type';
 import { CommentComponent } from '../comment/comment.component';
 import { COMMENT_BLOCK_INSTANCE, COMMENT_CHAT_INSTANCE } from '../token';
@@ -26,16 +26,16 @@ export class CommentBlockComponent {
 
 	readonly comments = contentChildren(CommentComponent, { read: CommentComponent, descendants: true });
 
-	readonly compact = input(false, { transform: booleanAttribute });
+	readonly compact = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Small is a shorthand to set the size to small
 	 *
 	 * If the size input is filled along with the small input, their values will have the priority
 	 */
-	readonly small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: luBooleanAttribute });
 
-	readonly chatAnswer = input(false, { transform: booleanAttribute });
+	readonly chatAnswer = input(false, { transform: luBooleanAttribute });
 
 	readonly authorName = input<PortalContent>();
 

--- a/packages/ng/comment/comment/comment.component.ts
+++ b/packages/ng/comment/comment/comment.component.ts
@@ -1,6 +1,6 @@
 import { DatePipe, NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuUserPictureModule } from '@lucca-front/ng/user';
 import { COMMENT_BLOCK_INSTANCE } from '../token';
 
@@ -52,7 +52,7 @@ export class CommentComponent {
 
 	readonly contentIsHTML = computed(() => !this.contentIsPortal() && /<\/?[a-z][\s\S]*>/i.test(this.content() as string));
 
-	readonly noInfos = input(false, { transform: booleanAttribute });
+	readonly noInfos = input(false, { transform: luBooleanAttribute });
 
 	readonly dateDisplay = computed(() => {
 		const formatted = this.#intlDateTimeFormat.format(this.date());

--- a/packages/ng/container/container.component.ts
+++ b/packages/ng/container/container.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { ContainerSize } from './container.type';
 
 @Component({
@@ -13,9 +14,9 @@ import { ContainerSize } from './container.type';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ContainerComponent {
-	readonly center = input(false, { transform: booleanAttribute });
+	readonly center = input(false, { transform: luBooleanAttribute });
 
-	readonly overflow = input(false, { transform: booleanAttribute });
+	readonly overflow = input(false, { transform: luBooleanAttribute });
 
 	readonly max = input<ContainerSize | null>(null);
 

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { computed, Directive, forwardRef, inject, input, OnInit } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
-import { isNotNil } from '@lucca-front/ng/core';
+import { isNotNil, luNullableNumberAttribute } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, TreeNode } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { ILuDepartment } from '@lucca-front/ng/department';
@@ -30,7 +30,7 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 	readonly filters = input<Record<string, string | number | boolean> | null>(null);
 	readonly operationIds = input<readonly number[] | null>(null);
 	readonly uniqueOperationIds = input<readonly number[] | null>(null);
-	readonly appInstanceId = input<number | null>(null);
+	readonly appInstanceId = input(null, { transform: luNullableNumberAttribute });
 	readonly searchDelimiter = input<string>(' ');
 
 	public override ngOnInit(): void {

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { DestroyRef, Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { luNullableNumberAttribute } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, debounceTime, filter, map, switchMap } from 'rxjs';
@@ -33,7 +34,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 	readonly filters = input<Record<string, string | number | boolean> | null>(null);
 	readonly operationIds = input<readonly number[] | null>(null);
 	readonly uniqueOperationIds = input<readonly number[] | null>(null);
-	readonly appInstanceId = input<number | null>(null);
+	readonly appInstanceId = input(null, { transform: luNullableNumberAttribute });
 	readonly searchDelimiter = input<string>(' ');
 
 	protected readonly clue = toSignal(this.clue$);

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -1,7 +1,6 @@
 import { OverlayConfig, OverlayContainer } from '@angular/cdk/overlay';
 import {
 	afterNextRender,
-	booleanAttribute,
 	ChangeDetectorRef,
 	computed,
 	Directive,
@@ -22,7 +21,7 @@ import {
 } from '@angular/core';
 import { outputFromObservable, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor } from '@angular/forms';
-import { isNotNil, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNotNil, luBooleanAttribute, luNumberAttribute, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { BehaviorSubject, defer, finalize, map, of, ReplaySubject, startWith, Subject, switchMap, takeUntil, tap } from 'rxjs';
 import { LuSimpleSelectDefaultOptionComponent } from '../option';
@@ -63,7 +62,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	protected updatePositionFn?: () => void;
 	public filterPillMode = false;
 
-	public readonly ignorePresentation = input(false, { transform: booleanAttribute });
+	public readonly ignorePresentation = input(false, { transform: luBooleanAttribute });
 
 	public selectParent$?: Subject<void>;
 	public selectChildren$?: Subject<void>;
@@ -82,7 +81,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	readonly placeholder = input<string>();
 
-	readonly clearableInput = input<boolean | null>(null, { transform: booleanAttribute, alias: 'clearable' });
+	readonly clearableInput = input<boolean | null>(null, { transform: luBooleanAttribute, alias: 'clearable' });
 
 	readonly isClearable = computed(() => this.clearableInput() ?? this.#defaultFilterPillClearable() ?? this.#defaultClearable);
 	readonly #defaultFilterPillClearable = signal<boolean | null>(null);
@@ -139,13 +138,13 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	readonly optionKeyInput = input<(option: TOption) => unknown>(coreSelectDefaultOptionKey, { alias: 'optionKey' });
 
-	readonly noClueIcon = input(false, { transform: booleanAttribute });
+	readonly noClueIcon = input(false, { transform: luBooleanAttribute });
 
-	readonly inputTabindex = input<number>(0);
+	readonly inputTabindex = input(0, { transform: luNumberAttribute });
 
-	readonly compact = input(false, { transform: booleanAttribute });
+	readonly compact = input(false, { transform: luBooleanAttribute });
 
-	readonly colorPicker = input(false, { transform: booleanAttribute });
+	readonly colorPicker = input(false, { transform: luBooleanAttribute });
 
 	protected get isNoClueIconClass(): boolean {
 		return this.noClueIcon();

--- a/packages/ng/core-select/legal-units/legal-units.directive.ts
+++ b/packages/ng/core-select/legal-units/legal-units.directive.ts
@@ -1,7 +1,7 @@
 import { HttpClient } from '@angular/common/http';
-import { Directive, OnInit, booleanAttribute, computed, forwardRef, inject, input, signal } from '@angular/core';
+import { Directive, OnInit, computed, forwardRef, inject, input, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { luBooleanAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, debounceTime, map, switchMap } from 'rxjs';
@@ -31,7 +31,7 @@ export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = L
 	readonly filters = input<Record<string, string | number | boolean> | null>(null);
 	readonly uniqueOperationIds = input<readonly number[] | null>(null);
 	readonly searchDelimiter = input<string>(' ');
-	readonly enableArchivedLegalUnits = input(false, { transform: booleanAttribute });
+	readonly enableArchivedLegalUnits = input(false, { transform: luBooleanAttribute });
 
 	readonly includeArchivedLegalUnits = signal(false);
 

--- a/packages/ng/core-select/option/option-outlet.directive.ts
+++ b/packages/ng/core-select/option/option-outlet.directive.ts
@@ -1,5 +1,5 @@
 import { ComponentRef, Directive, EmbeddedViewRef, inject, Injector, input, OnDestroy, TemplateRef, Type, ViewContainerRef } from '@angular/core';
-import { isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNotNil, luBooleanAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuOptionContext } from '../select.model';
 import { LU_OPTION_CONTEXT, provideOptionContext } from './option.token';
 
@@ -16,7 +16,7 @@ export class LuOptionOutletDirective<T> implements OnDestroy {
 
 	readonly luOptionOutletValue = input<T | undefined>();
 
-	readonly luOptionShowNull = input<boolean>(false);
+	readonly luOptionShowNull = input(false, { transform: luBooleanAttribute });
 
 	private viewContainerRef = inject(ViewContainerRef);
 	private injector = inject(Injector);

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
-import { intlInputOptions, isNil, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
+import { intlInputOptions, isNil, luBooleanAttribute, luOptionalNumberAttribute, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { asyncScheduler, observeOn } from 'rxjs';
 import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from '../panel/panel.instance';
@@ -34,13 +34,13 @@ export class LuOptionComponent<T> implements OnInit {
 
 	readonly grouping = input<LuOptionGrouping<T, unknown>>();
 
-	readonly hasChildren = input(false, { transform: booleanAttribute });
+	readonly hasChildren = input(false, { transform: luBooleanAttribute });
 
 	readonly onlyParent = output<void>();
 
 	readonly onlyChildren = output<void>();
 
-	readonly groupIndex = input<number>();
+	readonly groupIndex = input(undefined, { transform: luOptionalNumberAttribute });
 
 	public readonly optionIndex = input.required({ transform: (value: string | number) => `${value}` });
 

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -1,8 +1,8 @@
 import { HttpClient } from '@angular/common/http';
-import { Directive, Provider, TemplateRef, Type, booleanAttribute, computed, effect, forwardRef, inject, input, model, signal, untracked } from '@angular/core';
+import { Directive, Provider, TemplateRef, Type, computed, effect, forwardRef, inject, input, model, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiCollectionResponse } from '@lucca-front/ng/api';
-import { ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { luBooleanAttribute, luNullableNumberAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, LuOptionContext, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { LuDisplayFormat, LuDisplayFullname } from '@lucca-front/ng/user';
@@ -65,9 +65,9 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	readonly orderBy = input<string | null>(null);
 	readonly operationIds = input<readonly number[] | null>(null);
 	readonly uniqueOperationIds = input<readonly number[] | null>(null);
-	readonly appInstanceId = input<number | null>(null);
-	readonly enableFormerEmployees = input(false, { transform: booleanAttribute });
-	readonly displayMeOption = input(true);
+	readonly appInstanceId = input(null, { transform: luNullableNumberAttribute });
+	readonly enableFormerEmployees = input(false, { transform: luBooleanAttribute });
+	readonly displayMeOption = input(true, { transform: luBooleanAttribute });
 	readonly customUserOptionTpl = model<TemplateRef<LuOptionContext<T>> | Type<unknown> | undefined>();
 
 	readonly includeFormerEmployees = signal(false);

--- a/packages/ng/core/public-api.ts
+++ b/packages/ng/core/public-api.ts
@@ -8,6 +8,7 @@ export * from './portal/index';
 export * from './route';
 export * from './signal';
 export * from './tools/class';
+export * from './transform/index';
 export * from './translate/index';
 export * from './tree/index';
 export * from './type/index';

--- a/packages/ng/core/transform/boolean-transform.spec.ts
+++ b/packages/ng/core/transform/boolean-transform.spec.ts
@@ -1,0 +1,79 @@
+import { luBooleanAttribute, luNullableBooleanAttribute, luOptionalBooleanAttribute, luOptionalNullableBooleanAttribute } from './boolean-transform';
+
+describe('boolean transform', () => {
+	describe(luBooleanAttribute, () => {
+		it.each([
+			{ input: true as const, expected: true as const },
+			{ input: false as const, expected: false as const },
+			{ input: 'true' as const, expected: true as const },
+			{ input: 'false' as const, expected: false as const },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luBooleanAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: true = luBooleanAttribute<true>('true');
+			expect(result).toBe(true);
+		});
+	});
+
+	describe(luNullableBooleanAttribute, () => {
+		it.each([
+			{ input: true as const, expected: true as const },
+			{ input: false as const, expected: false as const },
+			{ input: 'true' as const, expected: true as const },
+			{ input: 'false' as const, expected: false as const },
+			{ input: null, expected: null },
+			{ input: 'null' as const, expected: null },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luNullableBooleanAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: true | null = luNullableBooleanAttribute<true>('true');
+			expect(result).toBe(true);
+		});
+	});
+
+	describe(luOptionalBooleanAttribute, () => {
+		it.each([
+			{ input: true as const, expected: true as const },
+			{ input: false as const, expected: false as const },
+			{ input: 'true' as const, expected: true as const },
+			{ input: 'false' as const, expected: false as const },
+			{ input: undefined, expected: undefined },
+			{ input: 'undefined' as const, expected: undefined },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luOptionalBooleanAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: true | undefined = luOptionalBooleanAttribute<true>('true');
+			expect(result).toBe(true);
+		});
+	});
+
+	describe(luOptionalNullableBooleanAttribute, () => {
+		it.each([
+			{ input: true as const, expected: true as const },
+			{ input: false as const, expected: false as const },
+			{ input: 'true' as const, expected: true as const },
+			{ input: 'false' as const, expected: false as const },
+			{ input: null, expected: null },
+			{ input: 'null' as const, expected: null },
+			{ input: undefined, expected: undefined },
+			{ input: 'undefined' as const, expected: undefined },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luOptionalNullableBooleanAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: true | null | undefined = luOptionalNullableBooleanAttribute<true>('true');
+			expect(result).toBe(true);
+		});
+	});
+});

--- a/packages/ng/core/transform/boolean-transform.ts
+++ b/packages/ng/core/transform/boolean-transform.ts
@@ -1,0 +1,62 @@
+import { booleanAttribute } from '@angular/core';
+
+/**
+ * Transforms a boolean or a string representation of a boolean into a boolean.
+ * @template T The specific boolean literal type to narrow to.
+ * @param value The value to transform, can be a boolean or a string representation of a boolean.
+ * @returns The transformed boolean value.
+ */
+export function luBooleanAttribute(value: boolean | `${boolean}`): boolean;
+export function luBooleanAttribute<T extends boolean>(value: T | `${T}`): T;
+export function luBooleanAttribute(value: boolean | `${boolean}`): boolean {
+	return booleanAttribute(value);
+}
+
+/**
+ * Transforms a boolean, a string representation of a boolean, null or a string representation of null into a boolean or null.
+ * @template T The specific boolean literal type to narrow to.
+ * @param value The value to transform, can be a boolean, a string representation of a boolean, null or a string representation of null.
+ * @returns The transformed boolean value or null.
+ */
+export function luNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}`): boolean | null;
+export function luNullableBooleanAttribute<T extends boolean>(value: T | `${T}` | null | `${null}`): T | null;
+export function luNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}`): boolean | null {
+	if (value === null || value === 'null') {
+		return null;
+	}
+
+	return booleanAttribute(value);
+}
+
+/**
+ * Transforms a boolean, a string representation of a boolean, undefined or a string representation of undefined into a boolean or undefined.
+ * @template T The specific boolean literal type to narrow to.
+ * @param value The value to transform, can be a boolean, a string representation of a boolean, undefined or a string representation of undefined.
+ * @returns The transformed boolean value or undefined.
+ */
+export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | undefined | `${undefined}`): boolean | undefined;
+export function luOptionalBooleanAttribute<T extends boolean>(value: T | `${T}` | undefined | `${undefined}`): T | undefined;
+export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | undefined | `${undefined}`): boolean | undefined {
+	if (value === undefined || value === 'undefined') {
+		return undefined;
+	}
+	return booleanAttribute(value);
+}
+
+/**
+ * Transforms a boolean, a string representation of a boolean, null, a string representation of null, undefined or a string representation of undefined into a boolean, null or undefined.
+ * @template T The specific boolean literal type to narrow to.
+ * @param value The value to transform.
+ * @returns The transformed boolean value, null or undefined.
+ */
+export function luOptionalNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}` | undefined | `${undefined}`): boolean | null | undefined;
+export function luOptionalNullableBooleanAttribute<T extends boolean>(value: T | `${T}` | null | `${null}` | undefined | `${undefined}`): T | null | undefined;
+export function luOptionalNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}` | undefined | `${undefined}`): boolean | null | undefined {
+	if (value === null || value === 'null') {
+		return null;
+	}
+	if (value === undefined || value === 'undefined') {
+		return undefined;
+	}
+	return booleanAttribute(value);
+}

--- a/packages/ng/core/transform/boolean-transform.ts
+++ b/packages/ng/core/transform/boolean-transform.ts
@@ -6,9 +6,9 @@ import { booleanAttribute } from '@angular/core';
  * @param value The value to transform, can be a boolean or a string representation of a boolean.
  * @returns The transformed boolean value.
  */
-export function luBooleanAttribute(value: boolean | `${boolean}`): boolean;
-export function luBooleanAttribute<T extends boolean>(value: T | `${T}`): T;
-export function luBooleanAttribute(value: boolean | `${boolean}`): boolean {
+export function luBooleanAttribute(value: boolean | `${boolean}` | ''): boolean;
+export function luBooleanAttribute<T extends boolean>(value: T | `${T}` | ''): T;
+export function luBooleanAttribute(value: boolean | `${boolean}` | ''): boolean {
 	return booleanAttribute(value);
 }
 
@@ -18,9 +18,9 @@ export function luBooleanAttribute(value: boolean | `${boolean}`): boolean {
  * @param value The value to transform, can be a boolean, a string representation of a boolean, null or a string representation of null.
  * @returns The transformed boolean value or null.
  */
-export function luNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}`): boolean | null;
-export function luNullableBooleanAttribute<T extends boolean>(value: T | `${T}` | null | `${null}`): T | null;
-export function luNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}`): boolean | null {
+export function luNullableBooleanAttribute(value: boolean | `${boolean}` | '' | null | `${null}`): boolean | null;
+export function luNullableBooleanAttribute<T extends boolean>(value: T | `${T}` | '' | null | `${null}`): T | null;
+export function luNullableBooleanAttribute(value: boolean | `${boolean}` | '' | null | `${null}`): boolean | null {
 	if (value === null || value === 'null') {
 		return null;
 	}
@@ -34,9 +34,9 @@ export function luNullableBooleanAttribute(value: boolean | `${boolean}` | null 
  * @param value The value to transform, can be a boolean, a string representation of a boolean, undefined or a string representation of undefined.
  * @returns The transformed boolean value or undefined.
  */
-export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | undefined | `${undefined}`): boolean | undefined;
-export function luOptionalBooleanAttribute<T extends boolean>(value: T | `${T}` | undefined | `${undefined}`): T | undefined;
-export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | undefined | `${undefined}`): boolean | undefined {
+export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | '' | undefined | `${undefined}`): boolean | undefined;
+export function luOptionalBooleanAttribute<T extends boolean>(value: T | `${T}` | '' | undefined | `${undefined}`): T | undefined;
+export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | '' | undefined | `${undefined}`): boolean | undefined {
 	if (value === undefined || value === 'undefined') {
 		return undefined;
 	}
@@ -49,9 +49,9 @@ export function luOptionalBooleanAttribute(value: boolean | `${boolean}` | undef
  * @param value The value to transform.
  * @returns The transformed boolean value, null or undefined.
  */
-export function luOptionalNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}` | undefined | `${undefined}`): boolean | null | undefined;
-export function luOptionalNullableBooleanAttribute<T extends boolean>(value: T | `${T}` | null | `${null}` | undefined | `${undefined}`): T | null | undefined;
-export function luOptionalNullableBooleanAttribute(value: boolean | `${boolean}` | null | `${null}` | undefined | `${undefined}`): boolean | null | undefined {
+export function luOptionalNullableBooleanAttribute(value: boolean | `${boolean}` | '' | null | `${null}` | undefined | `${undefined}`): boolean | null | undefined;
+export function luOptionalNullableBooleanAttribute<T extends boolean>(value: T | `${T}` | '' | null | `${null}` | undefined | `${undefined}`): T | null | undefined;
+export function luOptionalNullableBooleanAttribute(value: boolean | `${boolean}` | '' | null | `${null}` | undefined | `${undefined}`): boolean | null | undefined {
 	if (value === null || value === 'null') {
 		return null;
 	}

--- a/packages/ng/core/transform/index.ts
+++ b/packages/ng/core/transform/index.ts
@@ -1,0 +1,2 @@
+export * from './boolean-transform';
+export * from './number-transform';

--- a/packages/ng/core/transform/number-transform.spec.ts
+++ b/packages/ng/core/transform/number-transform.spec.ts
@@ -1,0 +1,79 @@
+import { luNullableNumberAttribute, luNumberAttribute, luOptionalNullableNumberAttribute, luOptionalNumberAttribute } from './number-transform';
+
+describe('number transform', () => {
+	describe(luNumberAttribute, () => {
+		it.each([
+			{ input: 42 as const, expected: 42 as const },
+			{ input: 0 as const, expected: 0 as const },
+			{ input: '42' as const, expected: 42 as const },
+			{ input: '0' as const, expected: 0 as const },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luNumberAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: 42 = luNumberAttribute<42>('42');
+			expect(result).toBe(42);
+		});
+	});
+
+	describe(luNullableNumberAttribute, () => {
+		it.each([
+			{ input: 42 as const, expected: 42 as const },
+			{ input: 0 as const, expected: 0 as const },
+			{ input: '42' as const, expected: 42 as const },
+			{ input: '0' as const, expected: 0 as const },
+			{ input: null, expected: null },
+			{ input: 'null' as const, expected: null },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luNullableNumberAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: 42 | null = luNullableNumberAttribute<42>('42');
+			expect(result).toBe(42);
+		});
+	});
+
+	describe(luOptionalNumberAttribute, () => {
+		it.each([
+			{ input: 42 as const, expected: 42 as const },
+			{ input: 0 as const, expected: 0 as const },
+			{ input: '42' as const, expected: 42 as const },
+			{ input: '0' as const, expected: 0 as const },
+			{ input: undefined, expected: undefined },
+			{ input: 'undefined' as const, expected: undefined },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luOptionalNumberAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: 42 | undefined = luOptionalNumberAttribute<42>('42');
+			expect(result).toBe(42);
+		});
+	});
+
+	describe(luOptionalNullableNumberAttribute, () => {
+		it.each([
+			{ input: 42 as const, expected: 42 as const },
+			{ input: 0 as const, expected: 0 as const },
+			{ input: '42' as const, expected: 42 as const },
+			{ input: '0' as const, expected: 0 as const },
+			{ input: null, expected: null },
+			{ input: 'null' as const, expected: null },
+			{ input: undefined, expected: undefined },
+			{ input: 'undefined' as const, expected: undefined },
+		])('should return $expected for $input', ({ input, expected }) => {
+			const result = luOptionalNullableNumberAttribute(input);
+			expect(result).toBe(expected);
+		});
+
+		it('should narrow type with explicit generic parameter', () => {
+			const result: 42 | null | undefined = luOptionalNullableNumberAttribute<42>('42');
+			expect(result).toBe(42);
+		});
+	});
+});

--- a/packages/ng/core/transform/number-transform.ts
+++ b/packages/ng/core/transform/number-transform.ts
@@ -1,0 +1,62 @@
+import { numberAttribute } from '@angular/core';
+
+/**
+ * Transforms a number or a string representation of a number into a number.
+ * @template T The specific number literal type to narrow to.
+ * @param value The value to transform, can be a number or a string representation of a number.
+ * @returns The transformed number value.
+ */
+export function luNumberAttribute(value: number | `${number}`): number;
+export function luNumberAttribute<T extends number>(value: T | `${T}`): T;
+export function luNumberAttribute(value: number | `${number}`): number {
+	return numberAttribute(value);
+}
+
+/**
+ * Transforms a number, a string representation of a number, null or a string representation of null into a number or null.
+ * @template T The specific number literal type to narrow to.
+ * @param value The value to transform, can be a number, a string representation of a number, null or a string representation of null.
+ * @returns The transformed number value or null.
+ */
+export function luNullableNumberAttribute(value: number | `${number}` | null | `${null}`): number | null;
+export function luNullableNumberAttribute<T extends number>(value: T | `${T}` | null | `${null}`): T | null;
+export function luNullableNumberAttribute(value: number | `${number}` | null | `${null}`): number | null {
+	if (value === null || value === 'null') {
+		return null;
+	}
+
+	return numberAttribute(value);
+}
+
+/**
+ * Transforms a number, a string representation of a number, undefined or a string representation of undefined into a number or undefined.
+ * @template T The specific number literal type to narrow to.
+ * @param value The value to transform, can be a number, a string representation of a number, undefined or a string representation of undefined.
+ * @returns The transformed number value or undefined.
+ */
+export function luOptionalNumberAttribute(value: number | `${number}` | undefined | `${undefined}`): number | undefined;
+export function luOptionalNumberAttribute<T extends number>(value: T | `${T}` | undefined | `${undefined}`): T | undefined;
+export function luOptionalNumberAttribute(value: number | `${number}` | undefined | `${undefined}`): number | undefined {
+	if (value === undefined || value === 'undefined') {
+		return undefined;
+	}
+	return numberAttribute(value);
+}
+
+/**
+ * Transforms a number, a string representation of a number, null, a string representation of null, undefined or a string representation of undefined into a number, null or undefined.
+ * @template T The specific number literal type to narrow to.
+ * @param value The value to transform.
+ * @returns The transformed number value, null or undefined.
+ */
+export function luOptionalNullableNumberAttribute(value: number | `${number}` | null | `${null}` | undefined | `${undefined}`): number | null | undefined;
+export function luOptionalNullableNumberAttribute<T extends number>(value: T | `${T}` | null | `${null}` | undefined | `${undefined}`): T | null | undefined;
+export function luOptionalNullableNumberAttribute(value: number | `${number}` | null | `${null}` | undefined | `${undefined}`): number | null | undefined {
+	if (value === null || value === 'null') {
+		return null;
+	}
+	if (value === undefined || value === 'undefined') {
+		return undefined;
+	}
+	return numberAttribute(value);
+}

--- a/packages/ng/data-table/base-data-table-cell.ts
+++ b/packages/ng/data-table/base-data-table-cell.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
-import { isNotNil } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { isNotNil, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_DATA_TABLE_BODY_INSTANCE } from './data-table-body/data-table-body.token';
 import { LU_DATA_TABLE_FOOT_INSTANCE } from './data-table-foot/data-table-foot.token';
 import { LU_DATA_TABLE_HEAD_INSTANCE } from './data-table-head/data-table-head.token';
@@ -19,7 +19,7 @@ export abstract class BaseDataTableCell {
 	readonly footRef = inject(LU_DATA_TABLE_FOOT_INSTANCE, { optional: true });
 	readonly rowRef = inject(LU_DATA_TABLE_ROW_INSTANCE, { optional: true });
 
-	readonly editable = input(false, { transform: booleanAttribute });
+	readonly editable = input(false, { transform: luBooleanAttribute });
 	readonly align = input<DataTableAlign | null>(null);
 
 	readonly isStickyStart = computed(() => {

--- a/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
+++ b/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
 
-import { isNotNil } from '@lucca-front/ng/core';
+import { isNotNil, luBooleanAttribute } from '@lucca-front/ng/core';
 import { BaseDataTableCell } from '../base-data-table-cell';
 import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
 
@@ -31,7 +31,7 @@ import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableRowCellComponent extends BaseDataTableCell {
-	readonly actions = input(false, { transform: booleanAttribute });
+	readonly actions = input(false, { transform: luBooleanAttribute });
 
 	readonly isSticky = computed(() => {
 		return this.isStickyStart() || this.isStickyEnd();

--- a/packages/ng/data-table/data-table-head/data-table-head.component.ts
+++ b/packages/ng/data-table/data-table-head/data-table-head.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, forwardRef, input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, forwardRef, input, signal, ViewEncapsulation } from '@angular/core';
 
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { DataTableRowCellHeaderComponent } from '../data-table-cell-header/data-table-cell-header.component';
 import { LU_DATA_TABLE_HEAD_INSTANCE } from './data-table-head.token';
 
@@ -23,7 +24,7 @@ import { LU_DATA_TABLE_HEAD_INSTANCE } from './data-table-head.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DataTableHeadComponent {
-	readonly sticky = input(false, { transform: booleanAttribute });
+	readonly sticky = input(false, { transform: luBooleanAttribute });
 	readonly isFirstVisible = signal(false);
 
 	readonly cols = contentChildren(DataTableRowCellHeaderComponent, { descendants: true });

--- a/packages/ng/data-table/data-table-row/data-table-row.component.ts
+++ b/packages/ng/data-table/data-table-row/data-table-row.component.ts
@@ -1,8 +1,8 @@
 import { CdkDragHandle } from '@angular/cdk/drag-drop';
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, ElementRef, forwardRef, inject, input, model, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, ElementRef, forwardRef, inject, input, model, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -49,6 +49,6 @@ export class DataTableRowComponent {
 
 	readonly selected = model<boolean>(false);
 	readonly selectedLabel = input<string | null>(null);
-	readonly mixed = input(false, { transform: booleanAttribute });
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly mixed = input(false, { transform: luBooleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/data-table/data-table.component.ts
+++ b/packages/ng/data-table/data-table.component.ts
@@ -1,6 +1,5 @@
 import {
 	afterNextRender,
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -11,13 +10,12 @@ import {
 	forwardRef,
 	inject,
 	input,
-	numberAttribute,
 	OnInit,
 	signal,
 	viewChild,
 	ViewEncapsulation,
 } from '@angular/core';
-import { ResponsiveConfig, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { luBooleanAttribute, luNumberAttribute, ResponsiveConfig, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { DataTableHeadComponent } from './data-table-head/data-table-head.component';
 import { DataTableRowComponent } from './data-table-row/data-table-row.component';
 import { LU_DATA_TABLE_INSTANCE } from './data-table.token';
@@ -47,13 +45,13 @@ export class DataTableComponent implements OnInit {
 	readonly tableRef = viewChild<ElementRef<Element>>('tableRef');
 	#destroyRef = inject(DestroyRef);
 
-	readonly hover = input(false, { transform: booleanAttribute });
-	readonly selectable = input(false, { transform: booleanAttribute });
-	readonly layoutFixed = input(false, { transform: booleanAttribute });
-	readonly cellBorder = input(false, { transform: booleanAttribute });
-	readonly nested = input(false, { transform: booleanAttribute });
-	readonly drag = input(false, { transform: booleanAttribute });
-	readonly noOverflow = input(false, { transform: booleanAttribute });
+	readonly hover = input(false, { transform: luBooleanAttribute });
+	readonly selectable = input(false, { transform: luBooleanAttribute });
+	readonly layoutFixed = input(false, { transform: luBooleanAttribute });
+	readonly cellBorder = input(false, { transform: luBooleanAttribute });
+	readonly nested = input(false, { transform: luBooleanAttribute });
+	readonly drag = input(false, { transform: luBooleanAttribute });
+	readonly noOverflow = input(false, { transform: luBooleanAttribute });
 
 	readonly responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
 
@@ -64,8 +62,8 @@ export class DataTableComponent implements OnInit {
 
 	readonly stickyHeader = computed(() => this.header()?.sticky());
 
-	readonly stickyColsStart = input(0, { transform: numberAttribute });
-	readonly stickyColsEnd = input(0, { transform: numberAttribute });
+	readonly stickyColsStart = input(0, { transform: luNumberAttribute });
+	readonly stickyColsEnd = input(0, { transform: luNumberAttribute });
 
 	readonly firstColumnVisibleAfterColsStart = signal(true);
 	readonly lastColumnVisibleBeforeColsEnd = signal(false);

--- a/packages/ng/date/select/date-select-input.component.ts
+++ b/packages/ng/date/select/date-select-input.component.ts
@@ -2,7 +2,7 @@ import { Overlay, OverlayModule } from '@angular/cdk/overlay';
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, input, Renderer2, ViewContainerRef } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { ALuDateAdapter, ELuDateGranularity, LuDateGranularity, syncInputSignal } from '@lucca-front/ng/core';
+import { ALuDateAdapter, ELuDateGranularity, luBooleanAttribute, LuDateGranularity, syncInputSignal } from '@lucca-front/ng/core';
 import { LuInputDisplayerDirective } from '@lucca-front/ng/input';
 import { ILuInputWithPicker } from '@lucca-front/ng/picker';
 import { ALuSelectInputComponent } from '@lucca-front/ng/select';
@@ -35,9 +35,10 @@ export class LuDateSelectInputComponent<D> extends ALuSelectInputComponent<D> im
 
 	readonly granularity = input<LuDateGranularity>(ELuDateGranularity.day);
 
-	readonly hideClearer = input<boolean>(false);
+	readonly hideClearer = input(false, { transform: luBooleanAttribute });
 
 	readonly startOn = input<D>();
+
 
 	protected _startOn: D = this._adapter.forgeToday();
 

--- a/packages/ng/date/select/date-select-input.component.ts
+++ b/packages/ng/date/select/date-select-input.component.ts
@@ -39,7 +39,6 @@ export class LuDateSelectInputComponent<D> extends ALuSelectInputComponent<D> im
 
 	readonly startOn = input<D>();
 
-
 	protected _startOn: D = this._adapter.forgeToday();
 
 	get format(): string {

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, inject, input, LOCALE_ID, model, output, signal } from '@angular/core';
-import { intlInputOptions, isNotNil } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, LOCALE_ID, model, output, signal } from '@angular/core';
+import { intlInputOptions, isNotNil, luBooleanAttribute, luNullableBooleanAttribute } from '@lucca-front/ng/core';
 import { addMonths, addYears, FirstWeekContainsDateOptions, isAfter, isBefore, isSameMonth, startOfDay, startOfMonth, startOfWeek, WeekOptions } from 'date-fns';
 import { WEEK_INFO } from './calendar.token';
 import { CalendarMode } from './calendar2/calendar-mode';
@@ -42,13 +42,13 @@ export abstract class AbstractDateComponent {
 	readonly ranges = input([], {
 		transform: (v: readonly DateRange[] | readonly DateRangeInput[]) => v.map(transformDateRangeInputToDateRange).filter((range): range is DateRange => range !== null),
 	});
-	readonly hideToday = input(false, { transform: booleanAttribute });
-	readonly hasTodayButton = input(false, { transform: booleanAttribute });
-	readonly clearable = input(null, { transform: booleanAttribute });
+	readonly hideToday = input(false, { transform: luBooleanAttribute });
+	readonly hasTodayButton = input(false, { transform: luBooleanAttribute });
+	readonly clearable = input(null, { transform: luNullableBooleanAttribute });
 	readonly clearBehavior = input<Date2ClearBehavior>('clear');
+	readonly hideWeekend = input(false, { transform: luBooleanAttribute });
 
 	readonly mode = input<CalendarMode>('day');
-	readonly hideWeekend = input(false, { transform: booleanAttribute });
 
 	readonly getCellInfo = input<((day: Date, mode: CalendarMode) => CellStatus) | null>();
 

--- a/packages/ng/date2/calendar2/calendar2.component.html
+++ b/packages/ng/date2/calendar2/calendar2.component.html
@@ -160,7 +160,7 @@
 											(keydown.space)="day.disabled ? null : onCellClicked(day.date)"
 											(focus)="day.isOverflow ? null : dateHovered.set(day.date)"
 											(blur)="day.isOverflow ? null : dateHovered.set(null)"
-											[luTooltip]="day.label"
+											[luTooltip]="day.label ?? ''"
 											tabindex="-1"
 										>
 											{{ day.day }}

--- a/packages/ng/date2/calendar2/calendar2.component.ts
+++ b/packages/ng/date2/calendar2/calendar2.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, LOCALE_ID, model, OnInit, output, viewChildren, ViewEncapsulation } from '@angular/core';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, LOCALE_ID, model, OnInit, output, viewChildren, ViewEncapsulation } from '@angular/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import {
 	addHours,
@@ -88,19 +88,19 @@ export class Calendar2Component implements OnInit {
 
 	readonly intl = input(...intlInputOptions(LU_DATE2_TRANSLATIONS));
 
-	readonly showOverflow = input(false, { transform: booleanAttribute });
+	readonly showOverflow = input(false, { transform: luBooleanAttribute });
 
-	readonly enableOverflow = input(false, { transform: booleanAttribute });
+	readonly enableOverflow = input(false, { transform: luBooleanAttribute });
 
-	readonly removeYearOverflow = input(false, { transform: booleanAttribute });
+	readonly removeYearOverflow = input(false, { transform: luBooleanAttribute });
 
-	readonly hideToday = input(false, { transform: booleanAttribute });
+	readonly hideToday = input(false, { transform: luBooleanAttribute });
 
-	readonly hasTodayButton = input(false, { transform: booleanAttribute });
+	readonly hasTodayButton = input(false, { transform: luBooleanAttribute });
 
-	readonly hideWeekend = input(false, { transform: booleanAttribute });
+	readonly hideWeekend = input(false, { transform: luBooleanAttribute });
 
-	readonly disableModeChange = input(false, { transform: booleanAttribute });
+	readonly disableModeChange = input(false, { transform: luBooleanAttribute });
 
 	// Date used to init the component and as internal focus model
 	readonly date = model.required<Date>();

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -2,7 +2,6 @@ import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { NgTemplateOutlet } from '@angular/common';
 import {
 	afterNextRender,
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -21,7 +20,7 @@ import {
 import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgModel, Validator } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { isNil, isNotNil, LuClass, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNil, isNotNil, luBooleanAttribute, LuClass, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { InputDirective, PresentationDisplayDirective } from '@lucca-front/ng/form-field';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -84,9 +83,9 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 
 	readonly placeholder = input<string>();
 
-	readonly disableOverflow = input(false, { transform: booleanAttribute });
-	readonly hideOverflow = input(false, { transform: booleanAttribute });
-	readonly widthAuto = input(false, { transform: booleanAttribute });
+	readonly disableOverflow = input(false, { transform: luBooleanAttribute });
+	readonly hideOverflow = input(false, { transform: luBooleanAttribute });
+	readonly widthAuto = input(false, { transform: luBooleanAttribute });
 
 	readonly filterPillDisabled = signal(false);
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -3,7 +3,6 @@ import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { NgTemplateOutlet } from '@angular/common';
 import {
 	afterNextRender,
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -24,7 +23,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { AbstractControl, ControlValueAccessor, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgModel, ValidationErrors, Validator } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { isNil, isNotNil, LuClass, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNil, isNotNil, luBooleanAttribute, LuClass, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { FORM_FIELD_INSTANCE, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -113,7 +112,7 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 	readonly placeholder = input<string>();
 
-	readonly widthAuto = input(false, { transform: booleanAttribute });
+	readonly widthAuto = input(false, { transform: luBooleanAttribute });
 
 	readonly label: Signal<PortalContent | undefined> = signal('');
 

--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
@@ -34,14 +34,17 @@ export function createDialogRoute<C>(dialogRouteConfig: DialogRouteConfig<C>): R
 				path: '',
 				canDeactivate: dialogRouteConfig.canDeactivate
 					?.map((fn) => toCanDeactivateFn(fn))
-					?.map((guard): CanDeactivateFn<C> => (dialogComponentInstance, route, state, nextState) => {
-						// If dialogComponentInstance is null, it means the dialog is already closed. We allow deactivation in this case.
-						if (!dialogComponentInstance) {
-							return true;
-						}
+					?.map(
+						(guard): CanDeactivateFn<C> =>
+							(dialogComponentInstance, route, state, nextState) => {
+								// If dialogComponentInstance is null, it means the dialog is already closed. We allow deactivation in this case.
+								if (!dialogComponentInstance) {
+									return true;
+								}
 
-						return guard(dialogComponentInstance, route, state, nextState);
-					}),
+								return guard(dialogComponentInstance, route, state, nextState);
+							},
+					),
 			},
 		],
 	};

--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.ts
@@ -34,17 +34,14 @@ export function createDialogRoute<C>(dialogRouteConfig: DialogRouteConfig<C>): R
 				path: '',
 				canDeactivate: dialogRouteConfig.canDeactivate
 					?.map((fn) => toCanDeactivateFn(fn))
-					?.map(
-						(guard): CanDeactivateFn<C> =>
-							(dialogComponentInstance, route, state, nextState) => {
-								// If dialogComponentInstance is null, it means the dialog is already closed. We allow deactivation in this case.
-								if (!dialogComponentInstance) {
-									return true;
-								}
+					?.map((guard): CanDeactivateFn<C> => (dialogComponentInstance, route, state, nextState) => {
+						// If dialogComponentInstance is null, it means the dialog is already closed. We allow deactivation in this case.
+						if (!dialogComponentInstance) {
+							return true;
+						}
 
-								return guard(dialogComponentInstance, route, state, nextState);
-							},
-					),
+						return guard(dialogComponentInstance, route, state, nextState);
+					}),
 			},
 		],
 	};

--- a/packages/ng/dialog/dialog/dialog.component.ts
+++ b/packages/ng/dialog/dialog/dialog.component.ts
@@ -1,4 +1,5 @@
-import { AfterViewInit, booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
 import { DialogFancyIllustration } from '../dialog.type';
 import { LuDialogRef } from '../model';
@@ -18,7 +19,7 @@ import { LuDialogRef } from '../model';
 export class DialogComponent implements AfterViewInit {
 	public readonly dialogRef = inject<LuDialogRef>(LuDialogRef);
 
-	readonly stacked = input(false, { transform: booleanAttribute });
+	readonly stacked = input(false, { transform: luBooleanAttribute });
 	readonly fancyIllustration = input<DialogFancyIllustration>('welcome');
 	readonly fancyIllustrationUrl = input<string | null>(null);
 

--- a/packages/ng/divider/divider.component.ts
+++ b/packages/ng/divider/divider.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, OnChanges, viewChild, ViewEncapsulation } from '@angular/core';
-import { LuClass } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, OnChanges, viewChild, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass } from '@lucca-front/ng/core';
 import { DividerSize } from './divider.type';
 
 @Component({
@@ -24,9 +24,9 @@ export class DividerComponent implements OnChanges {
 	 * Allows rendering the Divider as a native separator
 	 * (Any text content it may have will no longer be rendered)
 	 */
-	readonly separatorRole = input(false, { transform: booleanAttribute });
+	readonly separatorRole = input(false, { transform: luBooleanAttribute });
 
-	readonly vertical = input(false, { transform: booleanAttribute });
+	readonly vertical = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Which size should the chip be? Defaults or small
@@ -36,7 +36,7 @@ export class DividerComponent implements OnChanges {
 	/**
 	 * @deprecated
 	 */
-	readonly withRole = input(false, { transform: booleanAttribute });
+	readonly withRole = input(false, { transform: luBooleanAttribute });
 
 	readonly classesConfig = computed(() => ({ [`mod-${this.size()}`]: !!this.size() }));
 

--- a/packages/ng/dropdown/dropdown-action/dropdown-action.component.ts
+++ b/packages/ng/dropdown/dropdown-action/dropdown-action.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { PopoverContentComponent } from '@lucca-front/ng/popover2';
 
 @Component({
@@ -17,8 +18,8 @@ import { PopoverContentComponent } from '@lucca-front/ng/popover2';
 export class DropdownActionComponent {
 	#popoverContentRef = inject(PopoverContentComponent, { optional: true });
 
-	readonly disabled = input(false, { transform: booleanAttribute });
-	readonly critical = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
+	readonly critical = input(false, { transform: luBooleanAttribute });
 
 	closePanel() {
 		if (this.#popoverContentRef) {

--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, input, numberAttribute, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luNumberAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
 import { Hx, HxStyle } from '../empty-state.type';
 
@@ -59,9 +59,9 @@ export class EmptyStatePageComponent {
 
 	readonly description = input<PortalContent>();
 
-	readonly hx = input(1, { transform: numberAttribute as (value: Hx | `${Hx}`) => Hx });
+	readonly hx = input(1, { transform: luNumberAttribute<Hx> });
 
-	readonly hxStyle = input(1, { transform: numberAttribute as (value: HxStyle | `${HxStyle}`) => HxStyle });
+	readonly hxStyle = input(1, { transform: luNumberAttribute<HxStyle> });
 
 	public isStringPortalContent(message: PortalContent): message is string {
 		return typeof message === 'string';

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation, booleanAttribute, computed, input, numberAttribute } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 import { BubbleIllustration, BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration';
-import { Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { luBooleanAttribute, luNumberAttribute, Palette, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { Hx, ICON_TO_ILLUSTRATION } from '../empty-state.type';
 
 @Component({
@@ -17,7 +17,7 @@ export class EmptyStateSectionComponent {
 	readonly actionIllustration = computed(() => this.action() || this.icon()?.includes('Action.svg'));
 
 	readonly illustration = input<BubbleIllustration | string | null>(null);
-	readonly action = input(false, { transform: booleanAttribute });
+	readonly action = input(false, { transform: luBooleanAttribute });
 
 	readonly iconOrIllustration = computed(() => {
 		const icon = this.icon();
@@ -42,7 +42,7 @@ export class EmptyStateSectionComponent {
 	 */
 	readonly palette = input<Palette>('none');
 
-	readonly center = input(false, { transform: booleanAttribute });
+	readonly center = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * The title of the empty state section
@@ -57,7 +57,7 @@ export class EmptyStateSectionComponent {
 	/**
 	 * Define the aria level of the title
 	 */
-	readonly hx = input(3, { transform: numberAttribute as (value: Hx | `${Hx}`) => Hx });
+	readonly hx = input(3, { transform: luNumberAttribute<Hx> });
 
 	readonly emptyStateClasses = computed(() => ({ [`palette-${this.palette()}`]: !!this.palette() }));
 

--- a/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
+++ b/packages/ng/empty-state/empty-state-section/empty-state-section.component.ts
@@ -14,7 +14,7 @@ import { Hx, ICON_TO_ILLUSTRATION } from '../empty-state.type';
 export class EmptyStateSectionComponent {
 	/** @deprecated use illustration and action */
 	readonly icon = input<string | null>(null);
-	readonly actionIllustration = computed(() => this.action() || this.icon()?.includes('Action.svg'));
+	readonly actionIllustration = computed(() => this.action() || (this.icon()?.includes('Action.svg') ?? false));
 
 	readonly illustration = input<BubbleIllustration | string | null>(null);
 	readonly action = input(false, { transform: luBooleanAttribute });

--- a/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
+++ b/packages/ng/file-upload/base-file-upload/base-file-upload.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, computed, Directive, effect, inject, input, LOCALE_ID, output } from '@angular/core';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { computed, Directive, effect, inject, input, LOCALE_ID, output } from '@angular/core';
+import { intlInputOptions, luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE } from '@lucca-front/ng/form-field';
 import { LU_FILE_UPLOAD_TRANSLATIONS } from '../file-upload.translate';
 import { FileUploadSize } from '../file-upload.type';
@@ -52,15 +52,15 @@ export abstract class BaseFileUploadComponent {
 		return this.acceptAttribute().some((str) => str.includes('*'));
 	});
 
-	readonly structure = input(false, { transform: booleanAttribute });
+	readonly structure = input(false, { transform: luBooleanAttribute });
 
-	readonly fileMaxSize = input<number>(80 * MEGA_BYTE);
+	readonly fileMaxSize = input(80 * MEGA_BYTE, { transform: luNumberAttribute });
 
 	readonly maxSizeDisplay = computed(() => formatFileSize(this.locale, this.fileMaxSize()));
 
 	readonly size = input<FileUploadSize | null>(null);
 
-	readonly password = input(false, { transform: booleanAttribute });
+	readonly password = input(false, { transform: luBooleanAttribute });
 
 	readonly illustration = input<
 		/** @deprecated use 'invoice' instead */
@@ -77,9 +77,9 @@ export abstract class BaseFileUploadComponent {
 		}
 	});
 
-	readonly required = input(false, { transform: booleanAttribute });
+	readonly required = input(false, { transform: luBooleanAttribute });
 
-	readonly buttonFilled = input(false, { transform: booleanAttribute });
+	readonly buttonFilled = input(false, { transform: luBooleanAttribute });
 
 	constructor() {
 		effect(() => {

--- a/packages/ng/file-upload/file-entry/file-entry.component.ts
+++ b/packages/ng/file-upload/file-entry/file-entry.component.ts
@@ -35,7 +35,7 @@ export class FileEntryComponent {
 
 	readonly displayFileName = input(false, { transform: luBooleanAttribute });
 
-	readonly structure = input(false, { transform: booleanAttribute });
+	readonly structure = input(false, { transform: luBooleanAttribute });
 
 	readonly inlineMessageError = input<string | null>(null);
 
@@ -47,7 +47,7 @@ export class FileEntryComponent {
 
 	readonly downloadURL = input('');
 
-	readonly openInNewTab = input(false, { transform: booleanAttribute });
+	readonly openInNewTab = input(false, { transform: luBooleanAttribute });
 
 	readonly password = input('');
 	readonly passwordChange$ = new Subject<string>();

--- a/packages/ng/file-upload/file-entry/file-entry.component.ts
+++ b/packages/ng/file-upload/file-entry/file-entry.component.ts
@@ -1,8 +1,8 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, ViewEncapsulation } from '@angular/core';
 import { outputFromObservable } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@lucca-front/ng/button';
-import { intlInputOptions, IntlParamsPipe, isNotNil } from '@lucca-front/ng/core';
+import { intlInputOptions, IntlParamsPipe, isNotNil, luBooleanAttribute } from '@lucca-front/ng/core';
 import { DividerComponent } from '@lucca-front/ng/divider';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TextInputComponent } from '@lucca-front/ng/forms';
@@ -33,7 +33,7 @@ export class FileEntryComponent {
 
 	readonly state = input<FileEntryState>('default');
 
-	readonly displayFileName = input(false, { transform: booleanAttribute });
+	readonly displayFileName = input(false, { transform: luBooleanAttribute });
 
 	readonly structure = input(false, { transform: booleanAttribute });
 
@@ -57,7 +57,7 @@ export class FileEntryComponent {
 		return this.passwordChange$.observed;
 	}
 
-	readonly media = input(false, { transform: booleanAttribute });
+	readonly media = input(false, { transform: luBooleanAttribute });
 
 	readonly deleteFile$ = new Subject<void>();
 

--- a/packages/ng/file-upload/single/single-file-upload.component.ts
+++ b/packages/ng/file-upload/single/single-file-upload.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
 import { BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration';
-import { IntlParamsPipe } from '@lucca-front/ng/core';
+import { IntlParamsPipe, luBooleanAttribute } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.component';
 
@@ -12,4 +12,16 @@ import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.co
 	imports: [InputDirective, IntlParamsPipe, BubbleIllustrationComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SingleFileUploadComponent extends BaseFileUploadComponent {}
+export class SingleFileUploadComponent extends BaseFileUploadComponent {
+	readonly entry = input<FileEntry | null>(null);
+
+	readonly state = input<'loading' | 'success' | 'error' | 'default'>('default');
+
+	readonly inlineMessageError = input<string | null>(null);
+
+	readonly previewUrl = input<string | null>(null);
+
+	readonly deleteFile = output<void>();
+
+	readonly displayFileName = input(false, { transform: luBooleanAttribute });
+}

--- a/packages/ng/file-upload/single/single-file-upload.component.ts
+++ b/packages/ng/file-upload/single/single-file-upload.component.ts
@@ -3,6 +3,7 @@ import { BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration
 import { IntlParamsPipe, luBooleanAttribute } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.component';
+import { FileEntry } from '../file-upload-entry';
 
 @Component({
 	selector: 'lu-single-file-upload',

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -1,7 +1,6 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { NgTemplateOutlet } from '@angular/common';
 import {
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -22,7 +21,7 @@ import {
 import { FormsModule } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
@@ -81,7 +80,7 @@ export class FilterPillComponent {
 
 	readonly name = input<string>();
 
-	readonly optional = input(false, { transform: booleanAttribute });
+	readonly optional = input(false, { transform: luBooleanAttribute });
 
 	readonly disabled = computed(() => this.inputComponentRef()?.filterPillDisabled?.() || false);
 

--- a/packages/ng/footer/footer.component.ts
+++ b/packages/ng/footer/footer.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { FooterContainerMax, FooterNarrowAtMediaMax } from './footer.type';
 
 @Component({
@@ -11,18 +12,18 @@ import { FooterContainerMax, FooterNarrowAtMediaMax } from './footer.type';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FooterComponent {
-	readonly sticky = input(false, { transform: booleanAttribute });
+	readonly sticky = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Applies a container around the Page Header content
 	 */
-	readonly container = input(false, { transform: booleanAttribute });
+	readonly container = input(false, { transform: luBooleanAttribute });
 
 	readonly containerMax = input<FooterContainerMax | null>();
 
-	readonly forceNarrow = input(false, { transform: booleanAttribute });
+	readonly forceNarrow = input(false, { transform: luBooleanAttribute });
 
-	readonly dialog = input(false, { transform: booleanAttribute });
+	readonly dialog = input(false, { transform: luBooleanAttribute });
 
 	readonly narrowAtMediaMax = input<FooterNarrowAtMediaMax>('XXS');
 

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -13,7 +13,6 @@ import {
 	Injector,
 	input,
 	model,
-	numberAttribute,
 	OnDestroy,
 	Renderer2,
 	signal,
@@ -23,7 +22,18 @@ import {
 import { AbstractControl, NgControl, ReactiveFormsModule, RequiredValidator, Validators } from '@angular/forms';
 import { FormField } from '@angular/forms/signals';
 import { SafeHtml } from '@angular/platform-browser';
-import { intlInputOptions, isNotNil, LuClass, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import {
+	intlInputOptions,
+	isNotNil,
+	luBooleanAttribute,
+	LuClass,
+	luNullableBooleanAttribute,
+	luNullableNumberAttribute,
+	luNumberAttribute,
+	PortalContent,
+	PortalDirective,
+	ɵeffectWithDeps,
+} from '@lucca-front/ng/core';
 import { LU_FORM_INSTANCE } from '@lucca-front/ng/form';
 import { FormLabelComponent } from '@lucca-front/ng/form-label';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -90,13 +100,13 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	/**
 	 * Hide field label, while keeping it in DOM for screen readers
 	 */
-	readonly hiddenLabel = input(false, { transform: booleanAttribute });
+	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
 
 	readonly rolePresentationLabel = model(false);
 
 	readonly labelIsPresentation = computed(() => this.rolePresentationLabel() || this.presentation());
 
-	readonly inline = input(false, { transform: booleanAttribute });
+	readonly inline = input(false, { transform: luBooleanAttribute });
 
 	readonly statusControl = input<AbstractControl | null>(null);
 
@@ -104,18 +114,16 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	readonly tag = input<string | null>(null);
 
-	readonly AI = input(false, { transform: booleanAttribute });
+	readonly AI = input(false, { transform: luBooleanAttribute });
 	readonly iconAItooltip = input<string | null>(null);
 	readonly iconAIalt = input<string | null>(null);
 
-	readonly width = input<FormFieldWidth | null, FormFieldWidth | `${FormFieldWidth}` | null>(null, {
-		transform: numberAttribute as (value: FormFieldWidth | `${FormFieldWidth}`) => FormFieldWidth,
-	});
+	readonly width = input(null, { transform: luNullableNumberAttribute<FormFieldWidth> });
 
 	readonly #invalidStatus = signal(false);
 	invalidStatus = this.#invalidStatus.asReadonly();
 
-	readonly invalid = input<boolean | null, boolean>(null, { transform: booleanAttribute });
+	readonly invalid = input(null, { transform: luNullableBooleanAttribute });
 
 	readonly inlineMessage = input<PortalContent | null>(null);
 
@@ -143,11 +151,11 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 	/**
 	 * Max amount of characters allowed, defaults to 0, which means hidden, no maximum
 	 */
-	readonly counter = input<number>(0);
+	readonly counter = input(0, { transform: luNumberAttribute });
 
 	readonly contentLength = signal<number>(0);
 
-	readonly presentation = input(false, { transform: booleanAttribute });
+	readonly presentation = input(false, { transform: luBooleanAttribute });
 
 	readonly presentationMode = computed(() => this.parentForm?.presentation() || this.presentation());
 

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -1,7 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
 	afterNextRender,
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -268,7 +267,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	#isInputRequired(): boolean {
 		const hasRequiredFormControl = this.ownControls().some((c) => c.control?.hasValidator(Validators.required));
-		const hasRequiredNgModel = this.ownRequiredValidators().some((c) => booleanAttribute(c.required));
+		const hasRequiredNgModel = this.ownRequiredValidators().some((c) => luBooleanAttribute(c.required));
 		const hasRequiredFormField = this.ownFormFields().some((c) => c.state().required());
 		return hasRequiredFormField || hasRequiredNgModel || hasRequiredFormControl;
 	}

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -1,6 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
 import {
 	afterNextRender,
+	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -267,7 +268,7 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	#isInputRequired(): boolean {
 		const hasRequiredFormControl = this.ownControls().some((c) => c.control?.hasValidator(Validators.required));
-		const hasRequiredNgModel = this.ownRequiredValidators().some((c) => luBooleanAttribute(c.required));
+		const hasRequiredNgModel = this.ownRequiredValidators().some((c) => booleanAttribute(c.required));
 		const hasRequiredFormField = this.ownFormFields().some((c) => c.state().required());
 		return hasRequiredFormField || hasRequiredNgModel || hasRequiredFormControl;
 	}

--- a/packages/ng/form-field/input-framed/input-framed.component.ts
+++ b/packages/ng/form-field/input-framed/input-framed.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { InputFramedSize } from './input-framed.type';
 import { INPUT_FRAMED_INSTANCE } from './input-framed.token';
 
@@ -18,6 +18,6 @@ import { INPUT_FRAMED_INSTANCE } from './input-framed.token';
 })
 export class InputFramedComponent {
 	readonly framedPortal = input<PortalContent | null>(null);
-	readonly center = input(false, { transform: booleanAttribute });
+	readonly center = input(false, { transform: luBooleanAttribute });
 	readonly size = input<InputFramedSize | null>(null);
 }

--- a/packages/ng/form-field/input.directive.ts
+++ b/packages/ng/form-field/input.directive.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, Directive, ElementRef, inject, input, OnInit } from '@angular/core';
+import { Directive, ElementRef, inject, input, OnInit } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE } from './form-field.token';
 
 @Directive({
@@ -16,7 +17,7 @@ export class InputDirective implements OnInit {
 	/**
 	 * Prevents message and label ids from being propagated, useful if the input holds its own message and label (like for radios)
 	 */
-	readonly standalone = input(false, { transform: booleanAttribute, alias: 'luInputStandalone' });
+	readonly standalone = input(false, { transform: luBooleanAttribute, alias: 'luInputStandalone' });
 
 	ngOnInit(): void {
 		// If the field is used as standalone, we won't have the ref provided so it'll crash

--- a/packages/ng/form-field/value-presentation/data-presentation/data-presentation.component.ts
+++ b/packages/ng/form-field/value-presentation/data-presentation/data-presentation.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-data-presentation',
@@ -11,6 +11,6 @@ import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
 })
 export class DataPresentationComponent {
 	readonly label = input.required<PortalContent>();
-	readonly noValue = input(false, { transform: booleanAttribute });
+	readonly noValue = input(false, { transform: luBooleanAttribute });
 	readonly size = input<'S' | null>(null);
 }

--- a/packages/ng/form-header/form-header.component.ts
+++ b/packages/ng/form-header/form-header.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luNumberAttribute } from '@lucca-front/ng/core';
 import { FormHeaderHeadingLevel } from './form-header.type';
 
 @Component({
@@ -14,5 +15,5 @@ export class FormHeaderComponent {
 	/**
 	 * Define the aria level of the title
 	 */
-	readonly headingLevel = input<FormHeaderHeadingLevel>(1);
+	readonly headingLevel = input(1, { transform: luNumberAttribute<FormHeaderHeadingLevel> });
 }

--- a/packages/ng/form-label/form-label.component.ts
+++ b/packages/ng/form-label/form-label.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, ViewEncapsulation } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
-import { getIntlPluralLabel, intlInputOptions, IntlParamsPipe, LOCALE_PLURAL_RULES } from '@lucca-front/ng/core';
+import { getIntlPluralLabel, intlInputOptions, IntlParamsPipe, LOCALE_PLURAL_RULES, luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { TagComponent } from '@lucca-front/ng/tag';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
@@ -30,12 +30,12 @@ export class FormLabelComponent {
 	readonly pluralRules = inject(LOCALE_PLURAL_RULES);
 	readonly counterAltLabel = computed(() => getIntlPluralLabel(this.pluralRules, this.intl().counterAlt, this.counterStatus()));
 
-	readonly required = input(false, { transform: booleanAttribute });
-	readonly error = input(false, { transform: booleanAttribute });
+	readonly required = input(false, { transform: luBooleanAttribute });
+	readonly error = input(false, { transform: luBooleanAttribute });
 	readonly tooltip = input<string | SafeHtml | null>(null);
 	readonly tag = input<string | null>(null);
 	readonly size = input<FormLabelSize | null>(null);
-	readonly counterStatus = input(0, { transform: numberAttribute });
-	readonly counterMax = input(0, { transform: numberAttribute });
+	readonly counterStatus = input(0, { transform: luNumberAttribute });
+	readonly counterMax = input(0, { transform: luNumberAttribute });
 	readonly counterId = input<string | null>(null);
 }

--- a/packages/ng/form/form.component.ts
+++ b/packages/ng/form/form.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_FORM_INSTANCE } from './form-instance';
 import { LuDialogRef } from '@lucca-front/ng/dialog';
 
@@ -25,7 +26,7 @@ import { LuDialogRef } from '@lucca-front/ng/dialog';
 export class FormComponent {
 	protected readonly dialogRef = inject(LuDialogRef, { optional: true });
 
-	readonly maxWidth = input(false, { transform: booleanAttribute });
+	readonly maxWidth = input(false, { transform: luBooleanAttribute });
 
-	readonly presentation = input(false, { transform: booleanAttribute });
+	readonly presentation = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, input, signal, Signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, input, signal, Signal, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { getIntl } from '@lucca-front/ng/core';
+import { getIntl, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent, FilterPillLabelDirective, FilterPillLayout } from '@lucca-front/ng/filter-pills';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, INPUT_FRAMED_INSTANCE, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
@@ -35,12 +35,12 @@ export class CheckboxInputComponent implements FilterPillInputComponent {
 	readonly formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
 	readonly intl = getIntl(CHECKBOX_INPUT_TRANSLATIONS);
 
-	readonly checklist = input(false, { transform: booleanAttribute });
+	readonly checklist = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Should set aria-checked='mixed' attribute ?
 	 */
-	readonly mixed = input(false, { transform: booleanAttribute });
+	readonly mixed = input(false, { transform: luBooleanAttribute });
 
 	readonly isFilterPill = signal<boolean>(false);
 	filterPillInputId = `lu-checkbox-pill-input-${nextId++}`;

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -1,7 +1,7 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, Injector, input, OnInit, signal, Signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, Injector, input, OnInit, signal, Signal, ViewEncapsulation } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
-import { getIntl } from '@lucca-front/ng/core';
+import { getIntl, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent, FilterPillLabelDirective, FilterPillLayout } from '@lucca-front/ng/filter-pills';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, INPUT_FRAMED_INSTANCE, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
@@ -38,12 +38,12 @@ export class CheckboxInputComponent implements FilterPillInputComponent, OnInit 
 	readonly formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
 	readonly intl = getIntl(CHECKBOX_INPUT_TRANSLATIONS);
 
-	readonly checklist = input(false, { transform: booleanAttribute });
+	readonly checklist = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Should set aria-checked='mixed' attribute ?
 	 */
-	readonly mixed = input(false, { transform: booleanAttribute });
+	readonly mixed = input(false, { transform: luBooleanAttribute });
 
 	readonly isFilterPill = signal<boolean>(false);
 	filterPillInputId = `lu-checkbox-pill-input-${nextId++}`;

--- a/packages/ng/forms/color-input/color-input.component.ts
+++ b/packages/ng/forms/color-input/color-input.component.ts
@@ -1,8 +1,8 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, HostListener, input, Signal, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, HostListener, input, Signal, signal, ViewEncapsulation } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ColorComponent } from '@lucca-front/ng/color';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LuCoreSelectNoClueDirective, LuDisplayerDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
 import { ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
@@ -37,8 +37,8 @@ export class ColorInputComponent {
 
 	readonly clue = signal<string>('');
 	readonly colors = input.required<ColorOption[]>();
-	readonly clearable = input(false, { transform: booleanAttribute });
-	readonly compact = input(false, { transform: booleanAttribute });
+	readonly clearable = input(false, { transform: luBooleanAttribute });
+	readonly compact = input(false, { transform: luBooleanAttribute });
 
 	ngControl = injectNgControl();
 

--- a/packages/ng/forms/fieldset/fieldset.component.ts
+++ b/packages/ng/forms/fieldset/fieldset.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
+import { PortalContent, PortalDirective, luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { ButtonComponent } from '@lucca/prisme/button';
 import { FieldsetSize } from './fieldset.type';
@@ -20,9 +20,9 @@ export class FieldsetComponent {
 	readonly helper = input<PortalContent | null>(null);
 	readonly action = input<PortalContent | null>(null);
 	readonly size = input<FieldsetSize | null>(null);
-	readonly horizontal = input(false, { transform: booleanAttribute });
-	readonly expandable = input(false, { transform: booleanAttribute });
-	readonly hiddenLegend = input(false, { transform: booleanAttribute });
+	readonly horizontal = input(false, { transform: luBooleanAttribute });
+	readonly expandable = input(false, { transform: luBooleanAttribute });
+	readonly hiddenLegend = input(false, { transform: luBooleanAttribute });
 
 	readonly expanded = model(false);
 

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -1,5 +1,5 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, forwardRef, inject, input, LOCALE_ID, output, signal, ViewEncapsulation, WritableSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, forwardRef, inject, input, LOCALE_ID, output, signal, ViewEncapsulation, WritableSignal } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
 import { intlInputOptions, IntlParamsPipe, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
@@ -60,9 +60,9 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	readonly autocomplete = input<AutoFill>('off');
 
-	readonly hasNoInvariant = input(false, { transform: booleanAttribute });
+	readonly hasNoInvariant = input(false, { transform: luBooleanAttribute });
 
-	readonly hasAIButtons = input(false, { transform: booleanAttribute });
+	readonly hasAIButtons = input(false, { transform: luBooleanAttribute });
 
 	readonly displayLocale = input('');
 

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -1,7 +1,7 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, forwardRef, inject, input, LOCALE_ID, output, signal, ViewEncapsulation, WritableSignal } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR, ReactiveFormsModule } from '@angular/forms';
-import { intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
+import { intlInputOptions, IntlParamsPipe, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
@@ -56,7 +56,7 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	readonly placeholder = input('');
 
-	readonly openOnFocus = input(false, { transform: booleanAttribute });
+	readonly openOnFocus = input(false, { transform: luBooleanAttribute });
 
 	readonly autocomplete = input<AutoFill>('off');
 

--- a/packages/ng/forms/number-format-input/number-format-input.component.ts
+++ b/packages/ng/forms/number-format-input/number-format-input.component.ts
@@ -1,9 +1,9 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, booleanAttribute, ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, LOCALE_ID, signal, viewChild, ViewEncapsulation } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, LOCALE_ID, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, luOptionalNumberAttribute } from '@lucca-front/ng/core';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { NumberFormat, NumberFormatCurrencyDisplay, NumberFormatDirective, NumberFormatOptions, NumberFormatStyle, NumberFormatUnit, NumberFormatUnitDisplay } from '@lucca-front/ng/number-format';
 import { startWith } from 'rxjs/operators';
@@ -33,7 +33,7 @@ export class NumberFormatInputComponent implements AfterViewInit {
 
 	readonly formatStyle = input<NumberFormatStyle>('decimal');
 
-	readonly useAutoPrefixSuffix = input(false, { transform: booleanAttribute });
+	readonly useAutoPrefixSuffix = input(false, { transform: luBooleanAttribute });
 
 	readonly prefix = input<TextInputAddon | undefined>(undefined);
 
@@ -47,15 +47,15 @@ export class NumberFormatInputComponent implements AfterViewInit {
 
 	readonly unitDisplay = input<NumberFormatUnitDisplay | undefined>(undefined);
 
-	readonly min = input<number | undefined>(undefined);
+	readonly min = input(undefined, { transform: luOptionalNumberAttribute });
 
-	readonly max = input<number | undefined>(undefined);
+	readonly max = input(undefined, { transform: luOptionalNumberAttribute });
 
 	readonly placeholder = input<string>('');
 
-	readonly hasClearer = input(false, { transform: booleanAttribute });
+	readonly hasClearer = input(false, { transform: luBooleanAttribute });
 
-	readonly valueAlignRight = input(false, { transform: booleanAttribute });
+	readonly valueAlignRight = input(false, { transform: luBooleanAttribute });
 
 	readonly inputElementRef = viewChild<ElementRef<HTMLInputElement>>('inputElement');
 

--- a/packages/ng/forms/number-input/number-input.component.ts
+++ b/packages/ng/forms/number-input/number-input.component.ts
@@ -1,8 +1,8 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, input, numberAttribute, viewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, input, viewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, luNumberAttribute, luOptionalNumberAttribute } from '@lucca-front/ng/core';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { FormFieldIdDirective } from '../form-field-id.directive';
 import { injectNgControl } from '../inject-ng-control';
@@ -23,11 +23,11 @@ export class NumberInputComponent {
 
 	readonly placeholder = input<string>('');
 
-	readonly step = input<number, number>(1, { transform: numberAttribute });
+	readonly step = input(1, { transform: luNumberAttribute });
 
-	readonly noSpinButtons = input(false, { transform: booleanAttribute });
+	readonly noSpinButtons = input(false, { transform: luBooleanAttribute });
 
-	readonly hasClearer = input(false, { transform: booleanAttribute });
+	readonly hasClearer = input(false, { transform: luBooleanAttribute });
 
 	readonly inputElementRef = viewChild.required<ElementRef<HTMLInputElement>>('inputElement');
 
@@ -35,11 +35,11 @@ export class NumberInputComponent {
 
 	readonly suffix = input<TextInputAddon>();
 
-	readonly min = input<number>();
+	readonly min = input(undefined, { transform: luOptionalNumberAttribute });
 
-	readonly max = input<number>();
+	readonly max = input(undefined, { transform: luOptionalNumberAttribute });
 
-	readonly valueAlignRight = input(false, { transform: booleanAttribute });
+	readonly valueAlignRight = input(false, { transform: luBooleanAttribute });
 
 	readonly intl = input(...intlInputOptions(LU_NUMBERFIELD_TRANSLATIONS));
 

--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, forwardRef, inject, input, LOCALE_ID, output, signal, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, FormsModule, NG_VALIDATORS, NG_VALUE_ACCESSOR, ValidationErrors, Validator } from '@angular/forms';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { LuDisplayerDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
@@ -74,7 +75,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 	 */
 	readonly allowedCountries = input<ReadonlyArray<CountryCode | string>>([]);
 
-	readonly noAutoPlaceholder = input<boolean>(false);
+	readonly noAutoPlaceholder = input(false, { transform: luBooleanAttribute });
 
 	readonly defaultCountryCode = input<CountryCode>(undefined, { alias: 'country' });
 

--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -34,7 +34,7 @@ function tryParsePhoneNumber(phoneNumber: string, countryCode?: CountryCode): Pa
 		};
 	} catch {
 		return {
-			number: phoneNumber,
+			number: phoneNumber as E164Number,
 			nationalNumber: phoneNumber,
 			isValid: false,
 		};
@@ -195,7 +195,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 				this.#onChange?.(number);
 				return;
 			} catch {
-				this.#onChange?.(displayedNumber);
+				this.#onChange?.(displayedNumber as E164Number);
 			}
 		}
 	}

--- a/packages/ng/forms/phone-number-input/phone-number-input.component.ts
+++ b/packages/ng/forms/phone-number-input/phone-number-input.component.ts
@@ -34,7 +34,7 @@ function tryParsePhoneNumber(phoneNumber: string, countryCode?: CountryCode): Pa
 		};
 	} catch {
 		return {
-			number: phoneNumber as E164Number,
+			number: phoneNumber,
 			nationalNumber: phoneNumber,
 			isValid: false,
 		};
@@ -195,7 +195,7 @@ export class PhoneNumberInputComponent implements ControlValueAccessor, Validato
 				this.#onChange?.(number);
 				return;
 			} catch {
-				this.#onChange?.(displayedNumber as E164Number);
+				this.#onChange?.(displayedNumber);
 			}
 		}
 	}

--- a/packages/ng/forms/radio-group-input/radio-group-input.component.ts
+++ b/packages/ng/forms/radio-group-input/radio-group-input.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, input, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE, FormFieldComponent } from '@lucca-front/ng/form-field';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
@@ -34,9 +35,9 @@ export class RadioGroupInputComponent {
 
 	readonly size = input<RadioGroupInputSize>();
 
-	readonly framed = input(false, { transform: booleanAttribute });
+	readonly framed = input(false, { transform: luBooleanAttribute });
 
-	readonly framedCenter = input(false, { transform: booleanAttribute });
+	readonly framedCenter = input(false, { transform: luBooleanAttribute });
 
 	readonly framedSize = input<RadioGroupInputFramedSize | null>(null);
 

--- a/packages/ng/forms/radio-group-input/radio/radio.component.ts
+++ b/packages/ng/forms/radio-group-input/radio/radio.component.ts
@@ -1,12 +1,12 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
-import { LuClass, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { luBooleanAttribute, LuClass, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { InputDirective, InputFramedComponent, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { FormLabelComponent } from '@lucca-front/ng/form-label';
 import { InlineMessageComponent } from '@lucca-front/ng/inline-message';
 import { RADIO_GROUP_INSTANCE } from '../radio-group-token';
-import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 let nextId = 0;
 
@@ -30,7 +30,7 @@ export class RadioComponent<T = unknown> {
 
 	readonly value = input.required<T>();
 
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	readonly inlineMessage = input<PortalContent>();
 

--- a/packages/ng/forms/rich-text-input/plugins/headings/headings.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/headings/headings.component.ts
@@ -10,7 +10,7 @@ import { filter } from 'rxjs';
 import { RICH_TEXT_PLUGIN_COMPONENT, RichTextPluginComponent } from '../../rich-text-input.component';
 
 import { HeadingNode } from '@lexical/rich-text';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luNumberAttribute } from '@lucca-front/ng/core';
 import { LU_RICH_TEXT_INPUT_TRANSLATIONS } from '../../rich-text-input.translate';
 import { FORMAT_HEADINGS, registerHeadings, registerHeadingsSelectionChange } from './headings.command';
 
@@ -35,7 +35,7 @@ export class HeadingsComponent implements OnDestroy, RichTextPluginComponent {
 	readonly element = viewChild<LuSimpleSelectInputComponent<string>>('selectRef');
 
 	readonly tabindex = signal<number>(-1);
-	readonly maxHeadingLevel = input<1 | 2 | 3 | 4 | 5 | 6>(6);
+	readonly maxHeadingLevel = input(6, { transform: luNumberAttribute<1 | 2 | 3 | 4 | 5 | 6> });
 	readonly headingOptions = computed<CommandPayloadType<typeof FORMAT_HEADINGS>[]>(
 		() => Object.keys(this.headingLabels()).slice(0, this.maxHeadingLevel() + 1) as CommandPayloadType<typeof FORMAT_HEADINGS>[],
 	);

--- a/packages/ng/forms/rich-text-input/rich-text-input.component.ts
+++ b/packages/ng/forms/rich-text-input/rich-text-input.component.ts
@@ -1,7 +1,6 @@
 import { CdkPortalOutlet, DomPortal } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import {
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -24,7 +23,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { createEmptyHistoryState, registerHistory } from '@lexical/history';
 import { $canShowPlaceholderCurry, $isRootTextContentEmpty } from '@lexical/text';
 import { mergeRegister } from '@lexical/utils';
-import { isNil } from '@lucca-front/ng/core';
+import { isNil, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FormFieldComponent, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { $getRoot, createEditor, Klass, LexicalEditor, LexicalNode, LexicalNodeReplacement, SKIP_DOM_SELECTION_TAG, UpdateListenerPayload } from 'lexical';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from './formatters';
@@ -68,9 +67,9 @@ export class RichTextInputComponent implements OnInit, OnDestroy, ControlValueAc
 	readonly #formField = inject(FormFieldComponent, { optional: true });
 
 	readonly placeholder = input<string>('');
-	readonly disableSpellcheck = input(false, { transform: booleanAttribute });
-	readonly autoResize = input(false, { transform: booleanAttribute });
-	readonly hideToolbar = input(false, { transform: booleanAttribute });
+	readonly disableSpellcheck = input(false, { transform: luBooleanAttribute });
+	readonly autoResize = input(false, { transform: luBooleanAttribute });
+	readonly hideToolbar = input(false, { transform: luBooleanAttribute });
 
 	readonly content = viewChild<string, ElementRef<HTMLElement>>('content', {
 		read: ElementRef,

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -1,9 +1,9 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, input, output, signal, viewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, input, output, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions, PortalDirective } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, PortalDirective } from '@lucca-front/ng/core';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 import { FormFieldIdDirective } from '../form-field-id.directive';
@@ -35,11 +35,11 @@ export class TextInputComponent {
 
 	readonly autocomplete = input<AutoFill>('off');
 
-	readonly hasClearer = input(false, { transform: booleanAttribute });
+	readonly hasClearer = input(false, { transform: luBooleanAttribute });
 
-	readonly hasSearchIcon = input(false, { transform: booleanAttribute });
+	readonly hasSearchIcon = input(false, { transform: luBooleanAttribute });
 
-	readonly valueAlignRight = input(false, { transform: booleanAttribute });
+	readonly valueAlignRight = input(false, { transform: luBooleanAttribute });
 
 	readonly prefix = input<TextInputAddon>();
 

--- a/packages/ng/forms/textarea-input/textarea-input.component.ts
+++ b/packages/ng/forms/textarea-input/textarea-input.component.ts
@@ -1,11 +1,12 @@
-import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, ElementRef, inject, input, OnInit, viewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, DestroyRef, ElementRef, inject, input, OnInit, viewChild, ViewEncapsulation } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ReactiveFormsModule } from '@angular/forms';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
+import { ReadMoreComponent } from '@lucca-front/ng/read-more';
 import { startWith } from 'rxjs';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
-import { ReadMoreComponent } from '@lucca-front/ng/read-more';
 
 @Component({
 	selector: 'lu-textarea-input',
@@ -25,13 +26,13 @@ export class TextareaInputComponent implements OnInit {
 
 	readonly placeholder = input<string>('');
 
-	readonly rows = input<number>(3);
+	readonly rows = input(3, { transform: luNumberAttribute });
 
-	readonly autoResize = input(false, { transform: booleanAttribute });
+	readonly autoResize = input(false, { transform: luBooleanAttribute });
 
-	readonly autoResizeScrollIntoView = input(false, { transform: booleanAttribute });
+	readonly autoResizeScrollIntoView = input(false, { transform: luBooleanAttribute });
 
-	readonly disableSpellcheck = input(false, { transform: booleanAttribute });
+	readonly disableSpellcheck = input(false, { transform: luBooleanAttribute });
 
 	cloneValue = '';
 

--- a/packages/ng/gauge/gauge.component.ts
+++ b/packages/ng/gauge/gauge.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, numberAttribute, ViewEncapsulation } from '@angular/core';
-import { LuClass, Palette } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass, luNumberAttribute, Palette } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-gauge',
@@ -15,27 +15,27 @@ export class GaugeComponent {
 	/**
 	 * The progress of the gauge from 0 to 100
 	 */
-	readonly value = input(0, { transform: numberAttribute });
+	readonly value = input(0, { transform: luNumberAttribute });
 
 	/**
 	 * Make the gauge finer
 	 */
-	readonly thin = input(false, { transform: booleanAttribute });
+	readonly thin = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Display gaugue in circular
 	 */
-	readonly circular = input(false, { transform: booleanAttribute });
+	readonly circular = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Animate the gauge component
 	 */
-	readonly animated = input(false, { transform: booleanAttribute });
+	readonly animated = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Disabled alt display (overrides alt value)
 	 */
-	readonly noAlt = input(false, { transform: booleanAttribute });
+	readonly noAlt = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Which palette should be used for the entire gauge.
@@ -51,7 +51,7 @@ export class GaugeComponent {
 	/**
 	 * Which size should the gauge be? widht & height
 	 */
-	readonly size = input(40, { transform: numberAttribute });
+	readonly size = input(40, { transform: luNumberAttribute });
 
 	readonly thickness = computed(() => (this.thin() ? 4 : 8));
 

--- a/packages/ng/grid/grid-column/grid-column.component.ts
+++ b/packages/ng/grid/grid-column/grid-column.component.ts
@@ -1,5 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, numberAttribute, ViewEncapsulation } from '@angular/core';
-import { ResponsiveConfig } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { luNullableNumberAttribute, ResponsiveConfig } from '@lucca-front/ng/core';
 import { LU_GRID_INSTANCE } from '../grid.token';
 import { GridColumnAlignment, GridColumnResponsive } from './grid-column.type';
 
@@ -14,10 +14,10 @@ import { GridColumnAlignment, GridColumnResponsive } from './grid-column.type';
 	},
 })
 export class GridColumnComponent {
-	readonly colspan = input(null, { transform: numberAttribute });
-	readonly rowspan = input(null, { transform: numberAttribute });
-	readonly column = input(null, { transform: numberAttribute });
-	readonly row = input(null, { transform: numberAttribute });
+	readonly colspan = input(null, { transform: luNullableNumberAttribute });
+	readonly rowspan = input(null, { transform: luNullableNumberAttribute });
+	readonly column = input(null, { transform: luNullableNumberAttribute });
+	readonly row = input(null, { transform: luNullableNumberAttribute });
 	readonly align = input<GridColumnAlignment | null>(null);
 	readonly justify = input<GridColumnAlignment | null>(null);
 

--- a/packages/ng/grid/grid.component.ts
+++ b/packages/ng/grid/grid.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, luNullableNumberAttribute } from '@lucca-front/ng/core';
 import { GridMode } from './grid.type';
 import { LU_GRID_INSTANCE } from './grid.token';
 
@@ -18,13 +19,13 @@ import { LU_GRID_INSTANCE } from './grid.token';
 	],
 })
 export class GridComponent {
-	readonly container = input(false, { transform: booleanAttribute });
+	readonly container = input(false, { transform: luBooleanAttribute });
 
-	readonly columns = input(null, { transform: numberAttribute });
+	readonly columns = input(null, { transform: luNullableNumberAttribute });
 
-	readonly colspan = input(null, { transform: numberAttribute });
+	readonly colspan = input(null, { transform: luNullableNumberAttribute });
 
-	readonly rowspan = input(null, { transform: numberAttribute });
+	readonly rowspan = input(null, { transform: luNullableNumberAttribute });
 
 	readonly mode = input<GridMode | null>(null);
 

--- a/packages/ng/highlight-data/highlight-data.component.ts
+++ b/packages/ng/highlight-data/highlight-data.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, inject, input, ViewEncapsulation } from '@angular/core';
-import { LuClass, PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass, luOptionalNumberAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { HighlightDataBubble, HighlightDataIllustration, HighlightDataPalette, HighlightDataSize, HighlightDataTheme } from './highlight-data.type';
 
 @Component({
@@ -37,7 +37,7 @@ export class HighlightDataComponent {
 	/**
 	 * Define a bubble style based on the CDN image bubble number
 	 */
-	readonly bubble = input<HighlightDataBubble | number>();
+	readonly bubble = input<HighlightDataBubble | number>(undefined, { transform: luOptionalNumberAttribute });
 
 	/**
 	 * Define a specific them white light or dark. (White by default)
@@ -64,12 +64,12 @@ export class HighlightDataComponent {
 	/**
 	 * Adjust layout to text value
 	 */
-	readonly valueFirst = input(false, { transform: booleanAttribute });
+	readonly valueFirst = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Displayed in nested mode
 	 */
-	readonly nested = input(false, { transform: booleanAttribute });
+	readonly nested = input(false, { transform: luBooleanAttribute });
 
 	get lightClass() {
 		return this.theme() === 'light';

--- a/packages/ng/horizontal-navigation/horizontal-navigation-tab.component.ts
+++ b/packages/ng/horizontal-navigation/horizontal-navigation-tab.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
-import { PortalContent } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { luBooleanAttribute, PortalContent } from '@lucca-front/ng/core';
 import { LU_HORIZONTALNAVIGATION_INSTANCE } from './horizontal-navigation.token';
 
 @Component({
@@ -19,7 +19,7 @@ export class HorizontalNavigationTabComponent {
 	protected horizontalNavigationRef = inject(LU_HORIZONTALNAVIGATION_INSTANCE);
 
 	readonly label = input.required<PortalContent>();
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 	readonly index = computed(() => this.horizontalNavigationRef.getTabIndex(this));
 	readonly selected = computed(() => !this.disabled() && this.index() === this.horizontalNavigationRef.selectedIndex());
 }

--- a/packages/ng/horizontal-navigation/horizontal-navigation.component.ts
+++ b/packages/ng/horizontal-navigation/horizontal-navigation.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChildren, effect, ElementRef, forwardRef, inject, input, model, viewChildren, ViewEncapsulation } from '@angular/core';
-import { DecorativePalette, isNil, isNotNil, Palette, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, contentChildren, effect, ElementRef, forwardRef, inject, input, model, viewChildren, ViewEncapsulation } from '@angular/core';
+import { DecorativePalette, isNil, isNotNil, luBooleanAttribute, Palette, PortalDirective } from '@lucca-front/ng/core';
 import { LuDialogRef } from '@lucca-front/ng/dialog';
 import { HorizontalNavigationLinkDirective } from './horizontal-navigation-link.directive';
 import { HorizontalNavigationTabComponent } from './horizontal-navigation-tab.component';
@@ -33,11 +33,11 @@ export class HorizontalNavigationComponent {
 
 	readonly buttons = viewChildren<ElementRef<HTMLButtonElement>>('tabButton');
 
-	readonly noBorder = input(false, { transform: booleanAttribute });
+	readonly noBorder = input(false, { transform: luBooleanAttribute });
 
-	readonly container = input(false, { transform: booleanAttribute });
+	readonly container = input(false, { transform: luBooleanAttribute });
 
-	readonly vertical = input(false, { transform: booleanAttribute });
+	readonly vertical = input(false, { transform: luBooleanAttribute });
 
 	readonly palette = input<Palette | DecorativePalette | null>(null);
 	readonly paletteClass = computed(() => ({ [`palette-${this.palette()}`]: !!this.palette() }));

--- a/packages/ng/impersonation/impersonation/impersonation.component.ts
+++ b/packages/ng/impersonation/impersonation/impersonation.component.ts
@@ -1,5 +1,5 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, model, output, untracked, viewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, input, model, output, untracked, viewChild, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
 import { LuOptionDirective } from '@lucca-front/ng/core-select';
@@ -9,7 +9,7 @@ import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { ILuUser, LuUserDisplayPipe, LuUserPictureComponent } from '@lucca-front/ng/user';
 import { IconComponent } from '@lucca/prisme/icon';
 import { LU_IMPERSONATION_TRANSLATIONS } from './impersonation.translate';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-impersonation',
@@ -33,7 +33,7 @@ export class ImpersonationComponent {
 
 	readonly selectedUser = model<ILuUser>();
 
-	readonly enableFormerEmployees = input(false, { transform: booleanAttribute });
+	readonly enableFormerEmployees = input(false, { transform: luBooleanAttribute });
 
 	readonly isNotMe = computed(() => this.selectedUser()?.id !== this.currentUserId);
 	readonly clear = output<void>();

--- a/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
+++ b/packages/ng/index-table/index-table-cell-header/index-table-cell-header.component.ts
@@ -1,7 +1,8 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, forwardRef, inject, input, model, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ElementRef, forwardRef, inject, input, model, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@lucca-front/ng/button';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { BaseIndexTableCell } from '../base-index-table-cell';
 import { LU_INDEX_TABLE_CELL_INSTANCE } from '../index-table-cell.token';
@@ -42,10 +43,10 @@ export class IndexTableRowCellHeaderComponent extends BaseIndexTableCell {
 	readonly elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
 
 	readonly sort = model<IndexTableSort | null>(null);
-	readonly selectable = input(false, { transform: booleanAttribute });
-	readonly hiddenLabel = input(false, { transform: booleanAttribute });
-	readonly actions = input(false, { transform: booleanAttribute });
-	readonly inlineSize = input(0, { transform: numberAttribute });
+	readonly selectable = input(false, { transform: luBooleanAttribute });
+	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
+	readonly actions = input(false, { transform: luBooleanAttribute });
+	readonly inlineSize = input(0, { transform: luNumberAttribute });
 
 	toggleSort(): void {
 		if (this.sort()) {

--- a/packages/ng/index-table/index-table-cell/index-table-cell.component.ts
+++ b/packages/ng/index-table/index-table-cell/index-table-cell.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
 
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { BaseIndexTableCell } from '../base-index-table-cell';
 import { LU_INDEX_TABLE_CELL_INSTANCE } from '../index-table-cell.token';
 
@@ -29,8 +30,8 @@ import { LU_INDEX_TABLE_CELL_INSTANCE } from '../index-table-cell.token';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class IndexTableRowCellComponent extends BaseIndexTableCell {
-	readonly allowTextSelection = input(false, { transform: booleanAttribute });
-	readonly tfoot = input(false, { transform: booleanAttribute });
+	readonly allowTextSelection = input(false, { transform: luBooleanAttribute });
+	readonly tfoot = input(false, { transform: luBooleanAttribute });
 
 	readonly actions = computed(() => {
 		return this.tableRef.header()?.cols()[this.position()].actions();

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -1,6 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, ElementRef, forwardRef, inject, input, model, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, ElementRef, forwardRef, inject, input, model, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { LuTooltipAnchorRef } from '@lucca-front/ng/tooltip';
@@ -51,7 +52,7 @@ export class IndexTableRowComponent implements LuTooltipAnchorRef {
 
 	readonly selected = model<boolean>(false);
 	readonly selectedLabel = input<string | null>(null);
-	readonly disabled = input(false, { transform: booleanAttribute });
-	readonly mixed = input(false, { transform: booleanAttribute });
-	readonly stack = input(1, { transform: numberAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
+	readonly mixed = input(false, { transform: luBooleanAttribute });
+	readonly stack = input(1, { transform: luNumberAttribute });
 }

--- a/packages/ng/index-table/index-table.component.ts
+++ b/packages/ng/index-table/index-table.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, contentChildren, ElementRef, forwardRef, input, viewChild, ViewEncapsulation } from '@angular/core';
-import { ResponsiveConfig } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, contentChild, contentChildren, ElementRef, forwardRef, input, viewChild, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, ResponsiveConfig } from '@lucca-front/ng/core';
 
 import { IndexTableHeadComponent } from './index-table-head/index-table-head.component';
 import { IndexTableRowComponent } from './index-table-row/index-table-row.component';
@@ -25,9 +25,9 @@ import { LU_INDEX_TABLE_INSTANCE } from './index-table.token';
 export class IndexTableComponent {
 	readonly tableRef = viewChild<ElementRef<Element>>('tableRef');
 
-	readonly selectable = input(false, { transform: booleanAttribute });
-	readonly layoutFixed = input(false, { transform: booleanAttribute });
-	readonly empty = input(false, { transform: booleanAttribute });
+	readonly selectable = input(false, { transform: luBooleanAttribute });
+	readonly layoutFixed = input(false, { transform: luBooleanAttribute });
+	readonly empty = input(false, { transform: luBooleanAttribute });
 
 	readonly responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
 

--- a/packages/ng/inline-message/inline-message.component.ts
+++ b/packages/ng/inline-message/inline-message.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
-import { LuClass, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { InlineMessageState } from './inline-message-state';
 import { InlineMessageSize } from './inline-message.type';
@@ -37,7 +37,7 @@ export class InlineMessageComponent {
 	/**
 	 * Defines whether a tooltip is used in the inline message component
 	 */
-	readonly withTooltip = input(false, { transform: booleanAttribute });
+	readonly withTooltip = input(false, { transform: luBooleanAttribute });
 
 	constructor() {
 		ɵeffectWithDeps([this.size, this.state], (size, state) => {

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,7 +1,7 @@
 import { Location } from '@angular/common';
 import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_INDEX_TABLE_INSTANCE } from '@lucca-front/ng/index-table';
 
 import { LU_DATA_TABLE_INSTANCE } from '@lucca-front/ng/data-table';
@@ -58,17 +58,17 @@ export class LinkComponent {
 	/**
 	 * Disables the link
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Underlines the link only on hover
 	 */
-	readonly decorationHover = input(false, { transform: booleanAttribute });
+	readonly decorationHover = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Indicates that the link will open in a new tab
 	 */
-	readonly external = input(false, { transform: booleanAttribute });
+	readonly external = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * External icon only visible on hover/focus

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
 import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_INDEX_TABLE_INSTANCE } from '@lucca-front/ng/index-table';
@@ -73,7 +73,7 @@ export class LinkComponent {
 	/**
 	 * External icon only visible on hover/focus
 	 */
-	readonly hiddenIcon = input(false, { transform: booleanAttribute });
+	readonly hiddenIcon = input(false, { transform: luBooleanAttribute });
 
 	hrefBackup: string;
 

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, Router, UrlTree } from '@angular/router';
 import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_INDEX_TABLE_INSTANCE } from '@lucca-front/ng/index-table';
@@ -74,7 +74,7 @@ export class LinkComponent {
 	/**
 	 * External icon only visible on hover/focus
 	 */
-	readonly hiddenIcon = input(false, { transform: booleanAttribute });
+	readonly hiddenIcon = input(false, { transform: luBooleanAttribute });
 
 	hrefBackup: string;
 

--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,7 +1,7 @@
 import { Location } from '@angular/common';
 import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
 import { ActivatedRoute, Router, UrlTree } from '@angular/router';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_INDEX_TABLE_INSTANCE } from '@lucca-front/ng/index-table';
 
 import { LU_DATA_TABLE_INSTANCE } from '@lucca-front/ng/data-table';
@@ -59,17 +59,17 @@ export class LinkComponent {
 	/**
 	 * Disables the link
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Underlines the link only on hover
 	 */
-	readonly decorationHover = input(false, { transform: booleanAttribute });
+	readonly decorationHover = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Indicates that the link will open in a new tab
 	 */
-	readonly external = input(false, { transform: booleanAttribute });
+	readonly external = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * External icon only visible on hover/focus

--- a/packages/ng/listbox/listbox.component.ts
+++ b/packages/ng/listbox/listbox.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
 
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { LoadingComponent } from '@lucca-front/ng/loading';
 import { ListboxState } from './listbox.type';
 import { OptionComponent } from './option/option.component';
@@ -26,12 +27,12 @@ export class ListboxComponent {
 	/**
 	 * Applies multiple mod to the listbox
 	 */
-	readonly multiple = input(false, { transform: booleanAttribute });
+	readonly multiple = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Defines listbox role tree or listbox by default
 	 */
-	readonly tree = input(false, { transform: booleanAttribute });
+	readonly tree = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Listbox state

--- a/packages/ng/listbox/option/option.component.ts
+++ b/packages/ng/listbox/option/option.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, contentChild, Directive, forwardRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, contentChild, Directive, forwardRef, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LISTBOX_INSTANCE, OPTION_INSTANCE } from '../tokens';
 
@@ -33,19 +34,19 @@ export class OptionComponent {
 	#listboxRef = inject(LISTBOX_INSTANCE);
 	#parentOptionRef = inject(OPTION_INSTANCE, { skipSelf: true, optional: true });
 
-	readonly checked = input(false, { transform: booleanAttribute });
+	readonly checked = input(false, { transform: luBooleanAttribute });
 
-	readonly mixed = input(false, { transform: booleanAttribute });
+	readonly mixed = input(false, { transform: luBooleanAttribute });
 
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
-	readonly hovered = input(false, { transform: booleanAttribute });
+	readonly hovered = input(false, { transform: luBooleanAttribute });
 
-	readonly add = input(false, { transform: booleanAttribute });
+	readonly add = input(false, { transform: luBooleanAttribute });
 
-	readonly group = input(false, { transform: booleanAttribute });
+	readonly group = input(false, { transform: luBooleanAttribute });
 
-	readonly select = input(false, { transform: booleanAttribute });
+	readonly select = input(false, { transform: luBooleanAttribute });
 
 	readonly selectAll = input<'string' | null>();
 

--- a/packages/ng/listing/listing-item/listing-item.component.ts
+++ b/packages/ng/listing/listing-item/listing-item.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LU_LISTING_INSTANCE } from '../listing.token';
 
@@ -22,5 +23,5 @@ export class ListingItemComponent {
 	 */
 	readonly icon = input<LuccaIcon | null>(null);
 
-	readonly critical = input(false, { transform: booleanAttribute });
+	readonly critical = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/listing/listing.component.ts
+++ b/packages/ng/listing/listing.component.ts
@@ -1,7 +1,7 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
-import { Palette } from '@lucca-front/ng/core';
+import { luBooleanAttribute, luNumberAttribute, Palette } from '@lucca-front/ng/core';
 import { LU_LISTING_INSTANCE } from './listing.token';
 
 @Component({
@@ -22,22 +22,22 @@ export class ListingComponent {
 	/**
 	 * Create HTMLOListElement
 	 */
-	readonly ordered = input(false, { transform: booleanAttribute });
+	readonly ordered = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Create HTMLOListElement with fancy numbers
 	 */
-	readonly orderedFancy = input(false, { transform: booleanAttribute });
+	readonly orderedFancy = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Applies checklist mod to the listing
 	 */
-	readonly checklist = input(false, { transform: booleanAttribute });
+	readonly checklist = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Adds an icon to the listing
 	 */
-	readonly icons = input(false, { transform: booleanAttribute });
+	readonly icons = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Gives the desired icon.
@@ -53,22 +53,22 @@ export class ListingComponent {
 	/**
 	 * Allows you to start a list at a value other than 1
 	 */
-	readonly start = input(1, { transform: numberAttribute });
+	readonly start = input(1, { transform: luNumberAttribute });
 
 	/**
 	 * Applies inline mod to the listing
 	 */
-	readonly inline = input(false, { transform: booleanAttribute });
+	readonly inline = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Applies divider between list item
 	 */
-	readonly divider = input(false, { transform: booleanAttribute });
+	readonly divider = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Reversed the listing
 	 */
-	readonly reversed = input(false, { transform: booleanAttribute });
+	readonly reversed = input(false, { transform: luBooleanAttribute });
 
 	readonly paletteClass = computed(() => ({
 		[`palette-${this.palette()}`]: !!this.palette(),

--- a/packages/ng/loading/loading.component.ts
+++ b/packages/ng/loading/loading.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, effect, inject, input, ViewEncapsulation } from '@angular/core';
-import { LuClass } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, effect, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass } from '@lucca-front/ng/core';
 import { LoadingSize } from './loading.type';
 
 type DisplayMode =
@@ -29,11 +29,11 @@ export class LoadingComponent {
 
 	readonly size = input<LoadingSize | null>(null);
 
-	readonly invert = input(false, { transform: booleanAttribute });
+	readonly invert = input(false, { transform: luBooleanAttribute });
 
-	readonly block = input(false, { transform: booleanAttribute });
+	readonly block = input(false, { transform: luBooleanAttribute });
 
-	readonly hiddenLabel = input(false, { transform: booleanAttribute });
+	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
 
 	readonly template = input<DisplayMode | null>(null);
 

--- a/packages/ng/main-layout/block/main-layout-block.component.ts
+++ b/packages/ng/main-layout/block/main-layout-block.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-main-layout-block',
@@ -11,5 +12,5 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncaps
 	},
 })
 export class MainLayoutBlockComponent {
-	readonly overflow = input(false, { transform: booleanAttribute });
+	readonly overflow = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/main-layout/main-layout.component.ts
+++ b/packages/ng/main-layout/main-layout.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-main-layout',
@@ -17,10 +18,10 @@ export class MainLayoutComponent {
 	/**
 	 * Sticks header on the screen
 	 */
-	readonly headerSticky = input(false, { transform: booleanAttribute });
+	readonly headerSticky = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Sticks footer on the screen
 	 */
-	readonly footerSticky = input(false, { transform: booleanAttribute });
+	readonly footerSticky = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.html
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.html
@@ -12,7 +12,7 @@
 					luButton
 					type="button"
 					[palette]="submitPalette"
-					[disabled]="submitDisabled$ | async"
+					[disabled]="(submitDisabled$ | async) ?? false"
 					[class]="submitClass()"
 					(click)="submit()"
 				>

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -35,7 +35,7 @@ let nextID = 0;
 			</div>
 
 			@for (option of displayedOptions$ | async; track option; let index = $index) {
-				<lu-chip aria-hidden="true" class="multipleSelect-displayer-chip" withEllipsis (kill)="unselectOption(option, $event)" [unkillable]="select.disabled$ | async">
+				<lu-chip aria-hidden="true" class="multipleSelect-displayer-chip" withEllipsis (kill)="unselectOption(option, $event)" [unkillable]="(select.disabled$ | async) ?? false">
 					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
 				</lu-chip>
 			}

--- a/packages/ng/multi-select/input/select-all/multi-select-all-displayer.component.ts
+++ b/packages/ng/multi-select/input/select-all/multi-select-all-displayer.component.ts
@@ -19,7 +19,7 @@ import { MULTI_SELECT_WITH_SELECT_ALL_CONTEXT } from './select-all.models';
 			@if (displayerCount() !== null) {
 				<div class="multipleSelect-displayer-filter">
 					@if (displayerCount() === 1 && isIncludeMode()) {
-						<lu-chip withEllipsis (kill)="select.value && unselectOption(select.value[0], $event)" class="multipleSelect-displayer-chip" [unkillable]="disabled()">
+						<lu-chip withEllipsis (kill)="select.value && unselectOption(select.value[0], $event)" class="multipleSelect-displayer-chip" [unkillable]="disabled() ?? false">
 							<ng-template *luOptionOutlet="select.displayerTpl(); value: select.value?.[0]" />
 						</lu-chip>
 					} @else {

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -1,6 +1,5 @@
 import { AsyncPipe, CommonModule } from '@angular/common';
 import {
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -8,7 +7,6 @@ import {
 	inject,
 	input,
 	model,
-	numberAttribute,
 	OnDestroy,
 	OnInit,
 	Signal,
@@ -21,7 +19,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { ALuSelectInputComponent, LU_CORE_SELECT_TRANSLATIONS, LuOptionContext, provideLuSelectLabelsAndIds, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillLabelDirective } from '@lucca-front/ng/filter-pills';
 import { PresentationDisplayDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
@@ -82,9 +80,9 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 
 	readonly valuesTpl = model<TemplateRef<LuOptionContext<T[]>> | Type<unknown>>(LuMultiSelectDefaultDisplayerComponent);
 
-	readonly maxValuesShown = input(500, { transform: numberAttribute });
+	readonly maxValuesShown = input(500, { transform: luNumberAttribute });
 
-	readonly keepSearchAfterSelection = input(false, { transform: booleanAttribute });
+	readonly keepSearchAfterSelection = input(false, { transform: luBooleanAttribute });
 
 	readonly filterPillLabelPlural = input<string>();
 

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -1,6 +1,5 @@
 import { AsyncPipe } from '@angular/common';
 import {
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
 	computed,
@@ -9,7 +8,6 @@ import {
 	input,
 	LOCALE_ID,
 	model,
-	numberAttribute,
 	OnDestroy,
 	OnInit,
 	Signal,
@@ -22,7 +20,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { ALuSelectInputComponent, LU_CORE_SELECT_TRANSLATIONS, LuOptionContext, provideLuSelectLabelsAndIds, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective, FilterPillLabelDirective } from '@lucca-front/ng/filter-pills';
 import { PresentationDisplayDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
@@ -83,9 +81,9 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 
 	readonly valuesTpl = model<TemplateRef<LuOptionContext<T[]>> | Type<unknown>>(LuMultiSelectDefaultDisplayerComponent);
 
-	readonly maxValuesShown = input(500, { transform: numberAttribute });
+	readonly maxValuesShown = input(500, { transform: luNumberAttribute });
 
-	readonly keepSearchAfterSelection = input(false, { transform: booleanAttribute });
+	readonly keepSearchAfterSelection = input(false, { transform: luBooleanAttribute });
 
 	readonly filterPillLabelPlural = input<string>();
 

--- a/packages/ng/numeric-badge/numeric-badge.component.ts
+++ b/packages/ng/numeric-badge/numeric-badge.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
-import { LuClass, Palette, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass, luNumberAttribute, Palette, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { NumericBadgeSize } from './numeric-badge.type';
 
@@ -38,17 +38,17 @@ export class NumericBadgeComponent {
 	/**
 	 * Applies the loading state
 	 */
-	readonly loading = input(false, { transform: booleanAttribute });
+	readonly loading = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Indicates the maximum value of number for the numeric badge
 	 */
-	readonly maxValue = input<number>(999);
+	readonly maxValue = input(999, { transform: luNumberAttribute });
 
 	/**
 	 * Disabled tooltip on numeric badge
 	 */
-	readonly disableTooltip = input(false, { transform: booleanAttribute });
+	readonly disableTooltip = input(false, { transform: luBooleanAttribute });
 
 	readonly numericBadgeClasses = computed(() => {
 		const palette = this.palette();

--- a/packages/ng/page-header/page-header.component.ts
+++ b/packages/ng/page-header/page-header.component.ts
@@ -1,6 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-page-header',
@@ -24,9 +24,9 @@ export class PageHeaderComponent {
 	/**
 	 * Apply a container around the content
 	 */
-	readonly container = input(false, { transform: booleanAttribute });
+	readonly container = input(false, { transform: luBooleanAttribute });
 
-	readonly sticky = input(false, { transform: booleanAttribute });
+	readonly sticky = input(false, { transform: luBooleanAttribute });
 
 	readonly descriptionIsString = computed(() => this.isStringPortalContent(this.description()));
 	readonly labelIsString = computed(() => this.isStringPortalContent(this.label()));

--- a/packages/ng/pagination/pagination.component.ts
+++ b/packages/ng/pagination/pagination.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, effect, input, output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, effect, input, output, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
-import { intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
+import { intlInputOptions, IntlParamsPipe, luBooleanAttribute, luOptionalNullableNumberAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LU_PAGINATION_TRANSLATIONS } from './pagination.translate';
 import { PaginationMod } from './pagination.type';
@@ -19,27 +19,27 @@ export class PaginationComponent {
 	/**
 	 * Disabled the previous page arrow
 	 */
-	readonly isFirstPage = input(false, { transform: booleanAttribute });
+	readonly isFirstPage = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Disabled the next page arrow
 	 */
-	readonly isLastPage = input(false, { transform: booleanAttribute });
+	readonly isLastPage = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Where the pagination start
 	 */
-	readonly from = input<number | null>();
+	readonly from = input(undefined, { transform: luOptionalNullableNumberAttribute });
 
 	/**
 	 * Where the pagination end
 	 */
-	readonly to = input<number | null>();
+	readonly to = input(undefined, { transform: luOptionalNullableNumberAttribute });
 
 	/**
 	 * Total number of items in the pagination
 	 */
-	readonly itemsCount = input<number | null>();
+	readonly itemsCount = input(undefined, { transform: luOptionalNullableNumberAttribute });
 
 	/**
 	 * Pagination mod (default or compact)

--- a/packages/ng/plg-push/plg-push.component.ts
+++ b/packages/ng/plg-push/plg-push.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LU_PLG_PUSH_TRANSLATIONS } from './plg-push.translate';
 
@@ -26,7 +26,7 @@ export class PLGPushComponent {
 	/**
 	 * Display sign close button
 	 */
-	readonly removable = input(false, { transform: booleanAttribute });
+	readonly removable = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Is the callout removed? Works with two way binding too.

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -1,14 +1,13 @@
 import { ConnectedPosition, ConnectionPositionPair, FlexibleConnectedPositionStrategyOrigin, Overlay, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import {
-	booleanAttribute,
 	DestroyRef,
 	Directive,
 	ElementRef,
 	inject,
 	Injector,
 	input,
-	InputSignal,
+	InputSignalWithTransform,
 	linkedSignal,
 	model,
 	OnDestroy,
@@ -21,7 +20,7 @@ import {
 	ViewContainerRef,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { getPushPanelViewportMargin, intlInputOptions, isNotNil } from '@lucca-front/ng/core';
+import { getPushPanelViewportMargin, intlInputOptions, isNotNil, luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { combineLatest, debounce, filter, map, merge, Subject, switchMap, take, timer } from 'rxjs';
 import { PopoverContentComponent } from './content/popover-content/popover-content.component';
 import { POPOVER_CONFIG, PopoverConfig } from './popover-tokens';
@@ -106,7 +105,7 @@ export class PopoverDirective implements OnDestroy {
 
 	readonly overlayScrollStrategy = input<'reposition' | 'block' | 'close'>('reposition');
 
-	readonly luPopoverDisabledInput = input(false, { transform: booleanAttribute, alias: 'luPopoverDisabled' });
+	readonly luPopoverDisabledInput = input(false, { transform: luBooleanAttribute, alias: 'luPopoverDisabled' });
 
 	readonly luPopoverTrigger = model<'click' | 'click+hover' | 'hover+focus'>('click');
 
@@ -115,7 +114,7 @@ export class PopoverDirective implements OnDestroy {
 	/**
 	 * Removes close button entirely, this is bad for a11y but sometimes we want it.
 	 */
-	readonly luPopoverNoCloseButtonInput = input(false, { transform: booleanAttribute, alias: 'luPopoverNoCloseButton' });
+	readonly luPopoverNoCloseButtonInput = input(false, { transform: luBooleanAttribute, alias: 'luPopoverNoCloseButton' });
 
 	/**
 	 * Allows to anchor the popover to another element instead of the trigger one
@@ -131,9 +130,9 @@ export class PopoverDirective implements OnDestroy {
 	readonly luPopoverIgnoredOutsidePointerTargets = input<HTMLElement | HTMLElement[] | null>(null);
 
 	// We have to type these two for Compodoc to find the right type and tell Storybook these aren't strings
-	readonly luPopoverOpenDelay: InputSignal<number> = input<number>(300);
+	readonly luPopoverOpenDelay: InputSignalWithTransform<number, number | `${number}`> = input(300, { transform: luNumberAttribute });
 
-	readonly luPopoverCloseDelay: InputSignal<number> = input<number>(100);
+	readonly luPopoverCloseDelay: InputSignalWithTransform<number, number | `${number}`> = input(100, { transform: luNumberAttribute });
 
 	readonly luPopoverPositionRef = linkedSignal(() => this.luPopoverPosition() || 'above');
 

--- a/packages/ng/progress-bar/progress-bar.component.ts
+++ b/packages/ng/progress-bar/progress-bar.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { ProgressBarState } from './progress-bar.type';
 
 @Component({
@@ -12,7 +13,7 @@ export class ProgressBarComponent {
 	/**
 	 * Progress percentage (0 to 100)
 	 */
-	readonly value = input(0, { transform: numberAttribute });
+	readonly value = input(0, { transform: luNumberAttribute });
 
 	/**
 	 * Progress bar state
@@ -22,7 +23,7 @@ export class ProgressBarComponent {
 	/**
 	 * Displays a loading state without progress information
 	 */
-	readonly indeterminate = input(false, { transform: booleanAttribute });
+	readonly indeterminate = input(false, { transform: luBooleanAttribute });
 
 	readonly stateClass = computed(() => ({
 		[`is-${this.state()}`]: !!this.state(),

--- a/packages/ng/progress-stepper/progress-stepper.component.ts
+++ b/packages/ng/progress-stepper/progress-stepper.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, contentChildren, forwardRef, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { luNumberAttribute } from '@lucca-front/ng/core';
 import { ProgressStepperStepComponent } from './progress-stepper-step/progress-stepper-step.component';
 import { LU_PROGRESS_STEPPER_INSTANCE } from './progress-stepper.token';
 
@@ -21,5 +22,5 @@ import { LU_PROGRESS_STEPPER_INSTANCE } from './progress-stepper.token';
 export class ProgressStepperComponent {
 	public readonly steps = contentChildren(ProgressStepperStepComponent);
 
-	readonly current = input(1, { transform: numberAttribute });
+	readonly current = input(1, { transform: luNumberAttribute });
 }

--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -1,5 +1,5 @@
-import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, signal, viewChild, ViewEncapsulation } from '@angular/core';
-import { intlInputOptions, isNil } from '@lucca-front/ng/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, inject, input, signal, viewChild, ViewEncapsulation } from '@angular/core';
+import { intlInputOptions, isNil, luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { LU_READMORE_TRANSLATIONS } from './read-more.translate';
 import { ReadMoreSurface } from './read-more.type';
 
@@ -26,17 +26,17 @@ export class ReadMoreComponent {
 	/**
 	 * Change the number of lines displayed when collapsed
 	 */
-	readonly lineClamp = input<number>(5);
+	readonly lineClamp = input(5, { transform: luNumberAttribute });
 
 	/**
 	 * Prevent the component from closing by hiding the "Read less" button
 	 */
-	readonly openOnly = input(false, { transform: booleanAttribute });
+	readonly openOnly = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Change the background color under the "Read more / less" button
 	 */
-	readonly textFlow = input(false, { transform: booleanAttribute });
+	readonly textFlow = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Apply the spacing of the Text Flow component

--- a/packages/ng/resource-card/action/resource-card-button.component.ts
+++ b/packages/ng/resource-card/action/resource-card-button.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector
@@ -15,5 +16,5 @@ export class ResourceCardButtonComponent {
 	/**
 	 * Disabled the resource card button
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/resource-card/action/resource-card-link.component.ts
+++ b/packages/ng/resource-card/action/resource-card-link.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	// eslint-disable-next-line @angular-eslint/component-selector
@@ -16,5 +17,5 @@ export class ResourceCardLinkComponent {
 	/**
 	 * Disabled the resource card link
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/resource-card/resource-card.component.ts
+++ b/packages/ng/resource-card/resource-card.component.ts
@@ -1,5 +1,6 @@
 import { CdkDragHandle } from '@angular/cdk/drag-drop';
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { ResourceCardHeadingLevel, ResourceCardSize } from './resource-card.type';
 import { LU_RESOURCE_CARD_WRAPPER_INSTANCE } from './wrapper/resource-card-wrapper.token';
@@ -21,9 +22,9 @@ import { LU_RESOURCE_CARD_WRAPPER_INSTANCE } from './wrapper/resource-card-wrapp
 export class ResourceCardComponent {
 	readonly wrapperRef = inject(LU_RESOURCE_CARD_WRAPPER_INSTANCE, { optional: true });
 
-	readonly draggable = input(false, { transform: booleanAttribute });
+	readonly draggable = input(false, { transform: luBooleanAttribute });
 
-	readonly grid = input(false, { transform: booleanAttribute });
+	readonly grid = input(false, { transform: luBooleanAttribute });
 
 	readonly headingLevel = input<ResourceCardHeadingLevel>('3');
 

--- a/packages/ng/resource-card/wrapper/resource-card-wrapper.component.ts
+++ b/packages/ng/resource-card/wrapper/resource-card-wrapper.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { ResourceCardSize } from '../resource-card.type';
 import { LU_RESOURCE_CARD_WRAPPER_INSTANCE } from './resource-card-wrapper.token';
 
@@ -20,9 +21,9 @@ import { LU_RESOURCE_CARD_WRAPPER_INSTANCE } from './resource-card-wrapper.token
 	],
 })
 export class ResourceCardWrapperComponent {
-	readonly grid = input(false, { transform: booleanAttribute });
+	readonly grid = input(false, { transform: luBooleanAttribute });
 
-	readonly draggable = input(false, { transform: booleanAttribute });
+	readonly draggable = input(false, { transform: luBooleanAttribute });
 
 	readonly size = input<ResourceCardSize | null>(null);
 }

--- a/packages/ng/scroll-box/scroll-box.component.ts
+++ b/packages/ng/scroll-box/scroll-box.component.ts
@@ -1,4 +1,5 @@
-import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, ElementRef, inject, input, OnInit, signal, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, ElementRef, inject, input, OnInit, signal, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-scroll-box',
@@ -20,7 +21,7 @@ export class ScrollBoxComponent implements OnInit {
 	/**
 	 * Scroll box content vertically
 	 */
-	readonly vertical = input(false, { transform: booleanAttribute });
+	readonly vertical = input(false, { transform: luBooleanAttribute });
 
 	readonly isFirstVisible = signal(true);
 	readonly isLastVisible = signal(false);

--- a/packages/ng/scroll/scroll.directive.ts
+++ b/packages/ng/scroll/scroll.directive.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
 import { DestroyRef, Directive, ElementRef, inject, input, OnInit, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { luNumberAttribute } from '@lucca-front/ng/core';
 import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { ILuScrollable } from './scroll.model';
@@ -16,7 +17,7 @@ import { ILuScrollable } from './scroll.model';
 	},
 })
 export class LuScrollDirective implements ILuScrollable, OnInit {
-	readonly debounceTime = input<number>(100);
+	readonly debounceTime = input(100, { transform: luNumberAttribute });
 	readonly onScroll = output<Event>();
 	readonly onScrollTop = output<Event>();
 	readonly onScrollBottom = output<Event>();

--- a/packages/ng/segmented-control-tabs/segmented-control-tabs.component.ts
+++ b/packages/ng/segmented-control-tabs/segmented-control-tabs.component.ts
@@ -1,19 +1,6 @@
-import {
-	AfterContentInit,
-	booleanAttribute,
-	ChangeDetectionStrategy,
-	Component,
-	computed,
-	contentChildren,
-	ElementRef,
-	forwardRef,
-	input,
-	model,
-	viewChildren,
-	ViewEncapsulation,
-} from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, computed, contentChildren, ElementRef, forwardRef, input, model, viewChildren, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { PortalDirective } from '@lucca-front/ng/core';
+import { luBooleanAttribute, PortalDirective } from '@lucca-front/ng/core';
 import { NoopValueAccessorDirective } from '@lucca-front/ng/forms';
 import { SegmentedControlTabsPanelComponent } from './public-api';
 import { LU_SEGMENTEDCONTROLTABS_INSTANCE } from './segmented-control-tabs.token';
@@ -39,12 +26,12 @@ export class SegmentedControlTabsComponent<T = unknown> implements AfterContentI
 	/**
 	 * Applies small size to segmented control tabs
 	 */
-	readonly small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Display segmented control tabs vertically
 	 */
-	readonly vertical = input(false, { transform: booleanAttribute });
+	readonly vertical = input(false, { transform: luBooleanAttribute });
 
 	readonly active = model<T | null>(null);
 

--- a/packages/ng/segmented-control/filter/filter.component.ts
+++ b/packages/ng/segmented-control/filter/filter.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { luBooleanAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { LU_SEGMENTEDCONTROL_INSTANCE } from '../segmented-control.token';
 
 let nextId = 0;
@@ -22,7 +22,7 @@ export class SegmentedControlFilterComponent<T = unknown> {
 	/**
 	 * Disabled the segmented control filter
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Defines filtered value used

--- a/packages/ng/segmented-control/segmented-control.component.ts
+++ b/packages/ng/segmented-control/segmented-control.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, input, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { injectNgControl, NoopValueAccessorDirective } from '@lucca-front/ng/forms';
 import { LU_SEGMENTEDCONTROL_INSTANCE } from './segmented-control.token';
 
@@ -32,12 +33,12 @@ export class SegmentedControlComponent {
 	/**
 	 * Applies small size to segmented control
 	 */
-	readonly small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Display segmented control vertically
 	 */
-	readonly vertical = input(false, { transform: booleanAttribute });
+	readonly vertical = input(false, { transform: luBooleanAttribute });
 
 	readonly id = `segmentedControl${nextId++}`;
 }

--- a/packages/ng/select/input/select-input.component.ts
+++ b/packages/ng/select/input/select-input.component.ts
@@ -2,7 +2,6 @@
 import { Overlay } from '@angular/cdk/overlay';
 import {
 	AfterViewInit,
-	booleanAttribute,
 	ChangeDetectionStrategy,
 	ChangeDetectorRef,
 	Component,
@@ -21,7 +20,7 @@ import {
 import { outputFromObservable } from '@angular/core/rxjs-interop';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ALuClear, ILuClear } from '@lucca-front/ng/clear';
-import { isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNotNil, luBooleanAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { ALuInputDisplayer, ILuInputDisplayer } from '@lucca-front/ng/input';
 import { ALuPickerPanel, ILuPickerPanel } from '@lucca-front/ng/picker';
 import { ALuSelectInput } from './select-input.model';
@@ -47,7 +46,7 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 
 	tabindex = 0;
 
-	readonly pickerOverlap = input(false, { transform: booleanAttribute });
+	readonly pickerOverlap = input(false, { transform: luBooleanAttribute });
 
 	readonly placeholderInput = input<string>('', { alias: 'placeholder' });
 

--- a/packages/ng/simple-select/input/select-input.component.ts
+++ b/packages/ng/simple-select/input/select-input.component.ts
@@ -1,9 +1,9 @@
 import { OverlayModule } from '@angular/cdk/overlay';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, input, viewChild, ViewContainerRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, forwardRef, inject, input, viewChild, ViewContainerRef, ViewEncapsulation } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions, isNotNil, PortalDirective } from '@lucca-front/ng/core';
+import { intlInputOptions, isNotNil, luBooleanAttribute, PortalDirective } from '@lucca-front/ng/core';
 import { ALuSelectInputComponent, LU_CORE_SELECT_TRANSLATIONS, LuSelectPanelRef, provideLuSelectLabelsAndIds, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillDisplayerDirective } from '@lucca-front/ng/filter-pills';
 import { InputDirective, PresentationDisplayDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
@@ -63,7 +63,7 @@ export class LuSimpleSelectInputComponent<T> extends ALuSelectInputComponent<T, 
 
 	readonly autocomplete = input<AutoFill | null>('off');
 
-	readonly impersonation = input(false, { transform: booleanAttribute });
+	readonly impersonation = input(false, { transform: luBooleanAttribute });
 
 	readonly filterPillPanelAnchorRef = viewChild('filterPillPanelAnchor', { read: ViewContainerRef });
 

--- a/packages/ng/skeleton/skeleton-button/skeleton-button.component.ts
+++ b/packages/ng/skeleton/skeleton-button/skeleton-button.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { SkeletonButtonSize } from './skeleton-button.type';
 
 @Component({
@@ -11,7 +12,7 @@ export class SkeletonButtonComponent {
 	/**
 	 * Applies dark color for skeleton
 	 */
-	readonly dark = input(false, { transform: booleanAttribute });
+	readonly dark = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Changes the size of the skeleton button

--- a/packages/ng/skeleton/skeleton-card/skeleton-card.component.ts
+++ b/packages/ng/skeleton/skeleton-card/skeleton-card.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, input, numberAttribute } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { luNumberAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-skeleton-card',
@@ -10,7 +11,7 @@ export class SkeletonCardComponent {
 	/**
 	 * Defines the number of description lines in card
 	 */
-	readonly descriptionLines = input(1, { transform: numberAttribute });
+	readonly descriptionLines = input(1, { transform: luNumberAttribute });
 
 	readonly lines = computed(() => Array.from({ length: this.descriptionLines() }));
 

--- a/packages/ng/skeleton/skeleton-data-table/skeleton-data-table.component.ts
+++ b/packages/ng/skeleton/skeleton-data-table/skeleton-data-table.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { SkeletonColsAlign } from '../skeleton.type';
 
 @Component({
@@ -13,19 +14,19 @@ export class SkeletonDataTableComponent {
 	/**
 	 * Skeleton only show in data table body
 	 */
-	readonly dataTableBodyOnly = input(false, { transform: booleanAttribute });
+	readonly dataTableBodyOnly = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Defines the number of cols (5 by default)
 	 */
-	readonly cols = input<number>(5);
+	readonly cols = input(5, { transform: luNumberAttribute });
 
 	readonly colsAlign = input<Record<number, SkeletonColsAlign>>({});
 
 	/**
 	 * Defines the number of row (8 by default)
 	 */
-	readonly rows = input<number>(8);
+	readonly rows = input(8, { transform: luNumberAttribute });
 
 	readonly colsNumber = computed<unknown[]>(() => new Array(this.cols()));
 	readonly rowsNumber = computed<unknown[]>(() => new Array(this.rows()));

--- a/packages/ng/skeleton/skeleton-field/skeleton-field.component.ts
+++ b/packages/ng/skeleton/skeleton-field/skeleton-field.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, numberAttribute } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-skeleton-field',
@@ -10,12 +11,12 @@ export class SkeletonFieldComponent {
 	/**
 	 * Applies dark color for skeleton
 	 */
-	readonly dark = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly dark = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Hide the field label skeleton
 	 */
-	readonly hiddenLabel = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Changes the size of the skeleton field
@@ -25,7 +26,7 @@ export class SkeletonFieldComponent {
 	/**
 	 * Defines the number of row
 	 */
-	readonly rows = input<number, number | `${number}`>(1, { transform: numberAttribute });
+	readonly rows = input(1, { transform: luNumberAttribute });
 
 	readonly lines = computed(() => Array.from({ length: this.rows() }));
 

--- a/packages/ng/skeleton/skeleton-header/skeleton-header.component.ts
+++ b/packages/ng/skeleton/skeleton-header/skeleton-header.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-skeleton-header',
@@ -10,5 +11,5 @@ export class SkeletonHeaderComponent {
 	/**
 	 * Applies dark color for skeleton
 	 */
-	readonly dark = input(false, { transform: booleanAttribute });
+	readonly dark = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/skeleton/skeleton-highlight-data/skeleton-highlight-data.component.ts
+++ b/packages/ng/skeleton/skeleton-highlight-data/skeleton-highlight-data.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-skeleton-highlight-data',
@@ -10,7 +11,7 @@ export class SkeletonHighlightDataComponent {
 	/**
 	 * Applies dark color for skeleton
 	 */
-	readonly dark = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly dark = input(false, { transform: luBooleanAttribute });
 
 	readonly getRandomPercent = (min: number = 25, max: number = 75): string => `${Math.floor(Math.random() * (max - min) + min).toString()}%`;
 }

--- a/packages/ng/skeleton/skeleton-index-table/skeleton-index-table.component.ts
+++ b/packages/ng/skeleton/skeleton-index-table/skeleton-index-table.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { SkeletonColsAlign } from '../skeleton.type';
 
 @Component({
@@ -16,19 +17,19 @@ export class SkeletonIndexTableComponent {
 	/**
 	 * Skeleton only show in index table body
 	 */
-	readonly tableBodyOnly = input(false, { transform: booleanAttribute });
+	readonly tableBodyOnly = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Defines the number of cols (5 by default)
 	 */
-	readonly cols = input<number>(5);
+	readonly cols = input(5, { transform: luNumberAttribute });
 
 	readonly colsAlign = input<Record<number, SkeletonColsAlign>>({});
 
 	/**
 	 * Defines the number of row (8 by default)
 	 */
-	readonly rows = input<number>(8);
+	readonly rows = input(8, { transform: luNumberAttribute });
 
 	readonly rowsNumber = computed<unknown[]>(() => new Array(this.rows()));
 	readonly colsNumber = computed<unknown[]>(() => new Array(this.cols()));

--- a/packages/ng/skeleton/skeleton-table/skeleton-table.component.ts
+++ b/packages/ng/skeleton/skeleton-table/skeleton-table.component.ts
@@ -1,5 +1,6 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { SkeletonColsAlign } from '../skeleton.type';
 
 export type ColAlignTable = 'start' | 'center' | 'end';
@@ -15,19 +16,19 @@ export class SkeletonTableComponent {
 	/**
 	 * Skeleton only show in table body
 	 */
-	readonly tableBodyOnly = input(false, { transform: booleanAttribute });
+	readonly tableBodyOnly = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Defines the number of cols (5 by default)
 	 */
-	readonly cols = input<number>(5);
+	readonly cols = input(5, { transform: luNumberAttribute });
 
 	readonly colsAlign = input<Record<number, SkeletonColsAlign>>({});
 
 	/**
 	 * Defines the number of row (8 by default)
 	 */
-	readonly rows = input<number>(8);
+	readonly rows = input(8, { transform: luNumberAttribute });
 
 	readonly colsNumber = computed<unknown[]>(() => new Array(this.cols()));
 	readonly rowsNumber = computed<unknown[]>(() => new Array(this.rows()));

--- a/packages/ng/software-icon-wrapper/software-icon-wrapper.component.ts
+++ b/packages/ng/software-icon-wrapper/software-icon-wrapper.component.ts
@@ -1,8 +1,8 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, contentChildren, input, numberAttribute, TemplateRef, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, contentChildren, input, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { LU_SOFTWARE_ICON_WRAPPER } from '@lucca-front/ng/software-icon';
 
-import { intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
+import { intlInputOptions, IntlParamsPipe, luNumberAttribute } from '@lucca-front/ng/core';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LU_SOFTWARE_ICON_WRAPPER_TRANSLATIONS } from './software-icon-wrapper.translate';
 
@@ -20,7 +20,7 @@ import { LU_SOFTWARE_ICON_WRAPPER_TRANSLATIONS } from './software-icon-wrapper.t
 	},
 })
 export class SoftwareIconWrapperComponent {
-	readonly max = input(0, { transform: numberAttribute });
+	readonly max = input(0, { transform: luNumberAttribute });
 	readonly size = input<'XS' | 'S' | ''>('');
 	readonly intl = input(...intlInputOptions(LU_SOFTWARE_ICON_WRAPPER_TRANSLATIONS));
 

--- a/packages/ng/software-icon/software-icon.component.ts
+++ b/packages/ng/software-icon/software-icon.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { LuSafeExternalSvgPipe } from '@lucca-front/ng/safe-content';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { LU_SOFTWARE_ICON_WRAPPER } from './software-icon-wrapper.token';
@@ -21,8 +22,8 @@ export class SoftwareIconComponent {
 
 	readonly icon = input.required<SoftwareIcon>();
 
-	readonly disabled = input(false, { transform: booleanAttribute });
-	readonly withTooltip = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
+	readonly withTooltip = input(false, { transform: luBooleanAttribute });
 	readonly iconAlt = input<string>('');
 	readonly size = input<SoftwareIconSize | ''>('');
 	readonly iconUrl = computed(() => `${this.domain}${this.path}${this.icon()}${this.extension}`);

--- a/packages/ng/sortable-list/sortable-list-item/sortable-list-item.component.ts
+++ b/packages/ng/sortable-list/sortable-list-item/sortable-list-item.component.ts
@@ -1,7 +1,7 @@
 import { CdkDragHandle } from '@angular/cdk/drag-drop';
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { PortalContent, PortalDirective, luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 
@@ -34,22 +34,22 @@ export class SortableListItemComponent {
 	/**
 	 * Sortable list item can be clickable
 	 */
-	readonly clickable = input(false, { transform: booleanAttribute });
+	readonly clickable = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Disabled the possibility to clear the sortable list item
 	 */
-	readonly unclearable = input(false, { transform: booleanAttribute });
+	readonly unclearable = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Sortable list item can be draggable
 	 */
-	readonly drag = input(false, { transform: booleanAttribute });
+	readonly drag = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Applies small size to segmented control tabs
 	 */
-	readonly small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Emit event when click on clear

--- a/packages/ng/sortable-list/sortable-list.component.ts
+++ b/packages/ng/sortable-list/sortable-list.component.ts
@@ -1,4 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, input, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { SortableListItemComponent } from './sortable-list-item';
 
 @Component({
@@ -13,7 +14,7 @@ export class SortableListComponent {
 	/**
 	 * Applies small size to sortable list
 	 */
-	readonly small = input(false, { transform: booleanAttribute });
+	readonly small = input(false, { transform: luBooleanAttribute });
 
 	readonly sortableListItems = contentChildren(SortableListItemComponent, { descendants: true });
 }

--- a/packages/ng/status-badge/statusBadge.component.ts
+++ b/packages/ng/status-badge/statusBadge.component.ts
@@ -1,5 +1,5 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, OnChanges, ViewEncapsulation } from '@angular/core';
-import { LuClass, Palette } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, inject, input, OnChanges, ViewEncapsulation } from '@angular/core';
+import { luBooleanAttribute, LuClass, Palette } from '@lucca-front/ng/core';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { StatusBadgeSize } from './status-badge.type';
 
@@ -21,7 +21,7 @@ export class StatusBadgeComponent implements OnChanges {
 	/**
 	 * Truncates the text with an ellipsis and adds a tooltip when the label is too long
 	 */
-	readonly withEllipsis = input(false, { transform: booleanAttribute });
+	readonly withEllipsis = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Changes the text displayed by the status badge

--- a/packages/ng/tag/tag.component.ts
+++ b/packages/ng/tag/tag.component.ts
@@ -1,7 +1,7 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { LuccaIcon } from '@lucca-front/icons';
-import { DecorativePalette, Palette } from '@lucca-front/ng/core';
+import { DecorativePalette, luBooleanAttribute, Palette } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { TagSize } from './tag.type';
@@ -34,7 +34,7 @@ export class TagComponent {
 	/**
 	 * Should display be outlined?
 	 */
-	readonly outlined = input(false, { transform: booleanAttribute });
+	readonly outlined = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * For routerLink usage
@@ -50,12 +50,12 @@ export class TagComponent {
 	/**
 	 * Truncates the text with an ellipsis and adds a tooltip when the label is too long
 	 */
-	readonly withEllipsis = input(false, { transform: booleanAttribute });
+	readonly withEllipsis = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Applies AI colors
 	 */
-	readonly AI = input(false, { transform: booleanAttribute });
+	readonly AI = input(false, { transform: luBooleanAttribute });
 
 	readonly tagClasses = computed(() => {
 		const size = this.size();

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -1,6 +1,6 @@
 import { formatNumber } from '@angular/common';
-import { ChangeDetectionStrategy, Component, ElementRef, Inject, LOCALE_ID, ModelSignal, booleanAttribute, computed, input, model, numberAttribute, output, viewChild } from '@angular/core';
-import { ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, ElementRef, Inject, LOCALE_ID, ModelSignal, computed, input, model, output, viewChild } from '@angular/core';
+import { luBooleanAttribute, luNumberAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { FormLabelComponent } from '@lucca-front/ng/form-label';
 import { PickerControlDirection } from './misc.utils';
@@ -21,39 +21,27 @@ export class TimePickerPartComponent {
 
 	readonly value: ModelSignal<number | '––'> = model('––');
 
-	readonly display = input<number | '––'>();
-
-	readonly max = input(0, {
-		transform: numberAttribute,
+	readonly display = input(undefined, {
+		transform: (value: number | `${number}` | '––') => (value === '––' ? value : luNumberAttribute(value)),
 	});
 
-	readonly autoWidth = input(false, {
-		transform: booleanAttribute,
-	});
+	readonly max = input(0, { transform: luNumberAttribute });
 
-	readonly displayArrows = input(false, {
-		transform: booleanAttribute,
-	});
+	readonly autoWidth = input(false, { transform: luBooleanAttribute });
 
-	readonly isReadonly = input(false, {
-		transform: booleanAttribute,
-	});
+	readonly displayArrows = input(false, { transform: luBooleanAttribute });
 
-	readonly hideValue = input(false, {
-		transform: booleanAttribute,
-	});
+	readonly isReadonly = input(false, { transform: luBooleanAttribute });
 
-	readonly disabled = input(false, {
-		transform: booleanAttribute,
-	});
+	readonly hideValue = input(false, { transform: luBooleanAttribute });
 
-	readonly focused = input(false, {
-		transform: booleanAttribute,
-	});
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
-	readonly maxDigits = input<number>(2);
+	readonly focused = input(false, { transform: luBooleanAttribute });
 
-	readonly showZero = input(false, { transform: booleanAttribute });
+	readonly maxDigits = input(2, { transform: luNumberAttribute });
+
+	readonly showZero = input(false, { transform: luBooleanAttribute });
 
 	readonly digitNumber = model(2);
 	readonly isValueSet = model<boolean>(false);

--- a/packages/ng/time/duration-picker/duration-picker.component.ts
+++ b/packages/ng/time/duration-picker/duration-picker.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, input, model, output, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, forwardRef, input, model, output, signal, ViewEncapsulation } from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
-import { intlInputOptions, isNil, isNotNil } from '@lucca-front/ng/core';
+import { intlInputOptions, isNil, isNotNil, luBooleanAttribute } from '@lucca-front/ng/core';
 import { BasePickerComponent } from '../core/base-picker.component';
 import { ISO8601Duration } from '../core/date-primitives';
 import { createDurationFromHoursAndMinutes, getHoursPartFromDuration, getMinutesPartFromDuration, isISO8601Duration, isoDurationToDateFnsDuration, isoDurationToSeconds } from '../core/duration.utils';
@@ -32,11 +32,11 @@ export class DurationPickerComponent extends BasePickerComponent {
 	readonly value = model<ISO8601Duration>('PT0S');
 	readonly max = input<ISO8601Duration>('PT99H');
 
-	readonly displayArrows = input(false, { transform: booleanAttribute });
+	readonly displayArrows = input(false, { transform: luBooleanAttribute });
 
 	readonly label = input<string>();
 
-	readonly hideZeroValue = input(false, { transform: booleanAttribute });
+	readonly hideZeroValue = input(false, { transform: luBooleanAttribute });
 
 	readonly durationChange = output<DurationChangeEvent>();
 

--- a/packages/ng/time/time-picker/time-picker.component.ts
+++ b/packages/ng/time/time-picker/time-picker.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, inject, input, LOCALE_ID, model, output, signal, viewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, inject, input, LOCALE_ID, model, output, signal, viewChild, ViewEncapsulation } from '@angular/core';
 import { FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { intlInputOptions, isNil, isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { intlInputOptions, isNil, isNotNil, luBooleanAttribute, luNullableBooleanAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { BasePickerComponent } from '../core/base-picker.component';
 import { ISO8601Time } from '../core/date-primitives';
 import {
@@ -53,9 +53,9 @@ export class TimePickerComponent extends BasePickerComponent {
 
 	readonly max = input<ISO8601Time>(MAX_TIME);
 
-	readonly displayArrows = input(false, { transform: booleanAttribute });
+	readonly displayArrows = input(false, { transform: luBooleanAttribute });
 
-	readonly forceMeridiemDisplay = input<boolean | null>(null);
+	readonly forceMeridiemDisplay = input(null, { transform: luNullableBooleanAttribute });
 
 	readonly keyPressed = signal(false);
 

--- a/packages/ng/time/time-range-picker/time-range-picker.component.ts
+++ b/packages/ng/time/time-range-picker/time-range-picker.component.ts
@@ -1,6 +1,6 @@
-import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, inject, Injector, input, LOCALE_ID, OnInit, signal, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, computed, forwardRef, inject, Injector, input, LOCALE_ID, OnInit, signal, ViewEncapsulation } from '@angular/core';
 import { AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR, NgControl, NgModel, ValidationErrors, Validator } from '@angular/forms';
-import { intlInputOptions, isNil } from '@lucca-front/ng/core';
+import { intlInputOptions, isNil, luBooleanAttribute } from '@lucca-front/ng/core';
 import { FORM_FIELD_INSTANCE, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { IconComponent } from '@lucca/prisme/icon';
 import { ISO8601Duration, ISO8601Time } from '../core/date-primitives';
@@ -55,11 +55,11 @@ export class TimeRangePickerComponent implements ControlValueAccessor, OnInit, V
 
 	readonly intl = input(...intlInputOptions(LU_TIME_RANGE_PICKER_TRANSLATIONS));
 
-	readonly displayArrows = input(false, { transform: booleanAttribute });
+	readonly displayArrows = input(false, { transform: luBooleanAttribute });
 
-	readonly forceMeridiemDisplay = input(false, { transform: booleanAttribute });
+	readonly forceMeridiemDisplay = input(false, { transform: luBooleanAttribute });
 
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	readonly isDisabled = computed(() => this.disabled() || this.#disabledState());
 

--- a/packages/ng/toast/toasts.component.ts
+++ b/packages/ng/toast/toasts.component.ts
@@ -1,6 +1,6 @@
 import { AsyncPipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
-import { intlInputOptions, isNotNil, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { intlInputOptions, isNotNil, luBooleanAttribute, PortalContent, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { merge, Observable } from 'rxjs';
 import { LuToast, LuToastInput, LuToastType } from './toasts.model';
 import { LuToastsService } from './toasts.service';
@@ -16,7 +16,7 @@ import { LU_TOAST_TRANSLATIONS } from './toasts.translate';
 export class LuToastsComponent {
 	readonly #toastsService = inject(LuToastsService);
 
-	readonly bottom = input(false);
+	readonly bottom = input(false, { transform: luBooleanAttribute });
 	readonly sources = input<Array<Observable<LuToastInput>>>();
 
 	constructor() {

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -12,7 +12,6 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
 import {
 	afterRenderEffect,
-	booleanAttribute,
 	computed,
 	DestroyRef,
 	Directive,
@@ -23,14 +22,13 @@ import {
 	Injector,
 	input,
 	linkedSignal,
-	numberAttribute,
 	OnDestroy,
 	Renderer2,
 	signal,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { SafeHtml } from '@angular/platform-browser';
-import { getPushPanelViewportMargin, isNil, isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { getPushPanelViewportMargin, isNil, isNotNil, luBooleanAttribute, luNumberAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuPopoverPosition } from '@lucca-front/ng/popover';
 import { startWith, timer } from 'rxjs';
 import { debounce, filter, map, tap } from 'rxjs/operators';
@@ -68,13 +66,13 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly luTooltipInput = input<string | SafeHtml>('', { alias: 'luTooltip' });
 	readonly luTooltip = linkedSignal<string | SafeHtml>(() => this.luTooltipInput());
 
-	readonly luTooltipEnterDelay = input(300, { transform: numberAttribute });
-	readonly luTooltipLeaveDelay = input(100, { transform: numberAttribute });
-	readonly luTooltipDisabled = input(false, { transform: booleanAttribute });
-	readonly luTooltipOnlyForDisplay = input(false, { transform: booleanAttribute });
+	readonly luTooltipEnterDelay = input(300, { transform: luNumberAttribute });
+	readonly luTooltipLeaveDelay = input(100, { transform: luNumberAttribute });
+	readonly luTooltipDisabled = input(false, { transform: luBooleanAttribute });
+	readonly luTooltipOnlyForDisplay = input(false, { transform: luBooleanAttribute });
 	readonly luTooltipPosition = input<LuPopoverPosition>('above');
 
-	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });
+	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: luBooleanAttribute });
 	readonly luTooltipWhenEllipsis = linkedSignal(() => this.luTooltipWhenEllipsisInput());
 
 	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef | null | undefined>(this.#host);

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -10,22 +10,7 @@ import {
 } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
-import {
-	afterRenderEffect,
-	computed,
-	DestroyRef,
-	Directive,
-	effect,
-	EffectRef,
-	ElementRef,
-	inject,
-	Injector,
-	input,
-	linkedSignal,
-	OnDestroy,
-	Renderer2,
-	signal,
-} from '@angular/core';
+import { afterRenderEffect, computed, DestroyRef, Directive, effect, EffectRef, ElementRef, inject, Injector, input, linkedSignal, OnDestroy, Renderer2, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { SafeHtml } from '@angular/platform-browser';
 import { getPushPanelViewportMargin, isNil, isNotNil, luBooleanAttribute, luNumberAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';

--- a/packages/ng/tree-select/tree-branch/tree-branch.component.ts
+++ b/packages/ng/tree-select/tree-branch/tree-branch.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, inject, input, output, TemplateRef, Type, viewChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, input, output, TemplateRef, Type, viewChild, ViewEncapsulation } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { luBooleanAttribute, luNumberAttribute } from '@lucca-front/ng/core';
 import { ALuSelectInputComponent, LuIsOptionSelectedPipe, LuOptionComparer, LuOptionContext, TreeNode, ɵCoreSelectPanelElement, ɵLuOptionComponent } from '@lucca-front/ng/core-select';
 
 @Component({
@@ -31,9 +32,9 @@ export class TreeBranchComponent<T> {
 
 	unselectMany = output<T[]>();
 
-	readonly simpleMode = input(false, { transform: booleanAttribute });
+	readonly simpleMode = input(false, { transform: luBooleanAttribute });
 
-	readonly depth = input(1);
+	readonly depth = input(1, { transform: luNumberAttribute });
 
 	constructor() {
 		if (this.selectInputComponent.selectChildren$) {

--- a/packages/ng/user/picture/user-picture.component.ts
+++ b/packages/ng/user/picture/user-picture.component.ts
@@ -1,6 +1,6 @@
 import { NgStyle } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, linkedSignal, ViewEncapsulation } from '@angular/core';
-import { isNotNilOrEmptyString } from '@lucca-front/ng/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, linkedSignal, ViewEncapsulation } from '@angular/core';
+import { isNotNilOrEmptyString, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials, luUserDisplay } from '../display';
 import { UserPictureSize } from './user-picture.type';
 
@@ -62,7 +62,7 @@ export class LuUserPictureComponent {
 
 	readonly user = input<LuUserPictureUserInput>();
 
-	readonly AI = input(false, { transform: booleanAttribute });
+	readonly AI = input(false, { transform: luBooleanAttribute });
 
 	readonly placeholder = input(false, { transform: booleanAttribute });
 

--- a/packages/ng/user/picture/user-picture.component.ts
+++ b/packages/ng/user/picture/user-picture.component.ts
@@ -64,9 +64,9 @@ export class LuUserPictureComponent {
 
 	readonly AI = input(false, { transform: luBooleanAttribute });
 
-	readonly placeholder = input(false, { transform: booleanAttribute });
+	readonly placeholder = input(false, { transform: luBooleanAttribute });
 
-	readonly softRounded = input(false, { transform: booleanAttribute });
+	readonly softRounded = input(false, { transform: luBooleanAttribute });
 
 	readonly size = input<UserPictureSize>('M');
 

--- a/packages/ng/user/select/input/user-select-input.component.ts
+++ b/packages/ng/user/select/input/user-select-input.component.ts
@@ -2,7 +2,7 @@ import { Overlay, OverlayModule } from '@angular/cdk/overlay';
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, input, Input, Renderer2, ViewContainerRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions } from '@lucca-front/ng/core';
+import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
 import { LuInputDisplayerDirective } from '@lucca-front/ng/input';
 import { LuForOptionsDirective, LuOptionComparer, LuOptionItemComponent, LuOptionPickerAdvancedComponent } from '@lucca-front/ng/option';
 import { ILuInputWithPicker } from '@lucca-front/ng/picker';
@@ -55,8 +55,8 @@ export class LuUserSelectInputComponent<U extends import('../../user.model').ILu
 	@Input() orderBy: string;
 	@Input() appInstanceId: number | string;
 	@Input() operations: number[];
-	@Input() enableFormerEmployees = false;
-	@Input() disablePrincipal = false;
+	@Input({ transform: luBooleanAttribute }) enableFormerEmployees = false;
+	@Input({ transform: luBooleanAttribute }) disablePrincipal = false;
 
 	clue = '';
 

--- a/packages/ng/user/select/input/user-select-input.component.ts
+++ b/packages/ng/user/select/input/user-select-input.component.ts
@@ -2,7 +2,8 @@ import { Overlay, OverlayModule } from '@angular/cdk/overlay';
 import { AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forwardRef, input, Input, Renderer2, ViewContainerRef } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions, luBooleanAttribute } from '@lucca-front/ng/core';
+import { booleanAttribute } from '@angular/core';
+import { intlInputOptions } from '@lucca-front/ng/core';
 import { LuInputDisplayerDirective } from '@lucca-front/ng/input';
 import { LuForOptionsDirective, LuOptionComparer, LuOptionItemComponent, LuOptionPickerAdvancedComponent } from '@lucca-front/ng/option';
 import { ILuInputWithPicker } from '@lucca-front/ng/picker';
@@ -55,8 +56,8 @@ export class LuUserSelectInputComponent<U extends import('../../user.model').ILu
 	@Input() orderBy: string;
 	@Input() appInstanceId: number | string;
 	@Input() operations: number[];
-	@Input({ transform: luBooleanAttribute }) enableFormerEmployees = false;
-	@Input({ transform: luBooleanAttribute }) disablePrincipal = false;
+	@Input({ transform: booleanAttribute }) enableFormerEmployees = false;
+	@Input({ transform: booleanAttribute }) disablePrincipal = false;
 
 	clue = '';
 

--- a/packages/ng/user/select/searcher/user-searcher.component.ts
+++ b/packages/ng/user/select/searcher/user-searcher.component.ts
@@ -9,6 +9,7 @@ import {
 	ILuOnOpenSubscriber,
 	ILuOnScrollBottomSubscriber,
 	intlInputOptions,
+	luBooleanAttribute,
 	syncInputSignal,
 } from '@lucca-front/ng/core';
 import { ALuOptionOperator, LuOptionPlaceholderComponent } from '@lucca-front/ng/option';
@@ -77,7 +78,7 @@ export class LuUserPagedSearcherComponent<U extends ILuUser = ILuUser> implement
 
 	readonly operations = input<number[]>();
 
-	readonly enableFormerEmployees = input<boolean>(false);
+	readonly enableFormerEmployees = input(false, { transform: luBooleanAttribute });
 
 	readonly clueChange = output<string>();
 

--- a/packages/ng/vertical-navigation/group/vertical-navigation-group.component.ts
+++ b/packages/ng/vertical-navigation/group/vertical-navigation-group.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { luBooleanAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 
 @Component({
@@ -29,7 +29,7 @@ export class VerticalNavigationGroupComponent {
 	/**
 	 * Disabled the vertical navigation group
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	readonly expanded = model(true);
 

--- a/packages/ng/vertical-navigation/item/vertical-navigation-item.component.ts
+++ b/packages/ng/vertical-navigation/item/vertical-navigation-item.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, model, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 
 @Component({
 	selector: 'lu-vertical-navigation-item',
@@ -26,7 +27,7 @@ export class VerticalNavigationItemComponent {
 	/**
 	 * Disabled the vertical navigation item
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 
 	readonly expanded = model(true);
 

--- a/packages/ng/vertical-navigation/link/vertical-navigation-link.component.ts
+++ b/packages/ng/vertical-navigation/link/vertical-navigation-link.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, input, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 
 @Component({
@@ -24,5 +25,5 @@ export class VerticalNavigationLinkComponent {
 	/**
 	 * Disabled the vertical navigation link
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input(false, { transform: luBooleanAttribute });
 }

--- a/packages/ng/vertical-navigation/vertical-navigation.component.ts
+++ b/packages/ng/vertical-navigation/vertical-navigation.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, contentChildren, input, ViewEncapsulation } from '@angular/core';
-import { PortalContent, PortalDirective } from '@lucca-front/ng/core';
+import { luNumberAttribute, PortalContent, PortalDirective } from '@lucca-front/ng/core';
 import { VerticalNavigationGroupComponent } from './group/vertical-navigation-group.component';
 import { VerticalNavigationLinkComponent } from './link/vertical-navigation-link.component';
 
@@ -24,7 +24,7 @@ export class VerticalNavigationComponent {
 	/**
 	 * Defines aria level for heading title
 	 */
-	readonly level = input<number>(3);
+	readonly level = input(3, { transform: luNumberAttribute });
 
 	readonly verticalNavigationGroup = contentChildren(VerticalNavigationGroupComponent, { descendants: true });
 	readonly verticalNavigationLinks = contentChildren(VerticalNavigationLinkComponent, { descendants: true });

--- a/packages/prisme/button/button.component.ts
+++ b/packages/prisme/button/button.component.ts
@@ -33,7 +33,7 @@ export class ButtonComponent {
 	/**
 	 * Apply block display
 	 */
-	readonly block = input(false, { transform: booleanAttribute });
+	readonly block = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
 
 	/**
 	 * Disables the Button. Also applied automatically when `state` is `loading`
@@ -43,17 +43,17 @@ export class ButtonComponent {
 	/**
 	 * Indicates an action with significant or irreversible consequences on hover and focus. Only compatible with outlined and ghost
 	 */
-	readonly critical = input(false, { transform: booleanAttribute });
+	readonly critical = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
 
 	/**
 	 * @deprecated use `critical` input instead
 	 */
-	readonly delete = input(false, { transform: booleanAttribute });
+	readonly delete = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
 
 	/**
 	 * Indicates the presence of a menu
 	 */
-	readonly disclosure = input(false, { transform: booleanAttribute });
+	readonly disclosure = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
 
 	/**
 	 * Applies a color palette to the Button

--- a/packages/prisme/button/button.component.ts
+++ b/packages/prisme/button/button.component.ts
@@ -33,27 +33,27 @@ export class ButtonComponent {
 	/**
 	 * Apply block display
 	 */
-	readonly block = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly block = input<boolean, boolean | `${boolean}` | ''>(false, { transform: booleanAttribute });
 
 	/**
 	 * Disables the Button. Also applied automatically when `state` is `loading`
 	 */
-	readonly disabled = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly disabled = input<boolean, boolean | `${boolean}` | ''>(false, { transform: booleanAttribute });
 
 	/**
 	 * Indicates an action with significant or irreversible consequences on hover and focus. Only compatible with outlined and ghost
 	 */
-	readonly critical = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly critical = input<boolean, boolean | `${boolean}` | ''>(false, { transform: booleanAttribute });
 
 	/**
 	 * @deprecated use `critical` input instead
 	 */
-	readonly delete = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly delete = input<boolean, boolean | `${boolean}` | ''>(false, { transform: booleanAttribute });
 
 	/**
 	 * Indicates the presence of a menu
 	 */
-	readonly disclosure = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly disclosure = input<boolean, boolean | `${boolean}` | ''>(false, { transform: booleanAttribute });
 
 	/**
 	 * Applies a color palette to the Button

--- a/packages/prisme/button/button.component.ts
+++ b/packages/prisme/button/button.component.ts
@@ -38,7 +38,7 @@ export class ButtonComponent {
 	/**
 	 * Disables the Button. Also applied automatically when `state` is `loading`
 	 */
-	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly disabled = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
 
 	/**
 	 * Indicates an action with significant or irreversible consequences on hover and focus. Only compatible with outlined and ghost

--- a/packages/prisme/icon/icon.component.ts
+++ b/packages/prisme/icon/icon.component.ts
@@ -35,7 +35,7 @@ export class IconComponent {
 	/**
 	 * Display icon in AI mode
 	 */
-	readonly AI = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
+	readonly AI = input<boolean, boolean | `${boolean}` | ''>(false, { transform: booleanAttribute });
 
 	readonly iconClasses = computed(() => {
 		const size = this.size();

--- a/packages/prisme/icon/icon.component.ts
+++ b/packages/prisme/icon/icon.component.ts
@@ -35,7 +35,7 @@ export class IconComponent {
 	/**
 	 * Display icon in AI mode
 	 */
-	readonly AI = input(false, { transform: booleanAttribute });
+	readonly AI = input<boolean, boolean | `${boolean}`>(false, { transform: booleanAttribute });
 
 	readonly iconClasses = computed(() => {
 		const size = this.size();


### PR DESCRIPTION
This pull request standardizes the use of custom attribute transformers across the codebase, replacing Angular's built-in `booleanAttribute` and `numberAttribute` with `luBooleanAttribute` and `luNumberAttribute` (or their optional variants) from the `@lucca-front/ng/core` package. This change ensures consistent handling of input types and aligns with updated internal best practices. The documentation is also updated to reflect these conventions.

### Refactoring to use custom attribute transformers

**Boolean attribute handling:**
* Replaced all instances of `booleanAttribute` with `luBooleanAttribute` in component inputs, such as in `AppLayoutComponent`, `BoxComponent`, `BreadcrumbsComponent`, `BubbleIllustrationComponent`, `CalloutActionsComponent`, `CalloutDisclosureComponent`, `CalloutPopoverComponent`, `CalloutComponent`, `ChipComponent`, `ClearComponent`, `CodeComponent`, and `ColorComponent`. [[1]](diffhunk://#diff-3ea5de1a058d7a7ca06dffd3cbc352a190e519cd88e68808ccf0766cee54da7cL1-R2) [[2]](diffhunk://#diff-3ea5de1a058d7a7ca06dffd3cbc352a190e519cd88e68808ccf0766cee54da7cL15-R16) [[3]](diffhunk://#diff-6b4ba7cd5a40d8bedbb618a71fea4d704f514c6941784bf0772022b580a43e80L1-R3) [[4]](diffhunk://#diff-6b4ba7cd5a40d8bedbb618a71fea4d704f514c6941784bf0772022b580a43e80L20-R27) [[5]](diffhunk://#diff-1312f8558931d40bc8ca701bb545a356df40913335547d15f13d149c78464469L2-R3) [[6]](diffhunk://#diff-1312f8558931d40bc8ca701bb545a356df40913335547d15f13d149c78464469L26-R26) [[7]](diffhunk://#diff-e8dc18f635165f9331f93a1df52d49a4afe0dd7d30053638e3013b63f2e126cdL1-R2) [[8]](diffhunk://#diff-e8dc18f635165f9331f93a1df52d49a4afe0dd7d30053638e3013b63f2e126cdL23-R23) [[9]](diffhunk://#diff-b3a71eaefb0fc5ab9224fb94653dbfba89d46fde131125d43b4a11f17f25f609L1-R2) [[10]](diffhunk://#diff-b3a71eaefb0fc5ab9224fb94653dbfba89d46fde131125d43b4a11f17f25f609L14-R15) [[11]](diffhunk://#diff-ea5665311686081ded125e30a2e3663efcc311b851aa5f9849e0e41d7e4f14d7L1-R3) [[12]](diffhunk://#diff-ea5665311686081ded125e30a2e3663efcc311b851aa5f9849e0e41d7e4f14d7L52-R52) [[13]](diffhunk://#diff-445636f773eb9d972e487076a9eccfe89b35095237c1d507ecf10bbc241e2abaL44-R44) [[14]](diffhunk://#diff-cc3da5a2deca47067a3b686acf393b4cf48ba765b23bff4e23d881dbabf91f69L1-R3) [[15]](diffhunk://#diff-cc3da5a2deca47067a3b686acf393b4cf48ba765b23bff4e23d881dbabf91f69L64-R69) [[16]](diffhunk://#diff-cc3da5a2deca47067a3b686acf393b4cf48ba765b23bff4e23d881dbabf91f69L79-R79) Fc807dc9L1, [[17]](diffhunk://#diff-608cd64ab4dc796bf167551323c09f67331205b012793f47b7a37d7eec7368ccL32-R37) [[18]](diffhunk://#diff-608cd64ab4dc796bf167551323c09f67331205b012793f47b7a37d7eec7368ccL48-R48) [[19]](diffhunk://#diff-5965236698bf76e749b149f7153a5bcf44f787748003e4f585b04f3decc3dda2L1-R2) [[20]](diffhunk://#diff-5965236698bf76e749b149f7153a5bcf44f787748003e4f585b04f3decc3dda2L60-R46) [[21]](diffhunk://#diff-5965236698bf76e749b149f7153a5bcf44f787748003e4f585b04f3decc3dda2L70-R56) [[22]](diffhunk://#diff-e716ed97e0d5341e1f53891d878b1348282948ae2a01d26b2ed14d9c2ccbb605L1-R2) [[23]](diffhunk://#diff-e716ed97e0d5341e1f53891d878b1348282948ae2a01d26b2ed14d9c2ccbb605L11-R12) [[24]](diffhunk://#diff-4780e7659112b22700ffd0568e418d47ba0fd09cbbb7c1e0642ca8c89e52bb9dL1-R2) [[25]](diffhunk://#diff-4780e7659112b22700ffd0568e418d47ba0fd09cbbb7c1e0642ca8c89e52bb9dL19-R20)

**Number attribute handling:**
* Replaced all instances of `numberAttribute` with `luNumberAttribute` (or `luOptionalNumberAttribute` where appropriate) in component inputs, notably in `CalloutPopoverComponent`. [[1]](diffhunk://#diff-445636f773eb9d972e487076a9eccfe89b35095237c1d507ecf10bbc241e2abaL2-R4) [[2]](diffhunk://#diff-445636f773eb9d972e487076a9eccfe89b35095237c1d507ecf10bbc241e2abaL24-R29)

### Documentation updates

* Updated `contributing.md` to instruct developers to use `luBooleanAttribute`, `luOptionalBooleanAttribute`, `luNumberAttribute`, and `luOptionalNumberAttribute` instead of the Angular defaults for boolean and number input transforms. [[1]](diffhunk://#diff-0b82d9a8fc9c94f7729e7685fca44dd89a479746f7cb14171e6dcdc7beb94387L47-R49) [[2]](diffhunk://#diff-0b82d9a8fc9c94f7729e7685fca44dd89a479746f7cb14171e6dcdc7beb94387L21)

These changes improve consistency, maintainability, and clarity for both contributors and consumers of the component library.