### PR TITLE
chore: remove @ngneat/spectator in favor of native Angular TestBed

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,7 +72,7 @@ export default defineConfig(
 			'@typescript-eslint/no-restricted-imports': [
 				'error',
 				{
-					paths: ['rxjs/Rx', '@ngneat/spectator', '@lucca-front/ng'],
+					paths: ['rxjs/Rx', '@lucca-front/ng'],
 					patterns: [
 						{
 							regex: 'dist\/ng',

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "@lucca-front/eslint-plugin": "workspace:*",
         "@lucca/stylelint-config-prisme": "file:packages/stylelint-config",
         "@mdx-js/loader": "^3.1.1",
-        "@ngneat/spectator": "^22.1.0",
         "@storybook/addon-a11y": "~10.1.9",
         "@storybook/addon-coverage": "~3.0.0",
         "@storybook/addon-docs": "~10.1.9",
@@ -7891,23 +7890,6 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
-    },
-    "node_modules/@ngneat/spectator": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@ngneat/spectator/-/spectator-22.1.0.tgz",
-      "integrity": "sha512-5UxMxiSp8LeWCdAtMktd2NVPJhbm88nBbNoOlmBty7b4paHAFwEhr7NNSdNlnFH2ZF/iAE5fLqzkUAgCGSGmDA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@testing-library/dom": "^10.4.1",
-        "jquery": "^3.7.1",
-        "tslib": "^2.6.2"
-      },
-      "peerDependencies": {
-        "@angular/animations": ">= 20.0.0",
-        "@angular/common": ">= 20.0.0",
-        "@angular/router": ">= 20.0.0"
       }
     },
     "node_modules/@ngtools/webpack": {
@@ -23386,13 +23368,6 @@
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "@lucca-front/eslint-plugin": "workspace:*",
     "@lucca/stylelint-config-prisme": "file:packages/stylelint-config",
     "@mdx-js/loader": "^3.1.1",
-    "@ngneat/spectator": "^22.1.0",
     "@storybook/addon-a11y": "~10.1.9",
     "@storybook/addon-coverage": "~3.0.0",
     "@storybook/addon-docs": "~10.1.9",

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Directive } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
-import { Spectator, createComponentFactory } from '@ngneat/spectator/jest';
 import { Observable, map, of } from 'rxjs';
 import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { ALuCoreSelectApiDirective, MAGIC_DEBOUNCE_DURATION } from './api.directive';
@@ -51,72 +51,84 @@ class TestDirective extends ALuCoreSelectApiDirective<TestEntity> {
 class HostComponent {}
 
 describe('ALuCoreSelectApiDirective', () => {
-	let spectator: Spectator<HostComponent>;
+	let fixture: ComponentFixture<HostComponent>;
+	let selectElement: HTMLElement;
 	let select: LuSimpleSelectInputComponent<TestEntity>;
 	let testApi: TestDirective;
 	let getOptionsSpy: jest.SpyInstance<Observable<TestEntity[]>, []>;
 
-	const createComponent = createComponentFactory<HostComponent>({
-		component: HostComponent,
-	});
-
 	beforeEach(() => {
-		spectator = createComponent({ detectChanges: false });
-		testApi = spectator.query(TestDirective);
-		select = spectator.query<LuSimpleSelectInputComponent<TestEntity>>(LuSimpleSelectInputComponent);
+		TestBed.configureTestingModule({
+			imports: [HostComponent],
+		});
+
+		fixture = TestBed.createComponent(HostComponent);
+
+		const selectDebugElement = fixture.debugElement.query(By.directive(LuSimpleSelectInputComponent));
+		selectElement = selectDebugElement.nativeElement as HTMLElement;
+		select = selectDebugElement.componentInstance as LuSimpleSelectInputComponent<TestEntity>;
+		testApi = fixture.debugElement.query(By.directive(TestDirective)).injector.get(TestDirective);
+
 		getOptionsSpy = jest.spyOn(testApi, 'getOptions');
 	});
 
 	it('should query options when clicking on the select', fakeAsync(() => {
-		spectator.click('lu-simple-select');
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
+		selectElement.click();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
 	}));
 
 	it('should query options when ArrowDown keydown on the select', fakeAsync(() => {
-		spectator.dispatchKeyboardEvent('lu-simple-select', 'keydown', 'ArrowDown');
-		spectator.tick(10); // Wait for panel to be opened
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
+		selectElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+		fixture.detectChanges();
+		tick(10); // Wait for panel to be opened
+		tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
 	}));
 
 	it('should query options once when searching while the select is closed', fakeAsync(() => {
-		spectator.tick(); // Component initialization uses a setTimeout :see_no_evil:
+		tick(); // Component initialization uses a setTimeout :see_no_evil:
 		select.clueChanged('test');
-		spectator.tick(10); // Wait for panel to be opened
-		spectator.tick(MAGIC_DEBOUNCE_DURATION);
-		spectator.tick();
+		fixture.detectChanges();
+		tick(10); // Wait for panel to be opened
+		tick(MAGIC_DEBOUNCE_DURATION);
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({ clue: 'test' }, 0);
 
-		spectator.tick(); // Avoid "1 periodic timer(s) still in the queue." because of the debounceTime(0) in the ALuCoreSelectApiDirective
+		tick(); // Avoid "1 periodic timer(s) still in the queue." because of the debounceTime(0) in the ALuCoreSelectApiDirective
 	}));
 
 	it('should debounce clue options', fakeAsync(() => {
-		spectator.tick(); // Component initialization uses a setTimeout :see_no_evil:
+		tick(); // Component initialization uses a setTimeout :see_no_evil:
+		fixture.detectChanges();
 
 		select.clueChanged('h');
-		spectator.tick(MAGIC_DEBOUNCE_DURATION - 1);
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION - 1);
 		select.clueChanged('he');
-		spectator.tick(MAGIC_DEBOUNCE_DURATION - 1);
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION - 1);
 		select.clueChanged('hey');
-		spectator.tick(MAGIC_DEBOUNCE_DURATION);
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+		fixture.detectChanges();
+		tick(MAGIC_DEBOUNCE_DURATION);
+		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({ clue: 'hey' }, 0);
 
-		spectator.tick(); // Avoid "1 periodic timer(s) still in the queue." because of the debounceTime(0) in the ALuCoreSelectApiDirective
+		tick(); // Avoid "1 periodic timer(s) still in the queue." because of the debounceTime(0) in the ALuCoreSelectApiDirective
 	}));
 
 	it('should call each page will page not full', fakeAsync(() => {
 		// Arrange
-		spectator.tick(); // Component initialization uses a setTimeout :see_no_evil:
+		tick(); // Component initialization uses a setTimeout :see_no_evil:
 		testApi.setPageSize(2);
 
 		// Act (Page 1)
@@ -128,9 +140,9 @@ describe('ALuCoreSelectApiDirective', () => {
 		);
 
 		select.clueChanged('test');
-		spectator.tick(10); // Wait for panel to be opened
-		spectator.tick(MAGIC_DEBOUNCE_DURATION);
-		spectator.tick();
+		fixture.detectChanges();
+		tick(10); // Wait for panel to be opened
+		tick(MAGIC_DEBOUNCE_DURATION);
 
 		// Act (Page 2)
 		getOptionsSpy.mockReturnValue(
@@ -140,14 +152,12 @@ describe('ALuCoreSelectApiDirective', () => {
 			]),
 		);
 		select.nextPage$.next();
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
-		spectator.tick();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// // Act (Page 3)
 		getOptionsSpy.mockReturnValue(of([{ id: 5, name: 'test 5' }]));
 		select.nextPage$.next();
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
-		spectator.tick();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Act (do nothing)
 		select.nextPage$.next();
@@ -171,7 +181,7 @@ describe('ALuCoreSelectApiDirective', () => {
 
 	it('should allow multiple emission on same page', fakeAsync(() => {
 		// Arrange
-		spectator.tick(); // Component initialization uses a setTimeout :see_no_evil:
+		tick(); // Component initialization uses a setTimeout :see_no_evil:
 		testApi.setPageSize(2);
 
 		const getPageSpy = jest.spyOn(testApi, 'getOptionsPage');
@@ -194,11 +204,12 @@ describe('ALuCoreSelectApiDirective', () => {
 
 		// Act (Page 1)
 		select.openPanel();
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Act (Page 2)
 		select.nextPage$.next();
-		spectator.tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Assert
 		let options: readonly TestEntity[];

--- a/packages/ng/date2/date-input/date-input.component.spec.ts
+++ b/packages/ng/date2/date-input/date-input.component.spec.ts
@@ -1,17 +1,38 @@
-import { LOCALE_ID } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { DateInputComponent } from './date-input.component';
 
-describe('DateInputComponent', () => {
-	let spectator: SpectatorHost<DateInputComponent>;
+@Component({
+	template: `<lu-date-input [formControl]="formControl" />`,
+	imports: [FormsModule, ReactiveFormsModule, DateInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {
+	formControl = new FormControl<Date | null>(null);
+}
 
-	const createHost = createHostFactory({
-		component: DateInputComponent,
-		imports: [FormsModule, ReactiveFormsModule],
-		providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
-	});
+describe('DateInputComponent', () => {
+	let fixture: ComponentFixture<HostComponent>;
+
+	function createHost(formControl: FormControl<Date | null>): HTMLInputElement {
+		TestBed.configureTestingModule({
+			imports: [HostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
+		});
+
+		fixture = TestBed.createComponent(HostComponent);
+		fixture.componentInstance.formControl = formControl;
+		fixture.detectChanges();
+
+		return (fixture.nativeElement as HTMLElement).querySelector('[data-testid="lu-date-input"]') as HTMLInputElement;
+	}
+
+	function typeInElement(value: string, input: HTMLInputElement): void {
+		input.value = value;
+		input.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+	}
 
 	it('should emit null when user clear the input', () => {
 		const valueChanges = jest.fn();
@@ -21,14 +42,10 @@ describe('DateInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-			hostProps: { formControl },
-		});
-
-		const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
+		const input = createHost(formControl);
 		expect(input).toBeTruthy();
 
-		spectator.typeInElement('', input);
+		typeInElement('', input);
 
 		expect(formControl.value).toBeNull();
 	});
@@ -41,14 +58,10 @@ describe('DateInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-			hostProps: { formControl },
-		});
-
-		const input = spectator.query('[data-testid="lu-date-input"]') as HTMLInputElement;
+		const input = createHost(formControl);
 		expect(input).toBeTruthy();
 
-		spectator.typeInElement('12', input);
+		typeInElement('12', input);
 
 		expect(valueChanges).toHaveBeenCalledTimes(1);
 		expect(formControl.errors).toEqual({ date: true });
@@ -62,11 +75,9 @@ describe('DateInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-			hostProps: { formControl },
-		});
+		createHost(formControl);
 
-		spectator.tick();
+		tick();
 		expect(valueChanges).toHaveBeenCalledTimes(0);
 	}));
 
@@ -78,11 +89,9 @@ describe('DateInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-input [formControl]="formControl"></lu-date-input>`, {
-			hostProps: { formControl },
-		});
+		createHost(formControl);
 
-		spectator.tick();
+		tick();
 		expect(valueChanges).toHaveBeenCalledTimes(0);
 	}));
 });

--- a/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
@@ -1,29 +1,48 @@
-import { LOCALE_ID } from '@angular/core';
-import { fakeAsync } from '@angular/core/testing';
+import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { createHostFactory, SpectatorHost } from '@ngneat/spectator/jest';
 import { addMonths } from 'date-fns';
 import { DateRange } from '../calendar2/date-range';
 import { DateRangeInputComponent } from './date-range-input.component';
 
-describe('DateRangeInputComponent', () => {
-	let spectator: SpectatorHost<DateRangeInputComponent>;
+@Component({
+	template: `<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)" />`,
+	imports: [FormsModule, ReactiveFormsModule, DateRangeInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class NgModelHostComponent {
+	selected: DateRange | null = null;
+	ngModelChangeCallback = (_value: unknown): void => {};
+}
 
-	const createHost = createHostFactory({
-		component: DateRangeInputComponent,
-		imports: [FormsModule, ReactiveFormsModule],
-		providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
-	});
+@Component({
+	template: `<lu-date-range-input [formControl]="formControl" />`,
+	imports: [FormsModule, ReactiveFormsModule, DateRangeInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class FormControlHostComponent {
+	formControl = new FormControl<DateRange | null>(null);
+}
+
+describe('DateRangeInputComponent', () => {
+	function typeInElement(value: string, input: HTMLInputElement, fixture: ComponentFixture<unknown>): void {
+		input.value = value;
+		input.dispatchEvent(new Event('input'));
+		fixture.detectChanges();
+	}
 
 	it('should not called ngModelChange at init if null value', () => {
 		const ngModelChangeCallback = jest.fn();
 
-		spectator = createHost(`<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)"></lu-date-range-input>`, {
-			hostProps: {
-				selected: null,
-				ngModelChangeCallback,
-			},
+		TestBed.configureTestingModule({
+			imports: [NgModelHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
+
+		const fixture = TestBed.createComponent(NgModelHostComponent);
+		fixture.componentInstance.selected = null;
+		fixture.componentInstance.ngModelChangeCallback = ngModelChangeCallback;
+		fixture.detectChanges();
 
 		expect(ngModelChangeCallback).toHaveBeenCalledTimes(0);
 	});
@@ -38,31 +57,37 @@ describe('DateRangeInputComponent', () => {
 			end: addMonths(today, 1),
 		};
 
-		spectator = createHost(`<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)"></lu-date-range-input>`, {
-			hostProps: {
-				selected,
-				ngModelChangeCallback,
-			},
+		TestBed.configureTestingModule({
+			imports: [NgModelHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
 
-		spectator.tick();
+		const fixture = TestBed.createComponent(NgModelHostComponent);
+		fixture.componentInstance.selected = selected;
+		fixture.componentInstance.ngModelChangeCallback = ngModelChangeCallback;
+		fixture.detectChanges();
+
+		tick();
 		expect(ngModelChangeCallback).toHaveBeenCalledTimes(0);
 	}));
 
 	it('should called ngModelChange when the user enter a date with a keyboard', () => {
 		const ngModelChangeCallback = jest.fn();
 
-		spectator = createHost(`<lu-date-range-input [(ngModel)]="selected" (ngModelChange)="ngModelChangeCallback($event)"></lu-date-range-input>`, {
-			hostProps: {
-				selected: null,
-				ngModelChangeCallback,
-			},
+		TestBed.configureTestingModule({
+			imports: [NgModelHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
 
-		const input = spectator.query('.mod-start > input');
+		const fixture = TestBed.createComponent(NgModelHostComponent);
+		fixture.componentInstance.selected = null;
+		fixture.componentInstance.ngModelChangeCallback = ngModelChangeCallback;
+		fixture.detectChanges();
+
+		const input = (fixture.nativeElement as HTMLElement).querySelector('.mod-start > input') as HTMLInputElement;
 		expect(input).toBeTruthy();
 
-		spectator.typeInElement('18/06/2025', input);
+		typeInElement('18/06/2025', input, fixture);
 
 		expect(ngModelChangeCallback).toHaveBeenCalledTimes(1);
 		expect(ngModelChangeCallback).toHaveBeenCalledWith({
@@ -79,13 +104,16 @@ describe('DateRangeInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-range-input [formControl]="formControl"></lu-date-range-input>`, {
-			hostProps: {
-				formControl,
-			},
+		TestBed.configureTestingModule({
+			imports: [FormControlHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
 
-		spectator.tick();
+		const fixture = TestBed.createComponent(FormControlHostComponent);
+		fixture.componentInstance.formControl = formControl;
+		fixture.detectChanges();
+
+		tick();
 		expect(valueChanges).toHaveBeenCalledTimes(0);
 	}));
 
@@ -104,13 +132,16 @@ describe('DateRangeInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-range-input [formControl]="formControl"></lu-date-range-input>`, {
-			hostProps: {
-				formControl,
-			},
+		TestBed.configureTestingModule({
+			imports: [FormControlHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
 
-		spectator.tick();
+		const fixture = TestBed.createComponent(FormControlHostComponent);
+		fixture.componentInstance.formControl = formControl;
+		fixture.detectChanges();
+
+		tick();
 		expect(valueChanges).toHaveBeenCalledTimes(0);
 	}));
 
@@ -122,16 +153,19 @@ describe('DateRangeInputComponent', () => {
 			valueChanges(value);
 		});
 
-		spectator = createHost(`<lu-date-range-input [formControl]="formControl"></lu-date-range-input>`, {
-			hostProps: {
-				formControl,
-			},
+		TestBed.configureTestingModule({
+			imports: [FormControlHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
 
-		const input = spectator.query('.mod-start > input');
+		const fixture = TestBed.createComponent(FormControlHostComponent);
+		fixture.componentInstance.formControl = formControl;
+		fixture.detectChanges();
+
+		const input = (fixture.nativeElement as HTMLElement).querySelector('.mod-start > input') as HTMLInputElement;
 		expect(input).toBeTruthy();
 
-		spectator.typeInElement('18/06/2025', input);
+		typeInElement('18/06/2025', input, fixture);
 
 		expect(valueChanges).toHaveBeenCalledTimes(1);
 		expect(valueChanges).toHaveBeenCalledWith({

--- a/packages/ng/title/title.service.spec.ts
+++ b/packages/ng/title/title.service.spec.ts
@@ -1,8 +1,7 @@
-import { Location } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Injectable, OnInit } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
-import { ActivatedRouteSnapshot, Resolve, RouterLink, RouterOutlet } from '@angular/router';
-import { SpectatorRouting, createRoutingFactory, mockProvider } from '@ngneat/spectator/jest';
+import { ActivatedRouteSnapshot, Resolve, Router, RouterLink, RouterOutlet, Routes, provideRouter } from '@angular/router';
 import { Observable, of, timer } from 'rxjs';
 import { map, skip } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
@@ -91,150 +90,153 @@ export class OverrideTitlePartComponent implements OnInit {
 }
 
 describe('TitleService', () => {
-	let spectator: SpectatorRouting<AppComponent>;
+	let fixture: ComponentFixture<AppComponent>;
 
-	const createComponent = createRoutingFactory({
-		component: AppComponent,
-		providers: [
-			LuTitleService,
-			mockProvider(Title),
-			{
-				provide: LU_TITLE_TRANSLATE_SERVICE,
-				useClass: TranslateService,
-			},
-		],
-		stubsEnabled: false,
-		routes: [
-			{
-				path: '',
-				data: { title: 'Stub' },
-				component: StubComponent,
-				children: [
-					{
-						path: 'first',
-						component: StubComponent,
-						children: [
-							{
-								path: ':id',
-								data: { title: `Stubs' child {{id}}` },
-								component: StubComponent,
-								children: [
-									{
-										path: 'last',
-										data: { title: `` },
-										component: OverrideTitleComponent,
-									},
-									{
-										path: 'end',
-										data: { title: `Old title part` },
-										component: OverrideTitlePartComponent,
-									},
-									{
-										path: 'delayed',
-										data: { title: `` },
-										component: DelayedOverrideTitleComponent,
-										children: [
-											{
-												path: '',
-												component: OverrideTitleComponent,
-											},
-										],
-									},
-								],
-							},
-						],
-					},
-					{
-						path: 'second',
-						component: StubComponent,
-						children: [
-							{
-								path: ':id',
-								resolve: { name: TestNameResolver },
-								data: { title: `Stubs' child {{name}}` },
-								component: StubComponent,
-							},
-						],
-					},
-				],
-			},
-		],
+	const routes: Routes = [
+		{
+			path: '',
+			data: { title: 'Stub' },
+			component: StubComponent,
+			children: [
+				{
+					path: 'first',
+					component: StubComponent,
+					children: [
+						{
+							path: ':id',
+							data: { title: `Stubs' child {{id}}` },
+							component: StubComponent,
+							children: [
+								{
+									path: 'last',
+									data: { title: `` },
+									component: OverrideTitleComponent,
+								},
+								{
+									path: 'end',
+									data: { title: `Old title part` },
+									component: OverrideTitlePartComponent,
+								},
+								{
+									path: 'delayed',
+									data: { title: `` },
+									component: DelayedOverrideTitleComponent,
+									children: [
+										{
+											path: '',
+											component: OverrideTitleComponent,
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				{
+					path: 'second',
+					component: StubComponent,
+					children: [
+						{
+							path: ':id',
+							resolve: { name: TestNameResolver },
+							data: { title: `Stubs' child {{name}}` },
+							component: StubComponent,
+						},
+					],
+				},
+			],
+		},
+	];
+
+	async function clickLink(selector: string): Promise<void> {
+		(fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(selector)!.click();
+		fixture.detectChanges();
+		await fixture.whenStable();
+	}
+
+	beforeEach(async () => {
+		TestBed.configureTestingModule({
+			imports: [AppComponent],
+			providers: [
+				provideRouter(routes),
+				LuTitleService,
+				{ provide: Title, useValue: { setTitle: jest.fn(), getTitle: jest.fn().mockReturnValue('') } },
+				{
+					provide: LU_TITLE_TRANSLATE_SERVICE,
+					useClass: TranslateService,
+				},
+			],
+		});
+
+		fixture = TestBed.createComponent(AppComponent);
+		fixture.detectChanges();
+		await TestBed.inject(Router).navigateByUrl('/');
+		fixture.detectChanges();
 	});
-
-	beforeEach(() => (spectator = createComponent()));
 
 	it('should set title', async () => {
 		let resultTitle = '';
-		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
+		TestBed.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
-		await spectator.fixture.whenStable();
-		expect(spectator.inject(Location).path()).toBe('/');
+		await fixture.whenStable();
+		expect(TestBed.inject(Router).url).toBe('/');
 		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('should ignore empty or absent titles', async () => {
 		let resultTitle = '';
-		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
+		TestBed.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-2');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-2');
 		expect(resultTitle).toEqual(`Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('should include named params in title', async () => {
 		let resultTitle = '';
-		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
+		TestBed.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-3');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-3');
 		expect(resultTitle).toEqual(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('should prepend title when a component forces its own title', async () => {
 		let resultTitle = '';
-		spectator
-			.inject(LuTitleService)
+		TestBed.inject(LuTitleService)
 			// We need to skip first value because the title is overridden by the component's ngOnInit
 			.title$.pipe(skip(1))
 			.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-4');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-4');
 		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('should override title part when a component forces its own title part', async () => {
 		let resultTitle = '';
-		spectator
-			.inject(LuTitleService)
+		TestBed.inject(LuTitleService)
 			// We need to skip first value because the title is overridden by the component's ngOnInit
 			.title$.pipe(skip(1))
 			.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-5');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-5');
 		expect(resultTitle).toEqual(`New title part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('should handle observable inputs', async () => {
 		let resultTitle = '';
-		spectator
-			.inject(LuTitleService)
+		TestBed.inject(LuTitleService)
 			// We need to skip first value because the title is overridden by the component's ngOnInit
 			.title$.pipe(skip(1))
 			.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-6');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-6');
 		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Delayed part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 
 	it('should include named params in title', async () => {
 		let resultTitle = '';
-		spectator.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
+		TestBed.inject(LuTitleService).title$.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-7');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-7');
 		expect(resultTitle).toEqual(`Stubs' child Name 1${TitleSeparator}Stub${TitleSeparator}BU${TitleSeparator}Lucca`);
 	});
 });

--- a/packages/ng/title/title.strategy.spec.ts
+++ b/packages/ng/title/title.strategy.spec.ts
@@ -1,8 +1,7 @@
-import { Location } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
-import { ActivatedRouteSnapshot, RouterLink, RouterOutlet, TitleStrategy } from '@angular/router';
-import { SpectatorRouting, createRoutingFactory, mockProvider } from '@ngneat/spectator/jest';
+import { ActivatedRouteSnapshot, Router, RouterLink, RouterOutlet, Routes, TitleStrategy, provideRouter } from '@angular/router';
 import { of, timer } from 'rxjs';
 import { map, skip } from 'rxjs/operators';
 import { ILuTitleTranslateService } from './title-translate.service';
@@ -80,87 +79,97 @@ export class OverrideTitlePartComponent implements OnInit {
 }
 
 describe('TitleStrategy', () => {
-	let spectator: SpectatorRouting<AppComponent>;
+	let fixture: ComponentFixture<AppComponent>;
 	let pageTitleService: LuTitleStrategy;
 
-	const createComponent = createRoutingFactory({
-		component: AppComponent,
-		providers: [
-			mockProvider(Title),
-			provideLuTitleStrategy({
-				appTitle: () => 'BU',
-				translateService: () => new TranslateService(),
-			}),
-		],
-		stubsEnabled: false,
-		routes: [
-			{
-				path: '',
-				title: 'Stub',
-				component: StubComponent,
-				children: [
-					{
-						path: 'first',
-						component: StubComponent,
-						children: [
-							{
-								path: ':id',
-								title: `Stubs' child {{id}}`,
-								component: StubComponent,
-								children: [
-									{
-										path: 'last',
-										title: ``,
-										component: OverrideTitleComponent,
-									},
-									{
-										path: 'end',
-										title: `Old title part`,
-										component: OverrideTitlePartComponent,
-									},
-									{
-										path: 'delayed',
-										title: ``,
-										component: DelayedOverrideTitleComponent,
-										children: [
-											{
-												path: '',
-												component: OverrideTitleComponent,
-											},
-										],
-									},
-								],
-							},
-						],
-					},
-					{
-						path: 'second',
-						component: StubComponent,
-						children: [
-							{
-								path: ':id',
-								title: `Stubs' child {{name}}`,
-								resolve: { name: (route: ActivatedRouteSnapshot) => of(`Name ${route.paramMap.get('id')}`) },
-								component: StubComponent,
-							},
-						],
-					},
-				],
-			},
-		],
-	});
+	const routes: Routes = [
+		{
+			path: '',
+			title: 'Stub',
+			component: StubComponent,
+			children: [
+				{
+					path: 'first',
+					component: StubComponent,
+					children: [
+						{
+							path: ':id',
+							title: `Stubs' child {{id}}`,
+							component: StubComponent,
+							children: [
+								{
+									path: 'last',
+									title: ``,
+									component: OverrideTitleComponent,
+								},
+								{
+									path: 'end',
+									title: `Old title part`,
+									component: OverrideTitlePartComponent,
+								},
+								{
+									path: 'delayed',
+									title: ``,
+									component: DelayedOverrideTitleComponent,
+									children: [
+										{
+											path: '',
+											component: OverrideTitleComponent,
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+				{
+					path: 'second',
+					component: StubComponent,
+					children: [
+						{
+							path: ':id',
+							title: `Stubs' child {{name}}`,
+							resolve: { name: (route: ActivatedRouteSnapshot) => of(`Name ${route.paramMap.get('id')}`) },
+							component: StubComponent,
+						},
+					],
+				},
+			],
+		},
+	];
 
-	beforeEach(() => {
-		spectator = createComponent();
-		pageTitleService = spectator.inject(TitleStrategy) as unknown as LuTitleStrategy;
+	async function clickLink(selector: string): Promise<void> {
+		(fixture.nativeElement as HTMLElement).querySelector<HTMLAnchorElement>(selector)!.click();
+		fixture.detectChanges();
+		await fixture.whenStable();
+	}
+
+	beforeEach(async () => {
+		TestBed.configureTestingModule({
+			imports: [AppComponent],
+			providers: [
+				provideRouter(routes),
+				{ provide: Title, useValue: { setTitle: jest.fn(), getTitle: jest.fn().mockReturnValue('') } },
+				provideLuTitleStrategy({
+					appTitle: () => 'BU',
+					translateService: () => new TranslateService(),
+				}),
+			],
+		});
+
+		fixture = TestBed.createComponent(AppComponent);
+		pageTitleService = TestBed.inject(TitleStrategy) as unknown as LuTitleStrategy;
+		fixture.detectChanges();
+		await TestBed.inject(Router).navigateByUrl('/');
+		fixture.detectChanges();
 	});
 
 	it('should set title', async () => {
 		let resultTitle = '';
 		pageTitleService.title$.subscribe((title) => (resultTitle = title));
 
-		await spectator.fixture.whenStable();
-		expect(spectator.inject(Location).path()).toBe('/');
+		await fixture.whenStable();
+		expect(TestBed.inject(Router).url).toBe('/');
 		expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca BU`);
 	});
 
@@ -168,8 +177,7 @@ describe('TitleStrategy', () => {
 		let resultTitle = '';
 		pageTitleService.title$.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-2');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-2');
 		expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca BU`);
 	});
 
@@ -177,8 +185,7 @@ describe('TitleStrategy', () => {
 		let resultTitle = '';
 		pageTitleService.title$.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-3');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-3');
 		expect(resultTitle).toEqual(`Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
@@ -188,8 +195,7 @@ describe('TitleStrategy', () => {
 		// We need to skip first value because the title is overridden by the component's ngOnInit
 		pageTitleService.title$.pipe(skip(1)).subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-4');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-4');
 		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
@@ -198,8 +204,7 @@ describe('TitleStrategy', () => {
 		// We need to skip first value because the title is overridden by the component's ngOnInit
 		pageTitleService.title$.pipe(skip(1)).subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-5');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-5');
 		expect(resultTitle).toEqual(`New title part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
@@ -208,8 +213,7 @@ describe('TitleStrategy', () => {
 		// We need to skip first value because the title is overridden by the component's ngOnInit
 		pageTitleService.title$.pipe(skip(1)).subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-6');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-6');
 		expect(resultTitle).toEqual(`Overridden title${TitleSeparator}Delayed part${TitleSeparator}Stubs' child 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 
@@ -217,8 +221,7 @@ describe('TitleStrategy', () => {
 		let resultTitle = '';
 		pageTitleService.title$.subscribe((title) => (resultTitle = title));
 
-		spectator.click('.link-7');
-		await spectator.fixture.whenStable();
+		await clickLink('.link-7');
 		expect(resultTitle).toEqual(`Stubs' child Name 1${TitleSeparator}Stub${TitleSeparator}Lucca BU`);
 	});
 });

--- a/packages/ng/user/display/user-display.pipe.spec.ts
+++ b/packages/ng/user/display/user-display.pipe.spec.ts
@@ -1,6 +1,18 @@
-import { createPipeFactory, SpectatorPipe } from '@ngneat/spectator/jest';
+import { ChangeDetectionStrategy, Component, Provider, input } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
-import { luUserDisplay, LuUserDisplayPipe } from './user-display.pipe';
+import { luUserDisplay, LuUserDisplayInput, LuUserDisplayPipe } from './user-display.pipe';
+
+@Component({
+	template: ``,
+	imports: [LuUserDisplayPipe],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {
+	readonly user = input<LuUserDisplayInput>();
+	readonly users = input<LuUserDisplayInput[]>();
+	readonly formatter = input<Intl.ListFormat>();
+}
 
 describe(LuUserDisplayPipe.name, () => {
 	const users = [
@@ -87,83 +99,60 @@ describe(LuUserDisplayPipe.name, () => {
 	});
 
 	describe('| luUserDisplay', () => {
-		let spectator: SpectatorPipe<LuUserDisplayPipe>;
-		const createPipe = createPipeFactory(LuUserDisplayPipe);
+		function createPipe(template: string, inputs: Partial<{ user: LuUserDisplayInput; users: LuUserDisplayInput[]; formatter: Intl.ListFormat }>, providers: Provider[] = []): string {
+			TestBed.configureTestingModule({
+				imports: [HostComponent],
+				providers,
+			});
+			TestBed.overrideComponent(HostComponent, { set: { template } });
+
+			const fixture = TestBed.createComponent(HostComponent);
+			if (inputs.user) {
+				fixture.componentRef.setInput('user', inputs.user);
+			}
+			if (inputs.users) {
+				fixture.componentRef.setInput('users', inputs.users);
+			}
+			if (inputs.formatter) {
+				fixture.componentRef.setInput('formatter', inputs.formatter);
+			}
+			fixture.detectChanges();
+
+			return (fixture.nativeElement as HTMLElement).textContent?.trim() ?? '';
+		}
 
 		it(`should return the right single value with default 'lf' format`, () => {
-			spectator = createPipe(`{{ user | luUserDisplay }}`, {
-				hostProps: {
-					user,
-				},
-			});
-			expect(spectator.element).toHaveText('Doe John');
+			expect(createPipe(`{{ user() | luUserDisplay }}`, { user })).toBe('Doe John');
 		});
 
 		it(`should return the right single value with provide 'fl' format`, () => {
 			const provider = { provide: LU_DEFAULT_DISPLAY_POLICY, useValue: LuDisplayFullname.firstlast };
-			spectator = createPipe(`{{ user | luUserDisplay }}`, {
-				hostProps: {
-					user,
-				},
-				providers: [provider],
-			});
-			expect(spectator.element).toHaveText('John Doe');
+			expect(createPipe(`{{ user() | luUserDisplay }}`, { user }, [provider])).toBe('John Doe');
 		});
 
 		it(`should return the right single value with specify 'FL' format`, () => {
-			spectator = createPipe(`{{ user | luUserDisplay:'FL' }}`, {
-				hostProps: {
-					user,
-				},
-			});
-			expect(spectator.element).toHaveText('JD');
+			expect(createPipe(`{{ user() | luUserDisplay:'FL' }}`, { user })).toBe('JD');
 		});
 
 		it(`should return the right multiple value with default 'lf' format and default ', ' separator`, () => {
-			spectator = createPipe(`{{ users | luUserDisplay }}`, {
-				hostProps: {
-					users,
-				},
-			});
-			expect(spectator.element).toHaveText('Doe John, Scott Michael, Schrute Dwight');
+			expect(createPipe(`{{ users() | luUserDisplay }}`, { users })).toBe('Doe John, Scott Michael, Schrute Dwight');
 		});
 
 		it(`should return the right multiple value with default 'lf' format and '; ' separator`, () => {
-			spectator = createPipe(`{{ users | luUserDisplay:{ separator: '; ' } }}`, {
-				hostProps: {
-					users,
-				},
-			});
-			expect(spectator.element).toHaveText('Doe John; Scott Michael; Schrute Dwight');
+			expect(createPipe(`{{ users() | luUserDisplay:{ separator: '; ' } }}`, { users })).toBe('Doe John; Scott Michael; Schrute Dwight');
 		});
 
 		it(`should return the right multiple value with default 'Lf' format and default ', ' separator`, () => {
-			spectator = createPipe(`{{ users | luUserDisplay:{ format: 'Lf' } }}`, {
-				hostProps: {
-					users,
-				},
-			});
-			expect(spectator.element).toHaveText('D. John, S. Michael, S. Dwight');
+			expect(createPipe(`{{ users() | luUserDisplay:{ format: 'Lf' } }}`, { users })).toBe('D. John, S. Michael, S. Dwight');
 		});
 
 		it(`should return the right multiple value with specify 'Fl' format and ' ' separator`, () => {
-			spectator = createPipe(`{{ users | luUserDisplay:{ format: 'Fl', separator: ' ' } }}`, {
-				hostProps: {
-					users,
-				},
-			});
-			expect(spectator.element).toHaveText('J. Doe M. Scott D. Schrute');
+			expect(createPipe(`{{ users() | luUserDisplay:{ format: 'Fl', separator: ' ' } }}`, { users })).toBe('J. Doe M. Scott D. Schrute');
 		});
 
 		it(`should return the right multiple value with specify 'fL' format and formatter`, () => {
 			const formatter = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' });
-			spectator = createPipe(`{{ users | luUserDisplay:{ format: 'fL', formatter } }}`, {
-				hostProps: {
-					users,
-					formatter,
-				},
-			});
-			expect(spectator.element).toHaveText('John D., Michael S., and Dwight S.');
+			expect(createPipe(`{{ users() | luUserDisplay:{ format: 'fL', formatter: formatter() } }}`, { users, formatter })).toBe('John D., Michael S., and Dwight S.');
 		});
 	});
 });


### PR DESCRIPTION
## Description

Removes the `@ngneat/spectator` dev dependency and rewrites all of its remaining usages with the native **Angular `TestBed`** API.

Spectator was only used in a handful of spec files. Dropping it removes a third-party test abstraction in favor of the framework's own testing primitives, which are better typed, better maintained, and aligned with current Angular practices (signal inputs, `componentRef.setInput`, `provideRouter`, etc.).

## What changed

`@ngneat/spectator` removed from `devDependencies`, and the following specs migrated:

| Spec | Spectator API | Replaced with |
| --- | --- | --- |
| `core-select/api/api.directive.spec.ts` | `createComponentFactory` / `Spectator`, `query`, `click`, `dispatchKeyboardEvent`, `tick` | `TestBed.createComponent`, `By.directive`, native DOM events + `fixture.detectChanges()`, `tick()` |
| `date2/date-input/date-input.component.spec.ts` | `createHostFactory` / `SpectatorHost`, `typeInElement` | `TestBed` host component, `querySelector`, native `input` event |
| `date2/date-range-input/date-range-input.component.spec.ts` | `createHostFactory`, `typeInElement` | dedicated `ngModel` / reactive-forms host components + `TestBed` |
| `title/title.service.spec.ts` | `createRoutingFactory` / `SpectatorRouting`, `mockProvider(Title)`, `click` | `provideRouter`, `Router.navigateByUrl`, plain `Title` mock, anchor `.click()` |
| `title/title.strategy.spec.ts` | same as above | same as above |
| `user/display/user-display.pipe.spec.ts` | `createPipeFactory` / `SpectatorPipe`, `toHaveText` | `TestBed.overrideComponent` with signal `input()`s set via `componentRef.setInput`, asserting `textContent` |

## Notes

- Behaviour and assertions are preserved; only the test harness changed.
- Where Spectator ran change detection implicitly after each interaction, the equivalent `fixture.detectChanges()` calls were added explicitly.
- The root-path assertion in the title specs uses `Router.url` (`'/'`) instead of `Location.path()` (which returns `''` at root under plain `TestBed`).

## Test plan

- [x] `nx test ng` for the migrated specs passes locally (all green).
