### PR TITLE
tech(schematics): add switch sizes for fileUpload in deprecated-resolver schematics

### DIFF
--- a/packages/ng/schematics/deprecated-resolver/index.ts
+++ b/packages/ng/schematics/deprecated-resolver/index.ts
@@ -64,7 +64,10 @@ export default (options: SchematicContextOpts): Rule => {
 				'lu-divider': { withRole: '' },
 				'button': { delete: 'critical' },
 				'lu-loading': { type: { fullpage: 'fullPage' } },
-				'lu-single-file-upload': { illustration: { paper: 'invoice' } },
+				'lu-single-file-upload': { illustration: { paper: 'invoice' }, size: { 'S': 'L' } },
+				'lu-multi-file-upload': { size: { 'S': 'L' } },
+				'lu-file-entry': { size: { 'S': 'L' } },
+				'lu-file-dropzone': { size: { 'S': 'L' } },
 				'lu-highlight-data': { icon: { 'manifying-glass': 'magnifying-glass' } },
 			},
 		}).run();

--- a/packages/ng/schematics/deprecated-resolver/tests/template.input.html
+++ b/packages/ng/schematics/deprecated-resolver/tests/template.input.html
@@ -4,7 +4,8 @@
 <button luButton delete>Supprimer</button>
 <lu-loading type="fullpage"></lu-loading>
 <lu-loading [type]="'fullpage'"></lu-loading>
-<lu-single-file-upload illustration="paper"></lu-single-file-upload>
-<lu-single-file-upload [illustration]="'paper'"></lu-single-file-upload>
+<lu-single-file-upload illustration="paper" size="S"></lu-single-file-upload>
+<lu-single-file-upload [illustration]="'paper'" [size]="'S'"></lu-single-file-upload>
 <lu-highlight-data icon="manifying-glass"></lu-highlight-data>
 <lu-highlight-data [icon]="'manifying-glass'"></lu-highlight-data>
+<lu-file-entry size="S" />

--- a/packages/ng/schematics/deprecated-resolver/tests/template.output.html
+++ b/packages/ng/schematics/deprecated-resolver/tests/template.output.html
@@ -4,7 +4,8 @@
 <button luButton critical>Supprimer</button>
 <lu-loading type="fullPage"></lu-loading>
 <lu-loading [type]="'fullPage'"></lu-loading>
-<lu-single-file-upload illustration="invoice"></lu-single-file-upload>
-<lu-single-file-upload [illustration]="'invoice'"></lu-single-file-upload>
+<lu-single-file-upload illustration="invoice" size="L"></lu-single-file-upload>
+<lu-single-file-upload [illustration]="'invoice'" [size]="'L'"></lu-single-file-upload>
 <lu-highlight-data icon="magnifying-glass"></lu-highlight-data>
 <lu-highlight-data [icon]="'magnifying-glass'"></lu-highlight-data>
+<lu-file-entry size="L" />


### PR DESCRIPTION
## Description

This pull request updates the deprecated resolver schematic to handle the `size` property for several file upload and entry components, ensuring that a `size` value of `'S'` is migrated to `'L'`. It also updates the test templates to reflect these changes.

**Migration logic improvements:**

* Updated the resolver logic in `index.ts` to map the `size` property from `'S'` to `'L'` for `lu-single-file-upload`, `lu-multi-file-upload`, `lu-file-entry`, and `lu-file-dropzone` components.


-----


-----
