### PR TITLE
[palettes] add pineapple contrasted

### DIFF
--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -116,7 +116,7 @@ $palettesDefault: 'brand', 'brandContrasted', 'neutral', 'navigation', 'AI';
 $palettesProduct: 'product';
 $palettesOtherProduct: () !default;
 $palettesDecorative: 'kiwi', 'cucumber', 'mint', 'lagoon', 'blueberry', 'lavender', 'watermelon', 'pumpkin' !default;
-$palettesDecorativeMandatory: 'pineapple', 'lime', 'grape', 'glacier';
+$palettesDecorativeMandatory: 'pineapple', 'lime', 'grape', 'glacier', 'pineappleContrasted';
 
 // pineapple, lime, grape, glacier
 $palettesDeprecated: ('lucca', 'grey', 'primary', 'secondary') !default;
@@ -547,6 +547,19 @@ $pineapple: (
 	900: #665400,
 ) !default;
 
+$pineappleContrasted: (
+	50: #fef7d7,
+	100: #fbf1b6,
+	200: #fae999,
+	300: #f9e16c,
+	400: #f8dc4f,
+	500: #e7c623,
+	600: #b89600,
+	700: #8f7500,
+	800: #7b6500,
+	900: #665400,
+) !default;
+
 // https://sass-lang.com/documentation/variables/#advanced-variable-functions
 $productsInterpolation: (
 	'brand': $brand,
@@ -587,6 +600,7 @@ $palettesInterpolation: (
 	'watermelon': $watermelon,
 	'pumpkin': $pumpkin,
 	'pineapple': $pineapple,
+	'pineappleContrasted': $pineappleContrasted,
 	'pagga': $pagga,
 	'poplee': $poplee,
 	'coreHR': $coreHR,

--- a/packages/scss/src/commons/utils/color.scss
+++ b/packages/scss/src/commons/utils/color.scss
@@ -29,6 +29,7 @@
 	@include core.rosetta('--palettes-brand', '--palettes-brandContrasted', config.$palettesShades);
 	@include core.rosetta('--palettes-success', '--palettes-successContrasted', config.$palettesShades);
 	@include core.rosetta('--palettes-warning', '--palettes-warningContrasted', config.$palettesShades);
+	@include core.rosetta('--palettes-pineapple', '--palettes-pineappleContrasted', config.$palettesShades);
 }
 
 @mixin borderGradient($angle: 0, $color1: var(--palettes-neutral-0) , $color2:  var(--palettes-neutral-900), $radius: var(--pr-t-border-radius-default), $width: var(--commons-divider-width)) {

--- a/stories/qa/palettes-contrasted/palettes-contrasted.stories.html
+++ b/stories/qa/palettes-contrasted/palettes-contrasted.stories.html
@@ -34,6 +34,19 @@
 			</td>
 		</tr>
 		<tr>
+			<td>Brand</td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-50)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-100)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-200)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-300)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-400)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-500)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-600)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-700)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-800)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brand-900)'"></div></td>
+		</tr>
+		<tr>
 			<td>Brand contrasted</td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brandContrasted-50)'"></div></td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brandContrasted-100)'"></div></td>
@@ -45,6 +58,19 @@
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brandContrasted-700)'"></div></td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brandContrasted-800)'"></div></td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-brandContrasted-900)'"></div></td>
+		</tr>
+		<tr>
+			<td>Success</td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-50)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-100)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-200)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-300)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-400)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-500)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-600)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-700)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-800)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-success-900)'"></div></td>
 		</tr>
 		<tr>
 			<td>Success contrasted</td>
@@ -60,6 +86,19 @@
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-successContrasted-900)'"></div></td>
 		</tr>
 		<tr>
+			<td>Warning</td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-50)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-100)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-200)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-300)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-400)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-500)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-600)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-700)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-800)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warning-900)'"></div></td>
+		</tr>
+		<tr>
 			<td>Warning contrasted</td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warningContrasted-50)'"></div></td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warningContrasted-100)'"></div></td>
@@ -71,6 +110,32 @@
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warningContrasted-700)'"></div></td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warningContrasted-800)'"></div></td>
 			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-warningContrasted-900)'"></div></td>
+		</tr>
+		<tr>
+			<td>Pineapple</td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-50)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-100)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-200)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-300)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-400)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-500)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-600)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-700)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-800)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineapple-900)'"></div></td>
+		</tr>
+		<tr>
+			<td>Pineapple contrasted</td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-50)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-100)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-200)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-300)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-400)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-500)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-600)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-700)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-800)'"></div></td>
+			<td><div class="palette" [attr.style]="'--backgroundColor: var(--palettes-pineappleContrasted-900)'"></div></td>
 		</tr>
 	</tbody>
 </table>


### PR DESCRIPTION
## Description

Adding this palette resolves the issue of contrast between the tags and the pineapple decorative palette.

-----



-----

<img width="959" height="390" alt="Capture d’écran 2026-06-02 à 17 42 49" src="https://github.com/user-attachments/assets/18776e17-c706-42a1-b25f-3784d52ec5f5" />
