### PR TITLE
feat(core-select): dedicated API call for departments totalCount

### DIFF
--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -147,6 +147,14 @@ export const handlers = [
 		});
 	}),
 
+	http.get('/organization/structure/api/departments', async () => {
+		await delay(300);
+		const countNodes = (nodes: { children?: unknown[] }[]): number => nodes.reduce((acc, branch) => acc + 1 + countNodes((branch.children ?? []) as { children?: unknown[] }[]), 0);
+		return HttpResponse.json({
+			count: countNodes(mockDepartmentsTree),
+		});
+	}),
+
 	http.get('/api/v3/departments/scopedtree', async () => {
 		await delay(300);
 		return HttpResponse.json({

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -100,6 +100,7 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 			this.httpClient.get<{ count: number }>(url, {
 				params: {
 					...filters,
+					limit: 0,
 					['fields.root']: 'count',
 				},
 			}),

--- a/packages/ng/core-select/department/departments.directive.ts
+++ b/packages/ng/core-select/department/departments.directive.ts
@@ -1,11 +1,12 @@
 import { HttpClient } from '@angular/common/http';
 import { computed, Directive, forwardRef, inject, input, OnInit } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
+import { isNotNil } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, TreeNode } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { ILuDepartment } from '@lucca-front/ng/department';
 import { combineLatest, map, Observable, of } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { debounceTime, switchMap } from 'rxjs/operators';
 import { NoopTreeSelectDirective } from './noop-tree-select.directive';
 
 @Directive({
@@ -24,12 +25,13 @@ import { NoopTreeSelectDirective } from './noop-tree-select.directive';
 export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepartment> extends ALuCoreSelectApiDirective<TreeNode<T>> implements OnInit, CoreSelectApiTotalCountProvider {
 	protected httpClient = inject(HttpClient);
 
-	url = input<string>('/organization/structure/api/departments/tree');
-	filters = input<Record<string, string | number | boolean> | null>(null);
-	operationIds = input<readonly number[] | null>(null);
-	uniqueOperationIds = input<readonly number[] | null>(null);
-	appInstanceId = input<number | null>(null);
-	searchDelimiter = input<string>(' ');
+	readonly url = input<string>('/organization/structure/api/departments/tree');
+	readonly countUrl = input<string>('/organization/structure/api/departments');
+	readonly filters = input<Record<string, string | number | boolean> | null>(null);
+	readonly operationIds = input<readonly number[] | null>(null);
+	readonly uniqueOperationIds = input<readonly number[] | null>(null);
+	readonly appInstanceId = input<number | null>(null);
+	readonly searchDelimiter = input<string>(' ');
 
 	public override ngOnInit(): void {
 		super.ngOnInit();
@@ -53,12 +55,12 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null): Observable<TreeNode<T>[]> {
 		return this.httpClient
-			.get<TreeNode<T>>(this.url(), {
-				params,
+			.get<{ children?: TreeNode<T>[] }>(this.url(), {
+				params: params ?? {},
 			})
 			.pipe(
 				map((data) => {
-					return data.children;
+					return data.children ?? [];
 				}),
 			);
 	}
@@ -75,10 +77,10 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 				}
 				return undefined;
 			})
-			.filter((o) => !!o);
+			.filter(isNotNil);
 	}
 
-	protected override params$: Observable<Record<string, string | number | boolean>> = toObservable(
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const operationIds = this.operationIds();
 			const uniqueOperationIds = this.uniqueOperationIds();
@@ -92,17 +94,24 @@ export class LuCoreSelectDepartmentsDirective<T extends ILuDepartment = ILuDepar
 		}),
 	);
 
-	public totalCount$ = this.select.options$.pipe(
-		filter((opts) => opts.length > 0),
-		map((opts) => {
-			return opts.map((branch) => this.flattenTree(branch)).flat().length;
-		}),
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.countUrl(), filters: this.filters() }))).pipe(
+		debounceTime(250),
+		switchMap(({ url, filters }) =>
+			this.httpClient.get<{ count: number }>(url, {
+				params: {
+					...filters,
+					['fields.root']: 'count',
+				},
+			}),
+		),
+		map((res) => res?.count ?? 0),
 	);
 
 	protected flattenTree(branch: TreeNode<T>): T[] {
 		const result: T[] = [branch.node];
-		if (branch.children.length > 0) {
-			result.push(...branch.children.map((child) => this.flattenTree(child)).flat());
+		const children = branch.children ?? [];
+		if (children.length > 0) {
+			result.push(...children.map((child) => this.flattenTree(child)).flat());
 		}
 		return result;
 	}


### PR DESCRIPTION
## Description

Le `totalCount` du sélecteur de départements est désormais récupéré via un appel API dédié (endpoint count avec `fields.root=count`) plutôt que calculé en aplatissant l'arbre des départements chargé. On obtient ainsi le nombre total réel, indépendamment des données paginées/filtrées affichées.

-----

- Nouvel input `countUrl` (défaut `/organization/structure/api/departments`).
- `totalCount$` réagit à `countUrl` + `filters` (debounce 250ms, `switchMap`) et lit `res.count`.
- Ajout d'un handler MSW pour le nouvel endpoint dans `.storybook/msw/handlers.ts`.

-----

### Contribution

- [ ] Designs are respected and all relevant options are handled
- [ ] Responsive behavior addressed when needed
- [ ] Feature is accessible (keyboard navigation, screen reader support, ARIA tags, etc.)
- [ ] Stories are updated and Storybook controls have descriptions
- [ ] Feature is covered by E2E tests or UI diff
- [ ] `npm run build` OK
- [x] `npm run lint` OK

### Functional review

- [ ] UI diff OK
- [ ] Feature and all options are manually tested and comply with design and guidelines.

-----
