### PR TITLE
fix(tooltip): anchor ref and condition

### DIFF
--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -38,7 +38,7 @@ export class IndexTableRowComponent {
 	headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
 	footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
 
-	readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+	readonly elementRef = inject<ElementRef<HTMLTableRowElement>>(ElementRef);
 
 	public readonly cells = contentChildren(LU_INDEX_TABLE_CELL_INSTANCE);
 

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, forwardRef, inject, input, model, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, ElementRef, forwardRef, inject, input, model, numberAttribute, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
@@ -37,6 +37,8 @@ export class IndexTableRowComponent {
 	bodyRef = inject(LU_INDEX_TABLE_BODY_INSTANCE, { optional: true });
 	headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
 	footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
+
+	readonly elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	public readonly cells = contentChildren(LU_INDEX_TABLE_CELL_INSTANCE);
 

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -3,6 +3,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, contentChildren, 
 import { FormsModule } from '@angular/forms';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
+import { LuTooltipAnchorRef } from '@lucca-front/ng/tooltip';
 import { LU_INDEX_TABLE_BODY_INSTANCE } from '../index-table-body/index-table-body.token';
 import { LU_INDEX_TABLE_CELL_INSTANCE } from '../index-table-cell.token';
 import { LU_INDEX_TABLE_FOOT_INSTANCE } from '../index-table-foot/index-table-foot.token';
@@ -33,16 +34,20 @@ import { LU_INDEX_TABLE_ROW_INSTANCE } from './index-table-row.token';
 	],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class IndexTableRowComponent {
+export class IndexTableRowComponent implements LuTooltipAnchorRef {
+	readonly #elementRef = inject<ElementRef<HTMLTableRowElement>>(ElementRef);
+
 	bodyRef = inject(LU_INDEX_TABLE_BODY_INSTANCE, { optional: true });
 	headRef = inject(LU_INDEX_TABLE_HEAD_INSTANCE, { optional: true });
 	footRef = inject(LU_INDEX_TABLE_FOOT_INSTANCE, { optional: true });
 
-	readonly elementRef = inject<ElementRef<HTMLTableRowElement>>(ElementRef);
-
 	public readonly cells = contentChildren(LU_INDEX_TABLE_CELL_INSTANCE);
 
 	protected tableRef = inject(LU_INDEX_TABLE_INSTANCE);
+
+	getElementRef(): ElementRef<HTMLTableRowElement> {
+		return this.#elementRef;
+	}
 
 	selected = model<boolean>(false);
 	selectedLabel = input<string | null>(null);

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -20,7 +20,7 @@ import { LuTooltipPanelComponent } from '../panel';
 import { EllipsisRuler } from './ellipsis.ruler';
 
 export interface LuTooltipAnchorRef {
-	elementRef: ElementRef;
+	getElementRef(): ElementRef;
 }
 
 let nextId = 0;
@@ -370,8 +370,8 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 
 		if (isNil(anchor)) {
 			return this.#host;
-		} else if ('elementRef' in anchor) {
-			return anchor.elementRef;
+		} else if ('getElementRef' in anchor) {
+			return anchor.getElementRef();
 		} else {
 			return anchor;
 		}

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -332,7 +332,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 
 		return this.#overlay
 			.position()
-			.flexibleConnectedTo(this.luTooltipAnchor())
+			.flexibleConnectedTo(this.luTooltipAnchor() ?? this.#host)
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -12,12 +12,16 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { booleanAttribute, computed, DestroyRef, Directive, effect, EffectRef, ElementRef, inject, Injector, input, linkedSignal, numberAttribute, OnDestroy, Renderer2, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { SafeHtml } from '@angular/platform-browser';
-import { isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNil, isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuPopoverPosition } from '@lucca-front/ng/popover';
 import { from, of, startWith, switchMap, timer } from 'rxjs';
 import { debounce, debounceTime, filter, map, tap } from 'rxjs/operators';
 import { LuTooltipPanelComponent } from '../panel';
 import { EllipsisRuler } from './ellipsis.ruler';
+
+export interface LuTooltipAnchorRef {
+	elementRef: ElementRef<HTMLElement>;
+}
 
 let nextId = 0;
 
@@ -53,7 +57,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });
 	readonly luTooltipWhenEllipsis = linkedSignal(() => this.luTooltipWhenEllipsisInput());
 
-	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin>(this.#host);
+	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef>(this.#host);
 	readonly id = input<string>(`${this.#host.nativeElement.tagName.toLowerCase()}-tooltip-${nextId++}`);
 
 	readonly ariaDescribedBy = computed(() => {
@@ -332,7 +336,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 
 		return this.#overlay
 			.position()
-			.flexibleConnectedTo(this.luTooltipAnchor() ?? this.#host)
+			.flexibleConnectedTo(this.#resolveAnchor())
 			.withPositions([
 				{
 					originX: connectionPosition.originX,
@@ -359,6 +363,18 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 					overlayY: this.invertVerticalPos(overlayPosition.overlayY),
 				},
 			]);
+	}
+
+	#resolveAnchor(): FlexibleConnectedPositionStrategyOrigin {
+		const anchor = this.luTooltipAnchor();
+
+		if (isNil(anchor)) {
+			return this.#host;
+		} else if ('elementRef' in anchor) {
+			return anchor.elementRef;
+		} else {
+			return anchor;
+		}
 	}
 
 	private invertVerticalPos(y: VerticalConnectionPos): VerticalConnectionPos {

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -20,7 +20,7 @@ import { LuTooltipPanelComponent } from '../panel';
 import { EllipsisRuler } from './ellipsis.ruler';
 
 export interface LuTooltipAnchorRef {
-	elementRef: ElementRef<HTMLElement>;
+	elementRef: ElementRef;
 }
 
 let nextId = 0;
@@ -57,7 +57,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });
 	readonly luTooltipWhenEllipsis = linkedSignal(() => this.luTooltipWhenEllipsisInput());
 
-	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef>(this.#host);
+	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef | null | undefined>(this.#host);
 	readonly id = input<string>(`${this.#host.nativeElement.tagName.toLowerCase()}-tooltip-${nextId++}`);
 
 	readonly ariaDescribedBy = computed(() => {


### PR DESCRIPTION
## Description

First bug: on a tooltip anchor that is inside a condition, `luTooltipAnchor` is `undefined` because the variable is either not in the same scope or simply not loaded yet. In that case we use the `host` element itself as the default value. Is that a good solution? It's basically attaching the tooltip directly to the relevant element...

For the second bug, on the `IndexTableRowComponent` side, it is not an `ElementRef`, so `luTooltipAnchor` ends up with `x = undefined` and `y = undefined` causing the tooltip to be positioned in the top-left corner of the page.

One possible solution would be to accept an `ElementRef` and expose it as readonly in `IndexTableRowComponent`. But in that case, would we need to expose it for all of our components that are expected to support this pattern?

-----

https://github.com/LuccaSA/lucca-front/issues/3951

-----
