### PR TITLE
feat(dialog): add closing animation

### DIFF
--- a/packages/ng/dialog/dialog.service.ts
+++ b/packages/ng/dialog/dialog.service.ts
@@ -3,7 +3,6 @@ import { inject, Injectable, Injector, Renderer2 } from '@angular/core';
 import { isObservable, merge, of, take } from 'rxjs';
 import { filter, switchMap, takeUntil } from 'rxjs/operators';
 import { LuDialogConfig, LuDialogData, LuDialogRef, LuDialogResult } from './model';
-import { DISMISSED_VALUE } from './model/dialog-ref';
 
 @Injectable()
 export class LuDialogService {
@@ -74,8 +73,7 @@ export class LuDialogService {
 				)
 				.subscribe((canClose) => {
 					if (canClose) {
-						luDialogRef.detachSubscription?.unsubscribe();
-						cdkRef.close(DISMISSED_VALUE);
+						luDialogRef.animateAndDismiss();
 					}
 				});
 		}

--- a/packages/ng/dialog/model/dialog-ref.ts
+++ b/packages/ng/dialog/model/dialog-ref.ts
@@ -1,4 +1,5 @@
 import { DialogRef } from '@angular/cdk/dialog';
+import { waitForAnimations } from '@lucca-front/ng/core';
 import { isObservable, Observable, of, Subscription, take } from 'rxjs';
 import { filter, map, takeUntil } from 'rxjs/operators';
 import { LuDialogConfig, LuDialogData, LuDialogResult, LuDialogSize } from './dialog-config';
@@ -64,15 +65,39 @@ export class LuDialogRef<C = unknown, TData = LuDialogData<C>> {
 		const canClose$ = isObservable(canClose) ? canClose : of(canClose);
 		canClose$.pipe(take(1)).subscribe((close) => {
 			if (close) {
-				this.detachSubscription?.unsubscribe();
-				this.cdkRef.close(DISMISSED_VALUE);
+				this.animateAndDismiss();
 			}
 		});
 	}
 
 	close(res: LuDialogResult<C>): void {
 		this.detachSubscription?.unsubscribe();
-		this.cdkRef.close(res);
+		this.#playCloseAnimation(() => this.cdkRef.close(res));
+	}
+
+	/**
+	 * Plays the closing animation then dismisses the dialog with the DISMISSED_VALUE.
+	 * Used by the dismiss flows (close button, backdrop click, escape key).
+	 */
+	animateAndDismiss(): void {
+		this.detachSubscription?.unsubscribe();
+		this.#playCloseAnimation(() => this.cdkRef.close(DISMISSED_VALUE));
+	}
+
+	/**
+	 * Adds the `mod-closing` class on the dialog panel to trigger its closing animation,
+	 * then performs the actual close once the animation is done. Resolves immediately
+	 * when no animation runs (reduced motion, …).
+	 */
+	#playCloseAnimation(performClose: () => void): void {
+		const panel = this.cdkRef.overlayRef.overlayElement;
+		if (!panel) {
+			performClose();
+			return;
+		}
+
+		panel.classList.add('mod-closing');
+		void waitForAnimations(panel).then(performClose);
 	}
 
 	resize(size: LuDialogSize): void {

--- a/packages/scss/src/commons/utils/keyframe.scss
+++ b/packages/scss/src/commons/utils/keyframe.scss
@@ -10,6 +10,18 @@
 	}
 }
 
+@mixin fadeOut {
+	@keyframes fadeOut {
+		0% {
+			opacity: 1;
+		}
+
+		100% {
+			opacity: 0;
+		}
+	}
+}
+
 @mixin scaleIn {
 	@keyframes scaleIn {
 		0% {
@@ -18,6 +30,18 @@
 
 		100% {
 			transform: scale(1);
+		}
+	}
+}
+
+@mixin scaleOut {
+	@keyframes scaleOut {
+		0% {
+			transform: scale(1);
+		}
+
+		100% {
+			transform: scale(0);
 		}
 	}
 }
@@ -204,6 +228,30 @@
 
 		100% {
 			transform: translateY(0);
+		}
+	}
+}
+
+@mixin slideToRight {
+	@keyframes slideToRight {
+		0% {
+			transform: translateX(0);
+		}
+
+		100% {
+			transform: translateX(100%);
+		}
+	}
+}
+
+@mixin slideToBottom {
+	@keyframes slideToBottom {
+		0% {
+			transform: translateY(0);
+		}
+
+		100% {
+			transform: translateY(100%);
 		}
 	}
 }

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -26,11 +26,17 @@
 	translate: var(--components-dialog-translateX) var(--components-dialog-translateY);
 	scale: var(--components-dialog-scale);
 
+	&.mod-closing {
+		animation-name: var(--components-dialog-animationClosing);
+		animation-fill-mode: forwards;
+	}
+
 	@supports not (height: 1dvh) {
 		--components-dialog-maxHeight: var(--components-dialog-maxHeightFallback);
 	}
 
 	@include keyframe.scaleIn;
+	@include keyframe.scaleOut;
 
 	@at-root ($atRoot) {
 		.dialog-inside {

--- a/packages/scss/src/components/dialog/mods.scss
+++ b/packages/scss/src/components/dialog/mods.scss
@@ -40,8 +40,10 @@
 	--components-dialog-translateX: var(--components-dialog-translate);
 	--components-dialog-translateY: 0;
 	--components-dialog-translate-spacing: calc(var(--pr-t-spacings-500) * 2);
+	--components-dialog-animationClosing: slideToRight;
 
 	@include keyframe.slideFromRight;
+	@include keyframe.slideToRight;
 }
 
 @mixin fromBottom {
@@ -56,8 +58,10 @@
 	--components-dialog-translateX: 0;
 	--components-dialog-translateY: var(--components-dialog-translate);
 	--components-dialog-translate-spacing: var(--pr-t-spacings-500);
+	--components-dialog-animationClosing: slideToBottom;
 
 	@include keyframe.slideFromBottom;
+	@include keyframe.slideToBottom;
 }
 
 @mixin maxContent {

--- a/packages/scss/src/components/dialog/vars.scss
+++ b/packages/scss/src/components/dialog/vars.scss
@@ -8,6 +8,7 @@
 	--components-dialog-borderRadius: var(--pr-t-border-radius-structure);
 	--components-dialog-inset: 0 var(--commons-pushPanel-inlineSize) 0 0;
 	--components-dialog-animationOpening: scaleIn;
+	--components-dialog-animationClosing: scaleOut;
 	--components-dialog-insideHeaderAreas:
 		'container close'
 		'content content';


### PR DESCRIPTION
## Description

Les modales (`lu-dialog`) s'animent désormais à la **fermeture**, en plus de l'ouverture. L'animation de sortie reflète l'entrée selon le mode : `scaleOut` par défaut, `slideToRight` pour les drawers, `slideToBottom` pour les modales `from-bottom`. Respecte `prefers-reduced-motion`.

-----

**Technique :**

- Nouveau token `--components-dialog-animationClosing` (miroir de `animationOpening`) + keyframes `scaleOut` / `slideToRight` / `slideToBottom` / `fadeOut` dans les utils SCSS.
- `.dialog.mod-closing` joue l'animation de fermeture (`animation-fill-mode: forwards`).
- CDK Dialog ne permet pas `animate.leave` déclaratif sur du contenu fourni par l'utilisateur : `LuDialogRef` ajoute la classe `mod-closing` sur le panel, attend la fin de l'animation (`Element.getAnimations().finished`) puis détache l'overlay. Fallback `setTimeout` si aucune animation ne tourne (reduced-motion).
- Tous les chemins de fermeture passent par `animateAndDismiss()` (bouton, clic backdrop, touche Échap, `close()`).

-----
