### PR TITLE
core(misc): use utility functions

### DIFF
--- a/packages/ng/api/select/pager/api-pager.model.ts
+++ b/packages/ng/api/select/pager/api-pager.model.ts
@@ -1,4 +1,4 @@
-import { ILuOnOpenSubscriber, ILuOnScrollBottomSubscriber } from '@lucca-front/ng/core';
+import { ILuOnOpenSubscriber, ILuOnScrollBottomSubscriber, isNil } from '@lucca-front/ng/core';
 import { ILuOptionOperator } from '@lucca-front/ng/option';
 import { merge, Observable, of, Subject } from 'rxjs';
 import { catchError, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
@@ -49,7 +49,7 @@ export abstract class ALuApiOptionPager<T extends ILuApiItem = ILuApiItem, S ext
 			distinctUntilChanged(),
 			tap((p) => (this._page = p)),
 			switchMap((page) => {
-				if (page === undefined) {
+				if (isNil(page)) {
 					return of({ items: [] as T[], strategy: Strategy.replace });
 				}
 				return this._service.getPaged(page).pipe(

--- a/packages/ng/core-select/panel/selectable-item.ts
+++ b/packages/ng/core-select/panel/selectable-item.ts
@@ -1,5 +1,6 @@
 import { Highlightable } from '@angular/cdk/a11y';
 import { computed, Directive, ElementRef, inject, input, linkedSignal, model, OnDestroy, output, signal } from '@angular/core';
+import { isNotNil } from '@lucca-front/ng/core';
 import { ALuSelectInputComponent } from '../input/select-input.component';
 import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from './panel.instance';
 
@@ -57,7 +58,7 @@ export class CoreSelectPanelElement<T> implements Highlightable, OnDestroy {
 	setActiveStyles(): void {
 		this.isHighlighted.set(true);
 		const option = this.option();
-		if (option !== undefined) {
+		if (isNotNil(option)) {
 			this.#selectRef.highlightedOption.emit(option);
 		}
 	}

--- a/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
+++ b/packages/ng/data-table/data-table-cell/data-table-cell.component.ts
@@ -1,4 +1,5 @@
 import { booleanAttribute, ChangeDetectionStrategy, Component, computed, forwardRef, input, ViewEncapsulation } from '@angular/core';
+import { isNotNil } from '@lucca-front/ng/core';
 
 import { BaseDataTableCell } from '../base-data-table-cell';
 import { LU_DATA_TABLE_CELL_INSTANCE } from '../data-table-cell.token';
@@ -39,18 +40,18 @@ export class DataTableRowCellComponent extends BaseDataTableCell {
 	readonly alignCol = computed(() => {
 		const cols = this.tableRef?.header()?.cols?.();
 		const position = this.position();
-		return position !== undefined ? cols?.[position]?.align?.() : undefined;
+		return isNotNil(position) ? cols?.[position]?.align?.() : undefined;
 	});
 
 	readonly insetInlineStart = computed(() => {
 		const cols = this.tableRef?.header()?.cols?.();
 		const position = this.position();
-		return position !== undefined ? cols?.[position]?.insetInlineStart?.() : undefined;
+		return isNotNil(position) ? cols?.[position]?.insetInlineStart?.() : undefined;
 	});
 
 	readonly insetInlineEnd = computed(() => {
 		const cols = this.tableRef?.header()?.cols?.();
 		const position = this.position();
-		return position !== undefined ? cols?.[position]?.insetInlineEnd?.() : undefined;
+		return isNotNil(position) ? cols?.[position]?.insetInlineEnd?.() : undefined;
 	});
 }

--- a/packages/ng/department/department-select.spec.ts
+++ b/packages/ng/department/department-select.spec.ts
@@ -32,7 +32,7 @@ describe('department select', () => {
 		[operations]="[1]"
 		[filters]="['isactive=false']"
 		data-testid="lu-select"
-	></lu-department-select>
+	/>
 </label>`;
 
 	it('should display dialog with a click on a lu select ', async () => {

--- a/packages/ng/software-icon-wrapper/software-icon-wrapper.component.ts
+++ b/packages/ng/software-icon-wrapper/software-icon-wrapper.component.ts
@@ -2,7 +2,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, contentChildren, input, numberAttribute, TemplateRef, ViewEncapsulation } from '@angular/core';
 import { LU_SOFTWARE_ICON_WRAPPER } from '@lucca-front/ng/software-icon';
 
-import { intlInputOptions, IntlParamsPipe } from '@lucca-front/ng/core';
+import { intlInputOptions, IntlParamsPipe, isNil } from '@lucca-front/ng/core';
 import { PopoverDirective } from '@lucca-front/ng/popover2';
 import { LU_SOFTWARE_ICON_WRAPPER_TRANSLATIONS } from './software-icon-wrapper.translate';
 
@@ -27,11 +27,11 @@ export class SoftwareIconWrapperComponent {
 	protected readonly items = contentChildren(TemplateRef, { descendants: true });
 
 	readonly hiddenIcons = computed<readonly TemplateRef<unknown>[]>(() => {
-		return this.max() == null || this.max() <= 0 || this.items().length < this.max() ? [] : this.items().slice(this.max());
+		return isNil(this.max()) || this.max() <= 0 || this.items().length < this.max() ? [] : this.items().slice(this.max());
 	});
 
 	readonly visibleIcons = computed<readonly TemplateRef<unknown>[]>(() => {
-		return this.max() == null || this.max() <= 0 || this.items().length < this.max() ? this.items() : this.items().slice(0, this.hiddenCount() > 1 ? this.max() : this.max() + 1);
+		return isNil(this.max()) || this.max() <= 0 || this.items().length < this.max() ? this.items() : this.items().slice(0, this.hiddenCount() > 1 ? this.max() : this.max() + 1);
 	});
 
 	readonly hiddenCount = computed(() => this.hiddenIcons().length);

--- a/packages/ng/time/core/repeat-on-hold.directive.ts
+++ b/packages/ng/time/core/repeat-on-hold.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, OnDestroy, OnInit, output } from '@angular/core';
+import { isNil, isNotNil } from '@lucca-front/ng/core';
 
 const INITIAL_INTERVAL = 500;
 
@@ -9,7 +10,7 @@ export class RepeatOnHoldDirective implements OnDestroy, OnInit {
 	hold = output<void>();
 
 	onMouseDown = () => {
-		if (this.startTime !== undefined) {
+		if (isNotNil(this.startTime)) {
 			return;
 		}
 
@@ -46,11 +47,11 @@ export class RepeatOnHoldDirective implements OnDestroy, OnInit {
 	}
 
 	private animationFrameHandler = (time: number): void => {
-		if (this.startTime === undefined) {
+		if (isNil(this.startTime)) {
 			this.startTime = time;
 		}
 
-		if (this.previousTime === undefined) {
+		if (isNil(this.previousTime)) {
 			this.previousTime = time;
 		}
 

--- a/packages/ng/time/core/time-picker-part.component.ts
+++ b/packages/ng/time/core/time-picker-part.component.ts
@@ -1,6 +1,6 @@
 import { formatNumber } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ElementRef, Inject, LOCALE_ID, ModelSignal, booleanAttribute, computed, input, model, numberAttribute, output, viewChild } from '@angular/core';
-import { ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { FormLabelComponent } from '@lucca-front/ng/form-label';
 import { PickerControlDirection } from './misc.utils';
@@ -69,7 +69,7 @@ export class TimePickerPartComponent {
 		if (this.hideValue()) {
 			return '  ';
 		}
-		if (this.display() !== undefined) {
+		if (isNotNil(this.display())) {
 			return this.display();
 		}
 		const value = this.value();

--- a/packages/ng/user/display/user-display.pipe.ts
+++ b/packages/ng/user/display/user-display.pipe.ts
@@ -1,4 +1,5 @@
 import { inject, Pipe, PipeTransform } from '@angular/core';
+import { isNil } from '@lucca-front/ng/core';
 import { LU_DEFAULT_DISPLAY_POLICY, LuDisplayFormat, LuDisplayFullname, LuDisplayHybrid, LuDisplayInitials } from './display-format.model';
 
 function getFirstCharacter([firstCharacter]: string): string {
@@ -72,7 +73,7 @@ export class LuUserDisplayPipe implements PipeTransform {
 	public transform<T extends LuUserDisplayInput>(user: T, options?: Partial<LuUserDisplaySingleOptions>): string;
 	public transform<T extends LuUserDisplayInput>(users: T[], options?: Partial<LuUserDisplayMultipleOptions>): string;
 	public transform<T extends LuUserDisplayInput>(userOrUsers: T | T[], options?: Partial<LuUserDisplaySingleOptions> | Partial<LuUserDisplayMultipleOptions>): string {
-		if (userOrUsers == null) {
+		if (isNil(userOrUsers)) {
 			throw new Error("Parameter 'userOrUsers' must be a user or a user array");
 		}
 


### PR DESCRIPTION
## Description

This pull request standardizes the usage of `isNil` and `isNotNil` utility functions from `@lucca-front/ng/core` throughout the codebase, replacing direct `undefined` or `null` checks. This change enhances code readability and consistency when checking for nullish values. Additionally, there are minor formatting improvements in a test template.


-----


-----
