### PR TITLE
feat: Install specific npm version in workflow for stage release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 24.13.0
           registry-url: 'https://registry.npmjs.org'
 
+      - run: npm install -g npm@11.15.0
       - run: npm ci
       - run: npm run build
 


### PR DESCRIPTION
## Description

Note: Staged publishing requires [npm CLI](https://docs.npmjs.com/cli/v11) version 11.15.0 or later and Node version 22.14.0 or higher.

https://docs.npmjs.com/staged-publishing

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
