### PR TITLE
[pageHeader] fix responsive behaviour for long titles

### DIFF
--- a/packages/scss/src/components/pageHeader/component.scss
+++ b/packages/scss/src/components/pageHeader/component.scss
@@ -14,8 +14,8 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: flex-start;
-			flex-wrap: wrap;
-			row-gap: var(--pr-t-spacings-100);
+			gap: var(--pr-t-spacings-100);
+			flex-wrap: var(--components-pageHeader-content-flexWrap);
 		}
 
 		.pageHeader-content-title {
@@ -42,6 +42,7 @@
 			align-items: center;
 			flex-wrap: wrap;
 			row-gap: var(--pr-t-spacings-200);
+			flex-shrink: var(--components-pageHeader-content-action-flexShrink);
 
 			.button {
 				margin: 0;

--- a/packages/scss/src/components/pageHeader/mods.scss
+++ b/packages/scss/src/components/pageHeader/mods.scss
@@ -36,6 +36,8 @@
 }
 
 @mixin wide {
+	--components-pageHeader-content-action-flexShrink: 0;
+	--components-pageHeader-content-flexWrap: nowrap;
 	--components-pageHeader-padding: var(--pr-t-spacings-300) var(--pr-t-spacings-400);
 }
 

--- a/packages/scss/src/components/pageHeader/vars.scss
+++ b/packages/scss/src/components/pageHeader/vars.scss
@@ -2,5 +2,5 @@
 	--components-pageHeader-description-max-width: 50rem;
 	--components-pageHeader-padding: var(--pr-t-spacings-300) var(--pr-t-spacings-200);
 	--components-pageHeader-content-flexWrap: wrap;
-	--components-pageHeader-content-action-flexShrink: auto;
+	--components-pageHeader-content-action-flexShrink: 1;
 }

--- a/packages/scss/src/components/pageHeader/vars.scss
+++ b/packages/scss/src/components/pageHeader/vars.scss
@@ -1,4 +1,6 @@
 @mixin vars {
 	--components-pageHeader-description-max-width: 50rem;
 	--components-pageHeader-padding: var(--pr-t-spacings-300) var(--pr-t-spacings-200);
+	--components-pageHeader-content-flexWrap: wrap;
+	--components-pageHeader-content-action-flexShrink: auto;
 }


### PR DESCRIPTION
## Description



-----

#4007 

-----

<img width="1317" height="516" alt="2026-06-09 12 16 03" src="https://github.com/user-attachments/assets/8e23f2b0-444f-40e7-afea-e6a03a90fb7d" />

