### PR TITLE
fix(vertical-navigation): closing tag in stories

### DIFF
--- a/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-disabled.stories.ts
+++ b/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-disabled.stories.ts
@@ -43,7 +43,8 @@ export default {
 		<lu-vertical-navigation-item>
 			<a luVerticalNavigationLink href="#">Item 5</a>
 		</lu-vertical-navigation-item>
-	</lu-vertical-navigation-group>`,
+	</lu-vertical-navigation-group>
+</lu-vertical-navigation>`,
 		};
 	},
 } as Meta;

--- a/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-iconless.stories.ts
+++ b/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-iconless.stories.ts
@@ -34,7 +34,8 @@ export default {
 		<lu-vertical-navigation-item>
 			<a luVerticalNavigationLink href="#">Item 3</a>
 		</lu-vertical-navigation-item>
-	</lu-vertical-navigation-group>`,
+	</lu-vertical-navigation-group>
+</lu-vertical-navigation>`,
 		};
 	},
 } as Meta;


### PR DESCRIPTION
## Description

Fix missing closing tag in Vertical Navigation stories for `disabled` and `iconless` code example.

-----
