### PR TITLE
[popover] add inputs for max inline and max block sizes

### DIFF
--- a/packages/ng/popover2/content/popover-content/popover-content.component.html
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.html
@@ -1,4 +1,10 @@
-<div class="popover" (cdkObserveContent)="contentChanged()" [debounce]="contentChangedDebounceTime">
+<div
+	class="popover"
+	(cdkObserveContent)="contentChanged()"
+	[debounce]="contentChangedDebounceTime"
+	[style.--components-popover-content-maxBlockSize]="config.maxBlockSize"
+	[style.--components-popover-content-maxInlineSize]="config.maxInlineSize"
+>
 	@if (!config.noCloseButton) {
 		<div>
 			<button type="button" luButton class="popover-close button" (click)="close()">

--- a/packages/ng/popover2/popover-tokens.ts
+++ b/packages/ng/popover2/popover-tokens.ts
@@ -6,6 +6,8 @@ export interface PopoverConfig {
 	content: TemplateRef<unknown> | Type<unknown>;
 	ref: OverlayRef;
 	contentId: string;
+	maxBlockSize: string | null;
+	maxInlineSize: string | null;
 	disableCloseButtonFocus: boolean;
 	disableInitialTriggerFocus: boolean;
 	noCloseButton: boolean;

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -92,6 +92,9 @@ export class PopoverDirective implements OnDestroy {
 
 	luPopoverPosition = input<PopoverPosition | null>(null);
 
+	luPopoverMaxBlockSize = input<string | null>(null);
+	luPopoverMaxInlineSize = input<string | null>(null);
+
 	@Input()
 	overlayScrollStrategy: 'reposition' | 'block' | 'close' = 'reposition';
 
@@ -263,6 +266,8 @@ export class PopoverDirective implements OnDestroy {
 				ref: this.#overlayRef,
 				contentId: this.ariaControls,
 				triggerElement: this.elementRef.nativeElement,
+				maxBlockSize: this.luPopoverMaxBlockSize(),
+				maxInlineSize: this.luPopoverMaxInlineSize(),
 				disableCloseButtonFocus: disableCloseButtonFocus,
 				disableInitialTriggerFocus: disableInitialTriggerFocus,
 				noCloseButton: this.luPopoverNoCloseButton,

--- a/packages/scss/src/components/popover/component.scss
+++ b/packages/scss/src/components/popover/component.scss
@@ -36,6 +36,7 @@
 		.popover-content {
 			overflow: auto;
 			max-block-size: min(var(--components-popover-content-maxBlockSize), calc(100dvh - var(--pr-t-spacings-200)));
+			max-inline-size: min(var(--components-popover-content-maxInlineSize), calc(100dvw - var(--pr-t-spacings-400)));
 
 			&:focus-visible {
 				@include a11y.focusVisible($borderRadius: var(--pr-t-border-radius-default));

--- a/packages/scss/src/components/popover/vars.scss
+++ b/packages/scss/src/components/popover/vars.scss
@@ -1,4 +1,5 @@
 @mixin vars {
 	--components-popover-padding: var(--pr-t-spacings-100);
 	--components-popover-content-maxBlockSize: 9999px;
+	--components-popover-content-maxInlineSize: 9999px;
 }

--- a/stories/documentation/overlays/popover2/popover2.stories.ts
+++ b/stories/documentation/overlays/popover2/popover2.stories.ts
@@ -50,6 +50,14 @@ export default {
 		luPopoverNoCloseButton: {
 			description: 'Masque le bouton de fermeture du popover visible à la navigation clavier.',
 		},
+		luPopoverMaxBlockSize: {
+			control: 'text',
+			description: 'Modifie la hauteur max de la popover.',
+		},
+		luPopoverMaxInlineSize: {
+			control: 'text',
+			description: 'Modifie la largeur max de la popover.',
+		},
 	},
 } as Meta;
 
@@ -108,6 +116,8 @@ export const Basic: StoryObj<PopoverDirective> = {
 		luPopoverDisabled: false,
 		luPopoverPosition: 'above',
 		luPopoverNoCloseButton: false,
+		luPopoverMaxBlockSize: '',
+		luPopoverMaxInlineSize: '',
 	},
 };
 export const CustomPosition: StoryObj<PopoverDirective> = {

--- a/stories/qa/popover/popover.stories.html
+++ b/stories/qa/popover/popover.stories.html
@@ -47,21 +47,10 @@
 		<tr>
 			<td>With scrollbar</td>
 			<td>
-				<div class="popover" [attr.style]="'--components-popover-content-maxBlockSize: 5rem'">
-					<div>
-						<button type="button" lubutton="" class="button popover-close mod-onlyIcon">
-							<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
-							<span class="pr-u-mask">Close</span>
-						</button>
-					</div>
-					<div class="popover-content">popover<br />popover<br />popover<br />popover<br />popover<br />popover</div>
-				</div>
-			</td>
-		</tr>
-		<tr>
-			<td>With scrollbar and<br />optional content</td>
-			<td>
-				<div class="popover" [attr.style]="'--components-popover-content-maxBlockSize: 5rem'">
+				<div
+					class="popover"
+					[attr.style]="'--components-popover-content-maxBlockSize: 10rem; --components-popover-content-maxInlineSize: 10rem'"
+				>
 					<div>
 						<button type="button" lubutton="" class="button popover-close mod-onlyIcon">
 							<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
@@ -69,7 +58,34 @@
 						</button>
 					</div>
 					<div class="popover-content">
-						<div class="popover-contentOptional">popover<br />popover<br />popover<br />popover<br />popover<br />popover</div>
+						popover popover popover<br />
+						popover popover popover<br />
+						popover popover popover<br />
+						popover popover popover<br />
+					</div>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>With scrollbar and<br />optional content</td>
+			<td>
+				<div
+					class="popover"
+					[attr.style]="'--components-popover-content-maxBlockSize: 10rem; --components-popover-content-maxInlineSize: 10rem'"
+				>
+					<div>
+						<button type="button" lubutton="" class="button popover-close mod-onlyIcon">
+							<span aria-hidden="true" class="lucca-icon icon-signClose"></span>
+							<span class="pr-u-mask">Close</span>
+						</button>
+					</div>
+					<div class="popover-content">
+						<div class="popover-contentOptional">
+							popover popover popover<br />
+							popover popover popover<br />
+							popover popover popover<br />
+							popover popover popover<br />
+						</div>
 					</div>
 				</div>
 			</td>

--- a/stories/qa/popover/popover.stories.ts
+++ b/stories/qa/popover/popover.stories.ts
@@ -4,7 +4,14 @@ import { Meta } from '@storybook/angular';
 @Component({
 	selector: 'popover-stories',
 	templateUrl: './popover.stories.html',
-
+	styles: [
+		`
+			.popover {
+				inline-size: fit-content;
+				block-size: fit-content;
+			}
+		`,
+	],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class PopoverStory {}


### PR DESCRIPTION
## Description



-----

close #4183 

-----

<img width="669" height="436" alt="Capture d’écran 2026-06-09 à 14 48 09" src="https://github.com/user-attachments/assets/2ee0aae0-48ac-45a7-b79f-293adee8bb1d" />

