### PR TITLE
[dialog] fix footer shadow

### DIFF
--- a/packages/scss/src/components/footer/component.scss
+++ b/packages/scss/src/components/footer/component.scss
@@ -13,6 +13,7 @@
 	gap: var(--components-footer-gap);
 	align-items: var(--components-footer-alignItems);
 	flex-direction: var(--components-footer-direction);
+	isolation: var(--components-footer-isolation);
 
 	@at-root ($atRoot) {
 		.footer-content {

--- a/packages/scss/src/components/footer/mods.scss
+++ b/packages/scss/src/components/footer/mods.scss
@@ -14,6 +14,7 @@
 	--components-footer-paddingInline: var(--pr-t-spacings-300);
 	--commons-container-padding: 0;
 	--components-footer-overflow: hidden;
+	--components-footer-isolation: isolate;
 }
 
 @mixin wide {

--- a/packages/scss/src/components/footer/vars.scss
+++ b/packages/scss/src/components/footer/vars.scss
@@ -12,4 +12,5 @@
 	--components-footer-gap: var(--pr-t-spacings-200);
 	--components-footer-display: flex;
 	--components-footer-container-maxInlineSize: var(--commons-container-maxWidth);
+	--components-footer-isolation: auto;
 }


### PR DESCRIPTION
## Description



-----

Fix #4905 

-----

<img width="663" height="283" alt="Capture d’écran 2026-06-09 à 10 31 49" src="https://github.com/user-attachments/assets/181758e0-0f1f-4ab6-99be-d4f1c4d9e158" />