### PR TITLE
[select] fix highlight with mouse and keyboard navigation

### DIFF
--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -15,11 +15,13 @@ import {
 	output,
 	TemplateRef,
 	Type,
+	untracked,
 	ViewChild,
 } from '@angular/core';
 import { intlInputOptions, PortalDirective } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { asyncScheduler, observeOn, Subscription } from 'rxjs';
+import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from '../panel/panel.instance';
 import { GroupTemplateLocation } from '../panel/panel.utils';
 import { CoreSelectPanelElement } from '../panel/selectable-item';
 import { LuOptionContext, SELECT_ID } from '../select.model';
@@ -39,6 +41,8 @@ export const MAGIC_OPTION_SCROLL_DELAY = 15;
 	imports: [LuOptionOutletDirective, PortalDirective, LuOptionGroupPipe, LuTooltipTriggerDirective],
 })
 export class LuOptionComponent<T> implements AfterViewInit, OnDestroy, OnInit {
+	readonly #panelRef = inject<CoreSelectPanelInstance<T>>(SELECT_PANEL_INSTANCE);
+
 	protected selectableItem = inject(CoreSelectPanelElement);
 	readonly intl = input(...intlInputOptions(LU_OPTION_TRANSLATIONS));
 
@@ -81,7 +85,7 @@ export class LuOptionComponent<T> implements AfterViewInit, OnDestroy, OnInit {
 
 	constructor() {
 		effect(() => {
-			if (this.selectableItem.isHighlighted()) {
+			if (this.selectableItem.isHighlighted() && !untracked(this.#panelRef.pointerNavigation)) {
 				setTimeout(() => {
 					this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions);
 				}, MAGIC_OPTION_SCROLL_DELAY);
@@ -98,6 +102,10 @@ export class LuOptionComponent<T> implements AfterViewInit, OnDestroy, OnInit {
 	}
 
 	ngAfterViewInit(): void {
+		if (!this.optionContext) {
+			return;
+		}
+
 		this.subscription = this.optionContext.isDisabled$.pipe(observeOn(asyncScheduler)).subscribe((isDisabled) => {
 			this.selectableItem.disabled = isDisabled;
 			this.cdr.markForCheck();

--- a/packages/ng/core-select/panel/key-manager.ts
+++ b/packages/ng/core-select/panel/key-manager.ts
@@ -52,7 +52,7 @@ export class CoreSelectKeyManager<T> {
 	}
 
 	get activeItem(): CoreSelectPanelElement<T> | undefined {
-		return this.#cdkKeyManager?.activeItem;
+		return this.#cdkKeyManager?.activeItem ?? undefined;
 	}
 
 	get activeItemIndex(): number {
@@ -61,6 +61,13 @@ export class CoreSelectKeyManager<T> {
 
 	setActiveItem(index: number): void {
 		this.#cdkKeyManager?.setActiveItem(index);
+	}
+
+	setActiveItemByElement(item: CoreSelectPanelElement<T>): void {
+		const index = this.#queryList().indexOf(item);
+		if (index !== -1) {
+			this.#cdkKeyManager?.setActiveItem(index);
+		}
 	}
 
 	highlightOption(option: T): void {
@@ -93,9 +100,14 @@ export class CoreSelectKeyManager<T> {
 	}
 
 	#bindActiveOptionIdChanged(activeOptionIdChanged$: EventEmitter<string>): void {
-		this.#cdkKeyManager.change
+		const keyManager = this.#cdkKeyManager;
+		if (!keyManager) {
+			return;
+		}
+
+		keyManager.change
 			.pipe(
-				map(() => this.#cdkKeyManager.activeItem?.idAttribute()),
+				map(() => keyManager.activeItem?.idAttribute()),
 				takeUntilDestroyed(this.#destroyRef),
 			)
 			.subscribe((activeDescendant) => activeOptionIdChanged$.emit(activeDescendant));
@@ -108,6 +120,11 @@ export class CoreSelectKeyManager<T> {
 	 * 	- set to first item if no active item
 	 */
 	#bindOptionsChange({ options$ }: CoreSelectKeyManagerOptions<T>): void {
+		const keyManager = this.#cdkKeyManager;
+		if (!keyManager) {
+			return;
+		}
+
 		options$
 			.pipe(
 				debounceTime(0), // Wait until QueryList is updated
@@ -115,12 +132,12 @@ export class CoreSelectKeyManager<T> {
 			)
 			.subscribe(() => {
 				if (this.#queryList().length === 0) {
-					this.#cdkKeyManager.setActiveItem(-1);
+					keyManager.setActiveItem(-1);
 				} else if (this.#hasSearchChanged) {
 					this.#hasSearchChanged = false;
-					this.#cdkKeyManager.setFirstItemActive();
-				} else if (!this.#cdkKeyManager.activeItem) {
-					this.#cdkKeyManager.setFirstItemActive();
+					keyManager.setFirstItemActive();
+				} else if (!keyManager.activeItem) {
+					keyManager.setFirstItemActive();
 				}
 			});
 	}

--- a/packages/ng/core-select/panel/panel.instance.ts
+++ b/packages/ng/core-select/panel/panel.instance.ts
@@ -1,8 +1,9 @@
+import { InjectionToken, Signal, WritableSignal } from '@angular/core';
 import { CoreSelectPanelElement } from './selectable-item';
-import { InjectionToken, WritableSignal } from '@angular/core';
 
 export interface CoreSelectPanelInstance<T = unknown> {
 	options: WritableSignal<CoreSelectPanelElement<T>[]>;
+	pointerNavigation: Signal<boolean>;
 }
 
 export const SELECT_PANEL_INSTANCE = new InjectionToken<CoreSelectPanelInstance>('CoreSelect:PanelInstance');

--- a/packages/ng/core-select/panel/selectable-item.ts
+++ b/packages/ng/core-select/panel/selectable-item.ts
@@ -1,6 +1,7 @@
 import { Highlightable } from '@angular/cdk/a11y';
-import { computed, Directive, ElementRef, inject, Input, input, model, OnDestroy, output, signal } from '@angular/core';
+import { computed, Directive, ElementRef, inject, Input, input, model, OnDestroy, output, signal, untracked } from '@angular/core';
 import { ALuSelectInputComponent } from '../input/select-input.component';
+import { CoreSelectKeyManager } from './key-manager';
 import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from './panel.instance';
 
 @Directive({
@@ -10,6 +11,7 @@ import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from './panel.instance
 		'[attr.id]': 'idAttribute()',
 		'[attr.aria-selected]': 'isSelected()',
 		'[class.is-highlighted]': 'isHighlighted()',
+		'(mouseenter)': 'onMouseEnter()',
 		role: 'option',
 	},
 })
@@ -17,6 +19,7 @@ export class CoreSelectPanelElement<T> implements Highlightable, OnDestroy {
 	readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	readonly #panelRef = inject<CoreSelectPanelInstance<T>>(SELECT_PANEL_INSTANCE);
+	readonly #keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager, { optional: true });
 
 	readonly #selectRef = inject<ALuSelectInputComponent<T, T>>(ALuSelectInputComponent);
 
@@ -48,10 +51,21 @@ export class CoreSelectPanelElement<T> implements Highlightable, OnDestroy {
 
 	setActiveStyles(): void {
 		this.isHighlighted.set(true);
-		this.#selectRef.highlightedOption.emit(this.option());
+		const option = this.option();
+		if (option !== undefined) {
+			this.#selectRef.highlightedOption.emit(option);
+		}
 	}
 
 	setInactiveStyles(): void {
 		this.isHighlighted.set(false);
+	}
+
+	onMouseEnter(): void {
+		if (!this.#keyManager || this.disabled || !untracked(this.#panelRef.pointerNavigation)) {
+			return;
+		}
+
+		this.#keyManager.setActiveItemByElement(this);
 	}
 }

--- a/packages/ng/forms/color-input/color-input.component.ts
+++ b/packages/ng/forms/color-input/color-input.component.ts
@@ -1,4 +1,4 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, Signal, signal, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, HostListener, input, Signal, signal, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ColorComponent } from '@lucca-front/ng/color';
 import { intlInputOptions } from '@lucca-front/ng/core';
@@ -10,7 +10,7 @@ import { ColorOption } from './color';
 import { LU_COLOR_TRANSLATIONS } from './color.translate';
 import { ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { startWith } from 'rxjs';
+import { of, startWith } from 'rxjs';
 
 @Component({
 	selector: 'lu-color-input',
@@ -24,9 +24,16 @@ import { startWith } from 'rxjs';
 export class ColorInputComponent {
 	intl = input(...intlInputOptions(LU_COLOR_TRANSLATIONS));
 
+	pointerNavigation = signal(false);
 	mouseHighlighted = signal<string>('');
 	keyboardHighlighted = signal<string>('');
-	highlighted = computed(() => this.mouseHighlighted() || this.keyboardHighlighted());
+	highlighted = computed(() => {
+		if (!this.pointerNavigation()) {
+			return this.keyboardHighlighted();
+		}
+
+		return this.mouseHighlighted() || this.keyboardHighlighted();
+	});
 
 	clue = signal<string>('');
 	colors = input.required<ColorOption[]>();
@@ -39,7 +46,8 @@ export class ColorInputComponent {
 
 	constructor() {
 		if (this.ngControl) {
-			const controlValueSignal = toSignal(this.ngControl.valueChanges?.pipe(startWith(this.ngControl.value)));
+			const valueChanges$ = this.ngControl.valueChanges ?? of(this.ngControl.value);
+			const controlValueSignal = toSignal(valueChanges$.pipe(startWith(this.ngControl.value)));
 			this.currentColorPresentation = computed(() => {
 				return this.colors().find((c) => c.background === controlValueSignal()) || null;
 			});
@@ -52,4 +60,14 @@ export class ColorInputComponent {
 		}
 		return this.colors();
 	});
+
+	@HostListener('document:keydown')
+	onKeydown(): void {
+		this.pointerNavigation.set(false);
+	}
+
+	@HostListener('document:mousemove')
+	onMousemove(): void {
+		this.pointerNavigation.set(true);
+	}
 }

--- a/packages/ng/multi-select/input/select-all/multi-select-all-header.component.scss
+++ b/packages/ng/multi-select/input/select-all/multi-select-all-header.component.scss
@@ -27,7 +27,7 @@
 
 	@layer mods {
 		&:hover,
-		:host-context(.is-highlighted) & {
+		:host-context(.optionItem.is-highlighted) & {
 			background-color: var(--palettes-neutral-50);
 		}
 
@@ -35,7 +35,7 @@
 			background-color: var(--palettes-50, var(--palettes-product-50));
 
 			&:hover,
-			:host-context(.is-highlighted) & {
+			:host-context(.optionItem.is-highlighted) & {
 				background-color: var(--palettes-100, var(--palettes-product-100));
 			}
 		}

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -7,11 +7,7 @@
 	};
 	as ctx
 ) {
-	<div
-		class="lu-picker-panel lu-option-picker-panel mod-multiple"
-		[class.is-withPointerNavigation]="pointerNavigation()"
-		data-testid="dialog-panel"
-	>
+	<div class="lu-picker-panel lu-option-picker-panel mod-multiple" data-testid="dialog-panel">
 		<div
 			class="lu-picker-content"
 			[class.is-loading]="loading()"

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -7,7 +7,11 @@
 	};
 	as ctx
 ) {
-	<div class="lu-picker-panel lu-option-picker-panel mod-multiple" data-testid="dialog-panel">
+	<div
+		class="lu-picker-panel lu-option-picker-panel mod-multiple"
+		[class.is-withPointerNavigation]="pointerNavigation()"
+		data-testid="dialog-panel"
+	>
 		<div
 			class="lu-picker-content"
 			[class.is-loading]="loading()"

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,6 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, HostListener, inject, signal, TrackByFunction } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
@@ -78,6 +78,17 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	optionTpl = this.selectInput.optionTpl;
 
 	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
+	pointerNavigation = signal(false);
+
+	@HostListener('document:keydown')
+	onKeydown(): void {
+		this.pointerNavigation.set(false);
+	}
+
+	@HostListener('document:mousemove')
+	onMousemove(): void {
+		this.pointerNavigation.set(true);
+	}
 	keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 
 	someGroupOptionEnabled = computed(() => {

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -7,7 +7,7 @@
 	};
 	as ctx
 ) {
-	<div class="lu-picker-panel lu-option-picker-panel" [class.is-withPointerNavigation]="pointerNavigation()" cdkTrapFocus>
+	<div class="lu-picker-panel lu-option-picker-panel" cdkTrapFocus>
 		<div class="lu-picker-content" [class.is-loading]="loading()" (scroll)="onScroll($event)">
 			@if (selectInput.panelHeaderTpl(); as tpl) {
 				<div>

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -7,7 +7,7 @@
 	};
 	as ctx
 ) {
-	<div class="lu-picker-panel lu-option-picker-panel" cdkTrapFocus>
+	<div class="lu-picker-panel lu-option-picker-panel" [class.is-withPointerNavigation]="pointerNavigation()" cdkTrapFocus>
 		<div class="lu-picker-content" [class.is-loading]="loading()" (scroll)="onScroll($event)">
 			@if (selectInput.panelHeaderTpl(); as tpl) {
 				<div>

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -58,7 +58,7 @@
 								[groupTemplateLocation]="ctx.groupTemplateLocation"
 								[groupIndex]="groupIndex"
 								[grouping]="grouping()"
-								[scrollIntoViewOptions]="{ block: 'center' }"
+								[scrollIntoViewOptions]="{ block: 'nearest' }"
 								[isSelected]="option | luIsOptionSelected: optionComparer : selected()"
 								[class.withAddOption]="ctx.shouldDisplayAddOption"
 								(selected)="panelRef.emitValue(option)"

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -1,6 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, HostListener, inject, signal, TrackByFunction } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
@@ -80,6 +80,17 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	optionTpl = this.selectInput.optionTpl;
 
 	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
+	pointerNavigation = signal(false);
+
+	@HostListener('document:keydown')
+	onKeydown(): void {
+		this.pointerNavigation.set(false);
+	}
+
+	@HostListener('document:mousemove')
+	onMousemove(): void {
+		this.pointerNavigation.set(true);
+	}
 
 	public keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -76,33 +76,17 @@
 					border-end-end-radius: var(--pr-t-border-radius-default);
 				}
 
-				:host-context(.lu-picker-panel.is-withPointerNavigation) & {
-					&:hover {
-						background-color: var(--palettes-100, var(--palettes-product-100));
-					}
+				:host-context(.is-highlighted) & {
+					background-color: var(--palettes-100, var(--palettes-product-100));
 				}
 
 				&:active {
 					background-color: var(--palettes-200, var(--palettes-product-200));
 				}
-
-				:host-context(.is-highlighted) & {
-					:host-context(.lu-picker-panel:not(.is-withPointerNavigation)) & {
-						background-color: var(--palettes-100, var(--palettes-product-100));
-					}
-				}
-			}
-
-			:host-context(.lu-picker-panel.is-withPointerNavigation) & {
-				&:hover {
-					background-color: var(--palettes-neutral-50);
-				}
 			}
 
 			:host-context(.is-highlighted) & {
-				:host-context(.lu-picker-panel:not(.is-withPointerNavigation)) & {
-					background-color: var(--palettes-neutral-50);
-				}
+				background-color: var(--palettes-neutral-50);
 			}
 
 			&:active {
@@ -202,19 +186,9 @@
 					--components-options-checkbox-border-color: var(--palettes-neutral-500); // disabled token candidate
 				}
 
-				&:not(.is-disabled):hover {
-					:host-context(.lu-picker-panel.is-withPointerNavigation) & {
-						&::before {
-							box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
-						}
-					}
-				}
-
-				:host-context(.is-highlighted) & {
-					:host-context(.lu-picker-panel:not(.is-withPointerNavigation)) & {
-						&::before {
-							box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
-						}
+				:host-context(.is-highlighted) &:not(.is-disabled) {
+					&::before {
+						box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
 					}
 				}
 			}

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -76,7 +76,7 @@
 					border-end-end-radius: var(--pr-t-border-radius-default);
 				}
 
-				:host-context(.is-highlighted) & {
+				:host-context(.optionItem.is-highlighted) & {
 					background-color: var(--palettes-100, var(--palettes-product-100));
 				}
 
@@ -85,7 +85,7 @@
 				}
 			}
 
-			:host-context(.is-highlighted) & {
+			:host-context(.optionItem.is-highlighted) & {
 				background-color: var(--palettes-neutral-50);
 			}
 
@@ -112,7 +112,7 @@
 
 			@layer mods {
 				&:hover,
-				:host-context(.is-highlighted) & {
+				:host-context(.optionItem.is-highlighted) & {
 					background-color: inherit;
 				}
 			}
@@ -186,7 +186,7 @@
 					--components-options-checkbox-border-color: var(--palettes-neutral-500); // disabled token candidate
 				}
 
-				:host-context(.is-highlighted) &:not(.is-disabled) {
+				:host-context(.optionItem.is-highlighted) &:not(.is-disabled) {
 					&::before {
 						box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
 					}

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -203,8 +203,18 @@
 				}
 
 				&:not(.is-disabled):hover {
-					&::before {
-						box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
+					:host-context(.lu-picker-panel.is-withPointerNavigation) & {
+						&::before {
+							box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
+						}
+					}
+				}
+
+				:host-context(.is-highlighted) & {
+					:host-context(.lu-picker-panel:not(.is-withPointerNavigation)) & {
+						&::before {
+							box-shadow: inset 0 0 0 2px var(--components-options-checkbox-color);
+						}
 					}
 				}
 			}

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -76,8 +76,10 @@
 					border-end-end-radius: var(--pr-t-border-radius-default);
 				}
 
-				&:hover {
-					background-color: var(--palettes-100, var(--palettes-product-100));
+				:host-context(.lu-picker-panel.is-withPointerNavigation) & {
+					&:hover {
+						background-color: var(--palettes-100, var(--palettes-product-100));
+					}
 				}
 
 				&:active {
@@ -85,27 +87,21 @@
 				}
 
 				:host-context(.is-highlighted) & {
-					background-color: var(--palettes-100, var(--palettes-product-100));
-
-					&:hover {
-						background-color: var(--palettes-200, var(--palettes-product-200));
+					:host-context(.lu-picker-panel:not(.is-withPointerNavigation)) & {
+						background-color: var(--palettes-100, var(--palettes-product-100));
 					}
 				}
 			}
 
-			&:hover {
-				background-color: var(--palettes-neutral-50);
-			}
-
-			:host-context(.is-highlighted) & {
-				background-color: var(--palettes-neutral-50);
-
+			:host-context(.lu-picker-panel.is-withPointerNavigation) & {
 				&:hover {
 					background-color: var(--palettes-neutral-50);
 				}
+			}
 
-				&:active {
-					background-color: var(--palettes-neutral-100);
+			:host-context(.is-highlighted) & {
+				:host-context(.lu-picker-panel:not(.is-withPointerNavigation)) & {
+					background-color: var(--palettes-neutral-50);
 				}
 			}
 

--- a/packages/scss/src/components/color/index.scss
+++ b/packages/scss/src/components/color/index.scss
@@ -23,8 +23,8 @@
 			@include selected;
 		}
 
-		.optionItem.is-highlighted &,
-		[role='listbox'] .optionItem:hover & {
+		.lu-picker-panel:not(.is-withPointerNavigation) .optionItem.is-highlighted &,
+		.lu-picker-panel.is-withPointerNavigation [role='listbox'] .optionItem:hover & {
 			@include highlighted;
 		}
 	}

--- a/packages/scss/src/components/color/index.scss
+++ b/packages/scss/src/components/color/index.scss
@@ -23,8 +23,7 @@
 			@include selected;
 		}
 
-		.lu-picker-panel:not(.is-withPointerNavigation) .optionItem.is-highlighted &,
-		.lu-picker-panel.is-withPointerNavigation [role='listbox'] .optionItem:hover & {
+		.lu-picker-panel .optionItem.is-highlighted & {
 			@include highlighted;
 		}
 	}


### PR DESCRIPTION
## Description

This fix prevents two areas from being highlighted at the same time when navigating a listbox using both the keyboard and the mouse.

-----



-----
Before: 
<img width="1490" height="1056" alt="before" src="https://github.com/user-attachments/assets/2789a0f5-c017-424a-a9ae-383a488ab11e" />

After:
<img width="1490" height="1056" alt="after" src="https://github.com/user-attachments/assets/021cf906-3730-4e5c-ab30-f443fdcc0617" />


