### PR TITLE
fix(empty-state-page): fix inline style issue with illustration

### DIFF
--- a/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
+++ b/packages/ng/empty-state/empty-state-page/empty-state-page.component.html
@@ -3,10 +3,10 @@
 	[class.mod-headingStyleH2]="hxStyle() === 2"
 	[attr.role]="heading() ? null : 'presentation'"
 	[style.--components-emptyState-background-color]="contentBackgroundColor()"
-	[style.--components-emptyState-illustration-background-bottom-left]="bottomLeftBackground() ? `url(${bottomLeftBackground()})` : null"
-	[style.--components-emptyState-illustration-foreground-bottom-left]="bottomLeftForeground() ? `url(${bottomLeftForeground()})` : null"
-	[style.--components-emptyState-illustration-background-top-right]="topRightBackground() ? `url(${topRightBackground()})` : null"
-	[style.--components-emptyState-illustration-foreground-top-right]="topRightForeground() ? `url(${topRightForeground()})` : null"
+	[style.--components-emptyState-illustration-background-bottom-left]="bottomLeftBackground() ? `url(${bottomLeftBackground()})` : 'none'"
+	[style.--components-emptyState-illustration-foreground-bottom-left]="bottomLeftForeground() ? `url(${bottomLeftForeground()})` : 'none'"
+	[style.--components-emptyState-illustration-background-top-right]="topRightBackground() ? `url(${topRightBackground()})` : 'none'"
+	[style.--components-emptyState-illustration-foreground-top-right]="topRightForeground() ? `url(${topRightForeground()})` : 'none'"
 >
 	<div class="emptyState-container">
 		<div class="emptyState-content">


### PR DESCRIPTION
## Description

null in a binding like [style.--xxx] ="" not apply style which lets SCSS take advantage. To actually remove the background the ternary would need to return `none` instead of `null`.

-----


-----
