### PR TITLE
feat(schematics): add lu-grid schematics

### DIFF
--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -86,6 +86,11 @@
       "factory": "./lu-container/index",
       "schema": "./lu-container/schema.json"
     },
+    "lu-grid": {
+      "description": "Migrate HTML grid to the new lu-grid component",
+      "factory": "./lu-grid/index",
+      "schema": "./lu-grid/schema.json"
+    },
     "lu-button": {
       "description": "Migrate CSS-only buttons to the new luButton component",
       "factory": "./lu-button/index",

--- a/packages/ng/schematics/lu-grid/index.ts
+++ b/packages/ng/schematics/lu-grid/index.ts
@@ -1,0 +1,27 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { Rule } from '@angular-devkit/schematics';
+import { createSourceFile, ScriptTarget } from 'typescript';
+import { currentSchematicContext, migrateFile, SchematicContextOpts } from '../lib';
+import { migrateComponent } from './migration';
+
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+require('@angular-devkit/schematics');
+
+export default (options?: SchematicContextOpts): Rule => {
+
+	return async (tree, context) => {
+		await currentSchematicContext.init(context, options);
+
+		tree.visit((path, entry) => {
+			if (path.includes('node_modules') || !entry) {
+				return;
+			}
+			if ( path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+				migrateFile(path, entry, tree, (content) => {
+					const sourceFile = createSourceFile(path, content, ScriptTarget.ESNext);
+					return migrateComponent(sourceFile, path, tree);
+				});
+			}
+		});
+	};
+};

--- a/packages/ng/schematics/lu-grid/migration.spec.ts
+++ b/packages/ng/schematics/lu-grid/migration.spec.ts
@@ -1,0 +1,24 @@
+import * as path from 'path';
+import { createTreeFromFolder, expectTree, runSchematic } from '../lib';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.json'));
+const testsRoot = path.join(__dirname, 'tests');
+
+describe('lu-grid Migration', () => {
+	it('should handle basic case files', async () => {
+		// Arrange
+		const tree = createTreeFromFolder(path.join(testsRoot, 'input'));
+		const expectedTree = createTreeFromFolder(path.join(testsRoot, 'output'));
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'lu-grid', { skipInstallation: true }, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+});

--- a/packages/ng/schematics/lu-grid/migration.ts
+++ b/packages/ng/schematics/lu-grid/migration.ts
@@ -1,0 +1,345 @@
+import { Tree } from '@angular-devkit/schematics';
+import type { TmplAstElement } from '@angular/compiler';
+import { applyToUpdateRecorder } from '@schematics/angular/utility/change';
+import { SourceFile } from 'typescript';
+import { HtmlAst, extractNgTemplatesIncludingHtml, insertAngularImportIfNeeded, insertTSImportIfNeeded, isInterestingNode } from '../lib';
+
+// --- Grid container ---
+
+interface GridInputs {
+	mode?: string;
+	columns?: string;
+	extraClasses?: string;
+}
+
+interface HtmlGrid {
+	node: TmplAstElement;
+	inputs: GridInputs;
+	nodeOffset: number;
+	filePath: string;
+	componentTS: SourceFile;
+}
+
+// --- Grid column ---
+
+interface GridColumnInputs {
+	colspan?: string;
+	rowspan?: string;
+	column?: string;
+	row?: string;
+	justify?: string;
+	align?: string;
+	responsive?: Record<string, string>;
+}
+
+interface HtmlGridColumn {
+	node: TmplAstElement;
+	inputs: GridColumnInputs;
+	remainingStyle?: string;
+	extraClasses?: string;
+	nodeOffset: number;
+	filePath: string;
+	componentTS: SourceFile;
+}
+
+// --- CSS custom properties helpers ---
+
+function parseCssCustomProperties(style: string): Record<string, string> {
+	const result: Record<string, string> = {};
+	style.split(';').map((p) => p.trim()).filter(Boolean).forEach((part) => {
+		const colonIdx = part.indexOf(':');
+		if (colonIdx === -1) {
+			return;
+		}
+		const prop = part.substring(0, colonIdx).trim();
+		const value = part.substring(colonIdx + 1).trim();
+		result[prop] = value;
+	});
+	return result;
+}
+
+// CSS custom properties that map directly to GridColumnComponent inputs
+const GRID_COLUMN_DIRECT_PROPS: Record<string, string> = {
+	'--grid-colspan': 'colspan',
+	'--grid-rowspan': 'rowspan',
+	'--grid-column': 'column',
+	'--grid-row': 'row',
+	'--grid-justify': 'justify',
+	'--grid-align': 'align',
+};
+
+// Prefix for responsive CSS custom properties
+const RESPONSIVE_PREFIX = '--grid-';
+
+function extractGridColumnInputs(style: string): { inputs: GridColumnInputs; remainingStyle: string } {
+	const cssProps = parseCssCustomProperties(style);
+	const inputs: GridColumnInputs = {};
+	const responsive: Record<string, string> = {};
+	const remaining: string[] = [];
+
+	for (const [prop, value] of Object.entries(cssProps)) {
+		if (GRID_COLUMN_DIRECT_PROPS[prop]) {
+			(inputs as Record<string, string>)[GRID_COLUMN_DIRECT_PROPS[prop]] = value;
+		} else if (prop.startsWith(RESPONSIVE_PREFIX) && prop.includes('AtMedia')) {
+			// e.g. --grid-colspanAtMediaMinXS → colspanAtMediaMinXS
+			const key = prop.substring(RESPONSIVE_PREFIX.length);
+			responsive[key] = value;
+		} else if (prop.startsWith('--grid-')) {
+			// Unknown grid property — drop it (it was grid-specific)
+		} else {
+			remaining.push(`${prop}: ${value}`);
+		}
+	}
+
+	if (Object.keys(responsive).length > 0) {
+		inputs.responsive = responsive;
+	}
+
+	return { inputs, remainingStyle: remaining.join('; ') };
+}
+
+// --- Main migration ---
+
+export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tree): string {
+	const htmlGrids = findHTMLGrids(sourceFile, path, tree);
+	const htmlGridColumns = findHTMLGridColumns(sourceFile, path, tree);
+
+	if (htmlGrids.length === 0 && htmlGridColumns.length === 0) {
+		return tree.readText(path);
+	}
+
+	const tsUpdate = tree.beginUpdate(path);
+	const firstItem = htmlGrids[0] || htmlGridColumns[0];
+	const isInlineTemplate = firstItem.filePath === path;
+	const templateUpdate = isInlineTemplate ? tsUpdate : tree.beginUpdate(firstItem.filePath);
+
+	htmlGrids.forEach((grid) => migrateGridNode(grid, templateUpdate));
+	htmlGridColumns.forEach((col) => migrateGridColumnNode(col, templateUpdate));
+
+	const changesToApply = [];
+	if (htmlGrids.length > 0) {
+		changesToApply.push(
+			insertTSImportIfNeeded(sourceFile, path, 'GridComponent', '@lucca-front/ng/grid'),
+			insertAngularImportIfNeeded(sourceFile, path, 'GridComponent'),
+		);
+	}
+	if (htmlGridColumns.length > 0) {
+		changesToApply.push(
+			insertTSImportIfNeeded(sourceFile, path, 'GridColumnComponent', '@lucca-front/ng/grid'),
+			insertAngularImportIfNeeded(sourceFile, path, 'GridColumnComponent'),
+		);
+	}
+	applyToUpdateRecorder(tsUpdate, changesToApply);
+
+	tree.commitUpdate(tsUpdate);
+	if (!isInlineTemplate) {
+		tree.commitUpdate(templateUpdate);
+	}
+
+	return tree.readText(path);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function migrateGridNode(grid: HtmlGrid, templateUpdate: any): void {
+	const { node, nodeOffset, inputs } = grid;
+	const divLength = node.name.length; // 'div'
+	const classesNode = node.attributes.find((attr) => attr.name === 'class');
+	const styleNode = node.attributes.find((attr) => attr.name === 'style');
+
+	// Build inputs string (everything that comes after the element name)
+	let thingsToAdd = 'lu-grid';
+	if (inputs.mode) {
+		thingsToAdd += ` mode="${inputs.mode}"`;
+	}
+	if (inputs.columns) {
+		thingsToAdd += ` columns="${inputs.columns}"`;
+	}
+
+	// Remove element name 'div'
+	templateUpdate.remove(nodeOffset + node.startSourceSpan.start.offset + 1, divLength);
+
+	if (node.children.length > 0 && node.endSourceSpan) {
+		// Has children — replace end tag
+		templateUpdate.remove(nodeOffset + node.endSourceSpan.start.offset + 1, divLength + 1);
+		templateUpdate.insertRight(nodeOffset + node.startSourceSpan.start.offset + 1, thingsToAdd);
+		templateUpdate.insertLeft(nodeOffset + node.endSourceSpan.start.offset + 1, '/lu-grid');
+	} else if (!node.isSelfClosing) {
+		// Empty, not self-closing
+		const endSpanOffset = node.endSourceSpan?.start.offset || -1;
+		templateUpdate.remove(nodeOffset + node.startSourceSpan.end.offset, endSpanOffset - node.startSourceSpan.end.offset);
+		if (node.endSourceSpan?.start?.offset) {
+			templateUpdate.remove(nodeOffset + node.endSourceSpan.start.offset, node.endSourceSpan.toString().length);
+		}
+		templateUpdate.insertRight(nodeOffset + node.startSourceSpan.start.offset + 1, thingsToAdd);
+		templateUpdate.insertRight(nodeOffset + node.startSourceSpan.end.offset - 1, ` /`);
+	}
+
+	// Modify class attribute — remove 'grid' and mode-related classes
+	if (classesNode && classesNode.keySpan) {
+		const classes = classesNode.value;
+		const cleanedClasses = classes.split(' ').filter((c) => c !== 'grid' && c !== 'mod-auto').join(' ');
+		templateUpdate.remove(nodeOffset + classesNode.keySpan.start.offset - 1, classesNode.sourceSpan.toString().length + 1);
+		if (cleanedClasses) {
+			templateUpdate.insertRight(nodeOffset + classesNode.keySpan.start.offset, ` class="${cleanedClasses}"`);
+		}
+	}
+
+	// Modify style attribute — remove --grid-columns, keep the rest
+	if (styleNode && styleNode.keySpan) {
+		const cssProps = parseCssCustomProperties(styleNode.value);
+		const remaining = Object.entries(cssProps)
+			.filter(([key]) => key !== '--grid-columns')
+			.map(([key, val]) => `${key}: ${val}`)
+			.join('; ');
+		templateUpdate.remove(nodeOffset + styleNode.keySpan.start.offset - 1, styleNode.sourceSpan.toString().length + 1);
+		if (remaining) {
+			templateUpdate.insertRight(nodeOffset + styleNode.keySpan.start.offset, ` style="${remaining}"`);
+		}
+	}
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function migrateGridColumnNode(col: HtmlGridColumn, templateUpdate: any): void {
+	const { node, nodeOffset, inputs, remainingStyle, extraClasses } = col;
+	const divLength = node.name.length; // 'div'
+	const classesNode = node.attributes.find((attr) => attr.name === 'class');
+	const styleNode = node.attributes.find((attr) => attr.name === 'style');
+
+	// Build inputs string
+	let thingsToAdd = 'lu-grid-column';
+	if (inputs.colspan) {
+		thingsToAdd += ` colspan="${inputs.colspan}"`;
+	}
+	if (inputs.rowspan) {
+		thingsToAdd += ` rowspan="${inputs.rowspan}"`;
+	}
+	if (inputs.column) {
+		thingsToAdd += ` column="${inputs.column}"`;
+	}
+	if (inputs.row) {
+		thingsToAdd += ` row="${inputs.row}"`;
+	}
+	if (inputs.justify) {
+		thingsToAdd += ` justify="${inputs.justify}"`;
+	}
+	if (inputs.align) {
+		thingsToAdd += ` align="${inputs.align}"`;
+	}
+	if (inputs.responsive) {
+		const responsiveEntries = Object.entries(inputs.responsive)
+			.map(([key, val]) => `${key}: ${val}`)
+			.join(', ');
+		thingsToAdd += ` [responsive]="{ ${responsiveEntries} }"`;
+	}
+
+	// Remove element name 'div'
+	templateUpdate.remove(nodeOffset + node.startSourceSpan.start.offset + 1, divLength);
+
+	if (node.children.length > 0 && node.endSourceSpan) {
+		templateUpdate.remove(nodeOffset + node.endSourceSpan.start.offset + 1, divLength + 1);
+		templateUpdate.insertRight(nodeOffset + node.startSourceSpan.start.offset + 1, thingsToAdd);
+		templateUpdate.insertLeft(nodeOffset + node.endSourceSpan.start.offset + 1, '/lu-grid-column');
+	} else if (!node.isSelfClosing) {
+		const endSpanOffset = node.endSourceSpan?.start.offset || -1;
+		templateUpdate.remove(nodeOffset + node.startSourceSpan.end.offset, endSpanOffset - node.startSourceSpan.end.offset);
+		if (node.endSourceSpan?.start?.offset) {
+			templateUpdate.remove(nodeOffset + node.endSourceSpan.start.offset, node.endSourceSpan.toString().length);
+		}
+		templateUpdate.insertRight(nodeOffset + node.startSourceSpan.start.offset + 1, thingsToAdd);
+		templateUpdate.insertRight(nodeOffset + node.startSourceSpan.end.offset - 1, ` /`);
+	}
+
+	// Class attribute: remove 'grid-column', keep extra classes
+	if (classesNode && classesNode.keySpan) {
+		templateUpdate.remove(nodeOffset + classesNode.keySpan.start.offset - 1, classesNode.sourceSpan.toString().length + 1);
+		if (extraClasses) {
+			templateUpdate.insertRight(nodeOffset + classesNode.keySpan.start.offset, ` class="${extraClasses}"`);
+		}
+	}
+
+	// Style attribute: remove grid-specific properties, keep the rest
+	if (styleNode && styleNode.keySpan) {
+		templateUpdate.remove(nodeOffset + styleNode.keySpan.start.offset - 1, styleNode.sourceSpan.toString().length + 1);
+		if (remainingStyle) {
+			templateUpdate.insertRight(nodeOffset + styleNode.keySpan.start.offset, ` style="${remainingStyle}"`);
+		}
+	}
+}
+
+// --- Finders ---
+
+function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): HtmlGrid[] {
+	const results: HtmlGrid[] = [];
+	const ngTemplates = extractNgTemplatesIncludingHtml(sourceFile, tree, basePath);
+
+	ngTemplates.forEach((template) => {
+		const htmlAst = new HtmlAst(template.content);
+		htmlAst.visitNodes((node) => {
+			if (!isInterestingNode(node)) {
+				return;
+			}
+			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
+			if (!classes?.match(/(^|\s)grid(\s|$)/)) {
+				return;
+			}
+
+			const styleAttr = node.attributes.find((attr) => attr.name === 'style')?.value || '';
+			const cssProps = parseCssCustomProperties(styleAttr);
+
+			const classParts = classes.split(' ');
+			const extraClasses = classParts.filter((c) => c !== 'grid' && c !== 'mod-auto').join(' ');
+
+			const inputs: GridInputs = {
+				mode: classParts.includes('mod-auto') ? 'auto' : undefined,
+				columns: cssProps['--grid-columns'],
+				extraClasses: extraClasses || undefined,
+			};
+
+			results.push({
+				node,
+				inputs,
+				nodeOffset: template.offsetStart,
+				filePath: template.filePath,
+				componentTS: sourceFile,
+			});
+		});
+	});
+
+	return results;
+}
+
+function findHTMLGridColumns(sourceFile: SourceFile, basePath: string, tree: Tree): HtmlGridColumn[] {
+	const results: HtmlGridColumn[] = [];
+	const ngTemplates = extractNgTemplatesIncludingHtml(sourceFile, tree, basePath);
+
+	ngTemplates.forEach((template) => {
+		const htmlAst = new HtmlAst(template.content);
+		htmlAst.visitNodes((node) => {
+			if (!isInterestingNode(node)) {
+				return;
+			}
+			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
+			if (!classes?.match(/(^|\s)grid-column(\s|$)/)) {
+				return;
+			}
+
+			const styleAttr = node.attributes.find((attr) => attr.name === 'style')?.value || '';
+			const { inputs, remainingStyle } = extractGridColumnInputs(styleAttr);
+
+			const classParts = classes.split(' ');
+			const extraClasses = classParts.filter((c) => c !== 'grid-column').join(' ');
+
+			results.push({
+				node,
+				inputs,
+				remainingStyle: remainingStyle || undefined,
+				extraClasses: extraClasses || undefined,
+				nodeOffset: template.offsetStart,
+				filePath: template.filePath,
+				componentTS: sourceFile,
+			});
+		});
+	});
+
+	return results;
+}

--- a/packages/ng/schematics/lu-grid/schema.json
+++ b/packages/ng/schematics/lu-grid/schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "LuccaFrontLuGrid",
+  "title": "Migrate HTML Grid to the new lu-grid component",
+  "type": "object",
+  "properties": {
+    "dryRun": {
+      "type": "boolean",
+      "description": "Run through the migration without making any changes.",
+      "default": false
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip installing dependencies.",
+      "default": false
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose logging.",
+      "default": false
+    }
+  }
+}

--- a/packages/ng/schematics/lu-grid/tests/input/external-template.component.html
+++ b/packages/ng/schematics/lu-grid/tests/input/external-template.component.html
@@ -1,0 +1,35 @@
+<div class="grid">
+	<div class="grid-column" style="--grid-colspan: 6"><div class="gridDemo">col</div></div>
+	<div class="grid-column" style="--grid-colspan: 6"><div class="gridDemo">col</div></div>
+</div>
+<div class="grid mod-auto">
+	<div class="grid-column"><div class="gridDemo">auto</div></div>
+	<div class="grid-column"><div class="gridDemo">auto</div></div>
+</div>
+<div class="grid" style="--grid-columns: 4">
+	<div class="grid-column" style="--grid-column: 2"><div class="gridDemo">col 2</div></div>
+	<div class="grid-column" style="--grid-column: 3"><div class="gridDemo">col 3</div></div>
+	<div class="grid-column" style="--grid-column: 1"><div class="gridDemo">col 1</div></div>
+	<div class="grid-column"><div class="gridDemo">col</div></div>
+</div>
+<div class="grid" style="--grid-columns: 1">
+	<div class="grid-column" style="--grid-justify: start"><div class="gridDemo"></div></div>
+	<div class="grid-column" style="--grid-justify: center"><div class="gridDemo"></div></div>
+	<div class="grid-column" style="--grid-justify: end"><div class="gridDemo"></div></div>
+</div>
+<div class="grid">
+	<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinXS: 4"><div class="gridDemo">col</div></div>
+	<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinXS: 8"><div class="gridDemo">col</div></div>
+</div>
+<div class="grid">
+	<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3"><div class="gridDemo">col</div></div>
+	<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3"><div class="gridDemo">col</div></div>
+</div>
+<div class="grid-wrapper">
+	<div class="grid">
+		<div class="grid-column" style="--grid-colspan: 6"><div class="gridDemo">nested</div></div>
+	</div>
+</div>
+<div class="grid mod-custom-mod">
+	<div class="grid-column" style="--grid-colspan: 6; color: red"><div class="gridDemo">extra styles</div></div>
+</div>

--- a/packages/ng/schematics/lu-grid/tests/input/external-template.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/input/external-template.component.ts
@@ -1,0 +1,13 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	templateUrl: './external-template.component.html',
+	imports: [
+		ButtonComponent
+	]
+})
+export class ExternalTemplateComponent {
+}

--- a/packages/ng/schematics/lu-grid/tests/input/simple-cases.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/input/simple-cases.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<button luButton type="button">
+			<div class="grid">
+				<div class="grid-column" style="--grid-colspan: 6">col</div>
+				<div class="grid-column" style="--grid-colspan: 6">col</div>
+			</div>
+		</button>
+		<div class="grid mod-auto">
+			<div class="grid-column">auto</div>
+			<div class="grid-column">auto</div>
+		</div>
+		<div class="grid" style="--grid-columns: 1">
+			<div class="grid-column" style="--grid-justify: start">start</div>
+			<div class="grid-column" style="--grid-justify: end">end</div>
+		</div>
+		<div class="grid">
+			<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinXS: 4">col</div>
+			<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinXS: 8">col</div>
+		</div>
+	`,
+	imports: [
+		ButtonComponent
+	]
+})
+export class SimpleCasesComponent {
+}

--- a/packages/ng/schematics/lu-grid/tests/output/external-template.component.html
+++ b/packages/ng/schematics/lu-grid/tests/output/external-template.component.html
@@ -1,0 +1,35 @@
+<lu-grid>
+	<lu-grid-column colspan="6"><div class="gridDemo">col</div></lu-grid-column>
+	<lu-grid-column colspan="6"><div class="gridDemo">col</div></lu-grid-column>
+</lu-grid>
+<lu-grid mode="auto">
+	<lu-grid-column><div class="gridDemo">auto</div></lu-grid-column>
+	<lu-grid-column><div class="gridDemo">auto</div></lu-grid-column>
+</lu-grid>
+<lu-grid columns="4">
+	<lu-grid-column column="2"><div class="gridDemo">col 2</div></lu-grid-column>
+	<lu-grid-column column="3"><div class="gridDemo">col 3</div></lu-grid-column>
+	<lu-grid-column column="1"><div class="gridDemo">col 1</div></lu-grid-column>
+	<lu-grid-column><div class="gridDemo">col</div></lu-grid-column>
+</lu-grid>
+<lu-grid columns="1">
+	<lu-grid-column justify="start"><div class="gridDemo"></div></lu-grid-column>
+	<lu-grid-column justify="center"><div class="gridDemo"></div></lu-grid-column>
+	<lu-grid-column justify="end"><div class="gridDemo"></div></lu-grid-column>
+</lu-grid>
+<lu-grid>
+	<lu-grid-column colspan="12" [responsive]="{ colspanAtMediaMinXS: 4 }"><div class="gridDemo">col</div></lu-grid-column>
+	<lu-grid-column colspan="12" [responsive]="{ colspanAtMediaMinXS: 8 }"><div class="gridDemo">col</div></lu-grid-column>
+</lu-grid>
+<lu-grid>
+	<lu-grid-column colspan="12" [responsive]="{ colspanAtMediaMinS: 6, colspanAtMediaMinM: 3 }"><div class="gridDemo">col</div></lu-grid-column>
+	<lu-grid-column colspan="12" [responsive]="{ colspanAtMediaMinS: 6, colspanAtMediaMinM: 3 }"><div class="gridDemo">col</div></lu-grid-column>
+</lu-grid>
+<div class="grid-wrapper">
+	<lu-grid>
+		<lu-grid-column colspan="6"><div class="gridDemo">nested</div></lu-grid-column>
+	</lu-grid>
+</div>
+<lu-grid class="mod-custom-mod">
+	<lu-grid-column colspan="6" style="color: red"><div class="gridDemo">extra styles</div></lu-grid-column>
+</lu-grid>

--- a/packages/ng/schematics/lu-grid/tests/output/external-template.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/output/external-template.component.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { GridComponent } from '@lucca-front/ng/grid';
+import { GridColumnComponent } from '@lucca-front/ng/grid';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	templateUrl: './external-template.component.html',
+	imports: [
+		ButtonComponent, GridComponent, GridColumnComponent
+	]
+})
+export class ExternalTemplateComponent {
+}

--- a/packages/ng/schematics/lu-grid/tests/output/simple-cases.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/output/simple-cases.component.ts
@@ -1,0 +1,34 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { GridComponent } from '@lucca-front/ng/grid';
+import { GridColumnComponent } from '@lucca-front/ng/grid';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<button luButton type="button">
+			<lu-grid>
+				<lu-grid-column colspan="6">col</lu-grid-column>
+				<lu-grid-column colspan="6">col</lu-grid-column>
+			</lu-grid>
+		</button>
+		<lu-grid mode="auto">
+			<lu-grid-column>auto</lu-grid-column>
+			<lu-grid-column>auto</lu-grid-column>
+		</lu-grid>
+		<lu-grid columns="1">
+			<lu-grid-column justify="start">start</lu-grid-column>
+			<lu-grid-column justify="end">end</lu-grid-column>
+		</lu-grid>
+		<lu-grid>
+			<lu-grid-column colspan="12" [responsive]="{ colspanAtMediaMinXS: 4 }">col</lu-grid-column>
+			<lu-grid-column colspan="12" [responsive]="{ colspanAtMediaMinXS: 8 }">col</lu-grid-column>
+		</lu-grid>
+	`,
+	imports: [
+		ButtonComponent, GridComponent, GridColumnComponent
+	]
+})
+export class SimpleCasesComponent {
+}


### PR DESCRIPTION
## Description

This pull request introduces a new schematic to automate the migration of legacy HTML grid structures to the new `lu-grid` and `lu-grid-column` Angular components. The migration includes both the schematic logic and comprehensive tests to ensure correctness. The main changes are the addition of the schematic, its configuration, migration logic, and test cases covering various grid scenarios.

**New schematic for grid migration:**

* Added a new schematic `lu-grid` to `collection.json` to migrate old HTML grids to the new `lu-grid` component, including its description, factory, and schema references.
* Introduced the schematic implementation in `lu-grid/index.ts`, which traverses project files, identifies legacy grid markup, and applies the migration logic.
* Defined the migration logic in `lu-grid/migration.ts` to convert `<div class="grid">` and `<div class="grid-column">` elements to `<lu-grid>` and `<lu-grid-column>`, including handling of classes, styles, responsive properties, and necessary Angular imports.
* Added a JSON schema (`lu-grid/schema.json`) for the schematic's options, supporting dry runs, skipping installation, and verbose logging.


-----



-----