### PR TITLE
feat(schematics): deprecated-resolver

### DIFF
--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -41,6 +41,16 @@
       "factory": "./component-path/index",
       "schema": "./component-path/schema.json"
     },
+    "depreacted-resolver": {
+      "description": "Migrate deprecated NgModules and types to their standalone equivalents.",
+      "factory": "./deprecated-resolver/index",
+      "schema": "./deprecated-resolver/schema.json"
+    },
+    "deprecated-resolver": {
+      "description": "Migrate deprecated NgModules and types to their standalone equivalents.",
+      "factory": "./deprecated-resolver/index",
+      "schema": "./deprecated-resolver/schema.json"
+    },
     "tokens-typo": {
       "description": "Replace typography tokens with new names.",
       "factory": "./tokens-typo/index",

--- a/packages/ng/schematics/collection.json
+++ b/packages/ng/schematics/collection.json
@@ -41,13 +41,8 @@
       "factory": "./component-path/index",
       "schema": "./component-path/schema.json"
     },
-    "depreacted-resolver": {
-      "description": "Migrate deprecated NgModules and types to their standalone equivalents.",
-      "factory": "./deprecated-resolver/index",
-      "schema": "./deprecated-resolver/schema.json"
-    },
     "deprecated-resolver": {
-      "description": "Migrate deprecated NgModules and types to their standalone equivalents.",
+      "description": "Migrate deprecated NgModules, types and input output.",
       "factory": "./deprecated-resolver/index",
       "schema": "./deprecated-resolver/schema.json"
     },

--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -60,13 +60,13 @@ export default (options: SchematicContextOpts): Rule => {
 			types: {
 				ILuTranslation: 'LuTranslation',
 			},
-				inputsOutputs: {
-					'lu-divider': { withRole: '' },
-					'button': { delete: 'critical' },
-					'lu-loading': { type: { fullpage: 'fullPage' } },
-					'lu-single-file-upload': { illustration: { paper: 'invoice' } },
-					'lu-highlight-data': { icon: { 'manifying-glass': 'magnifying-glass' } },
-				},
+			inputsOutputs: {
+				'lu-divider': { withRole: '' },
+				'button': { delete: 'critical' },
+				'lu-loading': { type: { fullpage: 'fullPage' } },
+				'lu-single-file-upload': { illustration: { paper: 'invoice' } },
+				'lu-highlight-data': { icon: { 'manifying-glass': 'magnifying-glass' } },
+			},
 		}).run();
 	};
 };

--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -5,20 +5,6 @@ import { currentSchematicContext, DeprecatedMapper, SchematicContextOpts } from 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 require('@angular-devkit/schematics');
 
-export interface DeprecatedResolverOptions extends SchematicContextOpts {
-	/**
-	 * Mapping of deprecated NgModule names to their replacement standalone component/directive names.
-	 * @example { "LuDateSelectInputModule": "LuDateSelectInputComponent" }
-	 */
-	modules?: Record<string, string>;
-
-	/**
-	 * Mapping of deprecated type/interface names to their replacement names.
-	 * @example { "ILuTranslation": "LuTranslation" }
-	 */
-	types?: Record<string, string>;
-}
-
 export default (options: SchematicContextOpts): Rule => {
 	return async (tree, context) => {
 		await currentSchematicContext.init(context, options);

--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -1,0 +1,31 @@
+import type { Rule } from '@angular-devkit/schematics';
+import { currentSchematicContext, DeprecatedMapper, SchematicContextOpts } from '../lib';
+
+// Nx need to see "@angular-devkit/schematics" in order to run this migration correctly (see https://github.com/nrwl/nx/blob/d9fed4b832bf01d1b9a44ae9e486a5e5cd2d2253/packages/nx/src/command-line/migrate/migrate.ts#L1729-L1738)
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+require('@angular-devkit/schematics');
+
+export interface DeprecatedResolverOptions extends SchematicContextOpts {
+	/**
+	 * Mapping of deprecated NgModule names to their replacement standalone component/directive names.
+	 * @example { "LuDateSelectInputModule": "LuDateSelectInputComponent" }
+	 */
+	modules?: Record<string, string>;
+
+	/**
+	 * Mapping of deprecated type/interface names to their replacement names.
+	 * @example { "ILuTranslation": "LuTranslation" }
+	 */
+	types?: Record<string, string>;
+}
+
+export default (options: DeprecatedResolverOptions): Rule => {
+	return async (tree, context) => {
+		await currentSchematicContext.init(context, options);
+
+		new DeprecatedMapper(tree, {
+			modules: options.modules ?? {},
+			types: options.types ?? {},
+		}).run();
+	};
+};

--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -60,6 +60,13 @@ export default (options: SchematicContextOpts): Rule => {
 			types: {
 				ILuTranslation: 'LuTranslation',
 			},
+				inputsOutputs: {
+					'lu-divider': { withRole: '' },
+					'button': { delete: 'critical' },
+					'lu-loading': { type: { fullpage: 'fullPage' } },
+					'lu-single-file-upload': { illustration: { paper: 'invoice' } },
+					'lu-highlight-data': { icon: { 'manifying-glass': 'magnifying-glass' } },
+				},
 		}).run();
 	};
 };

--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -11,12 +11,55 @@ export default (options: SchematicContextOpts): Rule => {
 
 		new DeprecatedMapper(tree, {
 			modules: {
-					LuDateSelectInputModule: 'LuDateSelectInputComponent',
-					LuUserSelectInputModule: 'LuUserSelectInputComponent',
-				},
-				types: {
-					ILuTranslation: 'LuTranslation',
-				},
+				// LuDateModule
+				LuDatePickerModule: 'LuDatePickerComponent',
+				LuDateSelectInputModule: 'LuDateSelectInputComponent',
+				LuDateAdapterModule: 'LuDateAdapterPipe',
+				// LuApiModule
+				LuApiSelectInputModule: 'LuApiSelectInputComponent',
+				// LuDropdownModule
+				LuDropdownPanelModule: 'LuDropdownPanelComponent',
+				LuDropdownItemModule: 'LuDropdownItemDirective',
+				LuDropdownTriggerModule: 'LuDropdownTriggerDirective',
+				// LuDepartmentModule
+				LuDepartmentSelectInputModule: 'LuDepartmentSelectInputComponent',
+				// LuEstablishmentModule
+				LuEstablishmentSelectInputModule: 'LuEstablishmentSelectInputComponent',
+				// LuUserModule
+				LuUserSelectInputModule: 'LuUserSelectInputComponent',
+				LuUserDisplayModule: 'LuUserDisplayPipe',
+				LuUserPictureModule: 'LuUserPictureComponent',
+				LuUserTileModule: 'LuUserTileComponent',
+				LuUserMeOptionModule: 'LuUserMeOptionDirective',
+				LuUserSearcherModule: 'LuUserPagedSearcherComponent',
+				// LuOptionModule
+				LuOptionItemModule: 'LuOptionItemComponent',
+				LuOptionFeederModule: 'LuOptionFeederComponent',
+				LuOptionPagerModule: 'LuOptionPagerComponent',
+				LuOptionSearcherModule: 'LuOptionSearcherComponent',
+				LuOptionSelectAllModule: 'LuOptionSelectAllComponent',
+				LuForOptionsModule: 'LuForOptionsDirective',
+				// LuTreeOptionModule
+				LuTreeOptionItemModule: 'LuTreeOptionItemComponent',
+				LuTreeOptionFeederModule: 'LuTreeOptionFeederComponent',
+				LuForTreeOptionsModule: 'LuForTreeOptionsDirective',
+				LuTreeOptionSearcherModule: 'LuTreeOptionSearcherComponent',
+				// LuPopoverModule
+				LuPopoverPanelModule: 'LuPopoverPanelComponent',
+				// LuTooltipModule
+				LuTooltipTriggerModule: 'LuTooltipTriggerDirective',
+				// LuInputModule
+				LuInputClearerModule: 'LuInputClearerComponent',
+				LuInputDisplayerModule: 'LuInputDisplayerDirective',
+				// NgModules simples
+				LuToastsModule: 'LuToastsComponent',
+				LuNumberModule: 'LuNumberPipe',
+				LuScrollModule: 'LuScrollDirective',
+				LuSafeContentModule: 'LuSafeHtmlPipe',
+			},
+			types: {
+				ILuTranslation: 'LuTranslation',
+			},
 		}).run();
 	};
 };

--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -19,13 +19,18 @@ export interface DeprecatedResolverOptions extends SchematicContextOpts {
 	types?: Record<string, string>;
 }
 
-export default (options: DeprecatedResolverOptions): Rule => {
+export default (options: SchematicContextOpts): Rule => {
 	return async (tree, context) => {
 		await currentSchematicContext.init(context, options);
 
 		new DeprecatedMapper(tree, {
-			modules: options.modules ?? {},
-			types: options.types ?? {},
+			modules: {
+					LuDateSelectInputModule: 'LuDateSelectInputComponent',
+					LuUserSelectInputModule: 'LuUserSelectInputComponent',
+				},
+				types: {
+					ILuTranslation: 'LuTranslation',
+				},
 		}).run();
 	};
 };

--- a/packages/ng/schematics/deprecated-resolver/migration.spec.ts
+++ b/packages/ng/schematics/deprecated-resolver/migration.spec.ts
@@ -14,15 +14,7 @@ describe('Deprecated Resolver Migration', () => {
 
 		// Act
 		try {
-			await runSchematic('collection', collectionPath, 'deprecated-resolver', {
-				modules: {
-					LuDateSelectInputModule: 'LuDateSelectInputComponent',
-					LuUserSelectInputModule: 'LuUserSelectInputComponent',
-				},
-				types: {
-					ILuTranslation: 'LuTranslation',
-				},
-			}, tree);
+			await runSchematic('collection', collectionPath, 'deprecated-resolver', { skipInstallation: true }, tree);
 		} catch (error) {
 			// eslint-disable-next-line no-console
 			console.log(error);

--- a/packages/ng/schematics/deprecated-resolver/migration.spec.ts
+++ b/packages/ng/schematics/deprecated-resolver/migration.spec.ts
@@ -7,7 +7,7 @@ const testsRoot = path.join(__dirname, 'tests');
 const files = fs.readdirSync(testsRoot);
 
 describe('Deprecated Resolver Migration', () => {
-	it('should rename deprecated module and type identifiers', async () => {
+	it('should rename deprecated module, type identifiers and inputOutput ', async () => {
 		// Arrange
 		const tree = createTreeFromFiles(testsRoot, files, '.input.');
 		const expectedTree = createTreeFromFiles(testsRoot, files, '.output.');

--- a/packages/ng/schematics/deprecated-resolver/migration.spec.ts
+++ b/packages/ng/schematics/deprecated-resolver/migration.spec.ts
@@ -1,0 +1,34 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { createTreeFromFiles, expectTree, runSchematic } from '../lib';
+
+const collectionPath = path.normalize(path.join(__dirname, '..', 'collection.json'));
+const testsRoot = path.join(__dirname, 'tests');
+const files = fs.readdirSync(testsRoot);
+
+describe('Deprecated Resolver Migration', () => {
+	it('should rename deprecated module and type identifiers', async () => {
+		// Arrange
+		const tree = createTreeFromFiles(testsRoot, files, '.input.');
+		const expectedTree = createTreeFromFiles(testsRoot, files, '.output.');
+
+		// Act
+		try {
+			await runSchematic('collection', collectionPath, 'deprecated-resolver', {
+				modules: {
+					LuDateSelectInputModule: 'LuDateSelectInputComponent',
+					LuUserSelectInputModule: 'LuUserSelectInputComponent',
+				},
+				types: {
+					ILuTranslation: 'LuTranslation',
+				},
+			}, tree);
+		} catch (error) {
+			// eslint-disable-next-line no-console
+			console.log(error);
+		}
+
+		// Assert
+		expectTree(tree).toMatchTree(expectedTree);
+	});
+});

--- a/packages/ng/schematics/deprecated-resolver/schema.json
+++ b/packages/ng/schematics/deprecated-resolver/schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "LuccaFrontDeprecatedResolver",
+  "title": "Lucca Front Deprecated Resolver Schema",
+  "type": "object",
+  "properties": {
+    "dryRun": {
+      "type": "boolean",
+      "description": "Run through the migration without making any changes.",
+      "default": false
+    },
+    "skipInstall": {
+      "type": "boolean",
+      "description": "Skip installing dependencies.",
+      "default": false
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Enable verbose logging.",
+      "default": false
+    },
+    "modules": {
+      "type": "object",
+      "description": "Mapping of deprecated NgModule names to their replacement standalone component/directive names. The identifier is renamed everywhere it appears; the import path is kept unchanged.",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    },
+    "types": {
+      "type": "object",
+      "description": "Mapping of deprecated type/interface names to their replacement names. The identifier is renamed everywhere it appears; the import path is kept unchanged.",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {}
+    }
+  }
+}

--- a/packages/ng/schematics/deprecated-resolver/schema.json
+++ b/packages/ng/schematics/deprecated-resolver/schema.json
@@ -18,22 +18,6 @@
       "type": "boolean",
       "description": "Enable verbose logging.",
       "default": false
-    },
-    "modules": {
-      "type": "object",
-      "description": "Mapping of deprecated NgModule names to their replacement standalone component/directive names. The identifier is renamed everywhere it appears; the import path is kept unchanged.",
-      "additionalProperties": {
-        "type": "string"
-      },
-      "default": {}
-    },
-    "types": {
-      "type": "object",
-      "description": "Mapping of deprecated type/interface names to their replacement names. The identifier is renamed everywhere it appears; the import path is kept unchanged.",
-      "additionalProperties": {
-        "type": "string"
-      },
-      "default": {}
     }
   }
 }

--- a/packages/ng/schematics/deprecated-resolver/tests/module.input.ts
+++ b/packages/ng/schematics/deprecated-resolver/tests/module.input.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { LuDateSelectInputModule } from '@lucca-front/ng/date';
-import { LuUserSelectInputModule, LuEstablishmentSelectInputModule } from '@lucca-front/ng/user';
+import { LuUserSelectInputModule } from '@lucca-front/ng/user';
 
 @Component({
 	selector: 'my-component',

--- a/packages/ng/schematics/deprecated-resolver/tests/module.input.ts
+++ b/packages/ng/schematics/deprecated-resolver/tests/module.input.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { LuDateSelectInputModule } from '@lucca-front/ng/date';
+import { LuUserSelectInputModule, LuEstablishmentSelectInputModule } from '@lucca-front/ng/user';
+
+@Component({
+	selector: 'my-component',
+	standalone: true,
+	imports: [LuDateSelectInputModule, LuUserSelectInputModule],
+})
+export class MyComponent {}

--- a/packages/ng/schematics/deprecated-resolver/tests/module.output.ts
+++ b/packages/ng/schematics/deprecated-resolver/tests/module.output.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { LuDateSelectInputComponent } from '@lucca-front/ng/date';
+import { LuUserSelectInputComponent, LuEstablishmentSelectInputModule } from '@lucca-front/ng/user';
+
+@Component({
+	selector: 'my-component',
+	standalone: true,
+	imports: [LuDateSelectInputComponent, LuUserSelectInputComponent],
+})
+export class MyComponent {}

--- a/packages/ng/schematics/deprecated-resolver/tests/module.output.ts
+++ b/packages/ng/schematics/deprecated-resolver/tests/module.output.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { LuDateSelectInputComponent } from '@lucca-front/ng/date';
-import { LuUserSelectInputComponent, LuEstablishmentSelectInputModule } from '@lucca-front/ng/user';
+import { LuUserSelectInputComponent } from '@lucca-front/ng/user';
 
 @Component({
 	selector: 'my-component',

--- a/packages/ng/schematics/deprecated-resolver/tests/template.input.html
+++ b/packages/ng/schematics/deprecated-resolver/tests/template.input.html
@@ -1,0 +1,10 @@
+<lu-divider [withRole]="true"></lu-divider>
+<lu-divider withRole></lu-divider>
+<button luButton [delete]="true">Supprimer</button>
+<button luButton delete>Supprimer</button>
+<lu-loading type="fullpage"></lu-loading>
+<lu-loading [type]="'fullpage'"></lu-loading>
+<lu-single-file-upload illustration="paper"></lu-single-file-upload>
+<lu-single-file-upload [illustration]="'paper'"></lu-single-file-upload>
+<lu-highlight-data icon="manifying-glass"></lu-highlight-data>
+<lu-highlight-data [icon]="'manifying-glass'"></lu-highlight-data>

--- a/packages/ng/schematics/deprecated-resolver/tests/template.input.html
+++ b/packages/ng/schematics/deprecated-resolver/tests/template.input.html
@@ -1,5 +1,5 @@
 <lu-divider [withRole]="true"></lu-divider>
-<lu-divider withRole></lu-divider>
+<lu-divider withRole />
 <button luButton [delete]="true">Supprimer</button>
 <button luButton delete>Supprimer</button>
 <lu-loading type="fullpage"></lu-loading>

--- a/packages/ng/schematics/deprecated-resolver/tests/template.output.html
+++ b/packages/ng/schematics/deprecated-resolver/tests/template.output.html
@@ -1,5 +1,5 @@
 <lu-divider></lu-divider>
-<lu-divider></lu-divider>
+<lu-divider />
 <button luButton [critical]="true">Supprimer</button>
 <button luButton critical>Supprimer</button>
 <lu-loading type="fullPage"></lu-loading>

--- a/packages/ng/schematics/deprecated-resolver/tests/template.output.html
+++ b/packages/ng/schematics/deprecated-resolver/tests/template.output.html
@@ -1,0 +1,10 @@
+<lu-divider></lu-divider>
+<lu-divider></lu-divider>
+<button luButton [critical]="true">Supprimer</button>
+<button luButton critical>Supprimer</button>
+<lu-loading type="fullPage"></lu-loading>
+<lu-loading [type]="'fullPage'"></lu-loading>
+<lu-single-file-upload illustration="invoice"></lu-single-file-upload>
+<lu-single-file-upload [illustration]="'invoice'"></lu-single-file-upload>
+<lu-highlight-data icon="magnifying-glass"></lu-highlight-data>
+<lu-highlight-data [icon]="'magnifying-glass'"></lu-highlight-data>

--- a/packages/ng/schematics/deprecated-resolver/tests/type.input.ts
+++ b/packages/ng/schematics/deprecated-resolver/tests/type.input.ts
@@ -1,0 +1,7 @@
+import { ILuTranslation } from '@lucca-front/ng/core';
+
+export class MyComponent {
+	translations: ILuTranslation<string>;
+
+	constructor(private translation: ILuTranslation<number>) {}
+}

--- a/packages/ng/schematics/deprecated-resolver/tests/type.output.ts
+++ b/packages/ng/schematics/deprecated-resolver/tests/type.output.ts
@@ -1,0 +1,7 @@
+import { LuTranslation } from '@lucca-front/ng/core';
+
+export class MyComponent {
+	translations: LuTranslation<string>;
+
+	constructor(private translation: LuTranslation<number>) {}
+}

--- a/packages/ng/schematics/lib/deprecated-mapper.ts
+++ b/packages/ng/schematics/lib/deprecated-mapper.ts
@@ -1,0 +1,68 @@
+import { Tree } from '@angular-devkit/schematics';
+import { createSourceFile, forEachChild, isIdentifier, ScriptTarget } from 'typescript';
+import { createVisitor } from './angular-template';
+import { applyUpdates, FileUpdate } from './file-update';
+import { migrateFile } from './schematics';
+
+export interface DeprecatedMappings {
+	/**
+	 * Mapping of deprecated NgModule names to their replacement standalone component/directive names.
+	 * The identifier will be renamed everywhere it appears (import declarations, Angular imports array, etc.).
+	 * The import path is kept unchanged.
+	 * @example { "LuDateSelectInputModule": "LuDateSelectInputComponent" }
+	 */
+	modules: Record<string, string>;
+
+	/**
+	 * Mapping of deprecated type/interface names to their replacement names.
+	 * The identifier will be renamed everywhere it appears (import declarations, type annotations, etc.).
+	 * The import path is kept unchanged.
+	 * @example { "ILuTranslation": "LuTranslation" }
+	 */
+	types: Record<string, string>;
+}
+
+export class DeprecatedMapper {
+	private allIdentifierMappings: Record<string, string>;
+
+	constructor(
+		private tree: Tree,
+		private mappings: DeprecatedMappings,
+	) {
+		this.allIdentifierMappings = { ...mappings.modules, ...mappings.types };
+	}
+
+	run() {
+		this.tree.visit((path, entry) => {
+			if (path.includes('node_modules') || !entry) {
+				return;
+			}
+
+			if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
+				migrateFile(path, entry, this.tree, (content) => this.migrateTsFile(path, content));
+			}
+		});
+	}
+
+	private migrateTsFile(fileName: string, content: string): string {
+		const sourceFile = createSourceFile(fileName, content, ScriptTarget.ESNext);
+		const updates: FileUpdate[] = [];
+
+		forEachChild(
+			sourceFile,
+			createVisitor(isIdentifier, (node) => {
+				const newName = this.allIdentifierMappings[node.text];
+
+				if (newName !== undefined && newName !== node.text) {
+					updates.push({
+						position: node.getStart(sourceFile),
+						oldContent: node.text,
+						newContent: newName,
+					});
+				}
+			}),
+		);
+
+		return applyUpdates(content, updates);
+	}
+}

--- a/packages/ng/schematics/lib/deprecated-mapper.ts
+++ b/packages/ng/schematics/lib/deprecated-mapper.ts
@@ -1,35 +1,72 @@
 import { Tree } from '@angular-devkit/schematics';
 import { createSourceFile, forEachChild, isIdentifier, ScriptTarget } from 'typescript';
-import { createVisitor } from './angular-template';
-import { applyUpdates, FileUpdate } from './file-update';
+import { createVisitor, replaceComponentInput, replaceComponentInputName, updateAngularTemplate } from './angular-template';
+import { applyUpdates, FileUpdate, updateContent } from './file-update';
+import { HtmlAst, HtmlAstVisitor } from './html-ast';
 import { migrateFile } from './schematics';
+
+/**
+ * Describes how to migrate a deprecated HTML input attribute on a given element selector:
+ * - `""` (empty string): remove the attribute entirely (handles both `attr` and `[attr]="..."`)
+ * - `"newName"` (non-empty string): rename the attribute key (value is preserved)
+ * - `Record<string, string>`: replace the attribute value(s) while keeping the key
+ *   (e.g., `{ "fullpage": "fullPage" }`)
+ */
+export type AttributeMigration = string | Record<string, string>;
 
 export interface DeprecatedMappings {
 	/**
 	 * Mapping of deprecated NgModule names to their replacement standalone component/directive names.
-	 * The identifier will be renamed everywhere it appears (import declarations, Angular imports array, etc.).
-	 * The import path is kept unchanged.
+	 * The identifier is renamed everywhere it appears in `.ts` files; the import path is kept unchanged.
 	 * @example { "LuDateSelectInputModule": "LuDateSelectInputComponent" }
 	 */
 	modules: Record<string, string>;
 
 	/**
 	 * Mapping of deprecated type/interface names to their replacement names.
-	 * The identifier will be renamed everywhere it appears (import declarations, type annotations, etc.).
-	 * The import path is kept unchanged.
+	 * The identifier is renamed everywhere it appears in `.ts` files; the import path is kept unchanged.
 	 * @example { "ILuTranslation": "LuTranslation" }
 	 */
 	types: Record<string, string>;
+
+	/**
+	 * Mapping of HTML element selectors to their deprecated input/output attribute migrations.
+	 * Applied to `.html` files and inline templates in `.ts` files.
+	 *
+	 * Key: HTML element name (e.g., `"lu-divider"`, `"button"`, `"lu-loading"`).
+	 * Value: map of `{ attributeName: migration }` where migration is:
+	 *   - `""` (empty string) → remove the attribute (both static `attr` and bound `[attr]="..."`)
+	 *   - `"newName"` (non-empty string) → rename the attribute key (value is preserved)
+	 *   - `{ "oldValue": "newValue" }` → replace the attribute value(s)
+	 *
+	 * @example
+	 * ```typescript
+	 * {
+	 *   "lu-divider":            { "withRole": "" },
+	 *   "button":                { "delete": "critical" },
+	 *   "lu-loading":            { "type": { "fullpage": "fullPage" } },
+	 *   "lu-single-file-upload": { "illustration": { "paper": "invoice" } },
+	 *   "lu-highlight-data":     { "icon": { "manifying-glass": "magnifying-glass" } },
+	 * }
+	 * ```
+	 *
+	 * **Not supported (manual migration required):**
+	 * - `lu-empty-state-section` icon → illustration/action (conditional logic based on value)
+	 * - CoreSelectInputComponent `.grouping` → `.groupingSignal` (requires call-site transformation)
+	 */
+	inputsOutputs: Record<string, Record<string, AttributeMigration>>;
 }
 
 export class DeprecatedMapper {
 	private allIdentifierMappings: Record<string, string>;
+	private hasTemplateMigrations: boolean;
 
 	constructor(
 		private tree: Tree,
 		private mappings: DeprecatedMappings,
 	) {
 		this.allIdentifierMappings = { ...mappings.modules, ...mappings.types };
+		this.hasTemplateMigrations = Object.keys(mappings.inputsOutputs).length > 0;
 	}
 
 	run() {
@@ -40,11 +77,25 @@ export class DeprecatedMapper {
 
 			if (path.endsWith('.ts') && !path.endsWith('.d.ts')) {
 				migrateFile(path, entry, this.tree, (content) => this.migrateTsFile(path, content));
+			} else if (path.endsWith('.html') && this.hasTemplateMigrations) {
+				migrateFile(path, entry, this.tree, (content) => this.migrateTemplate(content));
 			}
 		});
 	}
 
 	private migrateTsFile(fileName: string, content: string): string {
+		// 1. Rename TypeScript identifiers (modules & types mappings)
+		let result = this.migrateTsIdentifiers(fileName, content);
+
+		// 2. Apply inputsOutputs migrations to any inline Angular template
+		if (this.hasTemplateMigrations) {
+			result = updateAngularTemplate(fileName, result, (template) => this.migrateTemplate(template));
+		}
+
+		return result;
+	}
+
+	private migrateTsIdentifiers(fileName: string, content: string): string {
 		const sourceFile = createSourceFile(fileName, content, ScriptTarget.ESNext);
 		const updates: FileUpdate[] = [];
 
@@ -64,5 +115,65 @@ export class DeprecatedMapper {
 		);
 
 		return applyUpdates(content, updates);
+	}
+
+	/**
+	 * Applies all `inputsOutputs` migrations to a template string.
+	 * Works on both standalone `.html` content and inline template strings extracted from `.ts` files.
+	 */
+	private migrateTemplate(template: string): string {
+		let result = template;
+
+		for (const [selector, inputs] of Object.entries(this.mappings.inputsOutputs)) {
+			for (const [inputName, migration] of Object.entries(inputs)) {
+				if (migration === '') {
+					result = this.removeAttribute(result, selector, inputName);
+				} else if (typeof migration === 'string') {
+					result = replaceComponentInputName(selector, inputName, migration, result);
+				} else {
+					result = replaceComponentInput(selector, inputName, migration, result);
+				}
+			}
+		}
+
+		return result;
+	}
+
+	/**
+	 * Removes all occurrences of a static or bound attribute on elements matching the given selector.
+	 *
+	 * Handles:
+	 * - Static boolean: `<lu-divider withRole>`
+	 * - Static with value: `<lu-divider withRole="true">`
+	 * - One-way bound: `<lu-divider [withRole]="expr">`
+	 *
+	 * The preceding whitespace is included in the removal to keep the markup clean.
+	 */
+	private removeAttribute(template: string, selector: string, attrName: string): string {
+		return updateContent(template, (updates) => {
+			const htmlAst = new HtmlAst(template);
+
+			htmlAst.visitElements(selector, (el) => {
+				const elAst = new HtmlAstVisitor(el);
+
+				// Static text attribute: `attrName` (boolean) or `attrName="value"`
+				elAst.visitAttribute(attrName, (attr) => {
+					const from = attr.sourceSpan.start.offset;
+					const to = attr.sourceSpan.end.offset;
+					const hasLeadingSpace = from > 0 && template[from - 1] === ' ';
+					const removeFrom = hasLeadingSpace ? from - 1 : from;
+					updates.push({ position: removeFrom, oldContent: template.slice(removeFrom, to), newContent: '' });
+				});
+
+				// Bound attribute: `[attrName]="expr"`
+				elAst.visitBoundAttribute(attrName, (attr) => {
+					const from = attr.sourceSpan.start.offset;
+					const to = attr.sourceSpan.end.offset;
+					const hasLeadingSpace = from > 0 && template[from - 1] === ' ';
+					const removeFrom = hasLeadingSpace ? from - 1 : from;
+					updates.push({ position: removeFrom, oldContent: template.slice(removeFrom, to), newContent: '' });
+				});
+			});
+		});
 	}
 }

--- a/packages/ng/schematics/lib/index.ts
+++ b/packages/ng/schematics/lib/index.ts
@@ -1,6 +1,7 @@
 export * from './angular-component-ast';
 export * from './angular-template';
 export * from './component-mapper';
+export * from './deprecated-mapper';
 export * from './css-mapper';
 export * from './file-update';
 export * from './html-ast';


### PR DESCRIPTION
## Description

This pull request introduces a new schematic, `deprecated-resolver`, to automate the migration of deprecated NgModules, types, and template inputs/outputs to their standalone or updated equivalents in the Angular codebase. It includes the schematic implementation, configuration, comprehensive tests, and supporting documentation. The migration covers both TypeScript and HTML/template files, ensuring consistent and safe updates.

**Key changes:**

### New Migration Schematic

* Added the `deprecated-resolver` schematic to `collection.json` to automate migration of deprecated NgModules, types, and template attributes/inputs/outputs to their standalone or updated equivalents.

### Schematic Implementation

* Implemented the `DeprecatedMapper` class in `lib/deprecated-mapper.ts`, which performs identifier renaming in `.ts` files and attribute/input/output migration in HTML and inline templates, according to a configurable mapping.
* Created the schematic entry point in `deprecated-resolver/index.ts`, configuring mappings for modules, types, and template migrations.
* Exported the new mapper from the library index for reuse.

### Testing

* Added comprehensive tests for the migration, including sample `.ts` and `.html` files before and after migration, and an automated test runner in `migration.spec.ts`.


### Config

```
/**
 * Describes how to migrate a deprecated HTML input attribute on a given element selector:
 * - `""` (empty string): remove the attribute entirely (handles both `attr` and `[attr]="..."`)
 * - `"newName"` (non-empty string): rename the attribute key (value is preserved)
 * - `Record<string, string>`: replace the attribute value(s) while keeping the key
 *   (e.g., `{ "fullpage": "fullPage" }`)
 */
export type AttributeMigration = string | Record<string, string>;

export interface DeprecatedMappings {
	/**
	 * Mapping of deprecated NgModule names to their replacement standalone component/directive names.
	 * The identifier is renamed everywhere it appears in `.ts` files; the import path is kept unchanged.
	 * @example { "LuDateSelectInputModule": "LuDateSelectInputComponent" }
	 */
	modules: Record<string, string>;

	/**
	 * Mapping of deprecated type/interface names to their replacement names.
	 * The identifier is renamed everywhere it appears in `.ts` files; the import path is kept unchanged.
	 * @example { "ILuTranslation": "LuTranslation" }
	 */
	types: Record<string, string>;

	/**
	 * Mapping of HTML element selectors to their deprecated input/output attribute migrations.
	 * Applied to `.html` files and inline templates in `.ts` files.
	 *
	 * Key: HTML element name (e.g., `"lu-divider"`, `"button"`, `"lu-loading"`).
	 * Value: map of `{ attributeName: migration }` where migration is:
	 *   - `""` (empty string) → remove the attribute (both static `attr` and bound `[attr]="..."`)
	 *   - `"newName"` (non-empty string) → rename the attribute key (value is preserved)
	 *   - `{ "oldValue": "newValue" }` → replace the attribute value(s)
	 *
	 * @example
	 * ```typescript
	 * {
	 *   "lu-divider":            { "withRole": "" },
	 *   "button":                { "delete": "critical" },
	 *   "lu-loading":            { "type": { "fullpage": "fullPage" } },
	 *   "lu-single-file-upload": { "illustration": { "paper": "invoice" } },
	 *   "lu-highlight-data":     { "icon": { "manifying-glass": "magnifying-glass" } },
	 * }
	 * ```
	 *
	 * **Not supported (manual migration required):**
	 * - `lu-empty-state-section` icon → illustration/action (conditional logic based on value)
	 * - CoreSelectInputComponent `.grouping` → `.groupingSignal` (requires call-site transformation)
	 */
	inputsOutputs: Record<string, Record<string, AttributeMigration>>;
}

```

-----



-----