### PR TITLE
Remove deprecated palettes

### DIFF
--- a/docs/portal-content.md
+++ b/docs/portal-content.md
@@ -26,7 +26,7 @@ Si vous avez besoin d'un rendu spécifique, vous pouvez passer une référence d
 <lu-page-header [label]="myTpl"></lu-page-header>
 
 <ng-template #myTpl>
-  <span class="u-textPrimary">Titre</span> personnalisé
+  <span class="u-textProduct">Titre</span> personnalisé
 </ng-template>
 ```
 

--- a/packages/prisme/core/style.ts
+++ b/packages/prisme/core/style.ts
@@ -3,7 +3,7 @@
  */
 // primary is deprecated
 // grey is deprecated
-export const PALETTE = ['success', 'warning', 'error', 'product', 'neutral', 'none', 'primary', 'grey', 'brand'] as const;
+export const PALETTE = ['success', 'warning', 'error', 'product', 'neutral', 'none', 'brand'] as const;
 export type Palette = (typeof PALETTE)[number];
 
 export const DECORATIVE_PALETTE = ['kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin', 'pineapple'] as const;

--- a/packages/prisme/icon/icon.component.scss
+++ b/packages/prisme/icon/icon.component.scss
@@ -5,10 +5,6 @@ lu-icon {
 }
 
 @layer mods {
-	// .icon-color-primary is deprecated
-	// .icon-color-secondary is deprecated
-	.icon-color-primary,
-	.icon-color-secondary,
 	.icon-color-product {
 		color: var(--palettes-product-700);
 	}

--- a/packages/prisme/icon/icon.type.ts
+++ b/packages/prisme/icon/icon.type.ts
@@ -5,5 +5,5 @@
 export const ICON_SIZE = ['XXS', 'XS', 'S', 'M', 'L', 'XL', 'XXL'] as const;
 export type IconSize = (typeof ICON_SIZE)[number];
 
-export const ICON_COLOR = ['primary', 'secondary', 'product', 'error', 'warning', 'success', 'light', 'placeholder', 'inherit'] as const;
+export const ICON_COLOR = ['product', 'error', 'warning', 'success', 'light', 'placeholder', 'inherit'] as const;
 export type IconColor = (typeof ICON_COLOR)[number];

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -781,12 +781,6 @@ $textLink: (
 
 // Deprecated
 
-// $colorsRgb are deprecated
-$colorsRgb: (
-	'neutral-400': '172, 187, 215',
-	'neutral-900': '19, 29, 53',
-) !default;
-
 // $borderRadius are deprecated
 $borderRadius: (
 	'M': 4px,

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -132,9 +132,6 @@ $palettesOtherProduct: () !default;
 $palettesDecorative: 'kiwi', 'cucumber', 'mint', 'lagoon', 'blueberry', 'lavender', 'watermelon', 'pumpkin' !default;
 $palettesDecorativeMandatory: 'pineapple', 'lime', 'grape', 'glacier', 'pineappleContrasted';
 
-// pineapple, lime, grape, glacier
-$palettesDeprecated: ('lucca', 'grey', 'primary', 'secondary') !default;
-
 @if $palettesOtherProduct == 'all' {
 	$palettesOtherProduct: ('pagga', 'poplee', 'coreHR', 'timmi', 'cleemy', 'cc');
 }
@@ -146,7 +143,6 @@ $palettesAll: function.flatMap(
 	$palettesOtherProduct,
 	$palettesDecorative,
 	$palettesDecorativeMandatory,
-	$palettesDeprecated
 );
 
 $palettesAssets: (
@@ -594,13 +590,9 @@ $productsInterpolation: (
 );
 
 $palettesInterpolation: (
-	'lucca': $brand,
 	'brand': $brand,
 	'brandContrasted': $brandContrasted,
-	'grey': $neutral,
 	'neutral': $neutral,
-	'primary': map.get($productsInterpolation, $product),
-	'secondary': map.get($productsInterpolation, $product),
 	'product': map.get($productsInterpolation, $product),
 	'navigation': $navigation,
 	'orchid': $orchid,
@@ -789,19 +781,10 @@ $textLink: (
 
 // Deprecated
 
-// $colors are deprecated
-$colors: (
-	'white': #ffffff,
-	'black': #121212,
-);
-
 // $colorsRgb are deprecated
 $colorsRgb: (
-	'white': '255, 255, 255',
 	'neutral-400': '172, 187, 215',
 	'neutral-900': '19, 29, 53',
-	'grey-400': '172, 187, 215',
-	'grey-900': '19, 29, 53',
 ) !default;
 
 // $borderRadius are deprecated

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -79,7 +79,6 @@
 	--palettes-assets-secondary-light: var(--palettes-#{map.get(map.get(config.$palettesAssets, config.$product), 'secondary')}-100);
 	// stylelint-enable custom-property-pattern
 
-	@include core.cssvars('colors', config.$colors, '-color');
 	@include core.cssvars('colors', config.$colorsRgb, '-rgb');
 
 	@include core.cssvars('palettes-ai', config.$paletteAI);

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -79,8 +79,6 @@
 	--palettes-assets-secondary-light: var(--palettes-#{map.get(map.get(config.$palettesAssets, config.$product), 'secondary')}-100);
 	// stylelint-enable custom-property-pattern
 
-	@include core.cssvars('colors', config.$colorsRgb, '-rgb');
-
 	@include core.cssvars('palettes-ai', config.$paletteAI);
 	@include core.cssvars('pr-t-color', config.$tokenAI, '-ai');
 

--- a/packages/scss/src/components/box/index.scss
+++ b/packages/scss/src/components/box/index.scss
@@ -7,9 +7,7 @@
 	}
 
 	@layer mods {
-		// .mod-grey is deprecated
-		&.mod-neutral,
-		&.mod-grey {
+		&.mod-neutral {
 			@include neutral;
 		}
 

--- a/packages/scss/src/components/box/mods.scss
+++ b/packages/scss/src/components/box/mods.scss
@@ -35,9 +35,7 @@
 	inset-block-end: var(--components-box-arrow-bottom);
 	inset-inline-start: var(--components-box-arrow-left);
 
-	// .mod-grey is deprecated
-	&.mod-neutral,
-	&.mod-grey {
+	&.mod-neutral {
 		--components-box-arrow-background: var(--palettes-neutral-25);
 	}
 }

--- a/packages/scss/src/components/card/index.scss
+++ b/packages/scss/src/components/card/index.scss
@@ -7,9 +7,7 @@
 	}
 
 	@layer mods {
-		// .mod-grey is deprecated
-		&.mod-neutral,
-		&.mod-grey {
+		&.mod-neutral {
 			@include neutral;
 		}
 

--- a/packages/scss/src/components/section/index.scss
+++ b/packages/scss/src/components/section/index.scss
@@ -8,9 +8,7 @@
 	}
 
 	@layer mods {
-		// .mod-grey is deprecated
-		&.mod-neutral,
-		&.mod-grey {
+		&.mod-neutral {
 			@include neutral;
 		}
 

--- a/stories/qa/button/button.stories.html
+++ b/stories/qa/button/button.stories.html
@@ -48,8 +48,6 @@
 					<button type="button" class="button">Default</button>
 					<button type="button" class="button palette-product">Product</button>
 					<button type="button" class="button palette-brand">Brand</button>
-					<button type="button" class="button palette-primary">Primary</button>
-					<button type="button" class="button palette-secondary">Secondary</button>
 					<button type="button" class="button palette-cleemy">Cleemy</button>
 					<button type="button" class="button palette-timmi">Timmi</button>
 					<button type="button" class="button palette-pagga">Pagga</button>
@@ -57,7 +55,6 @@
 					<button type="button" class="button palette-cc">CC</button>
 					<button type="button" class="button palette-poplee">Poplee</button>
 					<button type="button" class="button palette-neutral">Neutral</button>
-					<button type="button" class="button palette-grey">Gray</button>
 				</div>
 			</td>
 			<td>
@@ -65,8 +62,6 @@
 					<button type="button" luButton>Default</button>
 					<button type="button" luButton palette="product">Product</button>
 					<button type="button" luButton palette="brand">Brand</button>
-					<button type="button" luButton palette="primary">Primary</button>
-					<button type="button" luButton palette="secondary">Secondary</button>
 					<button type="button" luButton palette="cleemy">Cleemy</button>
 					<button type="button" luButton palette="timmi">Timmi</button>
 					<button type="button" luButton palette="pagga">Pagga</button>
@@ -74,7 +69,6 @@
 					<button type="button" luButton palette="cc">CC</button>
 					<button type="button" luButton palette="poplee">Poplee</button>
 					<button type="button" luButton palette="neutral">Neutral</button>
-					<button type="button" luButton palette="grey">Gray</button>
 				</div>
 			</td>
 		</tr>

--- a/stories/qa/icon/icon.stories.html
+++ b/stories/qa/icon/icon.stories.html
@@ -63,8 +63,6 @@
 			</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<lu-icon [icon]="'heart'" [color]="'primary'" />
-					<lu-icon [icon]="'heart'" [color]="'secondary'" />
 					<lu-icon [icon]="'heart'" [color]="'product'" />
 					<lu-icon [icon]="'heart'" [color]="'error'" />
 					<lu-icon [icon]="'heart'" [color]="'warning'" />


### PR DESCRIPTION
## Description

Remove deprecated palettes

- [ ] CSSvars palettes (`--palettes-grey-x`, `--palettes-primary-x`, `--palettes-secondary-x`, `--palettes-lucca-x`)
- [ ] CSSvars colors (`--colors-white-color`, `--colors-black-color`, `--colors-grey-400-color`, `--colors-grey-900-color`)
- [ ] CSSvars rgb colors (`--colors-grey-400-rgb`, `--colors-grey-900-rgb`, `--colors-neutral-400-rgb`, `--colors-neutral-900-rgb`, `--colors-white-rgb`)
- [ ] Palettes classes (palette-grey, palette-primary, palette-secondary, palette-lucca)
- [ ] Icon primary / secondary options
- [ ] Component color option (Box, Card, Section)
- [ ] Components using `PALETTE` type (Button, Callout, Gauge, Clear, Numeric Badge, Status Badge) (Grey, Primary)
-----
