### PR TITLE
fix(core-select): correct totalCount response type for users directive

### DIFF
--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -145,14 +145,14 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	public totalCount$ = toObservable(computed(() => ({ url: this.urlOrDefault(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
-			this.httpClient.get<{ count: number }>(url, {
+			this.httpClient.get<{ data: { count: number } }>(url, {
 				params: {
 					...filters,
 					fields: 'collection.count',
 				},
 			}),
 		),
-		map((res) => res?.count ?? 0),
+		map((res) => res?.data.count ?? 0),
 	);
 
 	protected getMe(): Observable<T | null> {

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -145,14 +145,14 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	public totalCount$ = toObservable(computed(() => ({ url: this.urlOrDefault(), filters: this.filters() }))).pipe(
 		debounceTime(250),
 		switchMap(({ url, filters }) =>
-			this.httpClient.get<{ data: { count: number } }>(url, {
+			this.httpClient.get<{ data: { count: number } } | { count: number }>(url, {
 				params: {
 					...filters,
 					fields: 'collection.count',
 				},
 			}),
 		),
-		map((res) => res?.data.count ?? 0),
+		map((res) => ('data' in res ? (res?.data.count ?? 0) : (res?.count ?? 0))),
 	);
 
 	protected getMe(): Observable<T | null> {


### PR DESCRIPTION
## Description

Fix the totalCount$ observable in LuCoreSelectUsersDirective to correctly handle the API response structure.

- **Issue**: The observable was incorrectly typed as { count: number } but the API returns { data: { count: number } }
- **Fix**: Updated type annotation and the map function to correctly access the nested count property

-----
