### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,12 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Tag or branch to deploy (e.g. v21.1.3 or master)'
+        required: true
+        default: master
 
 jobs:
   deploy:
@@ -16,8 +22,8 @@ jobs:
     permissions:
       contents: read
     outputs:
-      deploy-path: ${{ steps.vars.outputs.deploy-path }}
-      major-minor: ${{ steps.vars.outputs.major-minor }}
+      primary-path: ${{ steps.vars.outputs.primary-path }}
+      alias-path: ${{ steps.vars.outputs.alias-path }}
 
     env:
       R2_ENDPOINT: ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
@@ -29,17 +35,50 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: 24.13.0
 
+      - name: Compute deploy paths
+        id: vars
+        run: |
+          RAW="${{ github.event.inputs.ref }}"
+          if [ -z "$RAW" ]; then
+            RAW="${GITHUB_REF#refs/*/}"          # refs/tags/v21.1.3 -> v21.1.3 ; refs/heads/master -> master
+          fi
+
+          if [[ "$RAW" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            # Full semver tag: always deploy to the exact tag folder.
+            PRIMARY="${RAW}/storybook"                          # e.g. v21.1.3/storybook
+            if [[ "$RAW" == *-* ]]; then
+              # Prerelease (e.g. v21.1.1-beta): own folder only, do NOT move the major.minor alias.
+              ALIAS=""
+            else
+              MM="$(echo "$RAW" | grep -oE '^v[0-9]+\.[0-9]+')" # v21.1
+              ALIAS="${MM}/storybook"                           # v21.1/storybook
+            fi
+          else
+            # Branch (e.g. master): single folder, no alias.
+            PRIMARY="${RAW}/storybook"
+            ALIAS=""
+          fi
+
+          echo "primary-path=${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "alias-path=${ALIAS}" >> "$GITHUB_OUTPUT"
+          echo "Primary: ${PRIMARY}    Alias: ${ALIAS:-<none>}"
+
       - run: npm ci
       - run: npm run build-storybook
+
       - name: Install rclone
         run: |
           sudo apt-get update
           sudo apt-get install -y rclone
-      - name: Install and configure rclone
+
+      - name: Configure rclone
         run: |
           mkdir -p ~/.config/rclone
           cat > ~/.config/rclone/rclone.conf << EOF
@@ -52,6 +91,19 @@ jobs:
           acl = private
           no_check_bucket = true
           EOF
+
       - name: Upload results to R2
         run: |
-          rclone sync ./storybook-static/ "r2:${R2_BUCKET}/storybook/${{steps.vars.outputs.major-minor}}" --fast-list --checksum --transfers 8 --checkers 8
+          set -euo pipefail
+          PRIMARY="${{ steps.vars.outputs.primary-path }}"
+          ALIAS="${{ steps.vars.outputs.alias-path }}"
+
+          echo "Uploading build -> ${PRIMARY}"
+          rclone sync ./storybook-static/ "r2:${R2_BUCKET}/${PRIMARY}" \
+            --fast-list --checksum --transfers 8 --checkers 8
+
+          if [ -n "$ALIAS" ]; then
+            echo "Updating alias ${ALIAS} -> ${PRIMARY} (server-side copy)"
+            rclone sync "r2:${R2_BUCKET}/${PRIMARY}" "r2:${R2_BUCKET}/${ALIAS}" \
+              --fast-list --checksum --transfers 8 --checkers 8
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,14 @@ jobs:
 
       - name: Compute deploy paths
         id: vars
+        env:
+          # Pass untrusted input via env, NOT directly into the run block (prevents code injection).
+          INPUT_REF: ${{ github.event.inputs.ref }}
         run: |
           set -euo pipefail
 
           # Source the ref from the manual input, else the triggering ref.
-          RAW="${{ github.event.inputs.ref }}"
+          RAW="$INPUT_REF"
           if [ -z "$RAW" ]; then
             RAW="${GITHUB_REF#refs/*/}"   # refs/tags/v21.1.3 -> v21.1.3 ; refs/heads/master -> master
           else
@@ -80,6 +83,11 @@ jobs:
           sudo apt-get install -y rclone
 
       - name: Configure rclone
+        env:
+          # Secrets/vars via env, not interpolated into the script.
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_KEY }}
+          R2_ENDPOINT: ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
         run: |
           mkdir -p ~/.config/rclone
           cat > ~/.config/rclone/rclone.conf << EOF
@@ -94,10 +102,12 @@ jobs:
           EOF
 
       - name: Upload results to R2
+        env:
+          # Step outputs are derived from untrusted input -> pass via env, don't interpolate.
+          PRIMARY: ${{ steps.vars.outputs.primary-path }}
+          ALIAS: ${{ steps.vars.outputs.alias-path }}
         run: |
           set -euo pipefail
-          PRIMARY="${{ steps.vars.outputs.primary-path }}"
-          ALIAS="${{ steps.vars.outputs.alias-path }}"
 
           echo "Uploading build -> ${PRIMARY}"
           rclone sync ./storybook-static/ "r2:${R2_BUCKET}/${PRIMARY}" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           ref: ${{ github.event.inputs.ref || github.ref }}
+          fetch-tags: true        # ensure refs/tags/* are available for tag detection below
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
@@ -45,30 +46,30 @@ jobs:
       - name: Compute deploy paths
         id: vars
         run: |
+          set -euo pipefail
+
+          # Source the ref from the manual input, else the triggering ref.
           RAW="${{ github.event.inputs.ref }}"
           if [ -z "$RAW" ]; then
-            RAW="${GITHUB_REF#refs/*/}"          # refs/tags/v21.1.3 -> v21.1.3 ; refs/heads/master -> master
+            RAW="${GITHUB_REF#refs/*/}"   # refs/tags/v21.1.3 -> v21.1.3 ; refs/heads/master -> master
+          else
+            RAW="${RAW#refs/*/}"          # normalize a manually-entered refs/tags|heads/... value
           fi
 
-          if [[ "$RAW" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            # Full semver tag: always deploy to the exact tag folder.
-            PRIMARY="${RAW}/storybook"                          # e.g. v21.1.3/storybook
-            if [[ "$RAW" == *-* ]]; then
-              # Prerelease (e.g. v21.1.1-beta): own folder only, do NOT move the major.minor alias.
-              ALIAS=""
-            else
-              MM="$(echo "$RAW" | grep -oE '^v[0-9]+\.[0-9]+')" # v21.1
-              ALIAS="${MM}/storybook"                           # v21.1/storybook
+          PRIMARY="${RAW}/storybook"      # every deploy gets its own folder
+          ALIAS=""
+
+          # Only set the vX.Y alias when deploying an existing *stable* tag (vX.Y.Z with no suffix).
+          if git show-ref --tags --verify --quiet "refs/tags/$RAW"; then
+            if [[ "$RAW" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              MM="$(echo "$RAW" | grep -oE '^v[0-9]+\.[0-9]+')"   # v21.1
+              ALIAS="${MM}/storybook"                             # v21.1/storybook
             fi
-          else
-            # Branch (e.g. master): single folder, no alias.
-            PRIMARY="${RAW}/storybook"
-            ALIAS=""
           fi
 
           echo "primary-path=${PRIMARY}" >> "$GITHUB_OUTPUT"
           echo "alias-path=${ALIAS}" >> "$GITHUB_OUTPUT"
-          echo "Primary: ${PRIMARY}    Alias: ${ALIAS:-<none>}"
+          echo "Ref: ${RAW}    Primary: ${PRIMARY}    Alias: ${ALIAS:-<none>}"
 
       - run: npm ci
       - run: npm run build-storybook

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    name: Deploy Lucca Front staging
+    name: Deploy Lucca Front
     environment: production
     permissions:
       contents: read


### PR DESCRIPTION
## Description

## Goals / desired URLs

- master → `https://lucca-front.lucca.io/master/storybook`
- each full tag → `https://lucca-front.lucca.io/v21.1.3/storybook` (permanent, one folder per patch)
- major.minor alias → `https://lucca-front.lucca.io/v21.1/storybook` always points at the **latest stable** patch of that minor line
- prereleases (`v21.1.1-beta`) get their own folder but must **not** move the `v21.1` alias

## How it works

### 1. GitHub Actions workflow (`Deploy Lucca Front`)

**Triggers:**
- push to `master`
- push of a tag matching `v[0-9]+.[0-9]+.[0-9]+` (and `-*` prereleases)
- `workflow_dispatch` with a `ref` input, so anyone can manually pick a tag/branch to (re)deploy

**Logic:**
- Compute a slug from the ref:
  - branch → `master`
  - tag `v21.1.3` → primary `v21.1.3`, alias `v21.1`
  - tag `v21.1.1-beta` → primary `v21.1.1-beta`, **no alias**
- Build with `npm run build-storybook`
- `rclone sync` the build to `r2:<bucket>/<primary>/storybook`
- For stable tags, a second **server-side** `rclone sync` copies the primary folder to `<major.minor>/storybook` (no re-upload) so the alias mirrors the latest stable patch

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
