### PR TITLE
chore: fix hard-coded plural logic for polish

### DIFF
--- a/packages/ng/core/translate/index.ts
+++ b/packages/ng/core/translate/index.ts
@@ -1,3 +1,4 @@
-export * from './intl.model';
 export * from './intl-params.pipe';
+export * from './intl.model';
 export * from './translation.model';
+export * from './translation.token';

--- a/packages/ng/core/translate/translation.model.ts
+++ b/packages/ng/core/translate/translation.model.ts
@@ -12,3 +12,30 @@ export interface ILuTranslation<T> {
 }
 
 export type LuTranslation<T> = Record<string, T>;
+
+export interface LuPluralForms {
+	zero?: string;
+	one?: string;
+	two?: string;
+	few?: string;
+	many?: string;
+	other: string;
+}
+
+export function getIntlPluralLabel(pluralForms: Intl.PluralRules, label: LuPluralForms, count: number): string {
+	const pluralForm = pluralForms.select(count);
+	switch (pluralForm) {
+		case 'zero':
+			return label.zero ?? label.other ?? '';
+		case 'one':
+			return label.one ?? label.other ?? '';
+		case 'two':
+			return label.two ?? label.other ?? '';
+		case 'few':
+			return label.few ?? label.other ?? '';
+		case 'many':
+			return label.many ?? label.other ?? '';
+		default:
+			return label.other ?? '';
+	}
+}

--- a/packages/ng/core/translate/translation.model.ts
+++ b/packages/ng/core/translate/translation.model.ts
@@ -13,14 +13,7 @@ export interface ILuTranslation<T> {
 
 export type LuTranslation<T> = Record<string, T>;
 
-export interface LuPluralForms {
-	zero?: string;
-	one?: string;
-	two?: string;
-	few?: string;
-	many?: string;
-	other: string;
-}
+export type LuPluralForms = Partial<Record<Intl.LDMLPluralRule, string>>;
 
 export function getIntlPluralLabel(pluralForms: Intl.PluralRules, label: LuPluralForms, count: number): string {
 	const pluralForm = pluralForms.select(count);

--- a/packages/ng/core/translate/translation.model.ts
+++ b/packages/ng/core/translate/translation.model.ts
@@ -30,5 +30,5 @@ export function getIntlPluralLabel(pluralForms: Intl.PluralRules, label: LuPlura
 			return label.many ?? label.other ?? '';
 		default:
 			return label.other ?? '';
-	}
+	return label[pluralForm] ?? label.other ?? '';
 }

--- a/packages/ng/core/translate/translation.model.ts
+++ b/packages/ng/core/translate/translation.model.ts
@@ -29,6 +29,6 @@ export function getIntlPluralLabel(pluralForms: Intl.PluralRules, label: LuPlura
 		case 'many':
 			return label.many ?? label.other ?? '';
 		default:
-			return label.other ?? '';
-	return label[pluralForm] ?? label.other ?? '';
+			return label[pluralForm] ?? label.other ?? '';
+	}
 }

--- a/packages/ng/core/translate/translation.token.ts
+++ b/packages/ng/core/translate/translation.token.ts
@@ -1,0 +1,3 @@
+import { inject, InjectionToken, LOCALE_ID } from '@angular/core';
+
+export const LOCALE_PLURAL_RULES = new InjectionToken('LocalePluralRules', { factory: () => new Intl.PluralRules(inject(LOCALE_ID)) });

--- a/packages/ng/form-label/form-label.component.html
+++ b/packages/ng/form-label/form-label.component.html
@@ -13,10 +13,6 @@
 @if (counterMax() > 0) {
 	<span class="formLabel-counter" [attr.id]="counterId()" aria-live="polite">
 		<span aria-hidden="true">{{ counterStatus() }}/{{ counterMax() }}</span>
-		<span class="pr-u-mask">{{
-			counterStatus() <= 1
-				? (intl().counterAlt.one | intlParams: { counterStatus: counterStatus(), counterMax: counterMax() })
-				: (intl().counterAlt.other | intlParams: { counterStatus: counterStatus(), counterMax: counterMax() })
-		}}</span>
+		<span class="pr-u-mask">{{ counterAltLabel() | intlParams: { counterStatus: counterStatus(), counterMax: counterMax() } }}</span>
 	</span>
 }

--- a/packages/ng/form-label/form-label.component.ts
+++ b/packages/ng/form-label/form-label.component.ts
@@ -1,6 +1,6 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, numberAttribute, ViewEncapsulation } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
-import { getIntlPluralLabel, intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
+import { getIntlPluralLabel, intlInputOptions, IntlParamsPipe, LOCALE_PLURAL_RULES } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { TagComponent } from '@lucca-front/ng/tag';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
@@ -26,7 +26,7 @@ export class FormLabelComponent {
 	protected readonly intl = input(...intlInputOptions(LU_FORM_LABEL_TRANSLATIONS));
 
 	readonly locale = inject(LOCALE_ID);
-	readonly pluralRules = new Intl.PluralRules(this.locale);
+	readonly pluralRules = inject(LOCALE_PLURAL_RULES);
 	readonly counterAltLabel = computed(() => getIntlPluralLabel(this.pluralRules, this.intl().counterAlt, this.counterStatus()));
 
 	readonly required = input(false, { transform: booleanAttribute });

--- a/packages/ng/form-label/form-label.component.ts
+++ b/packages/ng/form-label/form-label.component.ts
@@ -1,6 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, inject, input, LOCALE_ID, numberAttribute, ViewEncapsulation } from '@angular/core';
 import { SafeHtml } from '@angular/platform-browser';
-import { intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
+import { getIntlPluralLabel, intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { TagComponent } from '@lucca-front/ng/tag';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
@@ -24,6 +24,10 @@ import { LU_FORM_LABEL_TRANSLATIONS } from './form-label.translate';
 })
 export class FormLabelComponent {
 	protected readonly intl = input(...intlInputOptions(LU_FORM_LABEL_TRANSLATIONS));
+
+	readonly locale = inject(LOCALE_ID);
+	readonly pluralRules = new Intl.PluralRules(this.locale);
+	readonly counterAltLabel = computed(() => getIntlPluralLabel(this.pluralRules, this.intl().counterAlt, this.counterStatus()));
 
 	readonly required = input(false, { transform: booleanAttribute });
 	readonly error = input(false, { transform: booleanAttribute });

--- a/packages/ng/form-label/form-label.component.ts
+++ b/packages/ng/form-label/form-label.component.ts
@@ -26,7 +26,7 @@ export class FormLabelComponent {
 	protected readonly intl = input(...intlInputOptions(LU_FORM_LABEL_TRANSLATIONS));
 
 	readonly locale = inject(LOCALE_ID);
-	readonly pluralRules = new Intl.PluralRules(this.locale);
+	readonly pluralRules = inject(LOCALE_PLURAL_RULES);
 	readonly counterAltLabel = computed(() => getIntlPluralLabel(this.pluralRules, this.intl().counterAlt, this.counterStatus()));
 
 	readonly required = input(false, { transform: booleanAttribute });

--- a/packages/ng/form-label/form-label.translate.ts
+++ b/packages/ng/form-label/form-label.translate.ts
@@ -1,5 +1,5 @@
 import { InjectionToken } from '@angular/core';
-import { LuTranslation } from '@lucca-front/ng/core';
+import { LuPluralForms, LuTranslation } from '@lucca-front/ng/core';
 import { Translations } from './translations';
 
 export const LU_FORM_LABEL_TRANSLATIONS = new InjectionToken('LuFormLabelTranslations', {
@@ -7,7 +7,7 @@ export const LU_FORM_LABEL_TRANSLATIONS = new InjectionToken('LuFormLabelTransla
 });
 
 export interface LuFormLabelTranslations {
-	counterAlt: { one: string; other: string };
+	counterAlt: LuPluralForms;
 	tooltipAlt: string;
 }
 


### PR DESCRIPTION
## Description

Added Polish language (pl) plural support by introducing a generic `getIntlPluralLabel` utility that resolves the correct plural form using Intl.PluralRules. Previously, plural logic was hard-coded to only handle one/other, which broke for languages like Polish that require other forms.

-----

