### PR TITLE
fix(popover2): replace blocking backdrop with outsidePointerEvents

### DIFF
--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.html
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.html
@@ -36,7 +36,9 @@
 			</span>
 		</button>
 		@if (inputIsClearable()) {
-			<lu-clear class="filterPill_clear" (onClear)="clear(); filterPillRef.focus()">{{ intl().clear }}</lu-clear>
+			<lu-clear class="filterPill_clear" (onClear)="clear(); popoverRef.opened() ? null : filterPillRef.focus()">{{
+				intl().clear
+			}}</lu-clear>
 		}
 	} @else {
 		<ng-container

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
@@ -30,6 +30,7 @@
 				[luPopover2]="popoverMultilanguage"
 				#popoverRef="luPopover2"
 				luPopoverNoCloseButton
+				[luPopoverIgnoredOutsidePointerTargets]="inputElement"
 				[customPositions]="popoverPositions"
 				[luTooltip]="intl().toggleMultilanguage"
 				luTooltipOnlyForDisplay

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -280,8 +280,8 @@ export class PopoverDirective implements OnDestroy {
 					// containing other interactive parts) is handled by their own open handlers (e.g. the
 					// click() HostListener). Ignore those here, otherwise we'd close on pointerdown then
 					// immediately reopen on click.
-					const target = event.target as Node;
-					if (this.elementRef.nativeElement.contains(target) || this.#anchorElement?.contains(target)) {
+					const target = event.target;
+					if (target instanceof Node && (this.elementRef.nativeElement.contains(target) || this.#anchorElement?.contains(target))) {
 						return;
 					}
 					this.#componentRef?.close();

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -276,9 +276,12 @@ export class PopoverDirective implements OnDestroy {
 				.outsidePointerEvents()
 				.pipe(takeUntilDestroyed(this.#destroyRef))
 				.subscribe((event) => {
-					// Re-clicking the trigger is handled by the click() HostListener (toggle).
-					// Ignore it here, otherwise we'd close then immediately reopen.
-					if (this.elementRef.nativeElement.contains(event.target as Node)) {
+					// Re-opening from the trigger (or from the anchor element, which may be a wrapper
+					// containing other interactive parts) is handled by their own open handlers (e.g. the
+					// click() HostListener). Ignore those here, otherwise we'd close on pointerdown then
+					// immediately reopen on click.
+					const target = event.target as Node;
+					if (this.elementRef.nativeElement.contains(target) || this.#anchorElement?.contains(target)) {
 						return;
 					}
 					this.#componentRef?.close();
@@ -336,6 +339,21 @@ export class PopoverDirective implements OnDestroy {
 
 	updatePosition() {
 		this.#overlayRef?.updatePosition();
+	}
+
+	/**
+	 * Resolves the anchor to its native element, when it is one. The anchor can be an ElementRef,
+	 * an Element or a plain coordinate (Point); only element-based anchors can contain a pointer target.
+	 */
+	get #anchorElement(): Element | null {
+		const anchor = this.luPopoverAnchor();
+		if (anchor instanceof ElementRef) {
+			return anchor.nativeElement as Element;
+		}
+		if (anchor instanceof Element) {
+			return anchor;
+		}
+		return null;
 	}
 
 	#buildPositions(): ConnectedPosition[] {

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -29,6 +29,13 @@ import { LU_POPOVER2_TRANSLATIONS } from './popover2.translate';
 
 export type PopoverPosition = 'above' | 'below' | 'before' | 'after';
 
+export interface PopoverOpenOptions {
+	/** Prevents focusing the close button (or first focusable element) when the popover opens. */
+	disableCloseButtonFocus?: boolean;
+	/** Prevents giving the focus back to the trigger element when the popover closes. */
+	disableInitialTriggerFocus?: boolean;
+}
+
 let nextId = 0;
 
 const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
@@ -172,7 +179,7 @@ export class PopoverDirective implements OnDestroy {
 			)
 			.subscribe(([event, type]: ['open' | 'close', 'focus' | 'click' | 'hover']) => {
 				if (event === 'open') {
-					this.openPopover(true, type === 'hover');
+					this.openPopover({ disableCloseButtonFocus: true, disableInitialTriggerFocus: type === 'hover' });
 					this.#listenToMouseLeave = type !== 'click';
 					if (type === 'focus' && !this.#screenReaderDescription) {
 						this.#screenReaderDescription = this.#renderer.createElement('span') as HTMLSpanElement;
@@ -235,14 +242,21 @@ export class PopoverDirective implements OnDestroy {
 		}
 	}
 
-	openPopover(disableCloseButtonFocus?: boolean, disableInitialTriggerFocus?: boolean): void;
-	/** @deprecated `withBackdrop` is no longer used: the popover no longer creates a blocking backdrop. Use `openPopover(disableCloseButtonFocus, disableInitialTriggerFocus)`. */
-	openPopover(withBackdrop: boolean, disableCloseButtonFocus?: boolean, disableInitialTriggerFocus?: boolean): void;
-	openPopover(arg1 = false, arg2 = false, arg3?: boolean): void {
-		// Reconcile the canonical 2-arg signature with the deprecated 3-arg one:
-		// when 3 args are passed, the first (withBackdrop) is ignored.
-		const disableCloseButtonFocus = arg3 === undefined ? arg1 : arg2;
-		const disableInitialTriggerFocus = arg3 === undefined ? arg2 : arg3;
+	openPopover(options?: PopoverOpenOptions): void;
+	/**
+	 * @deprecated The boolean signature is kept only for backward compatibility. `withBackdrop` is now ignored
+	 * (the popover no longer creates a blocking backdrop). Prefer `openPopover({ disableCloseButtonFocus, disableInitialTriggerFocus })`.
+	 */
+	openPopover(withBackdrop?: boolean, disableCloseButtonFocus?: boolean, disableInitialTriggerFocus?: boolean): void;
+	openPopover(optionsOrWithBackdrop?: PopoverOpenOptions | boolean, disableCloseButtonFocusArg?: boolean, disableInitialTriggerFocusArg?: boolean): void {
+		// New options-object form vs deprecated boolean form. With the boolean form the first
+		// positional argument is the now-ignored `withBackdrop`, so the focus flags shift by one.
+		const options: PopoverOpenOptions =
+			typeof optionsOrWithBackdrop === 'object' && optionsOrWithBackdrop !== null
+				? optionsOrWithBackdrop
+				: { disableCloseButtonFocus: disableCloseButtonFocusArg, disableInitialTriggerFocus: disableInitialTriggerFocusArg };
+		const disableCloseButtonFocus = options.disableCloseButtonFocus ?? false;
+		const disableInitialTriggerFocus = options.disableInitialTriggerFocus ?? false;
 		const content = this.content();
 
 		if (!this.opened() && !this.luPopoverDisabled() && isNotNil(content)) {

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -172,7 +172,7 @@ export class PopoverDirective implements OnDestroy {
 			)
 			.subscribe(([event, type]: ['open' | 'close', 'focus' | 'click' | 'hover']) => {
 				if (event === 'open') {
-					this.openPopover(type === 'focus', true, type === 'hover');
+					this.openPopover(true, type === 'hover');
 					this.#listenToMouseLeave = type !== 'click';
 					if (type === 'focus' && !this.#screenReaderDescription) {
 						this.#screenReaderDescription = this.#renderer.createElement('span') as HTMLSpanElement;
@@ -222,7 +222,7 @@ export class PopoverDirective implements OnDestroy {
 			this.#componentRef?.close();
 			this.#listenToMouseLeave = true;
 		} else {
-			this.openPopover(true);
+			this.openPopover();
 			this.#listenToMouseLeave = false;
 			this.#listenToMouseEnter = false;
 		}
@@ -235,7 +235,14 @@ export class PopoverDirective implements OnDestroy {
 		}
 	}
 
-	openPopover(withBackdrop = false, disableCloseButtonFocus = false, disableInitialTriggerFocus = false): void {
+	openPopover(disableCloseButtonFocus?: boolean, disableInitialTriggerFocus?: boolean): void;
+	/** @deprecated `withBackdrop` is no longer used: the popover no longer creates a blocking backdrop. Use `openPopover(disableCloseButtonFocus, disableInitialTriggerFocus)`. */
+	openPopover(withBackdrop: boolean, disableCloseButtonFocus?: boolean, disableInitialTriggerFocus?: boolean): void;
+	openPopover(arg1 = false, arg2 = false, arg3?: boolean): void {
+		// Reconcile the canonical 2-arg signature with the deprecated 3-arg one:
+		// when 3 args are passed, the first (withBackdrop) is ignored.
+		const disableCloseButtonFocus = arg3 === undefined ? arg1 : arg2;
+		const disableInitialTriggerFocus = arg3 === undefined ? arg2 : arg3;
 		const content = this.content();
 
 		if (!this.opened() && !this.luPopoverDisabled() && isNotNil(content)) {
@@ -247,15 +254,19 @@ export class PopoverDirective implements OnDestroy {
 					.flexibleConnectedTo(this.luPopoverAnchor())
 					.withPositions(this.customPositions() || this.#buildPositions()),
 				scrollStrategy: this.overlay.scrollStrategies[this.overlayScrollStrategy() ?? 'reposition'](),
-				hasBackdrop: withBackdrop,
-				backdropClass: '',
 				disposeOnNavigation: true,
 			});
-			// Close on backdrop click even if backdrop is invisible
+			// Close on outside interaction WITHOUT a blocking backdrop that would
+			// intercept pointer events on the rest of the page.
 			this.#overlayRef
-				.backdropClick()
+				.outsidePointerEvents()
 				.pipe(takeUntilDestroyed(this.#destroyRef))
-				.subscribe(() => {
+				.subscribe((event) => {
+					// Re-clicking the trigger is handled by the click() HostListener (toggle).
+					// Ignore it here, otherwise we'd close then immediately reopen.
+					if (this.elementRef.nativeElement.contains(event.target as Node)) {
+						return;
+					}
 					this.#componentRef?.close();
 					this.#listenToMouseLeave = true;
 				});

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -128,7 +128,7 @@ export class PopoverDirective implements OnDestroy {
 	 * originating from them won't close the popover. Useful when an external control opens the popover
 	 * (e.g. an input opening it on focus) and clicking it again should not trigger a close-then-reopen.
 	 */
-	luPopoverIgnoredOutsidePointerTargets = input<HTMLElement | HTMLElement[] | null>(null);
+	readonly luPopoverIgnoredOutsidePointerTargets = input<HTMLElement | HTMLElement[] | null>(null);
 
 	// We have to type these two for Compodoc to find the right type and tell Storybook these aren't strings
 	readonly luPopoverOpenDelay: InputSignal<number> = input<number>(300);

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -123,6 +123,13 @@ export class PopoverDirective implements OnDestroy {
 	 */
 	readonly luPopoverAnchor = input<FlexibleConnectedPositionStrategyOrigin>(this.elementRef);
 
+	/**
+	 * Extra element(s) to treat as "inside" the popover for outside-pointer detection. Pointer events
+	 * originating from them won't close the popover. Useful when an external control opens the popover
+	 * (e.g. an input opening it on focus) and clicking it again should not trigger a close-then-reopen.
+	 */
+	luPopoverIgnoredOutsidePointerTargets = input<HTMLElement | HTMLElement[] | null>(null);
+
 	// We have to type these two for Compodoc to find the right type and tell Storybook these aren't strings
 	readonly luPopoverOpenDelay: InputSignal<number> = input<number>(300);
 
@@ -277,11 +284,12 @@ export class PopoverDirective implements OnDestroy {
 				.pipe(takeUntilDestroyed(this.#destroyRef))
 				.subscribe((event) => {
 					// Re-opening from the trigger (or from the anchor element, which may be a wrapper
-					// containing other interactive parts) is handled by their own open handlers (e.g. the
-					// click() HostListener). Ignore those here, otherwise we'd close on pointerdown then
-					// immediately reopen on click.
+					// containing other interactive parts), as well as from explicitly ignored external
+					// controls, is handled by their own open handlers (e.g. the click() HostListener or
+					// an input opening on focus). Ignore those here, otherwise we'd close on pointerdown
+					// then immediately reopen on click.
 					const target = event.target;
-					if (target instanceof Node && (this.elementRef.nativeElement.contains(target) || this.#anchorElement?.contains(target))) {
+					if (target instanceof Node && (this.elementRef.nativeElement.contains(target) || this.#anchorElement?.contains(target) || this.#isIgnoredOutsidePointerTarget(target))) {
 						return;
 					}
 					this.#componentRef?.close();
@@ -339,6 +347,14 @@ export class PopoverDirective implements OnDestroy {
 
 	updatePosition() {
 		this.#overlayRef?.updatePosition();
+	}
+
+	#isIgnoredOutsidePointerTarget(target: Node): boolean {
+		const ignored = this.luPopoverIgnoredOutsidePointerTargets();
+		if (!ignored) {
+			return false;
+		}
+		return (Array.isArray(ignored) ? ignored : [ignored]).some((element) => element.contains(target));
 	}
 
 	/**


### PR DESCRIPTION
## Description

The popover2 directive created a full-screen `cdk-overlay-backdrop` for the sole purpose of detecting an outside click to close the popover. A backdrop has `pointer-events: auto`, so it intercepts the **first** interaction with the rest of the page: while a popover is open, clicking a neighbouring interactive element (e.g. the next radio button) closes the popover but the click is **swallowed by the backdrop** and never reaches the target — the user has to click a second time.

For a non-modal description tooltip/popover this freeze of the page is an unwanted side effect.

## Fix

- Replace `hasBackdrop` + `backdropClick()` with `overlayRef.outsidePointerEvents()`, the standard CDK mechanism for non-modal overlays. It emits on any `pointerdown` outside the overlay **without** rendering a blocking backdrop, so an outside interaction closes the popover **and** reaches its target in a single click.
- Ignore pointer events originating from the **trigger host** so the `click()` HostListener keeps handling the open/close toggle (otherwise the popover would close on `pointerdown` then immediately reopen on `click`).
- Also ignore pointer events originating from the **anchor element**. When `luPopoverAnchor` is a wrapper containing other interactive parts that reopen the popover (e.g. `date-input` opens from an `<input>` inside a surrounding `#popoverAnchor` div), clicking inside that anchor while open would otherwise close-then-reopen. The anchor is resolved to its native element (`ElementRef`/`Element`; coordinate `Point` anchors are skipped).

## API change (non-breaking)

`openPopover()`'s `withBackdrop` parameter is no longer used.

- **New canonical form** — options object: `openPopover({ disableCloseButtonFocus?, disableInitialTriggerFocus? })`.
- **Deprecated form kept for compatibility** — boolean signature with `withBackdrop` still in first position (ignored): `openPopover(withBackdrop?, disableCloseButtonFocus?, disableInitialTriggerFocus?)`.

The implementation discriminates on `typeof === 'object'`, so existing callers keep their exact meaning with **no silent behavior change**:

| Existing call | Resolves to | Behavior |
| --- | --- | --- |
| `openPopover(true)` (filter-pill, impersonation) | deprecated boolean | `withBackdrop` ignored, focus flags `false` — unchanged |
| `openPopover(true, true)` (date2) | deprecated boolean | `disableCloseButtonFocus=true` — unchanged |
| `openPopover(true, true, true)` (multilanguage-input) | deprecated boolean | unchanged |

A new `PopoverOpenOptions` interface is exported from the package public API.

## Behaviour preserved

- Outside click closes the popover for the 3 triggers (click / hover / focus).
- `mouseleave` (hover) and `Shift+Tab` (focus) still close.
- A11y unchanged: screen-reader description and focus management kept; only the backdrop is gone.