### PR TITLE
tech(ai): skills lucca-front-deprecated-resolver

### DIFF
--- a/.github/skills/lucca-front-deprecated-resolver/SKILL.md
+++ b/.github/skills/lucca-front-deprecated-resolver/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: lucca-front-deprecated-resolver
+description: 'Skill de migration des APIs dépréciées de Lucca Front (@lucca-front/ng). Charge ce skill pour identifier et migrer automatiquement les éléments marqués @deprecated : NgModules (LuApiModule, LuDateModule, LuDropdownModule, LuSelectModule, LuSidepanelModule, LuDepartmentModule, LuEstablishmentModule, LuUserModule, LuOptionModule, LuTreeOptionModule, LuModalModule, LuInputModule, LuTooltipModule, LuTitleModule, LuToastsModule, LuNumberModule, LuScrollModule, LuSafeContentModule, LuFormlyModule, LuPopoverModule, LuPopupModule), composants dépréciés (LuSelectInputComponent, LuDepartmentSelectInputComponent, LuEstablishmentSelectInputComponent, LuUserSelectInputComponent, LuDropdownPanelComponent), inputs dépréciés (withRole, delete→critical, fullpage→fullPage, icon→illustration), modèles dépréciés (ILuTranslation, sidepanel model), services dépréciés (LuSidepanel, LuDepartmentV3Service, LuTitleService), tokens dépréciés (USER_POPOVER_IS_ACTIVATED, APP_TITLE). Use when migrating deprecated lucca-front APIs.'
+---
+
+# lucca-front-deprecated-resolver
+
+Ce skill guide la migration automatique de tous les éléments marqués `@deprecated` dans `@lucca-front/ng` et `@lucca-front/prisme`.
+
+---
+
+## Étape 1 — Analyse
+
+Scanner le code source du projet à migrer :
+
+1. Chercher les imports depuis `@lucca-front/ng/*` et `@lucca-front/prisme/*`.
+2. Identifier les NgModules, composants, directives, services, tokens et types dépréciés présents.
+3. Chercher les attributs HTML dépréciés dans les templates (`.html` et templates inline).
+4. Associer chaque élément trouvé à son fichier de référence dans ce skill.
+
+### Éléments à détecter
+
+#### NgModules dépréciés → remplacer par imports standalone
+
+| Détecté | Référence |
+|---|---|
+| `LuApiModule`, `LuApiSelectModule`, `LuApiSelectInputModule`, `LuApiSearcherModule` | [LuApiModule.md](./references/LuApiModule.md) |
+| `LuDateModule`, `LuDatePickerModule`, `LuDateSelectInputModule`, `LuDateAdapterModule` | [LuDateModule.md](./references/LuDateModule.md) |
+| `LuDropdownModule`, `LuDropdownPanelModule`, `LuDropdownItemModule`, `LuDropdownTriggerModule` | [LuDropdownModule.md](./references/LuDropdownModule.md) |
+| `LuSelectModule`, `LuSelectInputModule` | [LuSelectModule.md](./references/LuSelectModule.md) |
+| `LuSidepanelModule` | [LuSidepanelModule.md](./references/LuSidepanelModule.md) |
+| `LuDepartmentModule`, `LuDepartmentSelectModule`, `LuDepartmentSelectInputModule` | [LuDepartmentModule.md](./references/LuDepartmentModule.md) |
+| `LuEstablishmentModule`, `LuEstablishmentSelectModule`, `LuEstablishmentSelectInputModule` | [LuEstablishmentModule.md](./references/LuEstablishmentModule.md) |
+| `LuUserModule`, `LuUserSelectModule`, `LuUserSelectInputModule`, `LuUserDisplayModule`, `LuUserPictureModule`, `LuUserTileModule`, `LuUserMeOptionModule`, `LuUserSearcherModule` | [LuUserModule.md](./references/LuUserModule.md) |
+| `LuOptionModule`, `LuOptionItemModule`, `LuOptionPickerModule`, `LuOptionFeederModule`, `LuOptionPagerModule`, `LuOptionSearcherModule`, `LuOptionSelectAllModule`, `LuForOptionsModule` | [LuOptionModule.md](./references/LuOptionModule.md) |
+| `LuTreeOptionModule`, `LuTreeOptionItemModule`, `LuTreeOptionPickerModule`, `LuTreeOptionFeederModule`, `LuForTreeOptionsModule`, `LuTreeOptionSearcherModule`, `LuTreeOptionOperatorModule` | [LuOptionModule.md](./references/LuOptionModule.md) |
+| `LuModalModule` | [LuModalModule.md](./references/LuModalModule.md) |
+| `LuPopupModule` | [LuModalModule.md](./references/LuModalModule.md) |
+| `LuPopoverModule`, `LuPopoverPanelModule` | [LuModalModule.md](./references/LuModalModule.md) |
+| `LuTooltipModule`, `LuTooltipTriggerModule` | [LuTooltipModule.md](./references/LuTooltipModule.md) |
+| `LuInputModule`, `LuInputClearerModule`, `LuInputDisplayerModule` | [LuInputModule.md](./references/LuInputModule.md) |
+| `LuTitleModule` | [LuTitleModule.md](./references/LuTitleModule.md) |
+| `LuToastsModule`, `LuNumberModule`, `LuScrollModule`, `LuSafeContentModule`, `LuFormlyModule` | [NgModulesSimples.md](./references/NgModulesSimples.md) |
+
+#### Composants dépréciés → migration HTML + TS
+
+| Détecté | Référence |
+|---|---|
+| `lu-select` / `LuSelectInputComponent` | [LuSelectModule.md](./references/LuSelectModule.md) |
+| `lu-department-select` / `LuDepartmentSelectInputComponent` | [LuDepartmentModule.md](./references/LuDepartmentModule.md) |
+| `lu-establishment-select` / `LuEstablishmentSelectInputComponent` | [LuEstablishmentModule.md](./references/LuEstablishmentModule.md) |
+| `lu-user-select` / `LuUserSelectInputComponent` | [LuUserModule.md](./references/LuUserModule.md) |
+| `lu-input-clearer` / `LuInputClearerComponent` | [LuInputModule.md](./references/LuInputModule.md) |
+
+#### Inputs/Outputs dépréciés
+
+| Élément | Input déprécié | Référence |
+|---|---|---|
+| `lu-divider` | `withRole` | [DividerComponent.md](./references/DividerComponent.md) |
+| `[luButton]` / `button[luButton]` | `delete` | [ButtonComponent.md](./references/ButtonComponent.md) |
+| `lu-loading` | `type="fullpage"` | [LoadingComponent.md](./references/LoadingComponent.md) |
+| `lu-empty-state-section` | `icon` | [EmptyStateSectionComponent.md](./references/EmptyStateSectionComponent.md) |
+| `lu-single-file-upload`, `lu-multi-file-upload` | `illustration="paper"` | [BaseFileUploadComponent.md](./references/BaseFileUploadComponent.md) |
+| `lu-highlight-data` | `icon="manifying-glass"` | [HighlightDataComponent.md](./references/HighlightDataComponent.md) |
+| Composants select (core-select) | `.grouping` / `.grouping =` | [CoreSelectInputComponent.md](./references/CoreSelectInputComponent.md) |
+
+#### Services, tokens et types dépréciés
+
+| Détecté | Référence |
+|---|---|
+| `LuSidepanel` (service), `LU_SIDEPANEL_DATA`, `ILuSidepanelRef`, `ALuSidepanelRef` | [LuSidepanelModule.md](./references/LuSidepanelModule.md) |
+| `LuDepartmentV3Service` | [LuDepartmentModule.md](./references/LuDepartmentModule.md) |
+| `LuTitleService`, `LuTitleStrategy`, `APP_TITLE` | [LuTitleModule.md](./references/LuTitleModule.md) |
+| `USER_POPOVER_IS_ACTIVATED`, `provideLuUserPopover` | [UserPopoverProviders.md](./references/UserPopoverProviders.md) |
+| `ILuTranslation` | [TranslationModel.md](./references/TranslationModel.md) |
+| `LuSimpleSelectApiV4Directive`, `ALuSimpleSelectApiDirective` (depuis `simple-select`) | [SimpleSelectApiAliases.md](./references/SimpleSelectApiAliases.md) |
+| `defaultOnClosedFn<C>()` (version générique) | [DialogRoutingComponent.md](./references/DialogRoutingComponent.md) |
+
+---
+
+## Étape 2 — Lecture de la référence
+
+Pour chaque élément déprécié identifié :
+1. Ouvrir le fichier de référence correspondant (voir table ci-dessus).
+2. Lire les règles de migration.
+3. Déterminer si la migration est automatique ou nécessite une intervention humaine.
+
+---
+
+## Étape 3 — Migration
+
+Appliquer les transformations selon les règles de chaque fichier de référence :
+
+- **NgModules** : remplacer le module dans les `imports` par la liste de composants standalone. Mettre à jour les imports TypeScript.
+- **Composants** : remplacer le sélecteur HTML et adapter le template. Mettre à jour les imports TypeScript.
+- **Inputs/Outputs** : renommer, supprimer ou transformer les attributs HTML.
+- **Services/Tokens** : remplacer les injections, providers et imports.
+- **Types/Interfaces** : renommer les types et mettre à jour les imports.
+
+### Règle générale pour les NgModules
+
+La plupart des NgModules dépréciés sont de simples wrappers standalone. La migration consiste à :
+1. Supprimer le module de `imports` dans `@NgModule` ou `@Component`.
+2. Ajouter directement les composants/directives/pipes standalone dans `imports`.
+3. Mettre à jour l'import TypeScript vers le bon chemin.
+
+---
+
+## Étape 4 — Annotation
+
+**Uniquement pour les migrations de composants** (changements potentiellement breaking), ajouter une annotation à proximité du code modifié.
+
+### Annotation dans un fichier TypeScript
+
+```ts
+/*
+** IA lucca-front-deprecated-resolver
+** try to migrate ${NomDuComposantDéprécié}
+*/
+```
+
+### Annotation dans un fichier HTML
+
+```html
+<!--
+  IA lucca-front-deprecated-resolver
+  try to migrate ${NomDuComposantDéprécié}
+-->
+```
+
+**Composants nécessitant une annotation :**
+- `LuSelectInputComponent` (`lu-select`)
+- `LuDepartmentSelectInputComponent` (`lu-department-select`)
+- `LuEstablishmentSelectInputComponent` (`lu-establishment-select`)
+- `LuUserSelectInputComponent` (`lu-user-select`)
+- `LuSidepanelModule` / `LuSidepanel`
+- `LuDropdownPanelComponent` (`lu-dropdown`)
+
+**Pas d'annotation nécessaire pour :**
+- Remplacement de NgModules simples (non breaking)
+- Renommage d'inputs simples
+- Suppression de tokens/providers obsolètes
+
+---
+
+## Étape 5 — Validation
+
+Après migration :
+
+1. **Vérifier les imports TypeScript** : s'assurer que tous les imports sont cohérents avec les nouveaux packages.
+2. **Vérifier la compilation** : lancer `ng build` ou `tsc --noEmit` pour vérifier l'absence d'erreurs.
+3. **Vérifier les nouvelles APIs** : confirmer que les nouveaux composants/directives sont correctement utilisés.
+4. **Signaler les migrations impossibles** : noter les cas nécessitant une intervention humaine.
+
+### Cas nécessitant une intervention humaine
+
+- Migration de `lu-select` vers `lu-simple-select` ou `lu-multi-select` avec des options complexes
+- Migration de `lu-department-select`, `lu-establishment-select`, `lu-user-select` avec des configurations avancées
+- Migration de `lu-dropdown` (ancienne architecture) vers la nouvelle approche menu Prisme
+- Migration de `LuSidepanel` si la logique de callback est complexe
+- Migration de `LuTitleService` si des observables sont utilisés pour le titre
+
+---
+
+## Étape 6 — Reporting
+
+Produire un rapport structuré contenant :
+
+### Migrations réalisées automatiquement
+- Liste des éléments migrés
+- Fichiers modifiés
+- Références utilisées
+
+### Migrations partiellement réalisées
+- Éléments partiellement migrés
+- Ce qui a été fait
+- Ce qui reste à faire manuellement
+
+### Migrations impossibles à automatiser
+- Éléments nécessitant une intervention humaine
+- Raison
+- Guidance pour la migration manuelle
+
+### Récapitulatif
+- Nombre total d'éléments dépréciés détectés
+- Nombre de migrations automatiques
+- Nombre de migrations manuelles requises
+- Fichiers modifiés

--- a/.github/skills/lucca-front-deprecated-resolver/_index.json
+++ b/.github/skills/lucca-front-deprecated-resolver/_index.json
@@ -1,0 +1,102 @@
+{
+  "LuApiModule": {
+    "description": "NgModules dépréciés LuApiModule, LuApiSelectModule, LuApiSelectInputModule, LuApiSearcherModule. Remplacer par imports standalone : LuApiFeederComponent, LuApiPagedSearcherComponent, LuApiSearcherComponent, LuApiPagerComponent, LuApiSelectInputComponent.",
+    "category": "Deprecated"
+  },
+  "LuDateModule": {
+    "description": "NgModules dépréciés LuDateModule, LuDatePickerModule, LuDateSelectInputModule, LuDateAdapterModule. Remplacer par : LuCalendarInputComponent, LuDatePickerComponent, LuDateInputDirective, LuDateAdapterPipe, LuDateSelectInputComponent.",
+    "category": "Deprecated"
+  },
+  "LuDropdownModule": {
+    "description": "NgModules dépréciés LuDropdownModule, LuDropdownPanelModule, LuDropdownItemModule, LuDropdownTriggerModule. LuDropdownPanelComponent (lu-dropdown) déprécié. Input luDropdownAlignment déprécié → customPositions.",
+    "category": "Deprecated"
+  },
+  "LuSelectModule": {
+    "description": "LuSelectModule, LuSelectInputModule, LuSelectInputComponent (lu-select) dépréciés. Migrer vers lu-simple-select ou lu-multi-select.",
+    "category": "Deprecated"
+  },
+  "LuSidepanelModule": {
+    "description": "LuSidepanelModule, LuSidepanel service, LU_SIDEPANEL_DATA, ILuSidepanelRef, ALuSidepanelRef dépréciés. Utiliser LuModal avec mode sidepanel.",
+    "category": "Deprecated"
+  },
+  "LuDepartmentModule": {
+    "description": "LuDepartmentModule, LuDepartmentSelectModule, LuDepartmentSelectInputModule, LuDepartmentSelectInputComponent (lu-department-select), LuDepartmentFeederComponent, LuDepartmentV3Service dépréciés.",
+    "category": "Deprecated"
+  },
+  "LuEstablishmentModule": {
+    "description": "LuEstablishmentModule, LuEstablishmentSelectModule, LuEstablishmentSelectInputModule, LuEstablishmentSelectInputComponent (lu-establishment-select) dépréciés. Migrer vers SimpleSelect/MultipleSelect avec directives establishments.",
+    "category": "Deprecated"
+  },
+  "LuUserModule": {
+    "description": "LuUserModule, LuUserSelectModule, LuUserSelectInputModule, LuUserDisplayModule, LuUserPictureModule, LuUserTileModule, LuUserMeOptionModule, LuUserSearcherModule, LuUserSelectInputComponent (lu-user-select) dépréciés.",
+    "category": "Deprecated"
+  },
+  "LuOptionModule": {
+    "description": "NgModules dépréciés du système option : LuOptionModule, LuOptionItemModule, LuOptionPickerModule, LuOptionFeederModule, LuOptionPagerModule, LuOptionSearcherModule, LuOptionSelectAllModule, LuForOptionsModule, LuTreeOptionModule et variantes tree. Composants picker dépréciés.",
+    "category": "Deprecated"
+  },
+  "LuModalModule": {
+    "description": "NgModules dépréciés LuModalModule, LuPopupModule, LuPopoverModule, LuPopoverPanelModule. Remplacer par imports/providers directs.",
+    "category": "Deprecated"
+  },
+  "LuTooltipModule": {
+    "description": "NgModules dépréciés LuTooltipModule, LuTooltipTriggerModule. Remplacer par LuTooltipTriggerDirective, LuTooltipPanelComponent.",
+    "category": "Deprecated"
+  },
+  "LuInputModule": {
+    "description": "NgModules dépréciés LuInputModule, LuInputClearerModule, LuInputDisplayerModule. LuInputClearerComponent (lu-input-clearer) → ClearComponent (lu-clear).",
+    "category": "Deprecated"
+  },
+  "LuTitleModule": {
+    "description": "LuTitleModule, LuTitleService, LuTitleStrategy (classe), APP_TITLE dépréciés. Migrer vers provideLuTitleStrategy().",
+    "category": "Deprecated"
+  },
+  "NgModulesSimples": {
+    "description": "NgModules dépréciés simples : LuToastsModule → LuToastsComponent, LuNumberModule → LuNumberPipe, LuScrollModule → LuScrollDirective, LuSafeContentModule → LuSafeHtmlPipe, LuFormlyModule → provideLuFormly().",
+    "category": "Deprecated"
+  },
+  "DividerComponent": {
+    "description": "Input déprécié withRole sur lu-divider. Supprimer l'attribut.",
+    "category": "Deprecated"
+  },
+  "ButtonComponent": {
+    "description": "Input déprécié delete sur [luButton]. Remplacer par critical.",
+    "category": "Deprecated"
+  },
+  "LoadingComponent": {
+    "description": "Valeur dépréciée 'fullpage' pour l'input type de lu-loading. Remplacer par 'fullPage'.",
+    "category": "Deprecated"
+  },
+  "EmptyStateSectionComponent": {
+    "description": "Input déprécié icon sur lu-empty-state-section. Remplacer par illustration et/ou action.",
+    "category": "Deprecated"
+  },
+  "BaseFileUploadComponent": {
+    "description": "Valeur dépréciée 'paper' pour l'input illustration des composants file upload. Remplacer par 'invoice'.",
+    "category": "Deprecated"
+  },
+  "HighlightDataComponent": {
+    "description": "Valeur dépréciée 'manifying-glass' (faute de frappe) pour l'icône de lu-highlight-data. Remplacer par 'magnifying-glass'.",
+    "category": "Deprecated"
+  },
+  "CoreSelectInputComponent": {
+    "description": "Propriété dépréciée grouping (getter/setter) sur les composants select. Remplacer par groupingSignal (Signal).",
+    "category": "Deprecated"
+  },
+  "TranslationModel": {
+    "description": "Interface dépréciée ILuTranslation<T>. Remplacer par LuTranslation<T> depuis @lucca-front/ng/core.",
+    "category": "Deprecated"
+  },
+  "SimpleSelectApiAliases": {
+    "description": "Aliases dépréciés LuSimpleSelectApiV4Directive et ALuSimpleSelectApiDirective depuis @lucca-front/ng/simple-select. Utiliser LuCoreSelectApiV4Directive et ALuCoreSelectApiDirective depuis @lucca-front/ng/core-select/api.",
+    "category": "Deprecated"
+  },
+  "UserPopoverProviders": {
+    "description": "Token USER_POPOVER_IS_ACTIVATED et fonction provideLuUserPopover() dépréciés. Supprimer ces providers.",
+    "category": "Deprecated"
+  },
+  "DialogRoutingComponent": {
+    "description": "Surcharge générique defaultOnClosedFn<C>() dépréciée. Utiliser la version non générique defaultOnClosedFn().",
+    "category": "Deprecated"
+  }
+}

--- a/.github/skills/lucca-front-deprecated-resolver/references/BaseFileUploadComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/BaseFileUploadComponent.md
@@ -1,0 +1,31 @@
+# BaseFileUploadComponent — valeur `paper` dépréciée pour l'input `illustration`
+
+## Contexte de dépréciation
+
+La valeur `'paper'` de l'input `illustration` du composant de file upload est dépréciée. Elle doit être remplacée par `'invoice'`.
+
+## Valeur dépréciée
+
+| Valeur dépréciée | Remplacement |
+|---|---|
+| `'paper'` | `'invoice'` |
+
+L'input accepte : `'paper'` (déprécié) | `'picture'` | `'invoice'`
+
+## Migration
+
+### Avant
+
+```html
+<lu-single-file-upload illustration="paper" />
+```
+
+### Après
+
+```html
+<lu-single-file-upload illustration="invoice" />
+```
+
+## Migration automatique
+
+Remplacer `illustration="paper"` et `[illustration]="'paper'"` par `illustration="invoice"` et `[illustration]="'invoice'"`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/ButtonComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/ButtonComponent.md
@@ -1,0 +1,37 @@
+# ButtonComponent (prisme) — input `delete` déprécié
+
+## Contexte de dépréciation
+
+L'input `delete` du composant bouton Prisme est déprécié. Il doit être remplacé par l'input `critical`.
+
+## Input déprécié
+
+| Input déprécié | Remplacement | Notes |
+|---|---|---|
+| `delete` | `critical` | Renommage simple |
+
+## Migration
+
+### Avant
+
+```html
+<button luButton [delete]="true">Supprimer</button>
+<!-- ou -->
+<button luButton delete>Supprimer</button>
+```
+
+### Après
+
+```html
+<button luButton critical>Supprimer</button>
+```
+
+## Migration automatique
+
+Remplacer `[delete]="true"` par `critical` et supprimer les occurrences de `[delete]="false"` (valeur par défaut).
+
+Règle de transformation :
+- `[delete]="true"` → `critical`
+- `delete` (attribut booléen) → `critical`
+- `[delete]="false"` → supprimer l'attribut
+- `[delete]="someVar"` → `[critical]="someVar"`

--- a/.github/skills/lucca-front-deprecated-resolver/references/CoreSelectInputComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/CoreSelectInputComponent.md
@@ -1,0 +1,32 @@
+# CoreSelectInputComponent — propriété `grouping` dépréciée
+
+## Contexte de dépréciation
+
+Les getter/setter `grouping` sur `ALuCoreSelectInputComponent` (et ses dérivés) sont dépréciés au profit du signal `groupingSignal`.
+
+## Propriété dépréciée
+
+| Propriété dépréciée | Remplacement |
+|---|---|
+| `grouping` (getter/setter) | `groupingSignal` (Signal) |
+
+## Migration TypeScript
+
+### Avant
+
+```ts
+this.selectComponent.grouping = myGrouping;
+const current = this.selectComponent.grouping;
+```
+
+### Après
+
+```ts
+this.selectComponent.groupingSignal.set(myGrouping);
+const current = this.selectComponent.groupingSignal();
+```
+
+## Migration automatique
+
+- Remplacer les assignments `component.grouping = value` par `component.groupingSignal.set(value)`.
+- Remplacer les lectures `component.grouping` par `component.groupingSignal()`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/DialogRoutingComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/DialogRoutingComponent.md
@@ -1,0 +1,35 @@
+# DialogRoutingComponent — defaultOnClosedFn générique déprécié
+
+## Contexte de dépréciation
+
+La surcharge générique `defaultOnClosedFn<C>()` de la fonction `defaultOnClosedFn` est dépréciée. La version non générique doit être utilisée.
+
+## Élément déprécié
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `defaultOnClosedFn<C>()` (surcharge générique) | `defaultOnClosedFn()` (version non générique) |
+
+## Migration
+
+### Avant
+
+```ts
+import { defaultOnClosedFn } from '@lucca-front/ng/dialog';
+
+// Utilisation avec paramètre de type générique
+onClosed: defaultOnClosedFn<MyComponent>
+```
+
+### Après
+
+```ts
+import { defaultOnClosedFn } from '@lucca-front/ng/dialog';
+
+// Sans paramètre de type
+onClosed: defaultOnClosedFn
+```
+
+## Migration automatique
+
+Supprimer les paramètres de type génériques `<...>` sur les appels à `defaultOnClosedFn`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/DividerComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/DividerComponent.md
@@ -1,0 +1,31 @@
+# DividerComponent — input `withRole` déprécié
+
+## Contexte de dépréciation
+
+L'input `withRole` du composant `lu-divider` est déprécié sans remplacement documenté. Il ne doit plus être utilisé.
+
+## Input déprécié
+
+| Input | Type | Action |
+|---|---|---|
+| `withRole` | `boolean` | Supprimer — ne plus utiliser |
+
+## Migration
+
+### Avant
+
+```html
+<lu-divider [withRole]="true" />
+```
+
+### Après
+
+```html
+<lu-divider />
+```
+
+Supprimer simplement l'attribut `[withRole]` ou `withRole` du template.
+
+## Migration automatique
+
+Supprimer l'attribut `[withRole]` ou `withRole` de toutes les occurrences de `lu-divider`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/EmptyStateSectionComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/EmptyStateSectionComponent.md
@@ -1,0 +1,55 @@
+# EmptyStateSectionComponent — input `icon` déprécié
+
+## Contexte de dépréciation
+
+L'input `icon` du composant `lu-empty-state-section` (`EmptyStateSectionComponent`) est déprécié. Il doit être remplacé par les inputs `illustration` et `action`.
+
+## Input déprécié
+
+| Input déprécié | Remplacement | Notes |
+|---|---|---|
+| `icon` | `illustration` + `action` | Voir logique ci-dessous |
+
+## Logique de migration
+
+L'ancien `icon` était un chemin d'image. La logique interne :
+- Si `icon` contient `'Action.svg'` → utiliser `[action]="true"`
+- Si `icon` contient `'Success'` → utiliser `illustration="thumbUp"`
+- Sinon → utiliser `[illustration]="iconValue"` avec une valeur `BubbleIllustration` appropriée
+
+## Migration
+
+### Avant
+
+```html
+<lu-empty-state-section [icon]="'/path/to/Action.svg'">
+  Aucun résultat
+</lu-empty-state-section>
+```
+
+### Après
+
+```html
+<lu-empty-state-section action>
+  Aucun résultat
+</lu-empty-state-section>
+```
+
+### Avant (icône Success)
+
+```html
+<lu-empty-state-section [icon]="'/path/to/Success.svg'">
+```
+
+### Après
+
+```html
+<lu-empty-state-section illustration="thumbUp">
+```
+
+## Migration automatique
+
+La migration est partiellement automatisable :
+- Si la valeur de `icon` contient `'Action'` → remplacer par `action`
+- Si la valeur de `icon` contient `'Success'` → remplacer par `illustration="thumbUp"`
+- Autres cas → signaler pour intervention humaine

--- a/.github/skills/lucca-front-deprecated-resolver/references/HighlightDataComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/HighlightDataComponent.md
@@ -1,0 +1,29 @@
+# HighlightDataComponent — valeur d'icône `manifying-glass` dépréciée
+
+## Contexte de dépréciation
+
+La valeur `'manifying-glass'` (faute de frappe) de l'input icon du composant `lu-highlight-data` est dépréciée. Elle doit être remplacée par `'magnifying-glass'`.
+
+## Valeur dépréciée
+
+| Valeur dépréciée | Remplacement | Raison |
+|---|---|---|
+| `'manifying-glass'` | `'magnifying-glass'` | Faute de frappe corrigée |
+
+## Migration
+
+### Avant
+
+```html
+<lu-highlight-data icon="manifying-glass" />
+```
+
+### Après
+
+```html
+<lu-highlight-data icon="magnifying-glass" />
+```
+
+## Migration automatique
+
+Remplacer toutes les occurrences de `'manifying-glass'` par `'magnifying-glass'`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LoadingComponent.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LoadingComponent.md
@@ -1,0 +1,31 @@
+# LoadingComponent — type `fullpage` déprécié
+
+## Contexte de dépréciation
+
+La valeur `'fullpage'` de l'input `type` du composant `lu-loading` est dépréciée. La casse correcte est `'fullPage'` (avec P majuscule).
+
+## Valeur dépréciée
+
+| Valeur dépréciée | Remplacement |
+|---|---|
+| `'fullpage'` | `'fullPage'` |
+
+## Migration
+
+### Avant
+
+```html
+<lu-loading type="fullpage" />
+<!-- ou -->
+<lu-loading [type]="'fullpage'" />
+```
+
+### Après
+
+```html
+<lu-loading type="fullPage" />
+```
+
+## Migration automatique
+
+Remplacer toutes les occurrences de `type="fullpage"` et `[type]="'fullpage'"` par `type="fullPage"` et `[type]="'fullPage'"`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuApiModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuApiModule.md
@@ -1,0 +1,57 @@
+# LuApiModule / LuApiSelectModule / LuApiSelectInputModule / LuApiSearcherModule
+
+## Contexte de dépréciation
+
+Ces NgModules sont des wrappers autour de composants standalone. Ils ont été conservés pour la compatibilité mais sont désormais inutiles.
+
+## Modules concernés
+
+| Module déprécié | Remplacement direct |
+|---|---|
+| `LuApiModule` | imports directs des composants standalone |
+| `LuApiSelectModule` | imports directs des composants standalone |
+| `LuApiSelectInputModule` | `LuApiSelectInputComponent` |
+| `LuApiSearcherModule` | `LuApiPagedSearcherComponent, LuApiSearcherComponent` |
+
+## Migration
+
+### Avant
+
+```ts
+import { LuApiModule } from '@lucca-front/ng/api';
+
+@NgModule({
+  imports: [LuApiModule],
+})
+```
+
+### Après
+
+```ts
+import {
+  LuApiFeederComponent,
+  LuApiPagedSearcherComponent,
+  LuApiSearcherComponent,
+  LuApiPagerComponent,
+  LuApiSelectInputComponent,
+} from '@lucca-front/ng/api';
+
+// Dans un composant standalone :
+@Component({
+  imports: [
+    LuApiFeederComponent,
+    LuApiPagedSearcherComponent,
+    LuApiSearcherComponent,
+    LuApiPagerComponent,
+    LuApiSelectInputComponent,
+  ],
+})
+```
+
+## Migration automatique
+
+- Remplacer `LuApiModule` dans les imports par la liste des composants standalone.
+- Remplacer `LuApiSelectModule` par `LuApiFeederComponent, LuApiPagedSearcherComponent, LuApiSearcherComponent, LuApiPagerComponent, LuApiSelectInputComponent`.
+- Remplacer `LuApiSelectInputModule` par `LuApiSelectInputComponent`.
+- Remplacer `LuApiSearcherModule` par `LuApiPagedSearcherComponent, LuApiSearcherComponent`.
+- Supprimer les imports depuis `@lucca-front/ng/api` qui correspondent aux modules dépréciés et les remplacer par les composants correspondants.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuDateModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuDateModule.md
@@ -1,0 +1,52 @@
+# LuDateModule / LuDatePickerModule / LuDateSelectInputModule / LuDateAdapterModule
+
+## Contexte de dépréciation
+
+Ces NgModules sont des wrappers de compatibilité autour de composants/pipes/directives standalone.
+
+## Modules concernés
+
+| Module déprécié | Remplacement direct |
+|---|---|
+| `LuDateModule` | `LuCalendarInputComponent, LuDatePickerComponent, LuDateInputDirective, LuDateAdapterPipe, LuDateSelectInputComponent` |
+| `LuDatePickerModule` | `LuDatePickerComponent` |
+| `LuDateSelectInputModule` | `LuDateSelectInputComponent` |
+| `LuDateAdapterModule` | `LuDateAdapterPipe` |
+
+## Migration
+
+### Avant
+
+```ts
+import { LuDateModule } from '@lucca-front/ng/date';
+
+@NgModule({
+  imports: [LuDateModule],
+})
+```
+
+### Après
+
+```ts
+import {
+  LuCalendarInputComponent,
+  LuDatePickerComponent,
+  LuDateInputDirective,
+  LuDateAdapterPipe,
+  LuDateSelectInputComponent,
+} from '@lucca-front/ng/date';
+
+@Component({
+  imports: [
+    LuCalendarInputComponent,
+    LuDatePickerComponent,
+    LuDateInputDirective,
+    LuDateAdapterPipe,
+    LuDateSelectInputComponent,
+  ],
+})
+```
+
+## Migration automatique
+
+Remplacer chaque module par ses équivalents standalone listés dans le tableau ci-dessus.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuDepartmentModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuDepartmentModule.md
@@ -1,0 +1,75 @@
+# LuDepartmentModule / LuDepartmentSelectModule / LuDepartmentSelectInputModule / LuDepartmentSelectInputComponent / LuDepartmentFeederComponent / LuDepartmentV3Service
+
+## Contexte de dépréciation
+
+L'ancien système de sélection de département utilise une architecture "picker" dépréciée. Il doit être remplacé par SimpleSelect ou MultipleSelect avec les directives department.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuDepartmentModule` | `LuDepartmentFeederComponent, LuDepartmentSelectInputComponent` (ou nouvelle API) |
+| `LuDepartmentSelectModule` | `LuDepartmentFeederComponent, LuDepartmentSelectInputComponent` |
+| `LuDepartmentSelectInputModule` | `LuDepartmentSelectInputComponent` |
+| `LuDepartmentSelectInputComponent` (`lu-department-select`) | nouvelle API (voir ci-dessous) |
+| `LuDepartmentFeederComponent` (`lu-department-feeder`) | directive department dans SimpleSelect/MultipleSelect |
+| `LuDepartmentV3Service` | `LuDepartmentService` |
+
+## Migration du composant
+
+### Avant
+
+```html
+<lu-department-select [(ngModel)]="department">
+  <lu-department-feeder />
+</lu-department-select>
+```
+
+```ts
+import { LuDepartmentModule } from '@lucca-front/ng/department';
+```
+
+### Après
+
+Utiliser `lu-simple-select` ou `lu-multi-select` avec la directive department appropriée. Consulter la documentation Prisme pour les directives disponibles.
+
+## Migration du service
+
+### Avant
+
+```ts
+import { LuDepartmentV3Service } from '@lucca-front/ng/department';
+
+providers: [{ provide: ILuDepartmentService, useClass: LuDepartmentV3Service }]
+```
+
+### Après
+
+```ts
+import { LuDepartmentService } from '@lucca-front/ng/department';
+
+providers: [{ provide: ILuDepartmentService, useClass: LuDepartmentService }]
+```
+
+## Migration automatique
+
+- Remplacer `LuDepartmentModule`, `LuDepartmentSelectModule` → imports standalone directs.
+- Remplacer `LuDepartmentSelectInputModule` → `LuDepartmentSelectInputComponent`.
+- Remplacer `LuDepartmentV3Service` → `LuDepartmentService`.
+- La migration HTML du composant `lu-department-select` nécessite une intervention humaine.
+
+## Annotation à ajouter lors de la migration
+
+```html
+<!--
+  IA lucca-front-deprecated-resolver
+  try to migrate LuDepartmentSelectInputComponent
+-->
+```
+
+```ts
+/*
+** IA lucca-front-deprecated-resolver
+** try to migrate LuDepartmentSelectInputComponent
+*/
+```

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuDropdownModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuDropdownModule.md
@@ -1,0 +1,44 @@
+# LuDropdownModule / LuDropdownPanelModule / LuDropdownItemModule / LuDropdownTriggerModule / LuDropdownPanelComponent
+
+## Contexte de dépréciation
+
+`LuDropdownPanelComponent` (sélecteur `lu-dropdown`) est déprécié au profit de la nouvelle approche menu de Prisme.
+Les NgModules wrappers sont également dépréciés au profit des imports directs des composants/directives standalone.
+
+## Modules concernés
+
+| Module déprécié | Remplacement |
+|---|---|
+| `LuDropdownModule` | `LuDropdownTriggerDirective, LuDropdownPanelComponent, LuDropdownItemDirective` |
+| `LuDropdownPanelModule` | `LuDropdownPanelComponent` |
+| `LuDropdownItemModule` | `LuDropdownItemDirective` |
+| `LuDropdownTriggerModule` | `LuDropdownTriggerDirective` |
+
+## Composant déprécié : LuDropdownPanelComponent
+
+**Remplacement recommandé :** nouvelle approche menu Prisme.
+Voir documentation : https://prisme.lucca.io/94310e217/p/557682-dropdown
+
+## Input déprécié : luDropdownAlignment
+
+L'input `luDropdownAlignment` sur la directive `LuDropdownTriggerDirective` est déprécié.
+
+**Remplacement :** utiliser `customPositions` à la place.
+
+### Avant
+
+```html
+<button [luDropdown]="panel" luDropdownAlignment="bottom">Ouvrir</button>
+```
+
+### Après
+
+```html
+<button [luDropdown]="panel" [luPopoverCustomPositions]="[...]">Ouvrir</button>
+```
+
+## Migration automatique des modules
+
+Remplacer chaque module par ses équivalents standalone listés dans le tableau ci-dessus.
+
+**Note :** La migration de `LuDropdownPanelComponent` vers la nouvelle approche menu nécessite une intervention humaine car l'architecture est différente.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuEstablishmentModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuEstablishmentModule.md
@@ -1,0 +1,52 @@
+# LuEstablishmentModule / LuEstablishmentSelectModule / LuEstablishmentSelectInputModule / LuEstablishmentSelectInputComponent
+
+## Contexte de dépréciation
+
+L'ancien système de sélection d'établissement est déprécié. Il doit être remplacé par SimpleSelect ou MultipleSelect avec les directives establishments.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuEstablishmentModule` | SimpleSelect / MultipleSelect avec directives establishments |
+| `LuEstablishmentSelectModule` | `LuEstablishmentSelectInputComponent, LuEstablishmentSearcherComponent, LuForLegalUnitsDirective, LuLegalUnitSelectorDirective, LuEstablishmentSelectAllComponent` |
+| `LuEstablishmentSelectInputModule` | `LuEstablishmentSelectInputComponent` |
+| `LuEstablishmentSelectInputComponent` (`lu-establishment-select`) | SimpleSelect / MultipleSelect avec directives establishments |
+
+## Migration du composant
+
+### Avant
+
+```html
+<lu-establishment-select [(ngModel)]="establishment">
+</lu-establishment-select>
+```
+
+```ts
+import { LuEstablishmentModule } from '@lucca-front/ng/establishment';
+```
+
+### Après
+
+Utiliser `lu-simple-select` ou `lu-multi-select` avec les directives establishments appropriées. Consulter la documentation Prisme pour les directives disponibles.
+
+## Migration automatique
+
+- Remplacer les modules NgModule par les imports standalone directs.
+- La migration HTML du composant `lu-establishment-select` nécessite une intervention humaine.
+
+## Annotation à ajouter lors de la migration
+
+```html
+<!--
+  IA lucca-front-deprecated-resolver
+  try to migrate LuEstablishmentSelectInputComponent
+-->
+```
+
+```ts
+/*
+** IA lucca-front-deprecated-resolver
+** try to migrate LuEstablishmentSelectInputComponent
+*/
+```

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuInputModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuInputModule.md
@@ -1,0 +1,52 @@
+# LuInputModule / LuInputClearerModule / LuInputDisplayerModule / LuInputClearerComponent / LuInputDisplayerDirective
+
+## Contexte de dépréciation
+
+Ces NgModules et certains composants/directives sont dépréciés au profit de leurs équivalents standalone.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuInputModule` | `LuInputDirective, LuInputDisplayerDirective, LuInputClearerComponent` |
+| `LuInputClearerModule` | `LuInputClearerComponent` |
+| `LuInputDisplayerModule` | `LuInputDisplayerDirective` |
+| `LuInputClearerComponent` (`lu-input-clearer`) | `ClearComponent` depuis `@lucca-front/ng/core-select` |
+| `LuInputDisplayerDirective` (`[luDisplayer]`) | utilisation directe de `LuInputDisplayerDirective` standalone |
+
+## Migration
+
+### LuInputClearerComponent → ClearComponent
+
+```html
+<!-- Avant -->
+<lu-input-clearer />
+
+<!-- Après -->
+<lu-clear />
+```
+
+```ts
+// Avant
+import { LuInputClearerModule } from '@lucca-front/ng/input';
+
+// Après
+import { ClearComponent } from '@lucca-front/ng/core-select';
+```
+
+### Modules NgModule → standalone
+
+```ts
+// Avant
+import { LuInputModule } from '@lucca-front/ng/input';
+@NgModule({ imports: [LuInputModule] })
+
+// Après
+import { LuInputDirective, LuInputDisplayerDirective, LuInputClearerComponent } from '@lucca-front/ng/input';
+@Component({ imports: [LuInputDirective, LuInputDisplayerDirective, LuInputClearerComponent] })
+```
+
+## Migration automatique
+
+1. Remplacer les NgModules par les imports standalone.
+2. Remplacer `lu-input-clearer` par `lu-clear` si `ClearComponent` est disponible dans le contexte.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuModalModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuModalModule.md
@@ -1,0 +1,68 @@
+# LuModalModule / LuPopupModule / LuPopoverModule / LuPopoverPanelModule
+
+## Contexte de dépréciation
+
+Ces NgModules sont des wrappers de compatibilité. Les imports et providers doivent être utilisés directement.
+
+## Modules concernés
+
+### LuModalModule
+
+**Déprécié :** `LuModalModule`
+
+**Remplacement :** `OverlayModule, DialogModule` en imports + `provideLuModal(), LuDialogService` en providers.
+
+```ts
+// Avant
+@NgModule({ imports: [LuModalModule] })
+
+// Après (providers dans le bootstrap ou le composant racine)
+bootstrapApplication(AppComponent, {
+  providers: [
+    importProvidersFrom(OverlayModule, DialogModule),
+    provideLuModal(),
+    LuDialogService,
+  ]
+})
+```
+
+### LuPopupModule
+
+**Déprécié :** `LuPopupModule`
+
+**Remplacement :** `OverlayModule` en imports + providers explicites.
+
+```ts
+// Avant
+@NgModule({ imports: [LuPopupModule] })
+
+// Après
+providers: [
+  importProvidersFrom(OverlayModule),
+  LuPopup,
+  { provide: LU_POPUP_CONFIG, useValue: luDefaultPopupConfig },
+  { provide: LU_POPUP_REF_FACTORY, useClass: LuPopupRefFactory },
+]
+```
+
+### LuPopoverModule
+
+**Déprécié :** `LuPopoverModule`
+
+**Remplacement :** `LuPopoverPanelComponent, LuPopoverTargetDirective, LuPopoverTriggerDirective`
+
+```ts
+@Component({
+  imports: [LuPopoverPanelComponent, LuPopoverTargetDirective, LuPopoverTriggerDirective],
+})
+```
+
+### LuPopoverPanelModule
+
+**Déprécié :** `LuPopoverPanelModule`
+
+**Remplacement :** `LuPopoverPanelComponent`
+
+## Migration automatique
+
+Remplacer chaque module par ses équivalents listés ci-dessus.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuOptionModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuOptionModule.md
@@ -1,0 +1,50 @@
+# LuOptionModule / LuTreeOptionModule et composants option dépréciés
+
+## Contexte de dépréciation
+
+Tous les NgModules wrappers du système "option" (ancienne architecture picker) sont dépréciés. Les composants et directives correspondants doivent être importés directement en standalone.
+
+## Modules NgModule dépréciés
+
+| Module déprécié | Remplacement |
+|---|---|
+| `LuOptionModule` | `LuOptionItemComponent, LuOptionPickerComponent, LuOptionPickerAdvancedComponent, LuOptionPagerComponent, LuOptionFeederComponent, LuOptionSearcherComponent, LuForOptionsDirective, LuForGroupsDirective, LuOptionSelectAllComponent, LuOptionPlaceholderComponent` |
+| `LuOptionItemModule` | `LuOptionItemComponent` |
+| `LuOptionPickerModule` | `LuOptionPickerComponent, LuOptionPickerAdvancedComponent, LuOptionItemComponent` |
+| `LuOptionFeederModule` | `LuOptionFeederComponent` |
+| `LuOptionPagerModule` | `LuOptionPagerComponent` |
+| `LuOptionSearcherModule` | `LuOptionSearcherComponent` |
+| `LuOptionSelectAllModule` | `LuOptionSelectAllComponent` |
+| `LuForOptionsModule` | `LuForOptionsDirective` |
+| `LuTreeOptionModule` | `LuTreeOptionItemComponent, LuTreeOptionPickerComponent, LuTreeOptionPickerAdvancedComponent, LuTreeOptionFeederComponent, LuForTreeOptionsDirective, LuTreeOptionPagerComponent, LuTreeOptionSearcherComponent, LuTreeOptionSelectAllComponent` |
+| `LuTreeOptionItemModule` | `LuTreeOptionItemComponent` |
+| `LuTreeOptionPickerModule` | `LuTreeOptionPickerComponent, LuTreeOptionPickerAdvancedComponent` |
+| `LuTreeOptionFeederModule` | `LuTreeOptionFeederComponent` |
+| `LuForTreeOptionsModule` | `LuForTreeOptionsDirective` |
+| `LuTreeOptionSearcherModule` | `LuTreeOptionSearcherComponent` |
+| `LuTreeOptionOperatorModule` | `LuTreeOptionFeederComponent, LuForTreeOptionsDirective, LuTreeOptionPagerComponent, LuTreeOptionSearcherComponent` |
+
+## Composants/Directives dépréciés (ancienne architecture)
+
+Ces éléments sont utilisés dans l'ancienne architecture "picker" et doivent être évités dans du nouveau code :
+
+- `LuOptionItemComponent` (`lu-option`)
+- `LuOptionPickerComponent` (`lu-option-picker`)
+- `ALuOptionPickerComponent`, `ALuOptionPickerAdvancedComponent` (classes abstraites)
+- `LuOptionPlaceholderComponent` (`lu-option-placeholder`)
+- `LuOptionSelectAllComponent` (`lu-option-select-all`)
+- `LuTreeOptionItemComponent` (`lu-tree-option`)
+- `LuTreeOptionPickerComponent` (`lu-tree-option-picker`)
+- `ALuTreeOptionPickerComponent`, `ALuTreeOptionPickerAdvancedComponent` (classes abstraites)
+- `LuTreeOptionFeederComponent` (`lu-tree-option-feeder`)
+- `LuTreeOptionPagerComponent` (`lu-tree-option-pager`)
+- `LuTreeOptionSearcherComponent` (`lu-tree-option-searcher`)
+- `LuForTreeOptionsDirective` (`[luForTreeOptions]`)
+- `LuTreeOptionSelectAllComponent` (`lu-tree-option-select-all`)
+- `LuDepartmentFeederComponent` (`lu-department-feeder`)
+
+## Migration automatique
+
+Remplacer chaque NgModule par les imports standalone directs listés dans le tableau.
+
+**Note :** L'utilisation des composants "picker" dans des templates nécessite une évaluation au cas par cas. Préférer les nouveaux composants `lu-simple-select` et `lu-multi-select`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuSelectModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuSelectModule.md
@@ -1,0 +1,76 @@
+# LuSelectModule / LuSelectInputModule / LuSelectInputComponent
+
+## Contexte de dépréciation
+
+`LuSelectInputComponent` (sélecteur `lu-select`) et ses modules sont dépréciés au profit de `SimpleSelect` ou `MultipleSelect`.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuSelectModule` | `lu-simple-select` ou `lu-multi-select` |
+| `LuSelectInputModule` | `lu-simple-select` ou `lu-multi-select` |
+| `LuSelectInputComponent` (`lu-select`) | `lu-simple-select` ou `lu-multi-select` |
+
+## Migration
+
+### Sélection simple — Avant
+
+```html
+<lu-select [(ngModel)]="value" [options]="options">
+  <lu-option *luForOptions let-option [value]="option">{{ option.name }}</lu-option>
+</lu-select>
+```
+
+```ts
+import { LuSelectModule } from '@lucca-front/ng/select';
+```
+
+### Sélection simple — Après
+
+```html
+<lu-simple-select [(ngModel)]="value" [options]="options" optionValue="id" optionLabel="name" />
+```
+
+```ts
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+```
+
+### Sélection multiple — Avant
+
+```html
+<lu-select multiple [(ngModel)]="values" [options]="options">
+  <lu-option *luForOptions let-option [value]="option">{{ option.name }}</lu-option>
+</lu-select>
+```
+
+### Sélection multiple — Après
+
+```html
+<lu-multi-select [(ngModel)]="values" [options]="options" optionValue="id" optionLabel="name" />
+```
+
+```ts
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+```
+
+## Cas particuliers
+
+- Si le composant utilise des options personnalisées via `luForOptions`, il faut adapter le template vers les nouvelles APIs `optionTpl` ou `optionValue`/`optionLabel`.
+- La migration vers SimpleSelect/MultipleSelect peut nécessiter une intervention humaine si la logique est complexe.
+
+## Annotation à ajouter lors de la migration
+
+```html
+<!--
+  IA lucca-front-deprecated-resolver
+  try to migrate LuSelectInputComponent
+-->
+```
+
+```ts
+/*
+** IA lucca-front-deprecated-resolver
+** try to migrate LuSelectInputComponent
+*/
+```

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuSidepanelModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuSidepanelModule.md
@@ -1,0 +1,83 @@
+# LuSidepanelModule / LuSidepanel / sidepanel.model
+
+## Contexte de dépréciation
+
+Le système de sidepanel a été fusionné avec le système de modal. `LuSidepanel` est désormais un alias de `LuModal` avec un mode `'sidepanel'`. Les tokens et types du sidepanel sont des alias des tokens et types du modal.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuSidepanelModule` | `LuModalModule` (ou `provideLuModal()`) |
+| `LuSidepanel` (service) | `LuModal` avec `modal.open(component, data, { mode: 'sidepanel' })` |
+| `LU_SIDEPANEL_DATA` | `LU_MODAL_DATA` depuis `@lucca-front/ng/modal` |
+| `ILuSidepanelRef` | `ILuModalRef` depuis `@lucca-front/ng/modal` |
+| `ALuSidepanelRef` | `ALuModalRef` depuis `@lucca-front/ng/modal` |
+
+## Migration TypeScript
+
+### Avant
+
+```ts
+import { LuSidepanelModule, LuSidepanel, LU_SIDEPANEL_DATA, ILuSidepanelRef } from '@lucca-front/ng/sidepanel';
+
+@NgModule({
+  imports: [LuSidepanelModule],
+})
+class AppModule {}
+
+@Injectable()
+class MyService {
+  constructor(private sidepanel: LuSidepanel) {}
+
+  open() {
+    this.sidepanel.open(MyComponent, { data: 'value' });
+  }
+}
+
+@Component()
+class MyComponent {
+  data = inject(LU_SIDEPANEL_DATA);
+  ref = inject<ILuSidepanelRef>(ILuSidepanelRef);
+}
+```
+
+### Après
+
+```ts
+import { provideLuModal, LuModal, LU_MODAL_DATA, ILuModalRef } from '@lucca-front/ng/modal';
+
+// providers: [provideLuModal()]
+
+@Injectable()
+class MyService {
+  constructor(private modal: LuModal) {}
+
+  open() {
+    this.modal.open(MyComponent, { data: 'value' }, { mode: 'sidepanel' });
+  }
+}
+
+@Component()
+class MyComponent {
+  data = inject(LU_MODAL_DATA);
+  ref = inject<ILuModalRef>(ILuModalRef);
+}
+```
+
+## Migration automatique
+
+1. Remplacer `LuSidepanelModule` par `LuModalModule` dans les imports NgModule, ou `provideLuModal()` dans les providers d'un composant standalone.
+2. Remplacer `LuSidepanel` par `LuModal` dans les injections.
+3. Ajouter `{ mode: 'sidepanel' }` comme 3e argument des appels `modal.open(...)`.
+4. Remplacer les imports de `LU_SIDEPANEL_DATA` par `LU_MODAL_DATA` depuis `@lucca-front/ng/modal`.
+5. Remplacer les types `ILuSidepanelRef` par `ILuModalRef` et `ALuSidepanelRef` par `ALuModalRef`.
+
+## Annotation à ajouter lors de la migration
+
+```ts
+/*
+** IA lucca-front-deprecated-resolver
+** try to migrate LuSidepanelModule
+*/
+```

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuTitleModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuTitleModule.md
@@ -1,0 +1,56 @@
+# LuTitleModule / LuTitleService / LuTitleStrategy / APP_TITLE
+
+## Contexte de dépréciation
+
+Le système de titre basé sur `LuTitleService` est déprécié au profit de `LuTitleStrategy` injectable. `LuTitleStrategy` elle-même utilise désormais `provideLuTitleStrategy()`. `APP_TITLE` est un alias déprécié.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuTitleModule` | titre strategy (voir ci-dessous) |
+| `LuTitleService` | `LuTitleStrategy` (Title Strategy Angular) |
+| `LuTitleStrategy` (classe) | `provideLuTitleStrategy()` |
+| `APP_TITLE` | `provideLuTitleStrategy()` avec configuration |
+
+## Migration
+
+### LuTitleModule / LuTitleService → Title Strategy
+
+```ts
+// Avant
+@NgModule({
+  imports: [LuTitleModule],
+  providers: [LuTitleService],
+})
+class AppModule {}
+```
+
+```ts
+// Après — bootstrapApplication
+import { provideLuTitleStrategy } from '@lucca-front/ng/title';
+
+bootstrapApplication(AppComponent, {
+  providers: [
+    provideLuTitleStrategy(),
+  ]
+})
+```
+
+### APP_TITLE → provideLuTitleStrategy
+
+```ts
+// Avant
+import { APP_TITLE } from '@lucca-front/ng/title';
+providers: [{ provide: APP_TITLE, useValue: 'Mon App' }]
+
+// Après
+import { provideLuTitleStrategy } from '@lucca-front/ng/title';
+providers: [provideLuTitleStrategy({ appTitle: 'Mon App' })]
+```
+
+## Migration automatique
+
+1. Supprimer `LuTitleModule` des imports NgModule.
+2. Remplacer `LuTitleService` par `provideLuTitleStrategy()` dans les providers.
+3. Remplacer `APP_TITLE` par la configuration de `provideLuTitleStrategy()`.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuTooltipModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuTooltipModule.md
@@ -1,0 +1,28 @@
+# LuTooltipModule / LuTooltipTriggerModule
+
+## Contexte de dépréciation
+
+Ces NgModules sont des wrappers de compatibilité.
+
+## Modules concernés
+
+| Module déprécié | Remplacement |
+|---|---|
+| `LuTooltipModule` | `LuTooltipTriggerDirective, LuTooltipPanelComponent` |
+| `LuTooltipTriggerModule` | `LuTooltipTriggerDirective` |
+
+## Migration
+
+```ts
+// Avant
+import { LuTooltipModule } from '@lucca-front/ng/tooltip';
+@NgModule({ imports: [LuTooltipModule] })
+
+// Après
+import { LuTooltipTriggerDirective, LuTooltipPanelComponent } from '@lucca-front/ng/tooltip';
+@Component({ imports: [LuTooltipTriggerDirective, LuTooltipPanelComponent] })
+```
+
+## Migration automatique
+
+Remplacer chaque module par ses équivalents standalone.

--- a/.github/skills/lucca-front-deprecated-resolver/references/LuUserModule.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/LuUserModule.md
@@ -1,0 +1,92 @@
+# LuUserModule / LuUserSelectModule / LuUserSelectInputModule / LuUserDisplayModule / LuUserPictureModule / LuUserTileModule / LuUserMeOptionModule / LuUserSearcherModule / LuUserSelectInputComponent
+
+## Contexte de dépréciation
+
+L'ancien système de sélection d'utilisateur est déprécié. Il doit être remplacé par SimpleSelect ou MultipleSelect avec la directive `luCustomUsers`.
+
+## Éléments dépréciés
+
+| Élément déprécié | Remplacement |
+|---|---|
+| `LuUserModule` | `LuUserDisplayPipe, LuUserPictureComponent, LuUserTileComponent` |
+| `LuUserSelectModule` | SimpleSelect / MultipleSelect avec `luCustomUsers` |
+| `LuUserSelectInputModule` | `LuUserSelectInputComponent` (ou nouvelle API) |
+| `LuUserSelectInputComponent` (`lu-user-select`) | SimpleSelect / MultipleSelect avec `luCustomUsers` |
+| `LuUserDisplayModule` | `LuUserDisplayPipe` en imports ET providers |
+| `LuUserPictureModule` | `LuUserPictureComponent` |
+| `LuUserTileModule` | `LuUserTileComponent` |
+| `LuUserMeOptionModule` | `LuUserMeOptionDirective` |
+| `LuUserSearcherModule` | `LuUserPagedSearcherComponent` |
+
+## Migration des modules simples
+
+### LuUserDisplayModule → LuUserDisplayPipe
+
+```ts
+// Avant
+@NgModule({ imports: [LuUserDisplayModule] })
+
+// Après (composant standalone)
+@Component({
+  imports: [LuUserDisplayPipe],
+  providers: [LuUserDisplayPipe],
+})
+```
+
+### LuUserPictureModule → LuUserPictureComponent
+
+```ts
+@Component({ imports: [LuUserPictureComponent] })
+```
+
+### LuUserTileModule → LuUserTileComponent
+
+```ts
+@Component({ imports: [LuUserTileComponent] })
+```
+
+### LuUserMeOptionModule → LuUserMeOptionDirective
+
+```ts
+@Component({ imports: [LuUserMeOptionDirective] })
+```
+
+### LuUserSearcherModule → LuUserPagedSearcherComponent
+
+```ts
+@Component({ imports: [LuUserPagedSearcherComponent] })
+```
+
+## Migration du composant LuUserSelectInputComponent
+
+### Avant
+
+```html
+<lu-user-select [(ngModel)]="user"></lu-user-select>
+```
+
+### Après
+
+Utiliser `lu-simple-select` ou `lu-multi-select` avec la directive `luCustomUsers`. Consulter la documentation Prisme pour les détails.
+
+## Migration automatique
+
+- Remplacer les modules NgModule par les imports standalone selon le tableau.
+- `LuUserDisplayModule` → `LuUserDisplayPipe` dans imports ET providers.
+- La migration HTML de `lu-user-select` nécessite une intervention humaine.
+
+## Annotation à ajouter lors de la migration
+
+```html
+<!--
+  IA lucca-front-deprecated-resolver
+  try to migrate LuUserSelectInputComponent
+-->
+```
+
+```ts
+/*
+** IA lucca-front-deprecated-resolver
+** try to migrate LuUserSelectInputComponent
+*/
+```

--- a/.github/skills/lucca-front-deprecated-resolver/references/NgModulesSimples.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/NgModulesSimples.md
@@ -1,0 +1,47 @@
+# Modules NgModule simples dépréciés
+
+Ce fichier regroupe les modules NgModule dépréciés dont la migration est triviale : remplacer le module par le composant/pipe/directive standalone correspondant.
+
+## Table de correspondance
+
+| Module déprécié | Package | Remplacement |
+|---|---|---|
+| `LuToastsModule` | `@lucca-front/ng/toast` | `LuToastsComponent` |
+| `LuNumberModule` | `@lucca-front/ng/number` | `LuNumberPipe` |
+| `LuScrollModule` | `@lucca-front/ng/scroll` | `LuScrollDirective` |
+| `LuSafeContentModule` | `@lucca-front/ng/safe-content` | `LuSafeHtmlPipe` |
+| `LuFormlyModule` | `@lucca-front/ng/formly` | `provideLuFormly()` dans les providers d'une route lazy-loaded |
+
+## Migration générique
+
+Pour chaque module NgModule de cette liste :
+
+```ts
+// Avant
+import { LuToastsModule } from '@lucca-front/ng/toast';
+@NgModule({ imports: [LuToastsModule] })
+
+// Après (composant standalone)
+import { LuToastsComponent } from '@lucca-front/ng/toast';
+@Component({ imports: [LuToastsComponent] })
+```
+
+## Cas particulier : LuFormlyModule
+
+`LuFormlyModule` doit être remplacé par `provideLuFormly()` dans une route lazy-loaded, pas globalement.
+
+```ts
+// Avant
+@NgModule({ imports: [LuFormlyModule] })
+
+// Après
+const routes: Routes = [{
+  path: 'my-form',
+  loadComponent: () => import('./my-form.component'),
+  providers: [provideLuFormly()],
+}]
+```
+
+## Migration automatique
+
+Remplacer chaque occurrence du module par son équivalent standalone selon la table de correspondance.

--- a/.github/skills/lucca-front-deprecated-resolver/references/SimpleSelectApiAliases.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/SimpleSelectApiAliases.md
@@ -1,0 +1,34 @@
+# SimpleSelect API aliases dépréciés
+
+## Contexte de dépréciation
+
+Les exports `LuSimpleSelectApiV4Directive` et `ALuSimpleSelectApiDirective` depuis `@lucca-front/ng/simple-select` sont des aliases dépréciés des exports du package `@lucca-front/ng/core-select`.
+
+## Éléments dépréciés
+
+| Élément déprécié | Package source | Remplacement |
+|---|---|---|
+| `LuSimpleSelectApiV4Directive` | `@lucca-front/ng/simple-select` | `LuCoreSelectApiV4Directive` depuis `@lucca-front/ng/core-select/api` |
+| `ALuSimpleSelectApiDirective` | `@lucca-front/ng/simple-select` | `ALuCoreSelectApiDirective` depuis `@lucca-front/ng/core-select/api` |
+
+## Migration
+
+### Avant
+
+```ts
+import { LuSimpleSelectApiV4Directive } from '@lucca-front/ng/simple-select';
+import { ALuSimpleSelectApiDirective } from '@lucca-front/ng/simple-select';
+```
+
+### Après
+
+```ts
+import { LuCoreSelectApiV4Directive } from '@lucca-front/ng/core-select/api';
+import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
+```
+
+## Migration automatique
+
+Remplacer les imports et renommer les références :
+- `LuSimpleSelectApiV4Directive` → `LuCoreSelectApiV4Directive` (changer aussi l'import)
+- `ALuSimpleSelectApiDirective` → `ALuCoreSelectApiDirective` (changer aussi l'import)

--- a/.github/skills/lucca-front-deprecated-resolver/references/TranslationModel.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/TranslationModel.md
@@ -1,0 +1,39 @@
+# TranslationModel — ILuTranslation déprécié
+
+## Contexte de dépréciation
+
+L'interface `ILuTranslation<T>` est dépréciée. Elle doit être remplacée par `LuTranslation<T>`.
+
+## Élément déprécié
+
+| Élément déprécié | Package | Remplacement |
+|---|---|---|
+| `ILuTranslation<T>` | `@lucca-front/ng/core` | `LuTranslation<T>` depuis `@lucca-front/ng/core` |
+
+## Migration
+
+### Avant
+
+```ts
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+const translations: ILuTranslation<string> = {
+  en: 'Hello',
+  fr: 'Bonjour',
+};
+```
+
+### Après
+
+```ts
+import { LuTranslation } from '@lucca-front/ng/core';
+
+const translations: LuTranslation<string> = {
+  en: 'Hello',
+  fr: 'Bonjour',
+};
+```
+
+## Migration automatique
+
+Remplacer `ILuTranslation` par `LuTranslation` dans tous les imports et usages TypeScript.

--- a/.github/skills/lucca-front-deprecated-resolver/references/UserPopoverProviders.md
+++ b/.github/skills/lucca-front-deprecated-resolver/references/UserPopoverProviders.md
@@ -1,0 +1,37 @@
+# UserPopoverProviders — dépréciés
+
+## Contexte de dépréciation
+
+Les tokens et fonctions liés à l'activation du user popover sont dépréciés car le popover est désormais toujours actif et utilise `luPopover2`.
+
+## Éléments dépréciés
+
+| Élément déprécié | Action |
+|---|---|
+| `USER_POPOVER_IS_ACTIVATED` (InjectionToken) | Supprimer — plus nécessaire |
+| `provideLuUserPopover()` | Supprimer — plus nécessaire |
+
+## Migration
+
+### Avant
+
+```ts
+import { USER_POPOVER_IS_ACTIVATED, provideLuUserPopover } from '@lucca-front/ng/user-popover';
+
+providers: [
+  provideLuUserPopover(),
+  { provide: USER_POPOVER_IS_ACTIVATED, useValue: of(true) },
+]
+```
+
+### Après
+
+```ts
+// Supprimer simplement ces providers — ils ne sont plus nécessaires.
+```
+
+## Migration automatique
+
+1. Supprimer tous les appels à `provideLuUserPopover()` des tableaux `providers`.
+2. Supprimer tous les tokens `USER_POPOVER_IS_ACTIVATED` et leurs providers.
+3. Supprimer les imports correspondants.

--- a/packages/ng/input/clearer/clearer.module.ts
+++ b/packages/ng/input/clearer/clearer.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { LuInputClearerComponent } from './clearer.component';
 
 /**
- * @deprecated use `ClearComponent` instead
+ * @deprecated use `LuInputClearerComponent` instead
  */
 @NgModule({
 	imports: [LuInputClearerComponent],

--- a/packages/ng/option/picker/tree-option-picker.module.ts
+++ b/packages/ng/option/picker/tree-option-picker.module.ts
@@ -7,7 +7,7 @@ import { LuTreeOptionPickerAdvancedComponent } from './tree-option-picker-advanc
 import { LuTreeOptionPickerComponent } from './tree-option-picker.component';
 
 /**
- * @deprecated
+ * @deprecated use `LuTreeOptionPickerComponent, LuTreeOptionPickerAdvancedComponent` instead
  */
 @NgModule({
 	imports: [CommonModule, OverlayModule, LuScrollDirective, A11yModule, LuTreeOptionPickerAdvancedComponent, LuTreeOptionPickerComponent],

--- a/packages/ng/option/tree-option.module.ts
+++ b/packages/ng/option/tree-option.module.ts
@@ -5,7 +5,7 @@ import { LuTreeOptionPickerModule } from './picker/index';
 import { LuTreeOptionSelectAllComponent } from './selector/index';
 
 /**
- * @deprecated use `LuTreeOptionSelectAllComponent` instead
+ * @deprecated use `LuTreeOptionItemComponent, LuTreeOptionPickerComponent, LuTreeOptionPickerAdvancedComponent, LuTreeOptionFeederComponent, LuForTreeOptionsDirective, LuTreeOptionPagerComponent, LuTreeOptionSearcherComponent, LuTreeOptionSelectAllComponent` instead
  */
 @NgModule({
 	imports: [LuTreeOptionItemModule, LuTreeOptionPickerModule, LuTreeOptionOperatorModule, LuTreeOptionSelectAllComponent],

--- a/packages/ng/tooltip/tooltip.module.ts
+++ b/packages/ng/tooltip/tooltip.module.ts
@@ -3,7 +3,7 @@ import { LuTooltipPanelComponent } from './panel/index';
 import { LuTooltipTriggerModule } from './trigger/index';
 
 /**
- * @deprecated use `LuTooltipTriggerDirective, OverlayModule, LuTooltipPanelComponent` instead
+ * @deprecated use `LuTooltipTriggerDirective, LuTooltipPanelComponent` instead
  */
 @NgModule({
 	imports: [LuTooltipTriggerModule, LuTooltipPanelComponent],

--- a/packages/ng/tooltip/trigger/tooltip-trigger.module.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.module.ts
@@ -3,7 +3,7 @@ import { NgModule } from '@angular/core';
 import { LuTooltipTriggerDirective } from './tooltip-trigger.directive';
 
 /**
- * @deprecated use `LuTooltipTriggerDirective, OverlayModule` instead
+ * @deprecated use `LuTooltipTriggerDirective` instead
  */
 @NgModule({
 	imports: [LuTooltipTriggerDirective, OverlayModule],


### PR DESCRIPTION
## Description

wip

This pull request introduces comprehensive documentation and structured metadata to support the automated migration of deprecated APIs from `@lucca-front/ng` and related packages. The changes include a new skill definition, a detailed migration guide, a JSON index of deprecated elements, and specific migration reference files for each deprecated component, input, or service. This will help identify, automate, and document the migration process for all deprecated Lucca Front APIs.

-----


-----
