### PR TITLE
[dialog] fix form optional

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -34,7 +34,7 @@
 
 	@at-root ($atRoot) {
 		.dialog-inside {
-			&:has(.dialog-inside-formOptional, .dialog-formOptional, .dialog-form) {
+			&:has(> .dialog-inside-formOptional, > .dialog-formOptional, > .dialog-form) {
 				display: contents;
 
 				.dialog-formOptional, // stylelint-disable-line selector-disallowed-list -- .dialog-formOptional is deprecated
@@ -62,7 +62,7 @@
 				}
 			}
 
-			&:not(:has(.dialog-inside-formOptional, .dialog-formOptional, .dialog-form)) {
+			&:not(:has(> .dialog-inside-formOptional, > .dialog-formOptional, > .dialog-form)) {
 				display: grid;
 				grid-template-areas:
 					'header  '


### PR DESCRIPTION
## Description

We make sure that the class is indeed a direct child of `.dialog-inside`.

-----



-----
