### PR TITLE
fix(rich-text-input): avoid double-encoding already-encoded link URLs

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/link-dialog/link-dialog.component.ts
@@ -29,7 +29,22 @@ export class LinkDialogComponent {
 			return;
 		}
 
-		this.dialogRef.close(encodeURI(this.formGroup.controls.href.value.trim()));
+		this.dialogRef.close(this.#encodeHref(this.formGroup.controls.href.value.trim()));
+	}
+
+	/**
+	 * Encodes a href without double-encoding URLs that are already (partially) encoded.
+	 * Pasted URLs (e.g. SharePoint links) often already contain percent-encoded characters
+	 * like `%20`; applying `encodeURI` directly would re-encode the `%` into `%25`.
+	 * We first decode to get back the raw URL, then re-encode it so the result is idempotent.
+	 */
+	#encodeHref(href: string): string {
+		try {
+			return encodeURI(decodeURI(href));
+		} catch {
+			// Malformed URI sequence (e.g. a lone `%`): fall back to encoding as-is.
+			return encodeURI(href);
+		}
 	}
 
 	public deleteLink() {


### PR DESCRIPTION
## Description

Closes #5015

Lorsqu'on insère un lien déjà encodé dans le rich-text input (typiquement un lien SharePoint contenant des `%20` pour les espaces), `encodeURI()` ré-encode le caractère `%` lui-même en `%25` → double-encodage.

Exemple :
```
entrée :    …/Documents%20partages/…/Catalogue%20de%20formation.pdf
avant fix : …/Documents%2520partages/…/Catalogue%2520de%2520formation.pdf
```

## Cause

Dans `LinkDialogComponent.save()`, `encodeURI()` était appliqué directement sur le href. `encodeURI` n'est pas idempotent : il transforme chaque `%` existant en `%25`.

## Correctif

On décode d'abord l'URL (`decodeURI`) pour revenir à sa forme brute, puis on ré-encode — l'opération devient idempotente. Un `try/catch` gère les séquences URI malformées (ex. un `%` isolé) en retombant sur l'ancien comportement.

```ts
encodeURI(decodeURI(href))
```

| Entrée | Résultat |
|---|---|
| `…/Documents%20partages/…` (déjà encodé) | `…/Documents%20partages/…` ✅ |
| `…/Documents partages/…` (brut) | `…/Documents%20partages/…` ✅ |

-----


-----