### PR TITLE
fix(e2e): test consistency

### DIFF
--- a/stories/documentation/forms/fields/checkbox/angular/checkbox-field.stories.ts
+++ b/stories/documentation/forms/fields/checkbox/angular/checkbox-field.stories.ts
@@ -5,7 +5,7 @@ import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular';
 import { cleanupTemplate, createTestStory, generateInputs, setStoryOptions } from 'stories/helpers/stories';
-import { sleep, waitForAngular } from 'stories/helpers/test';
+import { waitForAngular } from 'stories/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 import { StoryModelDisplayComponent } from 'stories/helpers/story-model-display.component';
 
@@ -127,7 +127,7 @@ export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) 
 	await step('Interaction souris - cocher', async () => {
 		const checkbox = canvas.getByRole('checkbox');
 		await userEvent.click(checkbox);
-		await sleep(200);
+		await waitForAngular();
 		await expect(checkbox).toBeChecked();
 	});
 

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -240,7 +240,7 @@ export const SelectAllTEST = createTestStory(SelectAll, async (context) => {
 	await userEvent.click(input);
 	await waitForAngular();
 	const panel = within(screen.getByRole('listbox'));
-	const selectAllCheckbox = panel.getByLabelText('Tout sélectionner');
+	const selectAllCheckbox = await panel.findByLabelText('Tout sélectionner');
 	await userEvent.click(selectAllCheckbox);
 	await waitForAngular();
 	const options = await panel.findAllByRole('option').then((opts) => opts.filter((el) => !el.id.includes('select-all')));
@@ -248,18 +248,14 @@ export const SelectAllTEST = createTestStory(SelectAll, async (context) => {
 	await userEvent.keyboard('{Escape}');
 	await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
 	await waitForAngular();
-	await waitFor(async () => {
-		await checkValues(input, optionValues);
-	});
+	await waitFor(() => checkValues(input, optionValues));
 	await context.step('Select all keyboard interactions', async () => {
 		input.focus();
 		await userEvent.keyboard('{ArrowDown}');
 		await waitForAngular();
 		await userEvent.keyboard('{Enter}');
 		await waitForAngular();
-		await waitFor(async () => {
-			await checkValues(input, []);
-		});
+		await waitFor(() => checkValues(input, []));
 	});
 });
 

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -24,7 +24,7 @@ import { LuUserDisplayPipe, LuUserPictureComponent } from '@lucca-front/ng/user'
 import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular';
 import { HiddenArgType } from 'stories/helpers/common-arg-types';
 import { createTestStory, getStoryGenerator, useDocumentationStory } from 'stories/helpers/stories';
-import { expect, screen, userEvent, within } from 'storybook/test';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 import { waitForAngular } from '../../../helpers/test';
 import { LuCoreSelectLegumesDirective } from './custom-api-example.component';
 import { LuCoreSelectCustomEstablishmentsDirective } from './custom-establishment-example.component';
@@ -71,7 +71,7 @@ const basePlay = async ({ canvasElement, step }) => {
 		await expect(screen.getByRole('listbox')).toBeVisible();
 		await userEvent.keyboard('{Escape}');
 		await waitForAngular();
-		await expect(screen.queryByText('listbox')).toBeNull();
+		await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
 		await expect(input).toHaveFocus();
 		// await userEvent.keyboard('{Space}');
 		// await waitForAngular();
@@ -685,9 +685,10 @@ export const AddOptionTEST = createTestStory(AddOption, async (context) => {
 	await waitForAngular();
 	await expect(screen.getByRole('listbox')).toBeVisible();
 	const panel = within(screen.getByRole('listbox').parentElement);
-	const addOptionButton = panel.getByRole('option', { name: /ajouter un /i });
+	const addOptionButton = await panel.findByRole('option', { name: /ajouter un /i });
 	await userEvent.click(addOptionButton);
-	await expect(+count.innerText).toBe(previousTotal + 1);
+	await waitForAngular();
+	await waitFor(() => expect(+count.innerText).toBe(previousTotal + 1));
 });
 
 export const CustomPanelHeader = generateStory({


### PR DESCRIPTION
## Description

Fix multi-select, simple-select, checkbox e2e tests.

`findByLabelText` waits for the element to become available.

Avoid sleep. Use waitForAngula().

`waitFor` accepts a function that returns a Promise and handles it properly, which preserves the retry mechanism while avoiding the issue of uncaught asynchronous rejections.

-----


-----
