### PR TITLE
chore(repository): add repository.directory to published package.json

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,5 +1,10 @@
 {
   "name": "@lucca-front/eslint-plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/LuccaSA/lucca-front.git",
+    "directory": "packages/eslint-plugin"
+  },
   "version": "1.0.0",
   "type": "module",
   "description": "Custom ESLint rules for Lucca Front",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,7 +4,8 @@
   "description": "A library of icons made by the team @Lucca",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LuccaSA/lucca-front.git"
+    "url": "git+https://github.com/LuccaSA/lucca-front.git",
+    "directory": "packages/icons"
   },
   "scripts": {},
   "main": "index.d.ts",

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -4,7 +4,8 @@
   "description": "A library of icons made by the team @Lucca",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LuccaSA/lucca-front.git"
+    "url": "git+https://github.com/LuccaSA/lucca-front.git",
+    "directory": "packages/ng"
   },
   "schematics": "./schematics/collection.json",
   "ng-update": {

--- a/packages/prisme/package.json
+++ b/packages/prisme/package.json
@@ -4,7 +4,8 @@
   "description": "Design system made by @lucca",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LuccaSA/lucca-front.git"
+    "url": "git+https://github.com/LuccaSA/lucca-front.git",
+    "directory": "packages/prisme"
   },
   "license": "MIT",
   "public": true,

--- a/packages/scss/package.json
+++ b/packages/scss/package.json
@@ -6,7 +6,8 @@
   "scripts": {},
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LuccaSA/lucca-front.git"
+    "url": "git+https://github.com/LuccaSA/lucca-front.git",
+    "directory": "packages/scss"
   },
   "keywords": [
     "lucca",

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -4,7 +4,8 @@
   "description": "Lucca Front stylelint configuration",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LuccaSA/lucca-front.git"
+    "url": "git+https://github.com/LuccaSA/lucca-front.git",
+    "directory": "packages/stylelint-config"
   },
   "main": "stylelint.config.mjs",
   "keywords": [


### PR DESCRIPTION
## Description

Add the npm-standard `repository.directory` field to the published workspace packages so each package maps to its monorepo subdirectory. Metadata-only — no runtime or public API change. Pilot of a fleet-wide convention rollout.

-----

One atomic commit, 6 `package.json`. For libs that already declared `repository`, only `directory` is added (+2/-1); for `@lucca-front/eslint-plugin`, which had none, the full standard block is inserted (+5/-0). Generated mechanically by a convention check (`repository-field-check.mjs`), so any tooling can resolve package → repo → subdirectory straight from the registry instead of scraping GitHub.

-----