### PR TITLE
fix(department-directive): fetch count at init

### DIFF
--- a/packages/ng/core-select/department/departments.directive.spec.ts
+++ b/packages/ng/core-select/department/departments.directive.spec.ts
@@ -58,8 +58,9 @@ describe('LuCoreSelectDepartmentsDirective', () => {
 
 		TestBed.flushEffects();
 		tick();
-		httpTestingController.expectOne(url).flush(treeMock);
+		httpTestingController.expectOne((req) => req.url === url).flush(treeMock);
 
+		// 5 departments below root: Lucca France + Tech + Admin + Lucca UK + Support
 		expect(emittedCount).toBe(5);
 
 		httpTestingController.verify();
@@ -76,7 +77,7 @@ describe('LuCoreSelectDepartmentsDirective', () => {
 
 		TestBed.flushEffects();
 		tick();
-		httpTestingController.expectOne(url).flush('failure', { status: 500, statusText: 'Server Error' });
+		httpTestingController.expectOne((req) => req.url === url).flush('failure', { status: 500, statusText: 'Server Error' });
 
 		expect(emittedCount).toBe(0);
 		expect(errored).toBe(false);

--- a/packages/ng/core-select/department/departments.directive.spec.ts
+++ b/packages/ng/core-select/department/departments.directive.spec.ts
@@ -1,0 +1,67 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ALuSelectInputComponent, TreeNode } from '@lucca-front/ng/core-select';
+import { ILuDepartment } from '@lucca-front/ng/department';
+import { BehaviorSubject, ReplaySubject, Subject } from 'rxjs';
+import { LuCoreSelectDepartmentsDirective } from './departments.directive';
+
+const treeMock: TreeNode<ILuDepartment> = {
+	node: { id: 0, name: 'root' },
+	children: [
+		{
+			node: { id: 1, name: 'Lucca France' },
+			children: [
+				{ node: { id: 11, name: 'Tech' }, children: [] },
+				{ node: { id: 12, name: 'Admin' }, children: [] },
+			],
+		},
+		{ node: { id: 2, name: 'Lucca UK' }, children: [{ node: { id: 21, name: 'Support' }, children: [] }] },
+	],
+};
+
+describe('LuCoreSelectDepartmentsDirective', () => {
+	let directive: LuCoreSelectDepartmentsDirective<ILuDepartment>;
+	let selectMock: ALuSelectInputComponent<TreeNode<ILuDepartment>, unknown>;
+	let httpTestingController: HttpTestingController;
+
+	const url = '/organization/structure/api/departments/tree';
+
+	beforeEach(() => {
+		selectMock = {
+			isPanelOpen$: new BehaviorSubject(false),
+			nextPage$: new Subject<void>(),
+			clueChange$: new Subject<string>(),
+			options$: new ReplaySubject(1),
+			loading$: new BehaviorSubject(false),
+		} as ALuSelectInputComponent<TreeNode<ILuDepartment>, unknown>;
+
+		TestBed.configureTestingModule({
+			providers: [
+				LuCoreSelectDepartmentsDirective,
+				{
+					provide: ALuSelectInputComponent,
+					useValue: selectMock,
+				},
+				provideHttpClient(),
+				provideHttpClientTesting(),
+			],
+		});
+
+		directive = TestBed.inject<LuCoreSelectDepartmentsDirective<ILuDepartment>>(LuCoreSelectDepartmentsDirective);
+		httpTestingController = TestBed.inject(HttpTestingController);
+	});
+
+	it('should emit the flattened total count without opening the panel', fakeAsync(() => {
+		let emittedCount: number | undefined;
+		directive.totalCount$.subscribe((count) => (emittedCount = count));
+
+		TestBed.flushEffects();
+		tick();
+		httpTestingController.expectOne(url).flush(treeMock);
+
+		expect(emittedCount).toBe(5);
+
+		httpTestingController.verify();
+	}));
+});

--- a/packages/ng/core-select/department/departments.directive.spec.ts
+++ b/packages/ng/core-select/department/departments.directive.spec.ts
@@ -54,7 +54,7 @@ describe('LuCoreSelectDepartmentsDirective', () => {
 
 	it('should emit the flattened total count without opening the panel', fakeAsync(() => {
 		let emittedCount: number | undefined;
-		directive.totalCount$.subscribe((count) => (emittedCount = count));
+		const subscription = directive.totalCount$.subscribe((count) => (emittedCount = count));
 
 		TestBed.flushEffects();
 		tick();
@@ -63,5 +63,25 @@ describe('LuCoreSelectDepartmentsDirective', () => {
 		expect(emittedCount).toBe(5);
 
 		httpTestingController.verify();
+		subscription.unsubscribe();
+	}));
+
+	it('should emit 0 instead of erroring when the tree request fails', fakeAsync(() => {
+		let emittedCount: number | undefined;
+		let errored = false;
+		const subscription = directive.totalCount$.subscribe({
+			next: (count) => (emittedCount = count),
+			error: () => (errored = true),
+		});
+
+		TestBed.flushEffects();
+		tick();
+		httpTestingController.expectOne(url).flush('failure', { status: 500, statusText: 'Server Error' });
+
+		expect(emittedCount).toBe(0);
+		expect(errored).toBe(false);
+
+		httpTestingController.verify();
+		subscription.unsubscribe();
 	}));
 });

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -91,11 +91,17 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 		}),
 	);
 
+	// The /departments/tree endpoint does not expose a `fields.root=count`, so the total is
+	// computed with a dedicated call fetching the tree and flattening it (every department,
+	// all levels included). This is independent of getOptions (the panel options loader).
 	public totalCount$ = combineLatest([this.params$, toObservable(this.url)]).pipe(
-		switchMap(([params]) => this.getOptions(params).pipe(catchError(() => of([] as TreeNode<T>[])))),
-		map((opts) => {
-			return opts.map((branch) => this.flattenTree(branch)).flat().length;
-		}),
+		switchMap(([params, url]) =>
+			this.httpClient.get<TreeNode<T>>(url, { params }).pipe(
+				map((data) => data.children ?? []),
+				catchError(() => of([] as TreeNode<T>[])),
+			),
+		),
+		map((branches) => branches.map((branch) => this.flattenTree(branch)).flat().length),
 	);
 
 	protected flattenTree(branch: TreeNode<T>): T[] {

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -4,8 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, TreeNode } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { ILuDepartment } from '@lucca-front/ng/department';
-import { combineLatest, map, Observable, of } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { combineLatest, map, Observable, of, switchMap } from 'rxjs';
 import { NoopTreeSelectDirective } from './noop-tree-select.directive';
 
 @Directive({
@@ -92,8 +91,8 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 		}),
 	);
 
-	public totalCount$ = this.select.options$.pipe(
-		filter((opts) => opts.length > 0),
+	public totalCount$ = this.params$.pipe(
+		switchMap((params) => this.getOptions(params)),
 		map((opts) => {
 			return opts.map((branch) => this.flattenTree(branch)).flat().length;
 		}),

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -4,7 +4,7 @@ import { toObservable } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, TreeNode } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { ILuDepartment } from '@lucca-front/ng/department';
-import { combineLatest, map, Observable, of, switchMap } from 'rxjs';
+import { catchError, combineLatest, map, Observable, of, switchMap } from 'rxjs';
 import { NoopTreeSelectDirective } from './noop-tree-select.directive';
 
 @Directive({
@@ -91,8 +91,8 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 		}),
 	);
 
-	public totalCount$ = this.params$.pipe(
-		switchMap((params) => this.getOptions(params)),
+	public totalCount$ = combineLatest([this.params$, toObservable(this.url)]).pipe(
+		switchMap(([params]) => this.getOptions(params).pipe(catchError(() => of([] as TreeNode<T>[])))),
 		map((opts) => {
 			return opts.map((branch) => this.flattenTree(branch)).flat().length;
 		}),


### PR DESCRIPTION
## Description

`[departments]`'s `totalCount$` is now fetched at init by fetching the tree via `params$` + `getOptions`, so the count is available right away.

-----

### Why

When combining `[departments]` with `[withSelectAll]` on a `lu-multi-select`, the chip displayed **"NaN"** on init.

In `exclude` mode, the counter computes `totalCount() - valuesCount()`. But the `[departments]` directive's `totalCount$` relied on `select.options$`, which is only loaded **when the dropdown opens** (lazy loading). As long as the panel stayed closed, `totalCount()` was `undefined` → `undefined - n = NaN`.

-----

close LCM-1898

CF : https://github.com/LuccaSA/lucca-front/pull/5073