### PR TITLE
[multiSelect] fix displayer

### DIFF
--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -27,7 +27,7 @@ let nextID = 0;
 			</div>
 			<div [attr.id]="valueID" class="pr-u-mask">
 				@for (option of displayedOptions$ | async; track option; let index = $index) {
-					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
+					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />&ngsp;
 				}
 				@if (overflowOptions$ | async; as overflow) {
 					+ {{ overflow }}

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -20,16 +20,22 @@ let nextID = 0;
 	template: `
 		<div class="multipleSelect-displayer">
 			<input [attr.aria-labelledby]="valueID" autocomplete="off" #inputElement (keydown.backspace)="inputBackspace()" (keydown.space)="inputSpace($event)" luMultiSelectDisplayerInput />
-			<div [attr.id]="valueID" class="multipleSelect-displayer-value">
+			<div [attr.id]="valueID" class="pr-u-mask">
 				@for (option of displayedOptions$ | async; track option; let index = $index) {
-					<lu-chip class="multipleSelect-displayer-chip" withEllipsis (kill)="unselectOption(option, $event)" [unkillable]="select.disabled$ | async">
-						<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
-					</lu-chip>
+					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
 				}
 				@if (overflowOptions$ | async; as overflow) {
-					<lu-chip class="multipleSelect-displayer-chip" unkillable>+ {{ overflow }}</lu-chip>
+					+ {{ overflow }}
 				}
 			</div>
+			@for (option of displayedOptions$ | async; track option; let index = $index) {
+				<lu-chip aria-hidden="true" class="multipleSelect-displayer-chip" withEllipsis (kill)="unselectOption(option, $event)" [unkillable]="select.disabled$ | async">
+					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
+				</lu-chip>
+			}
+			@if (overflowOptions$ | async; as overflow) {
+				<lu-chip aria-hidden="true" class="multipleSelect-displayer-chip" unkillable>+ {{ overflow }}</lu-chip>
+			}
 			@if (select.filterPillMode) {
 				<lu-icon icon="searchMagnifyingGlass" class="multiSelect-field-icon mod-search" />
 			}

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -19,7 +19,12 @@ let nextID = 0;
 	imports: [AsyncPipe, LuTooltipModule, ɵLuOptionOutletDirective, FormsModule, LuMultiSelectDisplayerInputDirective, ChipComponent, IconComponent],
 	template: `
 		<div class="multipleSelect-displayer">
-			<input [attr.aria-labelledby]="valueID" autocomplete="off" #inputElement (keydown.backspace)="inputBackspace()" (keydown.space)="inputSpace($event)" luMultiSelectDisplayerInput />
+			<div class="multipleSelect-displayer-suffix">
+				<input [attr.aria-labelledby]="valueID" autocomplete="off" #inputElement (keydown.backspace)="inputBackspace()" (keydown.space)="inputSpace($event)" luMultiSelectDisplayerInput />
+				@if (select.filterPillMode) {
+					<lu-icon icon="searchMagnifyingGlass" class="multiSelect-field-icon mod-search" />
+				}
+			</div>
 			<div [attr.id]="valueID" class="pr-u-mask">
 				@for (option of displayedOptions$ | async; track option; let index = $index) {
 					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
@@ -28,6 +33,7 @@ let nextID = 0;
 					+ {{ overflow }}
 				}
 			</div>
+
 			@for (option of displayedOptions$ | async; track option; let index = $index) {
 				<lu-chip aria-hidden="true" class="multipleSelect-displayer-chip" withEllipsis (kill)="unselectOption(option, $event)" [unkillable]="select.disabled$ | async">
 					<ng-container *luOptionOutlet="select.displayerTpl(); value: option" />
@@ -35,9 +41,6 @@ let nextID = 0;
 			}
 			@if (overflowOptions$ | async; as overflow) {
 				<lu-chip aria-hidden="true" class="multipleSelect-displayer-chip" unkillable>+ {{ overflow }}</lu-chip>
-			}
-			@if (select.filterPillMode) {
-				<lu-icon icon="searchMagnifyingGlass" class="multiSelect-field-icon mod-search" />
 			}
 		</div>
 	`,

--- a/packages/scss/src/components/multiSelect/component.scss
+++ b/packages/scss/src/components/multiSelect/component.scss
@@ -32,12 +32,6 @@
 			flex: 1;
 		}
 
-		.multipleSelect-displayer-value {
-			display: flex;
-			gap: var(--pr-t-spacings-50);
-			flex-wrap: wrap;
-		}
-
 		.multipleSelect-displayer-chip.chip {
 			min-inline-size: 0;
 

--- a/packages/scss/src/components/multiSelect/component.scss
+++ b/packages/scss/src/components/multiSelect/component.scss
@@ -32,6 +32,13 @@
 			flex: 1;
 		}
 
+		.multipleSelect-displayer-suffix {
+			display: var(--components-multiSelect-displayer-suffix-display);
+			gap: var(--pr-t-spacings-50);
+			flex: 1;
+			order: 1;
+		}
+
 		.multipleSelect-displayer-chip.chip {
 			min-inline-size: 0;
 

--- a/packages/scss/src/components/multiSelect/index.scss
+++ b/packages/scss/src/components/multiSelect/index.scss
@@ -23,10 +23,16 @@
 					@include filterPillDisplayerFocused;
 				}
 			}
+
+			&.is-selected {
+				@include filterPillSelected;
+			}
 		}
 
-		&.is-selected {
-			@include selected;
+		&:not(.mod-filterPill) {
+			&.is-selected {
+				@include selected;
+			}
 		}
 
 		&:has(.multipleSelect-displayer-search:focus-visible) {

--- a/packages/scss/src/components/multiSelect/mods.scss
+++ b/packages/scss/src/components/multiSelect/mods.scss
@@ -37,6 +37,8 @@
 }
 
 @mixin filterPill {
+	--components-multiSelect-displayer-suffix-display: flex;
+
 	flex-direction: column;
 	align-items: stretch;
 	box-shadow: none;

--- a/packages/scss/src/components/multiSelect/states.scss
+++ b/packages/scss/src/components/multiSelect/states.scss
@@ -42,8 +42,16 @@
 
 @mixin selected {
 	.multipleSelect-displayer-search {
-		&[readonly],
-		&:not(:focus) {
+		&:not(:focus),
+		&[readonly] {
+			@include a11y.mask;
+		}
+	}
+}
+
+@mixin filterPillSelected {
+	.multipleSelect-displayer-search {
+		&[readonly] {
 			@include a11y.mask;
 		}
 	}

--- a/packages/scss/src/components/multiSelect/vars.scss
+++ b/packages/scss/src/components/multiSelect/vars.scss
@@ -6,4 +6,5 @@
 	--components-multiSelect-border-color: var(--pr-t-color-input-border);
 	--components-multiSelect-placeholder: var(--pr-t-color-input-text-placeholder);
 	--components-multiSelect-arrow-color: var(--pr-t-color-input-icon);
+	--components-multiSelect-displayer-suffix-display: contents;
 }

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -80,7 +80,7 @@ async function checkValues(input: HTMLElement, values: string[]) {
 		await expect(counter).toHaveTextContent(values.length.toString());
 	} else {
 		for (const value of values) {
-			await expect(input.parentElement).toHaveTextContent(value.trim());
+			await expect(input.parentElement.parentElement).toHaveTextContent(value.trim());
 		}
 	}
 }

--- a/stories/documentation/forms/select/tree-select.stories.ts
+++ b/stories/documentation/forms/select/tree-select.stories.ts
@@ -118,7 +118,7 @@ async function checkValues(input: HTMLElement, values: string[]) {
 		await expect(counter).toHaveTextContent(values.length.toString());
 	} else {
 		for (const value of values) {
-			await expect(input.parentElement).toHaveTextContent(value);
+			await expect(input.parentElement.parentElement).toHaveTextContent(value);
 		}
 	}
 }


### PR DESCRIPTION
## Description

Adding a container to bind the input to its values caused a regression in the display.
The container has therefore been removed and replaced with a hidden div.

This also prevents the loss of focus in the filterPills, which used to cause the magnifying glass to jump out of position.

Finally, the input and the magnifying glass (in filter pill mode) are placed inside a container so that these two elements are never separated.

-----

#4164 

-----

<img width="448" height="460" alt="Capture d’écran 2026-06-15 à 11 16 32" src="https://github.com/user-attachments/assets/edd4eeb1-a73d-4610-bb67-e9c8a53d1808" />

