### PR TITLE
fix(checkbox-input): presentation display not updated when control value changes

### DIFF
--- a/packages/ng/forms/checkbox-input/checkbox-input.component.html
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.html
@@ -4,7 +4,10 @@
 		type="checkbox"
 		class="checkboxField-input"
 		[class.inputFramed-header-input]="framed"
-		[formControl]="ngControl.control"
+		[checked]="value()"
+		[disabled]="disabled()"
+		(change)="onCheckboxChange($event)"
+		(blur)="onTouched()"
 		[attr.aria-checked]="mixed() ? 'mixed' : null"
 	/>
 	<span class="checkboxField-icon" [class.inputFramed-header-icon]="framed" aria-hidden="true"
@@ -22,7 +25,10 @@
 			type="checkbox"
 			class="filterPill-checkbox-input"
 			luInput
-			[formControl]="ngControl.control"
+			[checked]="value()"
+			[disabled]="disabled()"
+			(change)="onCheckboxChange($event)"
+			(blur)="onTouched()"
 			[attr.aria-checked]="mixed() ? 'mixed' : null"
 			[attr.id]="filterPillInputId"
 		/>
@@ -31,4 +37,4 @@
 		</span>
 	</span>
 </ng-container>
-<ng-container *luPresentationDisplayDefault>{{ ngControl.value ? intl.yes : intl.no }}</ng-container>
+<ng-container *luPresentationDisplayDefault>{{ value() ? intl.yes : intl.no }}</ng-container>

--- a/packages/ng/forms/checkbox-input/checkbox-input.component.ts
+++ b/packages/ng/forms/checkbox-input/checkbox-input.component.ts
@@ -1,10 +1,8 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, forwardRef, inject, input, signal, Signal, ViewEncapsulation } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent, FilterPillLabelDirective, FilterPillLayout } from '@lucca-front/ng/filter-pills';
 import { FORM_FIELD_INSTANCE, FormFieldComponent, INPUT_FRAMED_INSTANCE, InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
-import { injectNgControl } from '../inject-ng-control';
-import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
 import { CHECKBOX_INPUT_TRANSLATIONS } from './checkbox-input.translate';
 import { getIntl } from '@lucca-front/ng/core';
 
@@ -12,13 +10,17 @@ let nextId = 0;
 
 @Component({
 	selector: 'lu-checkbox-input',
-	imports: [ReactiveFormsModule, InputDirective, FilterPillLabelDirective, LuTooltipTriggerDirective, ɵPresentationDisplayDefaultDirective],
-	hostDirectives: [NoopValueAccessorDirective],
+	imports: [InputDirective, FilterPillLabelDirective, LuTooltipTriggerDirective, ɵPresentationDisplayDefaultDirective],
 	templateUrl: './checkbox-input.component.html',
 	styleUrl: './checkbox-input.component.scss',
 	encapsulation: ViewEncapsulation.None,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	providers: [
+		{
+			provide: NG_VALUE_ACCESSOR,
+			multi: true,
+			useExisting: forwardRef(() => CheckboxInputComponent),
+		},
 		{
 			provide: FILTER_PILL_INPUT_COMPONENT,
 			useExisting: forwardRef(() => CheckboxInputComponent),
@@ -29,7 +31,7 @@ let nextId = 0;
 		'[class.mod-checklist]': 'checklist()',
 	},
 })
-export class CheckboxInputComponent implements FilterPillInputComponent {
+export class CheckboxInputComponent implements ControlValueAccessor, FilterPillInputComponent {
 	framed = inject(INPUT_FRAMED_INSTANCE, { optional: true }) !== null;
 	parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	formField = inject<FormFieldComponent>(FORM_FIELD_INSTANCE, { optional: true });
@@ -51,12 +53,42 @@ export class CheckboxInputComponent implements FilterPillInputComponent {
 	hideCombobox: Signal<boolean> = signal(true);
 	showColon: Signal<boolean> = signal(false);
 
-	ngControl = injectNgControl();
+	readonly value = signal<boolean>(false);
+	readonly disabled = signal<boolean>(false);
+
+	#onChange?: (value: boolean) => void;
+	#onTouched?: () => void;
 
 	constructor() {
 		if (this.formField) {
 			this.formField.layout.set('checkable');
 		}
+	}
+
+	writeValue(value: boolean): void {
+		this.value.set(value);
+	}
+
+	registerOnChange(fn: (value: boolean) => void): void {
+		this.#onChange = fn;
+	}
+
+	registerOnTouched(fn: () => void): void {
+		this.#onTouched = fn;
+	}
+
+	setDisabledState(isDisabled: boolean): void {
+		this.disabled.set(isDisabled);
+	}
+
+	onCheckboxChange(event: Event): void {
+		const checked = (event.target as HTMLInputElement).checked;
+		this.value.set(checked);
+		this.#onChange?.(checked);
+	}
+
+	onTouched(): void {
+		this.#onTouched?.();
 	}
 
 	clearFilterPillValue(): void {

--- a/stories/qa/forms/checkbox.stories.html
+++ b/stories/qa/forms/checkbox.stories.html
@@ -322,7 +322,15 @@
 					</div>
 				</div>
 			</td>
-			<td></td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip" errorInlineMessage="Helper text">
+					<lu-checkbox-input [formControl]="invalidControl" />
+				</lu-form-field>
+
+				<lu-form-field label="Label" tooltip="Tooltip" errorInlineMessage="Helper text">
+					<lu-checkbox-input [formControl]="invalidCheckedControl" />
+				</lu-form-field>
+			</td>
 		</tr>
 		<tr>
 			<td>Checklist</td>

--- a/stories/qa/forms/checkbox.stories.ts
+++ b/stories/qa/forms/checkbox.stories.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
@@ -7,10 +7,20 @@ import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 @Component({
 	selector: 'forms-checkbox-stories',
 	templateUrl: './checkbox.stories.html',
-	imports: [FormsModule, FormFieldComponent, CheckboxInputComponent],
+	imports: [FormsModule, ReactiveFormsModule, FormFieldComponent, CheckboxInputComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-class CheckboxStory {}
+class CheckboxStory {
+	// Invalid + touched → aria-invalid + error styling
+	invalidControl = new FormControl(false, Validators.requiredTrue);
+	// Always invalid, to QA the checked + invalid state
+	invalidCheckedControl = new FormControl(true, () => ({ custom: true }));
+
+	constructor() {
+		this.invalidControl.markAsTouched();
+		this.invalidCheckedControl.markAsTouched();
+	}
+}
 
 export default {
 	title: 'QA/Forms/Checkbox',

--- a/stories/qa/forms/presentation.stories.ts
+++ b/stories/qa/forms/presentation.stories.ts
@@ -1,6 +1,7 @@
 import { allLegumes } from '@/stories/forms/select/select.utils';
+import { DatePipe } from '@angular/common';
 import { LOCALE_ID } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DateInputComponent } from '@lucca-front/ng/date2';
 import { FormComponent } from '@lucca-front/ng/form';
 import { DataPresentationComponent, FormFieldComponent } from '@lucca-front/ng/form-field';
@@ -47,6 +48,8 @@ export default {
 				RadioComponent,
 				FormFieldComponent,
 				FormsModule,
+				ReactiveFormsModule,
+				DatePipe,
 				FormComponent,
 				DataPresentationComponent,
 				RichTextInputComponent,
@@ -432,6 +435,111 @@ export const GlobalToForm: StoryObj = {
 		phoneNumberValue: '+33700000000',
 		textAreaValue:
 			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?',
+	},
+};
+
+/**
+ * Repro: when a control value changes programmatically while the form field is in presentation mode,
+ * the presentation display is NOT updated.
+ *
+ * Steps: click on "Update all values programmatically" → every presentation display should reflect the new
+ * control values (displayed at the top), but some keep the old one.
+ *
+ * Affected (stale): number, checkbox, switch, radio.
+ * Accidentally working: text (ngx-mask side effect — remove `[mask]` from its template and it breaks too),
+ * textarea (`detectChanges()` call in its `valueChanges` subscription), date & simple-select (their
+ * `writeValue` updates internal signals, which refreshes their view).
+ *
+ * Root cause: the `*luPresentationDisplayDefault` templates interpolate `ngControl.value`, which is not reactive.
+ * The template is rendered through `ngTemplateOutlet` inside the OnPush FormFieldComponent, and a control value
+ * change marks neither the form field nor the declaring input component for check, so the embedded view is
+ * only refreshed when the input component happens to trigger CD on its own.
+ */
+export const ValueUpdateBugRepro: StoryObj = {
+	render: () => {
+		const controls = {
+			text: new FormControl('Text A'),
+			textarea: new FormControl('Textarea A'),
+			number: new FormControl(1),
+			checkbox: new FormControl(false),
+			switch: new FormControl(false),
+			date: new FormControl(new Date(2020, 0, 1)),
+			select: new FormControl(allLegumes[0]),
+			radio: new FormControl(1),
+		};
+		const updateAll = () => {
+			controls.text.setValue(controls.text.value === 'Text A' ? 'Text B' : 'Text A');
+			controls.textarea.setValue(controls.textarea.value === 'Textarea A' ? 'Textarea B' : 'Textarea A');
+			controls.number.setValue(controls.number.value === 1 ? 2 : 1);
+			controls.checkbox.setValue(!controls.checkbox.value);
+			controls.switch.setValue(!controls.switch.value);
+			controls.date.setValue(controls.date.value?.getFullYear() === 2020 ? new Date(2021, 5, 15) : new Date(2020, 0, 1));
+			controls.select.setValue(controls.select.value === allLegumes[0] ? allLegumes[1] : allLegumes[0]);
+			controls.radio.setValue(controls.radio.value === 1 ? 2 : 1);
+		};
+		return {
+			props: {
+				controls,
+				legumes: allLegumes,
+				updateAll,
+			},
+			template: cleanupTemplate(`
+<button type="button" class="button" (click)="updateAll()">Update all values programmatically</button>
+<br>
+<br>
+Control values:
+text=<strong>{{ controls.text.value }}</strong>,
+textarea=<strong>{{ controls.textarea.value }}</strong>,
+number=<strong>{{ controls.number.value }}</strong>,
+checkbox=<strong>{{ controls.checkbox.value }}</strong>,
+switch=<strong>{{ controls.switch.value }}</strong>,
+date=<strong>{{ controls.date.value | date }}</strong>,
+select=<strong>{{ controls.select.value?.name }}</strong>,
+radio=<strong>{{ controls.radio.value }}</strong>
+<hr>
+<lu-form-field presentation label="Text input">
+	<lu-text-input [formControl]="controls.text" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Textarea input">
+	<lu-textarea-input [formControl]="controls.textarea" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Number input">
+	<lu-number-input [formControl]="controls.number" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Checkbox input">
+	<lu-checkbox-input [formControl]="controls.checkbox" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Switch input">
+	<lu-switch-input [formControl]="controls.switch" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Date input">
+	<lu-date-input [formControl]="controls.date" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Simple select input">
+	<lu-simple-select [options]="legumes" [formControl]="controls.select" />
+</lu-form-field>
+<br>
+<br>
+<lu-form-field presentation label="Radio input">
+	<lu-radio-group-input [formControl]="controls.radio">
+		<lu-radio [value]="1">Option A</lu-radio>
+		<lu-radio [value]="2">Option B</lu-radio>
+	</lu-radio-group-input>
+</lu-form-field>
+`),
+		};
 	},
 };
 


### PR DESCRIPTION
## Description

### 🐛 Problem

In presentation mode (`<lu-form-field presentation>`), when the control value changes programmatically (setValue(), patchValue(), reset…), the displayed value is not updated.

video: checkbox=true but the presentation display still shows "No"

https://github.com/user-attachments/assets/4c7e4b22-ffd3-4047-bfc6-b75384a4fd1b

### Root cause

The *luPresentationDisplayDefault templates interpolate ngControl.value, which is not reactive. The template is rendered through ngTemplateOutlet inside the OnPush FormFieldComponent as a transplanted view (declared in the input component, inserted into the form field): it only gets refreshed when the declaring input component's view is refreshed — and a setValue() marks neither of these views dirty.

Affected inputs: 
- checkbox, 
- switch, 
- number, 
- radio-group. 

The other ones only work by accident (text: ngx-mask side effect; textarea: a detectChanges() call for auto-resize; date/select: their writeValue updates internal signals).

### 🔧 Fix (scope: checkbox only)

Replaced the NoopValueAccessorDirective + injectNgControl() pattern with a proper ControlValueAccessor implementation:

- writeValue() feeds a value signal, read by the presentation template → the signal read makes the view reactive, even transplanted under OnPush
- native inputs are bound through [checked]="value()" / [disabled]="disabled()" / (change) / (blur) (both the regular branch and the filter pill branch)

video: presentation display now updates

https://github.com/user-attachments/assets/3db93f54-9af5-44c4-ba65-7f542e81d58d



If this approach is approved, follow-up PRs could cover number, switch and radio-group.

### ⚠️ Behavior changes

- The ng-invalid/ng-touched/… classes are no longer applied to the inner native input, only on the lu-checkbox-input host. No style in this repo targeted them (error state goes through [aria-invalid], set by the form field — unchang/after). Risk is limited to custom CSS / e2e selectors in consumer apps.

Note: an invalid + touched checkbox used without a form field still has no erring behavior (error styling relies on [aria-invalid], which only the form field sets; the old ng-* classes on the native input were never styled). Could be addressed for all inputs in a separate enhancement.

### ✅ Verified

- Presentation display updates on setValue() (after video)
- Edition mode: user click, ngModel, formControl, disabled, validation (aria-invalid, error message, rendering verified identical before/after, including markAllAsTouched() on a wrapping form group)
- Filter pill: interaction OK, QA page renders without errors
- Without form-field: bare / ngModel / formControl / disabled, including progr
- QA stories: new ValueUpdateBugRepro story (bug matrix across 8 input types in presentation mode), and filled the empty Angular cell of the Invalid row in the existing QA/Forms/Checkbox
page

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
