### PR TITLE
fix(schematics): CommonJS build for schematics

### DIFF
--- a/build.js
+++ b/build.js
@@ -85,6 +85,11 @@ runTask('Lucca Front compilation', async () => {
 			output: OUTPUT_SCHEMATICS,
 		});
 
+		// ng-packagr sets "type": "module" in dist/ng/package.json.
+		// Schematics are compiled as CommonJS, so we need to override the module
+		// type locally to prevent Node.js from treating .js files as ES modules.
+		writeFile(path.join(OUTPUT_SCHEMATICS, 'package.json'), JSON.stringify({ type: 'commonjs' }, null, '\t'));
+
 		const npmIgnoreFile = path.join(OUTPUT_NG, '.npmignore');
 		const toIgnore = '!/schematics/lib/local-deps/package.json';
 		addLineToFile(npmIgnoreFile, toIgnore);


### PR DESCRIPTION
## Description

cause : ng-packagr génère dist/ng/package.json avec "type": "module". Node.js applique ce type à tous les .js du sous-arbre, y compris dist/ng/schematics/. Or nos schematics sont compilées en CommonJS (via build.js avec module: CommonJS) → conflit → exports is not defined.

Fix (build.js:91) : On écrit un dist/ng/schematics/package.json contenant {"type": "commonjs"} juste après la compilation. Node.js priorise le package.json le plus proche dans l'arborescence, donc ce fichier écrase localement le "type": "module" du parent pour tout ce qui est sous schematics/.

-----



-----