### PR TITLE
fix(time-picker): allow typing 0 in hours when value is empty when user wants to set the picker to midnight

### DIFF
--- a/packages/ng/time/time-picker/time-picker.component.html
+++ b/packages/ng/time/time-picker/time-picker.component.html
@@ -8,7 +8,7 @@
 			class="timePicker-fieldset-group"
 			[disabled]="disabled()"
 			[label]="intl().timePickerHours"
-			[value]="hours()"
+			[value]="hoursInputValue()"
 			[display]="hoursDisplay()"
 			[max]="maxHours()"
 			[decimalConf]="hoursDecimalConf"

--- a/packages/ng/time/time-picker/time-picker.component.spec.ts
+++ b/packages/ng/time/time-picker/time-picker.component.spec.ts
@@ -103,4 +103,22 @@ describe('TimePickerComponent', () => {
 		expect(hours).toBe('5');
 		expect(minutes).toBe('00');
 	});
+
+	it('should register typing 0 in hours when the value is empty', async () => {
+		const fixture = TestBed.createComponent(TimePickerNgModelTestComponent);
+		fixture.detectChanges();
+		await fixture.whenStable();
+
+		expect(getDisplayTexts(fixture).hours).toBe('––');
+
+		const hoursInput = (fixture.nativeElement as HTMLElement).querySelectorAll('.timePicker-fieldset-group-textfield-input')[0] as HTMLInputElement;
+		hoursInput.value = '0';
+		hoursInput.dispatchEvent(new InputEvent('input', { data: '0', inputType: 'insertText', bubbles: true }));
+		fixture.detectChanges();
+
+		const { hours, minutes } = getDisplayTexts(fixture);
+		// 12-hour test locale: midnight (hours 0) displays as 12, proving the 0 registered.
+		expect(hours).toBe('12');
+		expect(minutes).toBe('00');
+	});
 });

--- a/packages/ng/time/time-picker/time-picker.component.ts
+++ b/packages/ng/time/time-picker/time-picker.component.ts
@@ -85,6 +85,8 @@ export class TimePickerComponent extends BasePickerComponent {
 	protected readonly minutesDisplay = computed(() => getMinutesDisplayPartFromIsoTime(this.value()));
 
 	protected readonly hours = computed(() => getHoursPartFromIsoTime(this.value()));
+	// Empty must stay '––', not 0, or typing "0" is a deduped no-op.
+	protected readonly hoursInputValue = computed<number | '––'>(() => getHoursDisplayPartFromIsoTime(this.value()));
 	protected readonly minutes = computed(() => getMinutesPartFromIsoTime(this.value()));
 	protected readonly pickerClasses = computed(() => {
 		return {

--- a/packages/ng/time/time-picker/time-picker.component.ts
+++ b/packages/ng/time/time-picker/time-picker.component.ts
@@ -135,7 +135,7 @@ export class TimePickerComponent extends BasePickerComponent {
 	}
 
 	writeValue(value: ISO8601Time): void {
-		this.value.set(value || '––:––:––');
+		this.value.set(value || DEFAULT_MIN_TIME);
 		if (value) {
 			this.hoursPart()?.isValueSet.set(true);
 			this.minutesPart()?.isValueSet.set(true);

--- a/packages/ng/time/time-picker/time-picker.model.ts
+++ b/packages/ng/time/time-picker/time-picker.model.ts
@@ -9,6 +9,6 @@ export type TimeChangeEvent = {
 	  }
 	| { source: 'control'; part: 'minutes' | 'hours'; direction: 'up' | 'down' }
 );
-export const DEFAULT_MIN_TIME: ISO8601Time = '--:--:--';
+export const DEFAULT_MIN_TIME: ISO8601Time = '––:––:––';
 
 export const DEFAULT_TIME_DECIMAL_PIPE_FORMAT = '2.0-0';

--- a/stories/documentation/forms/time/angular/time-range-picker.stories.ts
+++ b/stories/documentation/forms/time/angular/time-range-picker.stories.ts
@@ -139,7 +139,7 @@ const basePlay = async ({ canvasElement, step, context }) => {
 		await userEvent.click(startHours);
 		await waitForAngular();
 		await expect(startHours).toHaveFocus();
-		await userEvent.type(startHours, '09:00');
+		await userEvent.type(startHours, '9');
 		await waitForAngular();
 		await expectNgModelDisplay(context.canvasElement, '{ "start": "09:00:00" }');
 
@@ -147,7 +147,7 @@ const basePlay = async ({ canvasElement, step, context }) => {
 		await userEvent.click(endHours);
 		await waitForAngular();
 		await expect(endHours).toHaveFocus();
-		await userEvent.type(endHours, '10:00');
+		await userEvent.type(endHours, '10');
 		await waitForAngular();
 		await expectNgModelDisplay(context.canvasElement, '{ "start": "09:00:00", "end": "10:00:00" }');
 	});


### PR DESCRIPTION
## Description

You couldn't type `0` into the hours field when the time picker was empty — so setting midnight (`00:00`) from a blank picker when interacting with the hours part was not possible. This fixes it: typing `0` in an empty picker now registers like any other value.

https://github.com/LuccaSA/lucca-front/issues/5007

-----

Two things were going on under the hood.

When the picker is empty, hours and minutes were handled a little differently. Minutes tracked "empty" as a real distinct state (the `––` dashes you see), but hours quietly treated empty as `0`. So when you typed `0`, the value was *already* `0` as far as the field was concerned — nothing actually changed, so no update ever got emitted. Hours now tracks the empty state the same way minutes already did, so typing `0` is seen as a genuine change.

On top of that, there were two slightly different "empty" placeholders floating around (one used regular hyphens, the other en-dashes), and only the en-dash one was recognized by the code reading the parts — so they never lined up. Unified everything on the en-dash `––` so the default value, the empty fallback, and the checks that read it all agree.

Added a test covering the original bug: empty picker → type `0` in hours → it registers and minutes fill in to `00`.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK <!-- ESLint clean; stylelint couldn't run locally (missing @stylistic/stylelint-config dep), no SCSS changed -->

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
