### PR TITLE
feat(callout-popver): allow `buttonLabel` number input

### DIFF
--- a/packages/ng/callout/callout-popover/callout-popover.component.ts
+++ b/packages/ng/callout/callout-popover/callout-popover.component.ts
@@ -31,7 +31,7 @@ export class CalloutPopoverComponent {
 	/**
 	 * Label (visual only) to put inside the button, often used to show just a number
 	 */
-	readonly buttonLabel = input<string>();
+	readonly buttonLabel = input<string | number>();
 
 	/**
 	 * Alternative for the button


### PR DESCRIPTION
This pull request makes a small update to the `CalloutPopoverComponent` to improve its flexibility. The `buttonLabel` input now accepts both strings and numbers, allowing you to use numeric values directly for button labels.

- Changed the `buttonLabel` input type from `string` to `string | number` in `callout-popover.component.ts`, enabling support for numeric button labels.