### PR TITLE
fix(schematics): depreacted-resolver prevent prototype-inherited properties from corrupting identifier migrations

### DIFF
--- a/packages/ng/schematics/lib/deprecated-mapper.ts
+++ b/packages/ng/schematics/lib/deprecated-mapper.ts
@@ -65,7 +65,7 @@ export class DeprecatedMapper {
 		private tree: Tree,
 		private mappings: DeprecatedMappings,
 	) {
-		this.allIdentifierMappings = { ...mappings.modules, ...mappings.types };
+		this.allIdentifierMappings = Object.assign(Object.create(null) as Record<string, string>, mappings.modules, mappings.types);
 		this.hasTemplateMigrations = Object.keys(mappings.inputsOutputs).length > 0;
 	}
 


### PR DESCRIPTION
## Description

Initialize allIdentifierMappings with a null-prototype object via `Object.assign(Object.create(null), ...)` so that property lookups never fall through to Object.prototype.

-----



-----
