### PR TITLE
tech(select): handle data source

### DIFF
--- a/packages/ng/core-select/api/api-v3.directive.spec.ts
+++ b/packages/ng/core-select/api/api-v3.directive.spec.ts
@@ -1,6 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ILuApiItem } from '@lucca-front/ng/api';
 import { ALuSelectInputComponent, SelectDataSource, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey } from '@lucca-front/ng/core-select';
@@ -41,7 +41,7 @@ describe('CoreSelectApiV3Directive', () => {
 			clueChange$: new Subject<string>(),
 			optionComparer: coreSelectDefaultOptionComparer,
 			optionKey: coreSelectDefaultOptionKey,
-			options: [],
+			options: signal([]),
 			dataSource: {
 				set: (ds: SelectDataSource<ILuApiItem>) => {
 					capturedDataSource = ds;
@@ -96,7 +96,8 @@ describe('CoreSelectApiV3Directive', () => {
 		tick(MAGIC_DEBOUNCE_DURATION);
 
 		// Act (Page 1)
-		capturedDataSource!.getOptions({ clue: '', page: 0 }).subscribe();
+		let page0Items: readonly ILuApiItem[] = [];
+		capturedDataSource!.getOptions({ clue: '', page: 0 }).subscribe((items) => (page0Items = items));
 		tick();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=0,20').flush({
 			data: { items: itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE) },
@@ -104,7 +105,8 @@ describe('CoreSelectApiV3Directive', () => {
 		tick();
 
 		// Act (Page 2)
-		capturedDataSource!.getOptions({ clue: '', page: 1 }).subscribe();
+		let page1Items: readonly ILuApiItem[] = [];
+		capturedDataSource!.getOptions({ clue: '', page: 1 }).subscribe((items) => (page1Items = items));
 
 		// Assert
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
@@ -112,7 +114,7 @@ describe('CoreSelectApiV3Directive', () => {
 		});
 		tick();
 
-		expect(selectMock.options()).toEqual(itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE * 2));
+		expect([...page0Items, ...page1Items]).toEqual(itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE * 2));
 	}));
 
 	it('should reset page when clue changes', fakeAsync(() => {
@@ -138,13 +140,14 @@ describe('CoreSelectApiV3Directive', () => {
 		tick(MAGIC_DEBOUNCE_DURATION);
 
 		// Assert — new query with clue, page 0
-		capturedDataSource!.getOptions({ clue: 'bob', page: 0 }).subscribe();
+		let bobItems: readonly ILuApiItem[] = [];
+		capturedDataSource!.getOptions({ clue: 'bob', page: 0 }).subscribe((items) => (bobItems = items));
 		tick();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&name=like,bob&paging=0,20').flush({
 			data: { items: itemsMocks.slice(0, 5) },
 		});
 		tick();
 
-		expect(selectMock.options()).toEqual(itemsMocks.slice(0, 5));
+		expect(bobItems).toEqual(itemsMocks.slice(0, 5));
 	}));
 });

--- a/packages/ng/core-select/api/api-v3.directive.spec.ts
+++ b/packages/ng/core-select/api/api-v3.directive.spec.ts
@@ -1,9 +1,9 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ILuApiItem } from '@lucca-front/ng/api';
-import { ALuSelectInputComponent, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey } from '@lucca-front/ng/core-select';
+import { ALuSelectInputComponent, SelectDataSource, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey } from '@lucca-front/ng/core-select';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { BehaviorSubject, Subject } from 'rxjs';
 import { LuCoreSelectApiV3Directive } from './api-v3.directive';
@@ -31,17 +31,25 @@ describe('CoreSelectApiV3Directive', () => {
 	let selectMock: LuSimpleSelectInputComponent<ILuApiItem>;
 	let httpTestingController: HttpTestingController;
 	let fixture: ComponentFixture<TestHostComponent>;
+	let capturedDataSource: SelectDataSource<ILuApiItem> | undefined;
 
 	beforeEach(() => {
+		capturedDataSource = undefined;
 		selectMock = {
 			isPanelOpen$: new BehaviorSubject(false),
 			nextPage$: new Subject<void>(),
 			clueChange$: new Subject<string>(),
-			loading$: new BehaviorSubject(false),
-			optionComparer: signal(coreSelectDefaultOptionComparer),
-			optionKey: signal(coreSelectDefaultOptionKey),
-			options: signal([]),
-			loading: signal(false),
+			optionComparer: coreSelectDefaultOptionComparer,
+			optionKey: coreSelectDefaultOptionKey,
+			options: [],
+			dataSource: {
+				set: (ds: SelectDataSource<ILuApiItem>) => {
+					capturedDataSource = ds;
+				},
+			},
+			loading: {
+				set: (_v: boolean) => {},
+			},
 		} as unknown as LuSimpleSelectInputComponent<ILuApiItem>;
 
 		TestBed.configureTestingModule({
@@ -69,34 +77,34 @@ describe('CoreSelectApiV3Directive', () => {
 		httpTestingController.verify();
 	}));
 
-	it('should call http.get on open', fakeAsync(() => {
+	it('should call http.get when getOptions is called', fakeAsync(() => {
 		// Arrange
 		fixture.detectChanges();
 		tick(MAGIC_DEBOUNCE_DURATION);
 
-		// Act
-		selectMock.isPanelOpen$.next(true);
+		// Act — simulate select component calling getOptions
+		capturedDataSource!.getOptions({ clue: '', page: 0 }).subscribe();
 		tick(MAGIC_DEBOUNCE_DURATION);
 
 		// Assert
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=0,20');
 	}));
 
-	it('should call http.get when page changes and aggregate options', fakeAsync(() => {
+	it('should call http.get for next page when getOptions is called with page 1', fakeAsync(() => {
 		// Arrange
 		fixture.detectChanges();
 		tick(MAGIC_DEBOUNCE_DURATION);
-		selectMock.isPanelOpen$.next(true);
-		tick(MAGIC_DEBOUNCE_DURATION);
 
+		// Act (Page 1)
+		capturedDataSource!.getOptions({ clue: '', page: 0 }).subscribe();
+		tick();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=0,20').flush({
 			data: { items: itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE) },
 		});
 		tick();
 
-		// Act
-		selectMock.nextPage$.next();
-		tick();
+		// Act (Page 2)
+		capturedDataSource!.getOptions({ clue: '', page: 1 }).subscribe();
 
 		// Assert
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
@@ -107,30 +115,31 @@ describe('CoreSelectApiV3Directive', () => {
 		expect(selectMock.options()).toEqual(itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE * 2));
 	}));
 
-	it('should call http.get when clue changes and reset options and page', fakeAsync(() => {
+	it('should reset page when clue changes', fakeAsync(() => {
 		// Arrange
 		fixture.detectChanges();
 		tick(MAGIC_DEBOUNCE_DURATION);
-		selectMock.isPanelOpen$.next(true);
-		tick(MAGIC_DEBOUNCE_DURATION);
 
+		capturedDataSource!.getOptions({ clue: '', page: 0 }).subscribe();
+		tick();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=0,20').flush({
 			data: { items: itemsMocks.slice(0, LU_SELECT_MAGIC_PAGE_SIZE) },
 		});
 		tick();
 
-		selectMock.nextPage$.next();
-		tick();
+		capturedDataSource!.getOptions({ clue: '', page: 1 }).subscribe();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&paging=20,20').flush({
 			data: { items: itemsMocks.slice(LU_SELECT_MAGIC_PAGE_SIZE, LU_SELECT_MAGIC_PAGE_SIZE * 2) },
 		});
 		tick();
 
-		// Act
+		// Act — clue changes (triggers reset via clueChange$ subscription in directive)
 		selectMock.clueChange$.next('bob');
 		tick(MAGIC_DEBOUNCE_DURATION);
 
-		// Assert
+		// Assert — new query with clue, page 0
+		capturedDataSource!.getOptions({ clue: 'bob', page: 0 }).subscribe();
+		tick();
 		httpTestingController.expectOne('/api/v3/axisSections?fields=id,name&orderBy=name,asc&name=like,bob&paging=0,20').flush({
 			data: { items: itemsMocks.slice(0, 5) },
 		});

--- a/packages/ng/core-select/api/api-v3.directive.spec.ts
+++ b/packages/ng/core-select/api/api-v3.directive.spec.ts
@@ -1,6 +1,6 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
-import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { ILuApiItem } from '@lucca-front/ng/api';
 import { ALuSelectInputComponent, SelectDataSource, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey } from '@lucca-front/ng/core-select';
@@ -41,7 +41,6 @@ describe('CoreSelectApiV3Directive', () => {
 			clueChange$: new Subject<string>(),
 			optionComparer: coreSelectDefaultOptionComparer,
 			optionKey: coreSelectDefaultOptionKey,
-			options: signal([]),
 			dataSource: {
 				set: (ds: SelectDataSource<ILuApiItem>) => {
 					capturedDataSource = ds;

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Directive } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
-import { Observable, map, of } from 'rxjs';
+import { NEVER, Observable, map, of } from 'rxjs';
 import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { ALuCoreSelectApiDirective, MAGIC_DEBOUNCE_DURATION } from './api.directive';
 
@@ -16,6 +16,8 @@ interface TestEntity {
 	selector: 'lu-simple-select[testApi]',
 })
 class TestDirective extends ALuCoreSelectApiDirective<TestEntity> {
+	public override totalCount$ = NEVER;
+
 	protected override readonly params$ = this.clue$.pipe(
 		map((clue) => ({
 			...(clue ? { clue } : {}),
@@ -166,8 +168,8 @@ describe('ALuCoreSelectApiDirective', () => {
 		expect(testApi.getOptions).toHaveBeenCalledTimes(3);
 
 		let options: readonly TestEntity[] = [];
-		fixture.detectChanges();
-		select.options$.subscribe((o) => (options = o));
+
+		options = select.dataSourceOptions();
 
 		expect(options).toEqual([
 			{ id: 1, name: 'test 1' },
@@ -212,8 +214,7 @@ describe('ALuCoreSelectApiDirective', () => {
 
 		// Assert
 		let options: readonly TestEntity[] = [];
-		fixture.detectChanges();
-		select.options$.subscribe((o) => (options = o));
+		options = select.dataSourceOptions();
 		expect(options).toEqual([
 			{ id: 1, name: 'test 1' },
 			{ id: 2, name: 'test 2' },

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, inject, OnDestroy, OnInit } from '@angular/core';
-import { ALuSelectInputComponent, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey, LuOptionComparer } from '@lucca-front/ng/core-select';
-import { catchError, combineLatest, concatMap, debounceTime, distinctUntilChanged, map, merge, Observable, of, pairwise, scan, startWith, Subject, switchMap, takeUntil, tap } from 'rxjs';
+import { ALuSelectInputComponent, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey, LuOptionComparer, SelectDataSource } from '@lucca-front/ng/core-select';
+import { catchError, combineLatest, concatMap, debounceTime, distinctUntilChanged, map, merge, Observable, of, pairwise, scan, startWith, Subject, switchMap, take, takeUntil, tap } from 'rxjs';
 
 export const LU_SELECT_MAGIC_PAGE_SIZE = 20;
 export const MAGIC_DEBOUNCE_DURATION = 250;
@@ -49,10 +49,23 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 			this.select.optionKey.set(this.optionKey);
 		}
 
-		this.buildOptions()
-			.pipe(takeUntil(this.destroy$))
-			.subscribe((options) => this.select.options.set(options));
+		const dataSource: SelectDataSource<TOption> = {
+			paramsChange: this.params$,
+			getTotalCount: () => this.totalCount$,
+			getOptions: ({ page }) =>
+				this.params$.pipe(
+					take(1),
+					switchMap((params) => this.getOptions(params, page)),
+				),
+		};
+
+		// this.buildOptions()
+		// 	.pipe(takeUntil(this.destroy$))
+		// 	.subscribe((options) => (this.select.options = options));
+		this.select.dataSource.set(dataSource);
 	}
+
+	public abstract totalCount$: Observable<number>;
 
 	protected buildOptions(): Observable<TOption[]> {
 		// Prevent a double call to getOptions when the clue is changed while the panel is closed
@@ -102,11 +115,8 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	}
 
 	protected getOptionsPage(params: TParams, page: number): Observable<{ items: TOption[]; isLastPage: boolean }> {
-		this.select.loading.set(true);
-
 		return this.getOptions(params, page).pipe(
 			catchError(() => of([] as TOption[])),
-			tap(() => this.select.loading.set(false)),
 			map((items) => ({ items, isLastPage: items.length < this.pageSize })),
 		);
 	}

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -1,6 +1,25 @@
 import { Directive, inject, OnDestroy, OnInit } from '@angular/core';
 import { ALuSelectInputComponent, coreSelectDefaultOptionComparer, coreSelectDefaultOptionKey, LuOptionComparer, SelectDataSource } from '@lucca-front/ng/core-select';
-import { catchError, combineLatest, concatMap, debounceTime, distinctUntilChanged, map, merge, Observable, of, pairwise, scan, startWith, Subject, switchMap, take, takeUntil, tap } from 'rxjs';
+import {
+	BehaviorSubject,
+	catchError,
+	combineLatest,
+	concatMap,
+	debounceTime,
+	distinctUntilChanged,
+	map,
+	merge,
+	Observable,
+	of,
+	pairwise,
+	scan,
+	startWith,
+	Subject,
+	switchMap,
+	take,
+	takeUntil,
+	tap,
+} from 'rxjs';
 
 export const LU_SELECT_MAGIC_PAGE_SIZE = 20;
 export const MAGIC_DEBOUNCE_DURATION = 250;
@@ -18,7 +37,16 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 		startWith(0),
 	);
 
-	protected readonly clue$ = this.select.clueChange$.pipe(debounceTime(this.debounceDuration), startWith(''));
+	/**
+	 * Current clue — updated by clueChange$ subscription (keeps select in searchable mode)
+	 * and by direct getOptions calls from the select component.
+	 */
+	protected readonly currentClue$ = new BehaviorSubject<string>('');
+
+	/**
+	 * Clue observable — no debounce (debounce is now handled by the select component).
+	 */
+	protected readonly clue$ = this.currentClue$.asObservable();
 
 	/**
 	 * Create an object that will be used as params for the api call
@@ -40,6 +68,8 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	 */
 	protected abstract getOptions(params: TParams, page: number): Observable<TOption[]>;
 
+	readonly #lastPageByClue = new Map<string, number>();
+
 	public ngOnInit(): void {
 		if (this.select.optionComparer() === coreSelectDefaultOptionComparer) {
 			this.select.optionComparer.set(this.optionComparer);
@@ -49,20 +79,44 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 			this.select.optionKey.set(this.optionKey);
 		}
 
+		// Subscribe to clueChange$ to (1) keep the select in searchable mode and (2) drive currentClue$
+		this.select.clueChange$.pipe(takeUntil(this.destroy$)).subscribe((clue) => {
+			this.currentClue$.next(clue);
+			this.#lastPageByClue.clear();
+		});
+
 		const dataSource: SelectDataSource<TOption> = {
 			paramsChange: this.params$,
+			clueDebounceMs: this.debounceDuration,
 			getTotalCount: () => this.totalCount$,
-			getOptions: ({ page }) =>
-				this.params$.pipe(
+			reset: () => this.#lastPageByClue.clear(),
+			getOptions: ({ clue, page }) => {
+				const lastPage = this.#lastPageByClue.get(clue);
+				if (lastPage !== undefined && page > lastPage) {
+					return of([] as readonly TOption[]);
+				}
+				return this.buildParamsFromClue(clue).pipe(
 					take(1),
-					switchMap((params) => this.getOptions(params, page)),
-				),
+					switchMap((params) =>
+						this.getOptionsPage(params, page).pipe(
+							tap(({ isLastPage }) => {
+								if (isLastPage) {
+									this.#lastPageByClue.set(clue, page);
+								}
+							}),
+							map(({ items }) => items as readonly TOption[]),
+						),
+					),
+				);
+			},
 		};
 
-		// this.buildOptions()
-		// 	.pipe(takeUntil(this.destroy$))
-		// 	.subscribe((options) => (this.select.options = options));
 		this.select.dataSource.set(dataSource);
+	}
+
+	protected buildParamsFromClue(clue: string): Observable<TParams> {
+		this.currentClue$.next(clue);
+		return this.params$.pipe(take(1));
 	}
 
 	public abstract totalCount$: Observable<number>;

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -68,7 +68,8 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	 */
 	protected abstract getOptions(params: TParams, page: number): Observable<TOption[]>;
 
-	readonly #lastPageByClue = new Map<string, number>();
+	#lastClue?: string;
+	#lastPage?: number;
 
 	public ngOnInit(): void {
 		if (this.select.optionComparer() === coreSelectDefaultOptionComparer) {
@@ -82,16 +83,16 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 		// Subscribe to clueChange$ to (1) keep the select in searchable mode and (2) drive currentClue$
 		this.select.clueChange$.pipe(takeUntil(this.destroy$)).subscribe((clue) => {
 			this.currentClue$.next(clue);
-			this.#lastPageByClue.clear();
+			this.clearLastPageByClue();
 		});
 
 		const dataSource: SelectDataSource<TOption> = {
 			paramsChange: this.params$,
 			clueDebounceMs: this.debounceDuration,
 			getTotalCount: () => this.totalCount$,
-			reset: () => this.#lastPageByClue.clear(),
+			reset: () => this.clearLastPageByClue(),
 			getOptions: ({ clue, page }) => {
-				const lastPage = this.#lastPageByClue.get(clue);
+				const lastPage = clue === this.#lastClue ? this.#lastPage : undefined;
 				if (lastPage !== undefined && page > lastPage) {
 					return of([] as readonly TOption[]);
 				}
@@ -101,7 +102,8 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 						this.getOptionsPage(params, page).pipe(
 							tap(({ isLastPage }) => {
 								if (isLastPage) {
-									this.#lastPageByClue.set(clue, page);
+									this.#lastClue = clue;
+									this.#lastPage = page;
 								}
 							}),
 							map(({ items }) => items as readonly TOption[]),
@@ -166,6 +168,11 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 					: of([] as TOption[]);
 			}),
 		);
+	}
+
+	protected clearLastPageByClue() {
+		this.#lastClue = undefined;
+		this.#lastPage = undefined;
 	}
 
 	protected getOptionsPage(params: TParams, page: number): Observable<{ items: TOption[]; isLastPage: boolean }> {

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -64,7 +64,7 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 			);
 	}
 
-	trim(options: TreeNode<T>[], clue: string): TreeNode<T>[] {
+	trim(options: readonly TreeNode<T>[], clue: string): TreeNode<T>[] {
 		return options
 			.map((option) => {
 				if (option.node.name.toLowerCase().includes(clue.toLowerCase())) {
@@ -93,7 +93,7 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 		}),
 	);
 
-	public readonly totalCount$ = this.select.options$.pipe(
+	public readonly totalCount$ = toObservable(this.select.dataSourceOptions).pipe(
 		filter((opts) => opts.length > 0),
 		map((opts) => {
 			return opts.map((branch) => this.flattenTree(branch)).flat().length;

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -42,6 +42,7 @@ import {
 	takeUntil,
 	takeWhile,
 	tap,
+	timer,
 } from 'rxjs';
 import { LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
@@ -200,7 +201,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	treeGenerator?: TreeGenerator<TOption, TreeNode<TOption>>;
 
 	readonly clueChange$ = new Subject<string>();
-	clueChange = outputFromObservable(this.clueChange$);
+	readonly clueChange = output<string>();
 	readonly nextPage$ = new Subject<void>();
 	nextPage = outputFromObservable(this.nextPage$);
 	readonly addOption = output<string>();
@@ -231,6 +232,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 			this.openPanel(clue);
 		} else if (this.lastEmittedClue !== clue) {
 			this.clueChange$.next(clue);
+			this.clueChange.emit(clue);
 			this.lastEmittedClue = clue;
 		}
 	}
@@ -408,6 +410,11 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 			distinctUntilChanged(),
 		);
 
+		// If a debounce is specified:
+		// - empty clue ('' ) passes through immediately (initial state / clear)
+		// - non-empty clue is debounced (user is typing)
+		const debouncedClue$ = ds.clueDebounceMs ? clue$.pipe(switchMap((clue) => (clue ? timer(ds.clueDebounceMs!).pipe(map(() => clue)) : of(clue)))) : clue$;
+
 		return this.isPanelOpen$.pipe(
 			distinctUntilChanged(),
 			switchMap((isOpen) => {
@@ -415,7 +422,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 					return of([] as readonly TOption[]);
 				}
 
-				return clue$.pipe(
+				return debouncedClue$.pipe(
 					switchMap((clue) =>
 						page$.pipe(
 							concatMap((page) => {
@@ -480,10 +487,11 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 				return;
 			}
 
+			const isSearchable = this.searchable;
 			this.isPanelOpen$.next(true);
 			this.panelOpened.emit();
 
-			if (this.searchable) {
+			if (isSearchable) {
 				this.clueChanged(clue);
 			}
 

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -422,8 +422,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 				}
 
 				return debouncedClue$.pipe(
-					switchMap((clue) =>
-						page$.pipe(
+					switchMap((clue) => {
+						ds.reset?.();
+						return page$.pipe(
 							concatMap((page) => {
 								this.loading.set(true);
 								return ds.getOptions({ clue, page }).pipe(
@@ -450,8 +451,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 							}),
 							map((pages) => Object.values(pages).flat()),
 							finalize(() => this.loading.set(false)), // Avoid infinite loading on complete API or error
-						),
-					),
+						);
+					}),
 				);
 			}),
 		);

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -25,12 +25,12 @@ import { ControlValueAccessor } from '@angular/forms';
 import { isNotNil, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
 import { BehaviorSubject, defer, finalize, map, of, ReplaySubject, startWith, Subject, switchMap, takeUntil, tap } from 'rxjs';
-import { buildOptionsFromDataSource } from './select-input.utils';
 import { LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
 import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, LuOptionGrouping, SELECT_LABEL, SELECT_LABEL_ID, SelectDataSource, SelectDataSourceParams } from '../select.model';
 import { LuCoreSelectLabel } from '../select.translate';
 import { TreeNode } from './model';
+import { buildOptionsFromDataSource } from './select-input.utils';
 import { TreeGenerator } from './tree-generator';
 
 export const coreSelectDefaultOptionComparer: LuOptionComparer<unknown> = (option1, option2) => JSON.stringify(option1) === JSON.stringify(option2);
@@ -287,26 +287,31 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	protected readonly destroyed$ = new Subject<void>();
 
+	private readonly injector = inject(Injector);
+
 	constructor() {
 		if (this.filterPillHost) {
 			this.filterPillHost.registerInput(this);
 		}
 
-		ɵeffectWithDeps([this.options], (options, onCleanup) => {
+		ɵeffectWithDeps([this.options], (options) => {
 			if (isNotNil(options)) {
 				this.manualOptions$.next(options);
-				if (this.panelRef) {
-					const ref = afterNextRender(
-						() => {
-							this.panelRef?.updatePosition();
-							this.updatePositionFn?.();
-							// If no fixes are found, last resort fix is here
-							// window.dispatchEvent(new Event('resize'));
-						},
-						{ injector: this.#injector },
-					);
-					onCleanup(() => ref.destroy());
-				}
+			}
+		});
+
+		// When options arrive asynchronously via a dataSource, dataSourceOptions changes but options doesn't.
+		// We need to reposition the panel after the DOM updates in both cases.
+		ɵeffectWithDeps([this.dataSourceOptions], (_options, onCleanup) => {
+			if (isNotNil(this.panelRef)) {
+				const ref = afterNextRender(
+					() => {
+						this.panelRef?.updatePosition();
+						this.updatePositionFn?.();
+					},
+					{ injector: this.injector },
+				);
+				onCleanup(() => ref.destroy());
 			}
 		});
 	}

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -201,7 +201,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	treeGenerator?: TreeGenerator<TOption, TreeNode<TOption>>;
 
 	readonly clueChange$ = new Subject<string>();
-	readonly clueChange = output<string>();
+	clueChange = outputFromObservable(this.clueChange$);
 	readonly nextPage$ = new Subject<void>();
 	nextPage = outputFromObservable(this.nextPage$);
 	readonly addOption = output<string>();
@@ -232,7 +232,6 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 			this.openPanel(clue);
 		} else if (this.lastEmittedClue !== clue) {
 			this.clueChange$.next(clue);
-			this.clueChange.emit(clue);
 			this.lastEmittedClue = clue;
 		}
 	}

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -24,26 +24,8 @@ import { outputFromObservable, toObservable, toSignal } from '@angular/core/rxjs
 import { ControlValueAccessor } from '@angular/forms';
 import { isNotNil, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
-import {
-	BehaviorSubject,
-	catchError,
-	concatMap,
-	defer,
-	distinctUntilChanged,
-	finalize,
-	map,
-	Observable,
-	of,
-	ReplaySubject,
-	scan,
-	startWith,
-	Subject,
-	switchMap,
-	takeUntil,
-	takeWhile,
-	tap,
-	timer,
-} from 'rxjs';
+import { BehaviorSubject, defer, finalize, map, of, ReplaySubject, startWith, Subject, switchMap, takeUntil, tap } from 'rxjs';
+import { buildOptionsFromDataSource } from './select-input.utils';
 import { LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
 import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, LuOptionGrouping, SELECT_LABEL, SELECT_LABEL_ID, SelectDataSource, SelectDataSourceParams } from '../select.model';
@@ -259,7 +241,19 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	readonly dataSource = model<SelectDataSource<TOption, unknown>>(this.getDefaultDataSource());
 
-	readonly dataSourceOptions = toSignal(toObservable(this.dataSource).pipe(switchMap((ds) => this.#buildOptionsFromDataSource(ds))), { initialValue: [] as readonly TOption[] });
+	readonly dataSourceOptions = toSignal(
+		toObservable(this.dataSource).pipe(
+			switchMap((ds) =>
+				buildOptionsFromDataSource(ds, {
+					nextPage$: this.nextPage$,
+					clue$: this.clue$,
+					isPanelOpen$: this.isPanelOpen$,
+					setLoading: (v) => this.loading.set(v),
+				}),
+			),
+		),
+		{ initialValue: [] as readonly TOption[] },
+	);
 	clue: string | null = null;
 	// This is the clue stored after we selected an option to know if we should emit an empty clue on open or not
 	lastEmittedClue: string = '';
@@ -396,66 +390,6 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		if (this.labelElement) {
 			this.labelElement.id = this.labelId;
 		}
-	}
-
-	#buildOptionsFromDataSource(ds: SelectDataSource<TOption>): Observable<readonly TOption[]> {
-		const page$ = this.nextPage$.pipe(
-			scan((page) => page + 1, 0),
-			startWith(0),
-		);
-
-		const clue$ = this.clue$.pipe(
-			map((clue) => clue ?? ''),
-			distinctUntilChanged(),
-		);
-
-		// If a debounce is specified:
-		// - empty clue ('' ) passes through immediately (initial state / clear)
-		// - non-empty clue is debounced (user is typing)
-		const debouncedClue$ = ds.clueDebounceMs ? clue$.pipe(switchMap((clue) => (clue ? timer(ds.clueDebounceMs!).pipe(map(() => clue)) : of(clue)))) : clue$;
-
-		return this.isPanelOpen$.pipe(
-			distinctUntilChanged(),
-			switchMap((isOpen) => {
-				if (!isOpen) {
-					return of([] as readonly TOption[]);
-				}
-
-				return debouncedClue$.pipe(
-					switchMap((clue) => {
-						ds.reset?.();
-						return page$.pipe(
-							concatMap((page) => {
-								this.loading.set(true);
-								return ds.getOptions({ clue, page }).pipe(
-									catchError(() => of([] as readonly TOption[])),
-									tap(() => this.loading.set(false)),
-									startWith([] as readonly TOption[]),
-									map((items) => ({ items, page })),
-								);
-							}),
-							scan(
-								(acc, { items, page }) => {
-									acc[page] = items;
-									return acc;
-								},
-								{} as Record<number, readonly TOption[]>,
-							),
-							// Stop calling pages when last two pages are empty
-							takeWhile((pages) => {
-								const indexes = Object.keys(pages)
-									.map((p) => parseInt(p))
-									.sort((a, b) => a - b);
-								const lastIndexes = indexes.slice(-2);
-								return lastIndexes.length < 2 || !lastIndexes.every((i) => pages[i]?.length === 0);
-							}),
-							map((pages) => Object.values(pages).flat()),
-							finalize(() => this.loading.set(false)), // Avoid infinite loading on complete API or error
-						);
-					}),
-				);
-			}),
-		);
 	}
 
 	clearValue(event?: Event): void {

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -6,7 +6,6 @@ import {
 	computed,
 	Directive,
 	ElementRef,
-	EventEmitter,
 	inject,
 	Injector,
 	input,
@@ -25,10 +24,28 @@ import { outputFromObservable, toObservable, toSignal } from '@angular/core/rxjs
 import { ControlValueAccessor } from '@angular/forms';
 import { isNotNil, PortalContent, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { FILTER_PILL_HOST_COMPONENT, FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '@lucca-front/ng/filter-pills';
-import { BehaviorSubject, defer, map, Observable, of, ReplaySubject, startWith, Subject, switchMap, take } from 'rxjs';
+import {
+	BehaviorSubject,
+	catchError,
+	concatMap,
+	defer,
+	distinctUntilChanged,
+	finalize,
+	map,
+	Observable,
+	of,
+	ReplaySubject,
+	scan,
+	startWith,
+	Subject,
+	switchMap,
+	takeUntil,
+	takeWhile,
+	tap,
+} from 'rxjs';
 import { LuSimpleSelectDefaultOptionComponent } from '../option';
 import { LuSelectPanelRef } from '../panel';
-import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, LuOptionGrouping, SELECT_LABEL, SELECT_LABEL_ID } from '../select.model';
+import { CoreSelectAddOptionStrategy, LuOptionComparer, LuOptionContext, LuOptionGrouping, SELECT_LABEL, SELECT_LABEL_ID, SelectDataSource, SelectDataSourceParams } from '../select.model';
 import { LuCoreSelectLabel } from '../select.translate';
 import { TreeNode } from './model';
 import { TreeGenerator } from './tree-generator';
@@ -124,6 +141,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	readonly activeDescendant$ = new BehaviorSubject('');
 
+	protected manualOptions$ = new ReplaySubject<readonly TOption[]>(1);
+
 	get ariaControls(): string {
 		return this.overlayContainerRef.id;
 	}
@@ -184,7 +203,6 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	clueChange = outputFromObservable(this.clueChange$);
 	readonly nextPage$ = new Subject<void>();
 	nextPage = outputFromObservable(this.nextPage$);
-	readonly previousPage = output<void>();
 	readonly addOption = output<string>();
 
 	public readonly valueSignal = signal<TValue | null>(null);
@@ -219,27 +237,48 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	protected _value: TValue | null = null;
 
-	readonly options$ = new ReplaySubject<readonly TOption[]>(1);
-	readonly loading$ = toObservable(this.loading);
+	private getDefaultDataSource(): SelectDataSource<TOption> {
+		let emittedKeys = new Set<unknown>();
 
+		return {
+			getOptions: (_params: SelectDataSourceParams) => {
+				let lastEmittedThisPage: readonly TOption[] = [];
+				return this.manualOptions$.pipe(
+					tap((options) => (lastEmittedThisPage = options)),
+					takeUntil(this.nextPage$),
+					finalize(() => (emittedKeys = new Set(lastEmittedThisPage.map((p) => this.optionKey()(p))))),
+					map((options) => options.filter((c) => !emittedKeys.has(this.optionKey()(c)))),
+				);
+			},
+			reset() {
+				emittedKeys.clear();
+			},
+		};
+	}
+
+	readonly dataSource = model<SelectDataSource<TOption, unknown>>(this.getDefaultDataSource());
+
+	readonly dataSourceOptions = toSignal(toObservable(this.dataSource).pipe(switchMap((ds) => this.#buildOptionsFromDataSource(ds))), { initialValue: [] as readonly TOption[] });
 	clue: string | null = null;
 	// This is the clue stored after we selected an option to know if we should emit an empty clue on open or not
 	lastEmittedClue: string = '';
 	readonly clue$ = defer(() => this.clueChange$.pipe(startWith(this.clue)));
 
-	shouldDisplayAddOption$ = toObservable(this.addOptionStrategy).pipe(
-		switchMap((strategy) => {
-			switch (strategy) {
-				case 'always':
-					return of(true);
-				case 'never':
-					return of(false);
-				case 'if-empty-clue':
-					return this.clue$.pipe(map((clue) => !clue));
-				case 'if-not-empty-clue':
-					return this.clue$.pipe(map((clue) => !!clue));
-			}
-		}),
+	readonly shouldDisplayAddOption = toSignal(
+		toObservable(this.addOptionStrategy).pipe(
+			switchMap((strategy) => {
+				switch (strategy) {
+					case 'always':
+						return of(true);
+					case 'never':
+						return of(false);
+					case 'if-empty-clue':
+						return this.clue$.pipe(map((clue) => !clue));
+					case 'if-not-empty-clue':
+						return this.clue$.pipe(map((clue) => !!clue));
+				}
+			}),
+		),
 	);
 
 	protected onChange?: (value: TValue | null) => void;
@@ -260,7 +299,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 		ɵeffectWithDeps([this.options], (options, onCleanup) => {
 			if (isNotNil(options)) {
-				this.options$.next(options);
+				this.manualOptions$.next(options);
 				if (this.panelRef) {
 					const ref = afterNextRender(
 						() => {
@@ -350,14 +389,66 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	ngOnDestroy(): void {
 		this.closePanel();
-		this.destroyed$.next();
-		this.destroyed$.complete();
 	}
 
 	ngOnInit(): void {
 		if (this.labelElement) {
 			this.labelElement.id = this.labelId;
 		}
+	}
+
+	#buildOptionsFromDataSource(ds: SelectDataSource<TOption>): Observable<readonly TOption[]> {
+		const page$ = this.nextPage$.pipe(
+			scan((page) => page + 1, 0),
+			startWith(0),
+		);
+
+		const clue$ = this.clue$.pipe(
+			map((clue) => clue ?? ''),
+			distinctUntilChanged(),
+		);
+
+		return this.isPanelOpen$.pipe(
+			distinctUntilChanged(),
+			switchMap((isOpen) => {
+				if (!isOpen) {
+					return of([] as readonly TOption[]);
+				}
+
+				return clue$.pipe(
+					switchMap((clue) =>
+						page$.pipe(
+							concatMap((page) => {
+								this.loading.set(true);
+								return ds.getOptions({ clue, page }).pipe(
+									catchError(() => of([] as readonly TOption[])),
+									tap(() => this.loading.set(false)),
+									startWith([] as readonly TOption[]),
+									map((items) => ({ items, page })),
+								);
+							}),
+							scan(
+								(acc, { items, page }) => {
+									acc[page] = items;
+									return acc;
+								},
+								{} as Record<number, readonly TOption[]>,
+							),
+							// Stop calling pages when last two pages are empty
+							takeWhile((pages) => {
+								const indexes = Object.keys(pages)
+									.map((p) => parseInt(p))
+									.sort((a, b) => a - b);
+								const lastIndexes = indexes.slice(-2);
+								return lastIndexes.length < 2 || !lastIndexes.every((i) => pages[i]?.length === 0);
+							}),
+							map((pages) => Object.values(pages).flat()),
+							finalize(() => this.loading.set(false)), // Avoid infinite loading on complete API or error
+						),
+					),
+				);
+			}),
+		);
 	}
 
 	clearValue(event?: Event): void {
@@ -414,9 +505,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		}
 
 		this.panelRef.valueChanged.subscribe((value) => this.updateValue(value));
-
-		this.#pageChanged(this.panelRef.nextPage).subscribe(() => this.nextPage$.next());
-		this.#pageChanged(this.panelRef.previousPage).subscribe(() => this.previousPage.emit());
+		this.panelRef.nextPage.subscribe(() => this.nextPage$.next());
 
 		this.panelRef.activeOptionIdChanged.subscribe((optionId) => {
 			this.activeDescendant$.next(optionId);
@@ -439,6 +528,8 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	}
 
 	public closePanel(): void {
+		this.dataSource().reset?.();
+
 		if (!this.isPanelOpen) {
 			return;
 		}
@@ -468,11 +559,6 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		}
 		this.onChange?.(value);
 		this.onTouched?.();
-	}
-
-	// Ensure nextPage/previousPage does not emit too often
-	#pageChanged(pageEmitter: EventEmitter<void>): Observable<void> {
-		return this.options$.pipe(switchMap(() => pageEmitter.pipe(take(1))));
 	}
 
 	// Filter pill interface

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -51,7 +51,6 @@ export const coreSelectDefaultOptionKey: (option: unknown) => unknown = (option)
 export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDestroy, OnInit, ControlValueAccessor, FilterPillInputComponent {
 	public parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	protected changeDetectorRef = inject(ChangeDetectorRef);
-	readonly #injector = inject(Injector);
 	protected overlayContainerRef: HTMLElement = inject(OverlayContainer).getContainerElement();
 
 	protected labelElement: HTMLElement | undefined = inject(SELECT_LABEL);

--- a/packages/ng/core-select/input/select-input.utils.spec.ts
+++ b/packages/ng/core-select/input/select-input.utils.spec.ts
@@ -1,0 +1,287 @@
+import { fakeAsync, tick } from '@angular/core/testing';
+import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
+import { SelectDataSource } from '../select.model';
+import { buildOptionsFromDataSource, BuildOptionsFromDataSourceDeps } from './select-input.utils';
+
+interface TestOption {
+	id: number;
+	name: string;
+}
+
+function createDeps(): {
+	nextPage$: Subject<void>;
+	clue$: Subject<string | null>;
+	isPanelOpen$: BehaviorSubject<boolean>;
+	setLoading: jest.Mock;
+	deps: BuildOptionsFromDataSourceDeps;
+} {
+	const nextPage$ = new Subject<void>();
+	const clue$ = new Subject<string | null>();
+	const isPanelOpen$ = new BehaviorSubject<boolean>(false);
+	const setLoading = jest.fn();
+	return { nextPage$, clue$, isPanelOpen$, setLoading, deps: { nextPage$, clue$, isPanelOpen$, setLoading } };
+}
+
+function createDs(pages: TestOption[][]): SelectDataSource<TestOption> & { getOptions: jest.Mock; reset: jest.Mock } {
+	let callIndex = 0;
+	return {
+		getOptions: jest.fn(() => of(pages[callIndex++] ?? [])),
+		reset: jest.fn(),
+	};
+}
+
+describe('buildOptionsFromDataSource', () => {
+	it('should emit empty array when panel is closed', fakeAsync(() => {
+		const { deps } = createDeps();
+		const ds = createDs([]);
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options: TestOption[]) => emitted.push(options));
+		tick();
+
+		expect(emitted).toEqual([[]]); // BehaviorSubject immediately emits false → of([])
+		expect(ds.getOptions).not.toHaveBeenCalled();
+
+		sub.unsubscribe();
+	}));
+
+	it('should emit options when panel opens and clue emits', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds = createDs([[{ id: 1, name: 'Option A' }]]);
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options: TestOption[]) => emitted.push(options));
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		expect(emitted[emitted.length - 1]).toEqual([{ id: 1, name: 'Option A' }]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should emit empty array when panel closes after being open', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds = createDs([[{ id: 1, name: 'Option A' }]]);
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options: TestOption[]) => emitted.push(options));
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		isPanelOpen$.next(false);
+		tick();
+
+		expect(emitted[emitted.length - 1]).toEqual([]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should call ds.reset on each clue change', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds = createDs([[{ id: 1, name: 'A' }], [{ id: 2, name: 'B' }]]);
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe();
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		clue$.next('test');
+		tick();
+
+		expect(ds.reset).toHaveBeenCalledTimes(2);
+
+		sub.unsubscribe();
+	}));
+
+	it('should accumulate options across pages', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$, nextPage$ } = createDeps();
+		const ds = createDs([
+			[{ id: 1, name: 'Page 0' }],
+			[{ id: 2, name: 'Page 1' }],
+			[], // two empty pages to stop pagination
+			[],
+		]);
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options: TestOption[]) => emitted.push(options));
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		nextPage$.next();
+		tick();
+
+		expect(emitted[emitted.length - 1]).toEqual([
+			{ id: 1, name: 'Page 0' },
+			{ id: 2, name: 'Page 1' },
+		]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should stop fetching when two consecutive empty pages are received', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$, nextPage$ } = createDeps();
+		const ds = createDs([
+			[{ id: 1, name: 'Page 0' }], // page 0: data
+			[], // page 1: empty
+			[], // page 2: empty → triggers takeWhile stop
+			[{ id: 999, name: 'Should never be called' }],
+		]);
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe();
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick(); // page 0
+
+		nextPage$.next(); // page 1
+		tick();
+
+		nextPage$.next(); // page 2 — triggers takeWhile
+		tick();
+
+		nextPage$.next(); // would be page 3, but stream already completed
+		tick();
+
+		// pages 0, 1, 2 called; page 3 not called
+		expect(ds.getOptions).toHaveBeenCalledTimes(3);
+
+		sub.unsubscribe();
+	}));
+
+	it('should not debounce empty clue even when clueDebounceMs is set', fakeAsync(() => {
+		const debounceMs = 300;
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds: SelectDataSource<TestOption> & { getOptions: jest.Mock } = {
+			getOptions: jest.fn(() => of([{ id: 1, name: 'A' }])),
+			clueDebounceMs: debounceMs,
+		};
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe();
+
+		isPanelOpen$.next(true);
+		clue$.next(''); // empty clue: should NOT be debounced
+		tick(0); // no timer advance needed
+
+		expect(ds.getOptions).toHaveBeenCalledWith({ clue: '', page: 0 });
+
+		sub.unsubscribe();
+		tick(debounceMs); // flush any pending timers
+	}));
+
+	it('should debounce non-empty clue when clueDebounceMs is set', fakeAsync(() => {
+		const debounceMs = 300;
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds: SelectDataSource<TestOption> & { getOptions: jest.Mock } = {
+			getOptions: jest.fn(() => of([{ id: 1, name: 'A' }])),
+			clueDebounceMs: debounceMs,
+		};
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe();
+
+		isPanelOpen$.next(true);
+		clue$.next('test');
+
+		tick(debounceMs - 1);
+		expect(ds.getOptions).not.toHaveBeenCalled();
+
+		tick(1);
+		expect(ds.getOptions).toHaveBeenCalledWith({ clue: 'test', page: 0 });
+
+		sub.unsubscribe();
+		tick(debounceMs); // flush any pending timers
+	}));
+
+	it('should return empty array on getOptions error', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds: SelectDataSource<TestOption> = {
+			getOptions: jest.fn(() => throwError(() => new Error('API error'))),
+		};
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options) => emitted.push(options));
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		expect(emitted[emitted.length - 1]).toEqual([]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should set loading to true when fetching and false when done', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$, setLoading } = createDeps();
+		const ds = createDs([[{ id: 1, name: 'A' }]]);
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe();
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		expect(setLoading).toHaveBeenCalledWith(true);
+		expect(setLoading).toHaveBeenCalledWith(false);
+		const calls = setLoading.mock.calls.map(([v]: [boolean]) => v);
+		// loading ends as false
+		expect(calls[calls.length - 1]).toBe(false);
+
+		sub.unsubscribe();
+	}));
+
+	it('should reset accumulated options when clue changes', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds: SelectDataSource<TestOption> & { getOptions: jest.Mock } = {
+			getOptions: jest
+				.fn()
+				.mockReturnValueOnce(of([{ id: 1, name: 'First clue result' }]))
+				.mockReturnValueOnce(of([{ id: 2, name: 'Second clue result' }])),
+		};
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options: TestOption[]) => emitted.push(options));
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+		expect(emitted[emitted.length - 1]).toEqual([{ id: 1, name: 'First clue result' }]);
+
+		clue$.next('test');
+		tick();
+		// new clue: only second result, not accumulated with first
+		expect(emitted[emitted.length - 1]).toEqual([{ id: 2, name: 'Second clue result' }]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should pass clue and page number to getOptions', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$, nextPage$ } = createDeps();
+		const ds: SelectDataSource<TestOption> & { getOptions: jest.Mock } = {
+			getOptions: jest
+				.fn()
+				.mockReturnValueOnce(of([{ id: 1, name: 'A' }]))
+				.mockReturnValueOnce(of([{ id: 2, name: 'B' }]))
+				.mockReturnValue(of([])),
+		};
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe();
+
+		isPanelOpen$.next(true);
+		clue$.next('hello');
+		tick();
+
+		nextPage$.next();
+		tick();
+
+		expect(ds.getOptions).toHaveBeenNthCalledWith(1, { clue: 'hello', page: 0 });
+		expect(ds.getOptions).toHaveBeenNthCalledWith(2, { clue: 'hello', page: 1 });
+
+		sub.unsubscribe();
+	}));
+});

--- a/packages/ng/core-select/input/select-input.utils.ts
+++ b/packages/ng/core-select/input/select-input.utils.ts
@@ -1,0 +1,71 @@
+import { catchError, concatMap, distinctUntilChanged, finalize, map, Observable, of, scan, startWith, switchMap, takeWhile, tap, timer } from 'rxjs';
+import { SelectDataSource } from '../select.model';
+
+export interface BuildOptionsFromDataSourceDeps {
+	nextPage$: Observable<void>;
+	clue$: Observable<string | null>;
+	isPanelOpen$: Observable<boolean>;
+	setLoading: (loading: boolean) => void;
+}
+
+export function buildOptionsFromDataSource<TOption>(ds: SelectDataSource<TOption>, deps: BuildOptionsFromDataSourceDeps): Observable<readonly TOption[]> {
+	const { nextPage$, clue$, isPanelOpen$, setLoading } = deps;
+
+	const page$ = nextPage$.pipe(
+		scan((page) => page + 1, 0),
+		startWith(0),
+	);
+
+	const normalizedClue$ = clue$.pipe(
+		map((clue) => clue ?? ''),
+		distinctUntilChanged(),
+	);
+
+	// If a debounce is specified:
+	// - empty clue ('') passes through immediately (initial state / clear)
+	// - non-empty clue is debounced (user is typing)
+	const debouncedClue$ = ds.clueDebounceMs ? normalizedClue$.pipe(switchMap((clue) => (clue ? timer(ds.clueDebounceMs!).pipe(map(() => clue)) : of(clue)))) : normalizedClue$;
+
+	return isPanelOpen$.pipe(
+		distinctUntilChanged(),
+		switchMap((isOpen) => {
+			if (!isOpen) {
+				return of([] as readonly TOption[]);
+			}
+
+			return debouncedClue$.pipe(
+				switchMap((clue) => {
+					ds.reset?.();
+					return page$.pipe(
+						concatMap((page) => {
+							setLoading(true);
+							return ds.getOptions({ clue, page }).pipe(
+								catchError(() => of([] as readonly TOption[])),
+								tap(() => setLoading(false)),
+								startWith([] as readonly TOption[]),
+								map((items) => ({ items, page })),
+							);
+						}),
+						scan(
+							(acc, { items, page }) => {
+								acc[page] = items;
+								return acc;
+							},
+							{} as Record<number, readonly TOption[]>,
+						),
+						// Stop calling pages when last two pages are empty
+						takeWhile((pages) => {
+							const indexes = Object.keys(pages)
+								.map((p) => parseInt(p))
+								.sort((a, b) => a - b);
+							const lastIndexes = indexes.slice(-2);
+							return lastIndexes.length < 2 || !lastIndexes.every((i) => pages[i]?.length === 0);
+						}),
+						map((pages) => Object.values(pages).flat()),
+						finalize(() => setLoading(false)), // Avoid infinite loading on complete API or error
+					);
+				}),
+			);
+		}),
+	);
+}

--- a/packages/ng/core-select/panel/key-manager.ts
+++ b/packages/ng/core-select/panel/key-manager.ts
@@ -1,14 +1,14 @@
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
-import { computed, DestroyRef, EventEmitter, inject, Injectable, Injector, Signal } from '@angular/core';
+import { afterRenderEffect, computed, DestroyRef, EventEmitter, inject, Injectable, Injector, Signal, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { isNotNil } from '@lucca-front/ng/core';
-import { asyncScheduler, debounceTime, filter, map, Observable, observeOn, take } from 'rxjs';
+import { asyncScheduler, filter, map, Observable, observeOn, take } from 'rxjs';
 import { LuOptionComparer } from '../select.model';
 import { CoreSelectPanelElement } from './selectable-item';
 
 interface CoreSelectKeyManagerOptions<T> {
 	queryList: Signal<readonly CoreSelectPanelElement<T>[]>;
-	options$: Observable<readonly T[]>;
+	options: Signal<readonly T[]>;
 	optionComparer: LuOptionComparer<T>;
 	activeOptionIdChanged$: EventEmitter<string>;
 	clueChange$: Observable<string>;
@@ -120,26 +120,28 @@ export class CoreSelectKeyManager<T> {
 	 * 	- set to first item if search has changed
 	 * 	- set to first item if no active item
 	 */
-	#bindOptionsChange({ options$ }: CoreSelectKeyManagerOptions<T>): void {
+	#bindOptionsChange({ options }: CoreSelectKeyManagerOptions<T>): void {
 		const keyManager = this.#cdkKeyManager;
 		if (!keyManager) {
 			return;
 		}
 
-		options$
-			.pipe(
-				debounceTime(0), // Wait until QueryList is updated
-				takeUntilDestroyed(this.#destroyRef),
-			)
-			.subscribe(() => {
-				if (this.#queryList().length === 0) {
-					keyManager.setActiveItem(-1);
-				} else if (this.#hasSearchChanged) {
-					this.#hasSearchChanged = false;
-					keyManager.setFirstItemActive();
-				} else if (!keyManager.activeItem) {
-					keyManager.setFirstItemActive();
-				}
-			});
+		afterRenderEffect(
+			() => {
+				options(); // Track option change
+
+				untracked(() => {
+					if (this.#queryList().length === 0) {
+						keyManager.setActiveItem(-1);
+					} else if (this.#hasSearchChanged) {
+						this.#hasSearchChanged = false;
+						keyManager.setFirstItemActive();
+					} else if (!keyManager.activeItem) {
+						keyManager.setFirstItemActive();
+					}
+				});
+			},
+			{ injector: this.#injector },
+		);
 	}
 }

--- a/packages/ng/core-select/panel/panel.models.ts
+++ b/packages/ng/core-select/panel/panel.models.ts
@@ -3,7 +3,6 @@ import { Observable } from 'rxjs';
 
 export abstract class LuSelectPanelRef<TOption, TValue> {
 	closed = new EventEmitter<void>();
-	previousPage = new EventEmitter<void>();
 	nextPage = new EventEmitter<void>();
 	valueChanged = new EventEmitter<TValue>();
 	clueChanged = new EventEmitter<string>();
@@ -22,7 +21,6 @@ export abstract class LuSelectPanelRef<TOption, TValue> {
 		this.closed.next();
 		this.closed.complete();
 		this.nextPage.complete();
-		this.previousPage.complete();
 		this.valueChanged.complete();
 		this.clueChanged.emit('');
 		this.clueChanged.complete();

--- a/packages/ng/core-select/panel/panel.utils.ts
+++ b/packages/ng/core-select/panel/panel.utils.ts
@@ -1,4 +1,4 @@
-import { Observable, distinctUntilChanged, map, of, skip, startWith, switchMap, take } from 'rxjs';
+import { computed, Signal } from '@angular/core';
 
 export type GroupTemplateLocation = 'group-header' | 'option' | 'none';
 
@@ -6,32 +6,35 @@ export type GroupTemplateLocation = 'group-header' | 'option' | 'none';
  * In order to avoid a blinking when we go from empty clue to a clue
  * We need to delay the change of group displayer location by waiting for the options to be updated.
  */
-export function getGroupTemplateLocation(
-	hasGrouping$: Observable<boolean>,
-	clueChange$: Observable<string>,
-	options$: Observable<readonly unknown[]>,
-	searchable = true,
-): Observable<GroupTemplateLocation> {
-	return hasGrouping$.pipe(
-		switchMap((hasGrouping) => {
-			if (!hasGrouping) {
-				return of<GroupTemplateLocation>('none');
-			}
+export function getGroupTemplateLocation(hasGrouping: Signal<boolean>, clue: Signal<string>, searchable = true): Signal<GroupTemplateLocation> {
+	const hasClue = computed(() => !!clue());
 
-			const getGroupTemplateLocation$ = (hasClue: boolean) =>
-				options$.pipe(
-					skip(1),
-					take(1),
-					map((): GroupTemplateLocation => (hasClue ? 'option' : 'group-header')),
-					startWith('group-header' as const satisfies GroupTemplateLocation),
-				);
-			return searchable
-				? clueChange$.pipe(
-						map((clue) => !!clue),
-						distinctUntilChanged(),
-						switchMap(getGroupTemplateLocation$),
-					)
-				: getGroupTemplateLocation$(false);
-		}),
-	);
+	return computed(() => {
+		if (!hasGrouping()) {
+			return 'none';
+		}
+
+		if (!searchable) {
+			return 'group-header';
+		}
+
+		return hasClue() ? 'option' : 'group-header';
+	});
+
+	// 		const getGroupTemplateLocation$ = (hasClue: boolean) =>
+	// 			options$.pipe(
+	// 				skip(1),
+	// 				take(1),
+	// 				map((): GroupTemplateLocation => (hasClue ? 'option' : 'group-header')),
+	// 				startWith('group-header' as const satisfies GroupTemplateLocation),
+	// 			);
+	// 		return searchable
+	// 			? clueChange$.pipe(
+	// 					map((clue) => !!clue),
+	// 					distinctUntilChanged(),
+	// 					switchMap(getGroupTemplateLocation$),
+	// 				)
+	// 			: getGroupTemplateLocation$(false);
+	// 	}),
+	// );
 }

--- a/packages/ng/core-select/panel/panel.utils.ts
+++ b/packages/ng/core-select/panel/panel.utils.ts
@@ -20,21 +20,4 @@ export function getGroupTemplateLocation(hasGrouping: Signal<boolean>, clue: Sig
 
 		return hasClue() ? 'option' : 'group-header';
 	});
-
-	// 		const getGroupTemplateLocation$ = (hasClue: boolean) =>
-	// 			options$.pipe(
-	// 				skip(1),
-	// 				take(1),
-	// 				map((): GroupTemplateLocation => (hasClue ? 'option' : 'group-header')),
-	// 				startWith('group-header' as const satisfies GroupTemplateLocation),
-	// 			);
-	// 		return searchable
-	// 			? clueChange$.pipe(
-	// 					map((clue) => !!clue),
-	// 					distinctUntilChanged(),
-	// 					switchMap(getGroupTemplateLocation$),
-	// 				)
-	// 			: getGroupTemplateLocation$(false);
-	// 	}),
-	// );
 }

--- a/packages/ng/core-select/select.model.ts
+++ b/packages/ng/core-select/select.model.ts
@@ -9,6 +9,8 @@ export interface SelectDataSourceParams {
 
 export interface SelectDataSource<TOption, TGroup = never> {
 	paramsChange?: Observable<unknown>;
+	/** Optional debounce in ms for clue-based re-queries (useful for API data sources) */
+	clueDebounceMs?: number;
 	getOptions(params: SelectDataSourceParams): Observable<readonly TOption[]>;
 	getTotalCount?(params: SelectDataSourceParams): Observable<number>;
 	getGroupOptions?: [TGroup] extends [never] ? never : (group: TGroup) => Observable<TOption[]>;

--- a/packages/ng/core-select/select.model.ts
+++ b/packages/ng/core-select/select.model.ts
@@ -2,6 +2,19 @@ import { Injectable, InjectionToken } from '@angular/core';
 import { PortalContent } from '@lucca-front/ng/core';
 import { Observable } from 'rxjs';
 
+export interface SelectDataSourceParams {
+	clue: string;
+	page: number;
+}
+
+export interface SelectDataSource<TOption, TGroup = never> {
+	paramsChange?: Observable<unknown>;
+	getOptions(params: SelectDataSourceParams): Observable<readonly TOption[]>;
+	getTotalCount?(params: SelectDataSourceParams): Observable<number>;
+	getGroupOptions?: [TGroup] extends [never] ? never : (group: TGroup) => Observable<TOption[]>;
+	reset?(): void;
+}
+
 export interface LuOptionContext<T> {
 	$implicit: T;
 }

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -1,6 +1,8 @@
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { ChangeDetectionStrategy, Component, Directive, forwardRef, viewChild } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { skip } from 'rxjs';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { MAGIC_DEBOUNCE_DURATION } from '../api/api.directive';
@@ -100,7 +102,7 @@ describe('LuCoreSelectUsersDirective', () => {
 
 		// Assert
 		let options: readonly LuCoreSelectUser[] = [];
-		simpleSelect.options$.subscribe((o) => (options = o));
+		options = simpleSelect.dataSourceOptions();
 
 		expect(options).toEqual(page1);
 		httpTestingController.verify();
@@ -167,10 +169,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Assert (Page 1)
-		let options: readonly LuCoreSelectUser[] = [];
-		simpleSelect.options$.subscribe((o) => (options = o));
-
-		expect(options).toEqual([meUser, ...page1]);
+		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, ...page1]);
 
 		// Act (Page 2)
 		simpleSelect.nextPage$.next();
@@ -183,7 +182,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		tick(MAGIC_OPTION_SCROLL_DELAY);
 
 		// Assert (Page 2)
-		expect(options).toEqual([meUser, ...page1, ...page2.filter((u) => u.id !== CURRENT_USER_ID)]);
+		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, ...page1, ...page2.filter((u) => u.id !== CURRENT_USER_ID)]);
 		httpTestingController.verify();
 	}));
 
@@ -212,7 +211,11 @@ describe('LuCoreSelectUsersDirective', () => {
 
 		// Act
 		const options: Array<readonly LuCoreSelectUser[]> = [];
-		simpleSelect.options$.subscribe((o) => options.push(o));
+		TestBed.runInInjectionContext(() =>
+			toObservable(simpleSelect.dataSourceOptions)
+				.pipe(skip(1))
+				.subscribe((o) => options.push(o)),
+		);
 
 		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
 		meReq.flush(usersResponse([meUser]));

--- a/packages/ng/multi-select/displayer/displayer-input.directive.ts
+++ b/packages/ng/multi-select/displayer/displayer-input.directive.ts
@@ -56,7 +56,7 @@ export class LuMultiSelectDisplayerInputDirective<T> implements OnInit {
 	}
 
 	get readonly() {
-		return !this.select.searchable;
+		return this.select.searchable ? null : true;
 	}
 
 	onInput() {

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -1,128 +1,119 @@
-@if (
-	{
-		options: (options$ | async) || [],
-		clueChange: (clueChange$ | async) || "",
-		groupTemplateLocation: groupTemplateLocation$ | async,
-		shouldDisplayAddOption: shouldDisplayAddOption$ | async,
-	};
-	as ctx
-) {
-	<div class="lu-picker-panel lu-option-picker-panel mod-multiple" data-testid="dialog-panel">
-		<div
-			class="lu-picker-content"
-			[class.is-loading]="loading()"
-			[class.is-filled]="ctx.options.length > 0"
-			tabindex="0"
-			role="listbox"
-			aria-multiselectable="true"
-			(scroll)="onScroll($event)"
-		>
-			@if (selectInput.panelHeaderTpl(); as tpl) {
-				<div>
-					<ng-container *luPortal="tpl" />
-				</div>
-			}
-			<div class="lu-picker-content-option">
-				@if (grouping() && ctx.groupTemplateLocation === "group-header") {
-					@for (
-						group of ctx.options | luOptionGroup: grouping().selector;
-						track trackGroupsBy(groupIndex, group);
-						let groupIndex = $index
-					) {
-						<div class="lu-picker-content-group" role="group" attr.aria-labelledby="lu-select-{{ selectId }}-group-{{ groupIndex }}">
-							@let groupCtx = group.options | luOptionsGroupContext: selectedOptions : optionComparer();
-							<div
-								luCoreSelectPanelElement
-								elementId="lu-select-{{ selectId }}-group-{{ groupIndex }}"
-								class="lu-picker-content-option-group-title"
-								role="presentation"
-								(selected)="toggleOptions(groupCtx.notSelectedOptions, group.options)"
-							>
-								<span #groupingTitleRef>
-									<ng-container *luPortal="grouping().content; context: { $implicit: group }" />
-								</span>
-
-								@if (someGroupOptionEnabled()(group.options)) {
-									<button
-										type="button"
-										class="link"
-										(click)="toggleOptions(groupCtx.notSelectedOptions, group.options)"
-										[id]="selectId + '-group-' + group.key"
-									>
-										<span class="pr-u-mask">{{ groupingTitleRef.innerText }} – </span
-										>{{ groupCtx.isGroupSelected ? intl().unselectAll : intl().selectAll }}
-									</button>
-								}
-							</div>
-							<ng-template
-								[ngTemplateOutlet]="optionsList"
-								[ngTemplateOutletContext]="{ $implicit: group.options, groupIndex: groupIndex }"
-							/>
-						</div>
-					}
-				}
-				@if (!grouping() || ctx.groupTemplateLocation !== "group-header") {
-					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
-				}
-				<ng-template #optionsList let-options let-groupIndex="groupIndex">
-					@if (treeGenerator) {
-						@for (branch of options | luTreeDisplay: treeGenerator; let index = $index; track trackBranchesBy(index, branch)) {
-							<lu-tree-branch
-								[branch]="branch"
-								[optionTpl]="optionTpl()"
-								[selectedOptions]="selectedOptions"
-								[optionComparer]="optionComparer()"
-								[optionIndex]="index"
-								(toggleOne)="toggleOption($event)"
-								(selectMany)="toggleOptions($event, [])"
-								(unselectMany)="toggleOptions([], $event)"
-							/>
-						}
-					} @else {
-						@for (option of options; track trackOptionsBy(index, option); let index = $index) {
-							<lu-select-option
-								luCoreSelectPanelElement
-								[option]="option"
-								[optionTpl]="optionTpl()"
-								[optionIndex]="index"
-								[grouping]="ctx.groupTemplateLocation === 'option' ? grouping() : undefined"
-								[groupIndex]="groupIndex"
-								[groupTemplateLocation]="ctx.groupTemplateLocation"
-								[scrollIntoViewOptions]="{ block: 'nearest' }"
-								[isSelected]="option | luIsOptionSelected: optionComparer() : selectedOptions"
-								(selected)="toggleOption(option)"
-								(click)="toggleOption(option)"
-								[class.withAddOption]="ctx.shouldDisplayAddOption"
-							/>
-						}
-					}
-				</ng-template>
-				@if (ctx.options.length === 0 && !loading()) {
-					<div class="lu-picker-content-option-emptyState">
-						{{ ctx.clueChange.length ? intl().emptyResults : intl().emptyOptions }}
-					</div>
-				}
+<div class="lu-picker-panel lu-option-picker-panel mod-multiple" data-testid="dialog-panel">
+	<div
+		class="lu-picker-content"
+		[class.is-loading]="loading()"
+		[class.is-filled]="options().length > 0"
+		tabindex="0"
+		role="listbox"
+		aria-multiselectable="true"
+		(scroll)="onScroll($event)"
+	>
+		@if (selectInput.panelHeaderTpl(); as tpl) {
+			<div>
+				<ng-container *luPortal="tpl" />
 			</div>
-			@if (loading()) {
-				<div class="lu-picker-content-loading">
-					<div class="loading">{{ intl().loading }}</div>
-				</div>
-			}
-			@if (ctx.shouldDisplayAddOption) {
-				<div
-					class="addOption palette-product"
-					[class.is-stuck]="true"
-					(click)="selectInput.emitAddOption()"
-					(selected)="selectInput.emitAddOption()"
-					elementId="picker-content-add"
-					luCoreSelectPanelElement
-				>
-					<div class="addOption-content">
-						<lu-icon icon="mathsPlus" />
-						<ng-container *luPortal="selectInput.addOptionLabel" />
+		}
+		<div class="lu-picker-content-option">
+			@if (grouping() && groupTemplateLocation() === "group-header") {
+				@for (group of dataSourceOptions() | luOptionGroup: grouping().selector; track group.key; let groupIndex = $index) {
+					<div class="lu-picker-content-group" role="group" attr.aria-labelledby="lu-select-{{ selectId }}-group-{{ groupIndex }}">
+						@let groupCtx = group.options | luOptionsGroupContext: selectedOptions : optionComparer();
+						<div
+							luCoreSelectPanelElement
+							elementId="lu-select-{{ selectId }}-group-{{ groupIndex }}"
+							class="lu-picker-content-option-group-title"
+							role="presentation"
+							(selected)="toggleOptions(groupCtx.notSelectedOptions, group.options, group.key)"
+						>
+							<span #groupingTitleRef>
+								<ng-container *luPortal="grouping().content; context: { $implicit: group }" />
+							</span>
+
+							@if (someGroupOptionEnabled()(group.options)) {
+								<button
+									type="button"
+									class="link"
+									[disabled]="groupLoadingKey() === group.key"
+									(click)="toggleOptions(groupCtx.notSelectedOptions, group.options, group.key)"
+									[id]="selectId + '-group-' + group.key"
+								>
+									@if (groupLoadingKey() === group.key) {
+										<span class="loading"></span>
+									} @else {
+										<span class="pr-u-mask">{{ groupingTitleRef.innerText }}&nbsp;– </span
+										>{{ groupCtx.isGroupSelected ? intl().unselectAll : intl().selectAll }}
+									}
+								</button>
+							}
+						</div>
+						<ng-template
+							[ngTemplateOutlet]="optionsList"
+							[ngTemplateOutletContext]="{ $implicit: group.options, groupIndex: groupIndex }"
+						/>
 					</div>
+				}
+			}
+			@if (!grouping() || groupTemplateLocation() !== "group-header") {
+				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: dataSourceOptions() }" />
+			}
+			<ng-template #optionsList let-options let-groupIndex="groupIndex">
+				@if (treeGenerator) {
+					@for (branch of options | luTreeDisplay: treeGenerator; let index = $index; track optionKey()(branch.node)) {
+						<lu-tree-branch
+							[branch]="branch"
+							[optionTpl]="optionTpl()"
+							[selectedOptions]="selectedOptions"
+							[optionComparer]="optionComparer()"
+							[optionIndex]="index"
+							(toggleOne)="toggleOption($event)"
+							(selectMany)="toggleOptions($event, [])"
+							(unselectMany)="toggleOptions([], $event)"
+						/>
+					}
+				} @else {
+					@for (option of options; track optionKey()(option); let index = $index) {
+						<lu-select-option
+							luCoreSelectPanelElement
+							[option]="option"
+							[optionTpl]="optionTpl()"
+							[optionIndex]="index"
+							[grouping]="groupTemplateLocation() === 'option' ? grouping() : undefined"
+							[groupIndex]="groupIndex"
+							[groupTemplateLocation]="groupTemplateLocation()"
+							[scrollIntoViewOptions]="{ block: 'nearest' }"
+							[isSelected]="option | luIsOptionSelected: optionComparer : selectedOptions"
+							(selected)="toggleOption(option)"
+							(click)="toggleOption(option)"
+							[class.withAddOption]="shouldDisplayAddOption()"
+						/>
+					}
+				}
+			</ng-template>
+			@if (options().length === 0 && !loading()) {
+				<div class="lu-picker-content-option-emptyState">
+					{{ clue().length ? intl().emptyResults : intl().emptyOptions }}
 				</div>
 			}
 		</div>
+		@if (loading()) {
+			<div class="lu-picker-content-loading">
+				<div class="loading">{{ intl().loading }}</div>
+			</div>
+		}
+		@if (shouldDisplayAddOption()) {
+			<div
+				class="addOption palette-product"
+				[class.is-stuck]="true"
+				(click)="selectInput.emitAddOption()"
+				(selected)="selectInput.emitAddOption()"
+				elementId="picker-content-add"
+				luCoreSelectPanelElement
+			>
+				<div class="addOption-content">
+					<lu-icon icon="mathsPlus" />
+					<ng-container *luPortal="selectInput.addOptionLabel" />
+				</div>
+			</div>
+		}
 	</div>
-}
+</div>

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -33,11 +33,11 @@
 								<button
 									type="button"
 									class="link"
-									[disabled]="groupLoadingKey() === group.key"
+									[disabled]="groupLoadingKeys().has(group.key)"
 									(click)="toggleOptions(groupCtx.notSelectedOptions, group.options, group.key)"
 									[id]="selectId + '-group-' + group.key"
 								>
-									@if (groupLoadingKey() === group.key) {
+									@if (groupLoadingKeys().has(group.key)) {
 										<span class="loading"></span>
 									} @else {
 										<span class="pr-u-mask">{{ groupingTitleRef.innerText }}&nbsp;– </span

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -81,7 +81,7 @@
 							[groupIndex]="groupIndex"
 							[groupTemplateLocation]="groupTemplateLocation()"
 							[scrollIntoViewOptions]="{ block: 'nearest' }"
-							[isSelected]="option | luIsOptionSelected: optionComparer : selectedOptions"
+							[isSelected]="option | luIsOptionSelected: optionComparer() : selectedOptions"
 							(selected)="toggleOption(option)"
 							(click)="toggleOption(option)"
 							[class.withAddOption]="shouldDisplayAddOption()"

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -136,10 +136,14 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		const dataSource = this.selectInput.dataSource();
 		if (groupKey !== undefined && dataSource.getGroupOptions) {
 			this.groupLoadingKey.set(groupKey);
-			void firstValueFrom(dataSource.getGroupOptions(groupKey)).then((allGroupOptions) => {
-				this.groupLoadingKey.set(null);
-				this.#applyGroupToggle(allGroupOptions, allGroupOptions);
-			});
+			void firstValueFrom(dataSource.getGroupOptions(groupKey))
+				.then((allGroupOptions) => {
+					this.groupLoadingKey.set(null);
+					this.#applyGroupToggle(allGroupOptions, allGroupOptions);
+				})
+				.catch(() => {
+					this.groupLoadingKey.set(null);
+				});
 			return;
 		}
 		this.#applyGroupToggle(notSelectedOptions, groupOptions);

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -98,7 +98,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		};
 	});
 
-	readonly groupLoadingKey = signal<unknown>(null);
+	readonly groupLoadingKeys = signal<Set<unknown>>(new Set());
 
 	readonly hasGrouping = computed(() => !!this.grouping());
 	public readonly clue = toSignal(this.selectInput.clue$.pipe(map((clue) => clue ?? '')), { initialValue: '' });
@@ -135,14 +135,22 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	toggleOptions(notSelectedOptions: T[], groupOptions: T[], groupKey?: unknown): void {
 		const dataSource = this.selectInput.dataSource();
 		if (groupKey !== undefined && dataSource.getGroupOptions) {
-			this.groupLoadingKey.set(groupKey);
+			this.groupLoadingKeys.update((keys) => new Set(keys).add(groupKey));
 			void firstValueFrom(dataSource.getGroupOptions(groupKey))
 				.then((allGroupOptions) => {
-					this.groupLoadingKey.set(null);
-					this.#applyGroupToggle(allGroupOptions, allGroupOptions);
+					this.groupLoadingKeys.update((keys) => {
+						const s = new Set(keys);
+						s.delete(groupKey);
+						return s;
+					});
+					this.#applyGroupToggle(allGroupOptions as T[], allGroupOptions as T[]);
 				})
 				.catch(() => {
-					this.groupLoadingKey.set(null);
+					this.groupLoadingKeys.update((keys) => {
+						const s = new Set(keys);
+						s.delete(groupKey);
+						return s;
+					});
 				});
 			return;
 		}

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -143,7 +143,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 						s.delete(groupKey);
 						return s;
 					});
-					this.#applyGroupToggle(allGroupOptions as T[], allGroupOptions as T[]);
+					this.#applyGroupToggle(allGroupOptions, allGroupOptions);
 				})
 				.catch(() => {
 					this.groupLoadingKeys.update((keys) => {

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,18 +1,16 @@
 import { A11yModule } from '@angular/cdk/a11y';
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, Injector, signal, TrackByFunction } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { NgTemplateOutlet } from '@angular/common';
+import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, Injector, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { isNotNil, PortalDirective } from '@lucca-front/ng/core';
 import {
 	CoreSelectKeyManager,
 	CoreSelectPanelInstance,
 	LuIsOptionSelectedPipe,
-	LuOptionGroup,
 	SELECT_ID,
 	SELECT_PANEL_INSTANCE,
 	TreeDisplayPipe,
-	TreeNode,
 	ɵCoreSelectPanelElement,
 	ɵgetGroupTemplateLocation,
 	ɵLuOptionComponent,
@@ -20,7 +18,7 @@ import {
 } from '@lucca-front/ng/core-select';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { TreeBranchComponent } from '@lucca-front/ng/tree-select';
-import { EMPTY } from 'rxjs';
+import { EMPTY, firstValueFrom } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LuMultiSelectInputComponent } from '../input';
 import { LuMultiSelectPanelRef } from '../input/panel.model';
@@ -38,7 +36,6 @@ import { LuOptionsGroupContextPipe } from './option-group-context.pipe';
 	},
 	imports: [
 		A11yModule,
-		AsyncPipe,
 		FormsModule,
 		LuIsOptionSelectedPipe,
 		ɵLuOptionComponent,
@@ -64,19 +61,14 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	readonly panelRef = inject<LuMultiSelectPanelRef<T>>(LuMultiSelectPanelRef);
 	readonly selectId = inject(SELECT_ID);
 
-	readonly options$ = this.selectInput.options$;
+	readonly dataSourceOptions = this.selectInput.dataSourceOptions;
 	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
-	readonly loading = toSignal(this.selectInput.loading$);
-	readonly loading$ = this.selectInput.loading$;
+	readonly loading = this.selectInput.loading;
 	searchable = this.selectInput.searchable;
 	readonly optionComparer = this.selectInput.optionComparer;
 	readonly optionKey = this.selectInput.optionKey;
 	intl = this.selectInput.intl;
-
-	trackOptionsBy: TrackByFunction<T> = (_, option) => this.optionKey()(option);
-	trackGroupsBy: TrackByFunction<LuOptionGroup<T, unknown>> = (_, group) => group.key;
-	trackBranchesBy: TrackByFunction<TreeNode<T>> = (_, option) => this.optionKey()(option.node);
 
 	selectedOptions: T[] = this.selectInput.value || [];
 	readonly optionTpl = this.selectInput.optionTpl;
@@ -106,19 +98,17 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		};
 	});
 
-	readonly hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
-	public readonly clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));
-	public readonly shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
+	readonly groupLoadingKey = signal<unknown>(null);
 
-	readonly groupTemplateLocation$ = ɵgetGroupTemplateLocation(this.hasGrouping$, this.clueChange$, this.options$, this.searchable);
+	readonly hasGrouping = computed(() => !!this.grouping());
+	public readonly clue = toSignal(this.selectInput.clue$.pipe(map((clue) => clue ?? '')), { initialValue: '' });
+	public readonly shouldDisplayAddOption = this.selectInput.shouldDisplayAddOption;
+
+	readonly groupTemplateLocation = ɵgetGroupTemplateLocation(this.hasGrouping, this.clue, this.searchable);
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {
 			return;
-		}
-
-		if (evt.target.scrollTop === 0) {
-			this.panelRef.previousPage.emit();
 		}
 
 		if (evt.target.scrollHeight - evt.target.scrollTop - evt.target.clientHeight < 1) {
@@ -142,7 +132,20 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		afterNextRender(() => this.panelRef.updatePosition(), { injector: this.#injector });
 	}
 
-	toggleOptions(notSelectedOptions: T[], groupOptions: T[]): void {
+	toggleOptions(notSelectedOptions: T[], groupOptions: T[], groupKey?: unknown): void {
+		const dataSource = this.selectInput.dataSource();
+		if (groupKey !== undefined && dataSource.getGroupOptions) {
+			this.groupLoadingKey.set(groupKey);
+			void firstValueFrom(dataSource.getGroupOptions(groupKey)).then((allGroupOptions) => {
+				this.groupLoadingKey.set(null);
+				this.#applyGroupToggle(allGroupOptions, allGroupOptions);
+			});
+			return;
+		}
+		this.#applyGroupToggle(notSelectedOptions, groupOptions);
+	}
+
+	#applyGroupToggle(notSelectedOptions: T[], groupOptions: T[]): void {
 		// Filter out disabled options
 		const disabledOptionIds = this.options()
 			.filter((o) => o.disabled)
@@ -167,7 +170,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	protected initKeyManager(): void {
 		this.keyManager.init({
 			queryList: this.options,
-			options$: this.options$,
+			options: this.dataSourceOptions,
 			optionComparer: this.optionComparer(),
 			activeOptionIdChanged$: this.panelRef.activeOptionIdChanged,
 			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange$ : EMPTY,

--- a/packages/ng/simple-select/panel/panel.component.html
+++ b/packages/ng/simple-select/panel/panel.component.html
@@ -1,102 +1,88 @@
-@if (
-	{
-		options: (options$ | async) || [],
-		clueChange: (clueChange$ | async) || "",
-		groupTemplateLocation: groupTemplateLocation$ | async,
-		shouldDisplayAddOption: shouldDisplayAddOption$ | async,
-	};
-	as ctx
-) {
-	<div class="lu-picker-panel lu-option-picker-panel" cdkTrapFocus>
-		<div class="lu-picker-content" [class.is-loading]="loading()" (scroll)="onScroll($event)">
-			@if (selectInput.panelHeaderTpl(); as tpl) {
-				<div>
-					<ng-container *luPortal="tpl" />
-				</div>
-			}
-			<div role="listbox" class="lu-picker-content-option">
-				@if (grouping() && ctx.groupTemplateLocation === "group-header") {
-					@for (
-						group of ctx.options | luOptionGroup: grouping().selector;
-						track trackGroupsBy(groupIndex, group);
-						let groupIndex = $index
-					) {
-						<div class="lu-picker-content-option-group" role="group" [attr.aria-labelledby]="selectId + '-group-' + group.key">
-							<span class="lu-picker-content-option-group-title" role="presentation" [id]="selectId + '-group-' + group.key">
-								<ng-container *luPortal="grouping().content; context: { $implicit: group }" />
-							</span>
-							<ng-template
-								[ngTemplateOutlet]="optionsList"
-								[ngTemplateOutletContext]="{ $implicit: group.options, groupIndex: groupIndex }"
-							/>
-						</div>
-					}
-				}
-				@if (!grouping() || ctx.groupTemplateLocation !== "group-header") {
-					<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: ctx.options }" />
-				}
-				<ng-template #optionsList let-options let-groupIndex="groupIndex">
-					@if (treeGenerator) {
-						@for (branch of options | luTreeDisplay: treeGenerator; let index = $index; track trackBranchesBy(index, branch)) {
-							<lu-tree-branch
-								[branch]="branch"
-								[optionTpl]="optionTpl()"
-								[optionComparer]="optionComparer()"
-								[selectedOptions]="[selected()]"
-								[optionIndex]="index"
-								(toggleOne)="panelRef.emitValue($event)"
-								simpleMode
-							/>
-						}
-					} @else {
-						@for (option of options; track trackOptionsBy(index, option); let index = $index) {
-							<lu-select-option
-								luCoreSelectPanelElement
-								[option]="option"
-								[optionTpl]="optionTpl()"
-								[optionIndex]="index"
-								[groupTemplateLocation]="ctx.groupTemplateLocation"
-								[groupIndex]="groupIndex"
-								[grouping]="grouping()"
-								[scrollIntoViewOptions]="{ block: 'nearest' }"
-								[isSelected]="option | luIsOptionSelected: optionComparer() : selected()"
-								[class.withAddOption]="ctx.shouldDisplayAddOption"
-								(selected)="panelRef.emitValue(option)"
-								(click)="panelRef.emitValue(option)"
-							/>
-						}
-					}
-				</ng-template>
-				@if (ctx.options.length === 0 && !loading()) {
-					<div class="lu-picker-content-option-emptyState">
-						{{ ctx.clueChange.length ? intl().emptyResults : intl().emptyOptions }}
-					</div>
-				}
+<div class="lu-picker-panel lu-option-picker-panel" cdkTrapFocus>
+	<div class="lu-picker-content" [class.is-loading]="loading()" (scroll)="onScroll($event)">
+		@if (selectInput.panelHeaderTpl(); as tpl) {
+			<div>
+				<ng-container *luPortal="tpl" />
 			</div>
-			@if (loading()) {
-				<div class="lu-picker-content-loading">
-					<div class="loading">{{ intl().loading }}</div>
-				</div>
-			}
-			@if (ctx.shouldDisplayAddOption) {
-				<div
-					class="addOption palette-product is-stuck"
-					(click)="selectInput.emitAddOption()"
-					(selected)="selectInput.emitAddOption()"
-					elementId="picker-content-add"
-					luCoreSelectPanelElement
-				>
-					<div class="addOption-content">
-						<lu-icon icon="mathsPlus" />
-						<ng-container *luPortal="selectInput.addOptionLabel" />
+		}
+		<div role="listbox">
+			@if (grouping() && groupTemplateLocation() === "group-header") {
+				@for (group of dataSourceOptions() | luOptionGroup: grouping().selector; track group.key; let groupIndex = $index) {
+					<div class="lu-picker-content-option-group" role="group" [attr.aria-labelledby]="selectId + '-group-' + group.key">
+						<span class="lu-picker-content-option-group-title" role="presentation" [id]="selectId + '-group-' + group.key">
+							<ng-container *luPortal="grouping().content; context: { $implicit: group }" />
+						</span>
+						<ng-template
+							[ngTemplateOutlet]="optionsList"
+							[ngTemplateOutletContext]="{ $implicit: group.options, groupIndex: groupIndex }"
+						/>
 					</div>
-				</div>
+				}
 			}
-			@if (selectInput.panelFooterTpl(); as tpl) {
-				<div>
-					<ng-container *luPortal="tpl" />
+			@if (!grouping() || groupTemplateLocation() !== "group-header") {
+				<ng-template [ngTemplateOutlet]="optionsList" [ngTemplateOutletContext]="{ $implicit: dataSourceOptions() }" />
+			}
+			<ng-template #optionsList let-options let-groupIndex="groupIndex">
+				@if (treeGenerator) {
+					@for (branch of options | luTreeDisplay: treeGenerator; let index = $index; track optionKey()(branch.node)) {
+						<lu-tree-branch
+							[branch]="branch"
+							[optionTpl]="optionTpl()"
+							[optionComparer]="optionComparer()"
+							[selectedOptions]="[selected()]"
+							[optionIndex]="index"
+							(toggleOne)="panelRef.emitValue($event)"
+							simpleMode
+						/>
+					}
+				} @else {
+					@for (option of options; track optionKey()(option); let index = $index) {
+						<lu-select-option
+							luCoreSelectPanelElement
+							[option]="option"
+							[optionTpl]="optionTpl()"
+							[optionIndex]="index"
+							[groupTemplateLocation]="groupTemplateLocation()"
+							[groupIndex]="groupIndex"
+							[grouping]="grouping()"
+							[scrollIntoViewOptions]="{ block: 'center' }"
+							[isSelected]="option | luIsOptionSelected: optionComparer() : selected()"
+							[class.withAddOption]="shouldDisplayAddOption()"
+							(selected)="panelRef.emitValue(option)"
+							(click)="panelRef.emitValue(option)"
+						/>
+					}
+				}
+			</ng-template>
+			@if (dataSourceOptions().length === 0 && !loading()) {
+				<div class="lu-picker-content-option-emptyState">
+					{{ clue().length ? intl().emptyResults : intl().emptyOptions }}
 				</div>
 			}
 		</div>
+		@if (loading()) {
+			<div class="lu-picker-content-loading">
+				<div class="loading">{{ intl().loading }}</div>
+			</div>
+		}
+		@if (shouldDisplayAddOption()) {
+			<div
+				class="addOption palette-product is-stuck"
+				(click)="selectInput.emitAddOption()"
+				(selected)="selectInput.emitAddOption()"
+				elementId="picker-content-add"
+				luCoreSelectPanelElement
+			>
+				<div class="addOption-content">
+					<lu-icon icon="mathsPlus" />
+					<ng-container *luPortal="selectInput.addOptionLabel" />
+				</div>
+			</div>
+		}
+		@if (selectInput.panelFooterTpl(); as tpl) {
+			<div>
+				<ng-container *luPortal="tpl" />
+			</div>
+		}
 	</div>
-}
+</div>

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -1,6 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, forwardRef, inject, signal } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
@@ -62,8 +62,6 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	public intl = this.selectInput.intl;
 
 	readonly dataSourceOptions = this.selectInput.dataSourceOptions;
-	a = effect(() => console.log('dataSourceOptions', this.dataSourceOptions()));
-
 	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
 	readonly loading = this.selectInput.loading;

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -5,16 +5,16 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
 import {
-    CoreSelectKeyManager,
-    CoreSelectPanelInstance,
-    LuSelectPanelRef,
-    SELECT_ID,
-    SELECT_PANEL_INSTANCE,
-    TreeDisplayPipe,
-    ɵCoreSelectPanelElement,
-    ɵgetGroupTemplateLocation,
-    ɵLuOptionComponent,
-    ɵLuOptionGroupPipe,
+	CoreSelectKeyManager,
+	CoreSelectPanelInstance,
+	LuSelectPanelRef,
+	SELECT_ID,
+	SELECT_PANEL_INSTANCE,
+	TreeDisplayPipe,
+	ɵCoreSelectPanelElement,
+	ɵgetGroupTemplateLocation,
+	ɵLuOptionComponent,
+	ɵLuOptionGroupPipe,
 } from '@lucca-front/ng/core-select';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { TreeBranchComponent } from '@lucca-front/ng/tree-select';

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -1,22 +1,20 @@
 import { A11yModule } from '@angular/cdk/a11y';
-import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { NgTemplateOutlet } from '@angular/common';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, effect, forwardRef, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
 import {
-	CoreSelectKeyManager,
-	CoreSelectPanelInstance,
-	LuOptionGroup,
-	LuSelectPanelRef,
-	SELECT_ID,
-	SELECT_PANEL_INSTANCE,
-	TreeDisplayPipe,
-	TreeNode,
-	ɵCoreSelectPanelElement,
-	ɵgetGroupTemplateLocation,
-	ɵLuOptionComponent,
-	ɵLuOptionGroupPipe,
+    CoreSelectKeyManager,
+    CoreSelectPanelInstance,
+    LuSelectPanelRef,
+    SELECT_ID,
+    SELECT_PANEL_INSTANCE,
+    TreeDisplayPipe,
+    ɵCoreSelectPanelElement,
+    ɵgetGroupTemplateLocation,
+    ɵLuOptionComponent,
+    ɵLuOptionGroupPipe,
 } from '@lucca-front/ng/core-select';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { TreeBranchComponent } from '@lucca-front/ng/tree-select';
@@ -38,7 +36,6 @@ import { LuIsOptionSelectedPipe } from './option-selected.pipe';
 	},
 	imports: [
 		A11yModule,
-		AsyncPipe,
 		FormsModule,
 		NgTemplateOutlet,
 		ɵLuOptionGroupPipe,
@@ -64,19 +61,16 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	public selectId = inject(SELECT_ID);
 	public intl = this.selectInput.intl;
 
-	readonly options$ = this.selectInput.options$;
+	readonly dataSourceOptions = this.selectInput.dataSourceOptions;
+	a = effect(() => console.log('dataSourceOptions', this.dataSourceOptions()));
+
 	readonly grouping = this.selectInput.groupingSignal;
 	treeGenerator = this.selectInput.treeGenerator;
-	readonly loading = toSignal(this.selectInput.loading$);
-	readonly loading$ = this.selectInput.loading$;
+	readonly loading = this.selectInput.loading;
 	searchable = this.selectInput.searchable;
 	readonly optionComparer = this.selectInput.optionComparer;
 	readonly optionKey = this.selectInput.optionKey;
 	colorPanel = this.selectInput.colorPicker;
-
-	trackOptionsBy: TrackByFunction<T> = (_, option) => this.optionKey()(option);
-	trackGroupsBy: TrackByFunction<LuOptionGroup<T, unknown>> = (_, group) => group.key;
-	trackBranchesBy: TrackByFunction<TreeNode<T>> = (_, option) => this.optionKey()(option.node);
 
 	initialValue: T | null = this.selectInput.value;
 	readonly optionTpl = this.selectInput.optionTpl;
@@ -96,18 +90,14 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 
 	public readonly selected = computed(() => this.selectInput.valueSignal());
 
-	readonly hasGrouping$ = toObservable(this.grouping).pipe(map((grouping) => !!grouping));
-	public clueChange$ = this.selectInput.clue$.pipe(map((clue) => clue ?? ''));
-	public shouldDisplayAddOption$ = this.selectInput.shouldDisplayAddOption$;
-	public groupTemplateLocation$ = ɵgetGroupTemplateLocation(this.hasGrouping$, this.clueChange$, this.options$, this.searchable);
+	readonly hasGrouping = computed(() => !!this.grouping());
+	public readonly clue = toSignal(this.selectInput.clue$.pipe(map((clue) => clue ?? '')), { initialValue: '' });
+	public shouldDisplayAddOption = this.selectInput.shouldDisplayAddOption;
+	public groupTemplateLocation = ɵgetGroupTemplateLocation(this.hasGrouping, this.clue, this.searchable);
 
 	onScroll(evt: Event): void {
 		if (!(evt.target instanceof HTMLElement)) {
 			return;
-		}
-
-		if (evt.target.scrollTop === 0) {
-			this.panelRef.previousPage.emit();
 		}
 
 		if (evt.target.scrollHeight - evt.target.scrollTop - evt.target.clientHeight < 1) {
@@ -118,7 +108,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	ngAfterViewInit(): void {
 		this.keyManager.init({
 			queryList: this.options,
-			options$: this.options$,
+			options: this.dataSourceOptions,
 			optionComparer: this.optionComparer(),
 			activeOptionIdChanged$: this.panelRef.activeOptionIdChanged,
 			clueChange$: this.selectInput.searchable ? this.selectInput.clueChange$ : EMPTY,

--- a/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
+++ b/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
@@ -75,7 +75,6 @@ export default {
 		},
 		clueChange: HiddenArgType,
 		nextPage: HiddenArgType,
-		previousPage: HiddenArgType,
 		optionComparer: HiddenArgType,
 		options: HiddenArgType,
 		optionTpl: HiddenArgType,

--- a/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
+++ b/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
@@ -77,7 +77,6 @@ export default {
 		valueTpl: HiddenArgType,
 		clueChange: HiddenArgType,
 		nextPage: HiddenArgType,
-		previousPage: HiddenArgType,
 	},
 } as Meta;
 

--- a/stories/documentation/forms/select/select.utils.ts
+++ b/stories/documentation/forms/select/select.utils.ts
@@ -155,7 +155,6 @@ export const coreSelectStory = {
 		overlayConfig: HiddenArgType,
 		page: HiddenArgType,
 		placeholder: HiddenArgType,
-		previousPage: HiddenArgType,
 		valueTpl: HiddenArgType,
 	},
 } satisfies StoryObj<LuCoreSelectInputStoryComponent>;

--- a/stories/qa/multi-select/multi-select-group-datasource.stories.ts
+++ b/stories/qa/multi-select/multi-select-group-datasource.stories.ts
@@ -1,0 +1,71 @@
+import { JsonPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { LuOptionGroupDirective, SelectDataSource, SelectDataSourceParams } from '@lucca-front/ng/core-select';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { Meta, StoryObj } from '@storybook/angular';
+import { delay, Observable, of } from 'rxjs';
+import { allLegumes, colorNameByColor, ILegume, LegumeColor } from '../../documentation/forms/select/select.utils';
+
+const PAGE_SIZE = 20;
+const LOAD_DELAY_MS = 1000;
+
+function buildDataSource(): SelectDataSource<ILegume, LegumeColor> {
+	return {
+		getOptions({ clue, page }: SelectDataSourceParams): Observable<readonly ILegume[]> {
+			const filtered = allLegumes.sort((a, b) => (a.color < b.color ? 1 : -1)).filter((l) => !clue || l.name.toLowerCase().includes(clue.toLowerCase()));
+			const start = page * PAGE_SIZE;
+			console.log({ clue, page, options: filtered.slice(start, start + PAGE_SIZE) });
+			return of(filtered.slice(start, start + PAGE_SIZE)).pipe(delay(LOAD_DELAY_MS));
+		},
+		getGroupOptions(color: LegumeColor): Observable<ILegume[]> {
+			return of(allLegumes.filter((l) => l.color === color)).pipe(delay(LOAD_DELAY_MS));
+		},
+	};
+}
+
+@Component({
+	selector: 'multi-select-group-datasource-story',
+	imports: [JsonPipe, FormsModule, LuMultiSelectInputComponent, FormFieldComponent, LuOptionGroupDirective],
+	template: `
+		<lu-form-field label="Légumes par couleur">
+			<lu-multi-select #selectRef placeholder="Choisir des légumes" clearable [(ngModel)]="selectedLegumes" [dataSource]="dataSource">
+				<ng-container *luOptionGroup="let group; by: legumeColor; select: selectRef">
+					{{ colorNameByColor[group.key] }}
+				</ng-container>
+			</lu-multi-select>
+		</lu-form-field>
+
+		<p style="margin-top: 1rem; font-size: 0.875rem; color: var(--colors-neutral-700)">
+			Options paginées par {{ pageSize }} avec un délai de {{ delayMs }}ms.<br />
+			"Tout sélectionner" charge <strong>toutes</strong> les options du groupe via <code>getGroupOptions</code> (délai {{ delayMs }}ms).
+		</p>
+
+		<pre>{{ selectedLegumes | json }}</pre>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MultiSelectGroupDataSourceStory {
+	readonly pageSize = PAGE_SIZE;
+	readonly delayMs = LOAD_DELAY_MS;
+	readonly colorNameByColor = colorNameByColor;
+	readonly legumeColor = (legume: ILegume): LegumeColor => legume.color;
+
+	selectedLegumes: ILegume[] = [];
+
+	readonly dataSource = buildDataSource();
+}
+
+export default {
+	title: 'QA/MultiSelect/GroupDataSource',
+	component: MultiSelectGroupDataSourceStory,
+} as Meta;
+
+export const GroupWithDataSource: StoryObj<MultiSelectGroupDataSourceStory> = {
+	args: {},
+	render: (args) => ({ props: args }),
+	parameters: {
+		controls: { include: [] },
+	},
+};


### PR DESCRIPTION
## Description

Refactors the core select input to introduce a SelectDataSource<TOption> interface as the new first-class way to feed options into any select component. The SelectInputComponent exposes a dataSource model signal, and the API directive now builds and sets a SelectDataSource instead of directly subscribing to options.

**What changed**

- New SelectDataSource<TOption, TGroup> interface (select.model.ts) — encapsulates getOptions, getTotalCount, getGroupOptions, clueDebounceMs, paramsChange, and reset.

- New buildOptionsFromDataSource utility (select-input.utils.ts) — extracted, pure, observable pipeline for pagination + clue debounce + panel-open gating (with unit tests).

- ALuCoreSelectApiDirective — instead of imperatively pushing options, it now builds a SelectDataSource object and sets it on select.dataSource. The clue$ is now a BehaviorSubject (currentClue$). totalCount$ is now abstract and public. The TParams default changes from Record<string, ...> to Record<string, ...> | null.

- Simple/multi-select panels — updated to consume dataSourceOptions signal.

- Option comparer / key — calls on select.optionComparer()/select.optionKey() instead of direct property access.

**Beaking Changes**

- ALuCoreSelectApiDirective.totalCount$ — is now abstract and public. Subclasses must declare it (most already did; those that didn't will get a compile error).

- select.options is now an input() — programmatic assignment (select.options = [...]) is removed. Pass options via the [options] binding, or implement SelectDataSource and set select.dataSource




---------

---------

