### PR TITLE
tech(schematics): restrict lu-grid migration to neutral-element-only templates

### DIFF
--- a/packages/ng/schematics/lu-grid/migration.ts
+++ b/packages/ng/schematics/lu-grid/migration.ts
@@ -1,109 +1,8 @@
 import { Tree } from '@angular-devkit/schematics';
-import type { TmplAstElement } from '@angular/compiler';
-import { applyToUpdateRecorder } from '@schematics/angular/utility/change';
+import { Change, applyToUpdateRecorder } from '@schematics/angular/utility/change';
 import { SourceFile } from 'typescript';
 import { HtmlAst, extractNgTemplatesIncludingHtml, insertAngularImportIfNeeded, insertTSImportIfNeeded, isInterestingNode } from '../lib';
-
-// --- Grid container ---
-
-interface GridInputs {
-	mode?: string;
-	columns?: string;
-	extraClasses?: string;
-}
-
-interface HtmlGrid {
-	node: TmplAstElement;
-	inputs: GridInputs;
-	nodeOffset: number;
-	filePath: string;
-	componentTS: SourceFile;
-}
-
-// --- Grid column ---
-
-interface GridColumnInputs {
-	colspan?: string;
-	rowspan?: string;
-	column?: string;
-	row?: string;
-	justify?: string;
-	align?: string;
-	responsive?: Record<string, string>;
-}
-
-interface HtmlGridColumn {
-	node: TmplAstElement;
-	inputs: GridColumnInputs;
-	remainingStyle?: string;
-	extraClasses?: string;
-	nodeOffset: number;
-	filePath: string;
-	componentTS: SourceFile;
-}
-
-// --- CSS custom properties helpers ---
-
-function parseCssCustomProperties(style: string): Record<string, string> {
-	const result: Record<string, string> = {};
-	style.split(';').map((p) => p.trim()).filter(Boolean).forEach((part) => {
-		const colonIdx = part.indexOf(':');
-		if (colonIdx === -1) {
-			return;
-		}
-		const prop = part.substring(0, colonIdx).trim();
-		const value = part.substring(colonIdx + 1).trim();
-		result[prop] = value;
-	});
-	return result;
-}
-
-// CSS custom properties that map directly to GridColumnComponent inputs
-const GRID_COLUMN_DIRECT_PROPS: Record<string, string> = {
-	'--grid-colspan': 'colspan',
-	'--grid-rowspan': 'rowspan',
-	'--grid-column': 'column',
-	'--grid-row': 'row',
-	'--grid-justify': 'justify',
-	'--grid-align': 'align',
-};
-
-// Prefix for responsive CSS custom properties
-const RESPONSIVE_PREFIX = '--grid-';
-
-function extractGridColumnInputs(style: string): { inputs: GridColumnInputs; remainingStyle: string } {
-	const cssProps = parseCssCustomProperties(style);
-	const inputs: GridColumnInputs = {};
-	const responsive: Record<string, string> = {};
-	const remaining: string[] = [];
-
-	for (const [prop, value] of Object.entries(cssProps)) {
-		if (GRID_COLUMN_DIRECT_PROPS[prop]) {
-			(inputs as Record<string, string>)[GRID_COLUMN_DIRECT_PROPS[prop]] = value;
-		} else if (prop.startsWith(RESPONSIVE_PREFIX) && prop.includes('AtMedia')) {
-			// e.g. --grid-colspanAtMediaMinXS → colspanAtMediaMinXS
-			const key = prop.substring(RESPONSIVE_PREFIX.length);
-			responsive[key] = value;
-		} else if (prop.startsWith('--grid-')) {
-			// Unknown grid property — drop it (it was grid-specific)
-		} else {
-			remaining.push(`${prop}: ${value}`);
-		}
-	}
-
-	if (Object.keys(responsive).length > 0) {
-		inputs.responsive = responsive;
-	}
-
-	return { inputs, remainingStyle: remaining.join('; ') };
-}
-
-const NEUTRAL_HTML_ELEMENTS = ['div', 'span', 'section'] as const;
-type NeutralHtmlElement = (typeof NEUTRAL_HTML_ELEMENTS)[number];
-
-function isNeutralElement(name: string): name is NeutralHtmlElement {
-	return (NEUTRAL_HTML_ELEMENTS as readonly string[]).includes(name);
-}
+import { GridInputs, HtmlGrid, HtmlGridColumn, extractGridColumnInputs, isNeutralElement, parseCssCustomProperties } from './migration.utils';
 
 // --- Main migration ---
 
@@ -123,7 +22,8 @@ export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tre
 	htmlGrids.forEach((grid) => migrateGridNode(grid, templateUpdate));
 	htmlGridColumns.forEach((col) => migrateGridColumnNode(col, templateUpdate));
 
-	const changesToApply = [];
+	const changesToApply: Change[] = [];
+
 	if (htmlGrids.length > 0) {
 		changesToApply.push(
 			insertTSImportIfNeeded(sourceFile, path, 'GridComponent', '@lucca-front/ng/grid'),

--- a/packages/ng/schematics/lu-grid/migration.ts
+++ b/packages/ng/schematics/lu-grid/migration.ts
@@ -142,7 +142,7 @@ export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tre
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function migrateGridNode(grid: HtmlGrid, templateUpdate: any): void {
 	const { node, nodeOffset, inputs } = grid;
-	const divLength = node.name.length; // 'div'
+	const divLength = node.name.length; // 'div' or 'span'
 	const classesNode = node.attributes.find((attr) => attr.name === 'class');
 	const styleNode = node.attributes.find((attr) => attr.name === 'style');
 
@@ -201,7 +201,7 @@ function migrateGridNode(grid: HtmlGrid, templateUpdate: any): void {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function migrateGridColumnNode(col: HtmlGridColumn, templateUpdate: any): void {
 	const { node, nodeOffset, inputs, remainingStyle, extraClasses } = col;
-	const divLength = node.name.length; // 'div'
+	const divLength = node.name.length; // 'div' or 'span'
 	const classesNode = node.attributes.find((attr) => attr.name === 'class');
 	const styleNode = node.attributes.find((attr) => attr.name === 'style');
 
@@ -275,7 +275,7 @@ function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): Ht
 	ngTemplates.forEach((template) => {
 		const htmlAst = new HtmlAst(template.content);
 		htmlAst.visitNodes((node) => {
-			if (!isInterestingNode(node) || node.name !== 'div') {
+			if (!isInterestingNode(node) || (node.name !== 'div' && node.name !== 'span')) {
 				return;
 			}
 			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
@@ -315,7 +315,7 @@ function findHTMLGridColumns(sourceFile: SourceFile, basePath: string, tree: Tre
 	ngTemplates.forEach((template) => {
 		const htmlAst = new HtmlAst(template.content);
 		htmlAst.visitNodes((node) => {
-			if (!isInterestingNode(node)) {
+			if (!isInterestingNode(node) || (node.name !== 'div' && node.name !== 'span')) {
 				return;
 			}
 			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;

--- a/packages/ng/schematics/lu-grid/migration.ts
+++ b/packages/ng/schematics/lu-grid/migration.ts
@@ -1,3 +1,4 @@
+import { TmplAstElement } from '@angular/compiler';
 import { Tree } from '@angular-devkit/schematics';
 import { Change, applyToUpdateRecorder } from '@schematics/angular/utility/change';
 import { SourceFile } from 'typescript';
@@ -175,6 +176,16 @@ function migrateGridColumnNode(col: HtmlGridColumn, templateUpdate: any): void {
 
 // --- Finders ---
 
+function gridHasNonNeutralColumnChildren(node: TmplAstElement): boolean {
+	return node.children.some((child: unknown) => {
+		if (!isInterestingNode(child) || isNeutralElement(child.name)) {
+			return false;
+		}
+		const childClasses = child.attributes.find((attr) => attr.name === 'class')?.value;
+		return !!childClasses?.match(/(^|\s)grid-column(\s|$)/);
+	});
+}
+
 function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): HtmlGrid[] {
 	const results: HtmlGrid[] = [];
 	const ngTemplates = extractNgTemplatesIncludingHtml(sourceFile, tree, basePath);
@@ -187,6 +198,9 @@ function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): Ht
 			}
 			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
 			if (!classes?.match(/(^|\s)grid(\s|$)/)) {
+				return;
+			}
+			if (gridHasNonNeutralColumnChildren(node)) {
 				return;
 			}
 
@@ -222,7 +236,7 @@ function findHTMLGridColumns(sourceFile: SourceFile, basePath: string, tree: Tre
 	ngTemplates.forEach((template) => {
 		const htmlAst = new HtmlAst(template.content);
 		htmlAst.visitNodes((node, parent) => {
-			if (!isInterestingNode(node) || !isNeutralElement(node.name)) {
+			if (!isInterestingNode(node)) {
 				return;
 			}
 			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
@@ -236,6 +250,9 @@ function findHTMLGridColumns(sourceFile: SourceFile, basePath: string, tree: Tre
 			}
 			const parentClasses = parent.attributes.find((attr) => attr.name === 'class')?.value;
 			if (!parentClasses?.match(/(^|\s)grid(\s|$)/)) {
+				return;
+			}
+			if (gridHasNonNeutralColumnChildren(parent)) {
 				return;
 			}
 

--- a/packages/ng/schematics/lu-grid/migration.ts
+++ b/packages/ng/schematics/lu-grid/migration.ts
@@ -98,6 +98,13 @@ function extractGridColumnInputs(style: string): { inputs: GridColumnInputs; rem
 	return { inputs, remainingStyle: remaining.join('; ') };
 }
 
+const NEUTRAL_HTML_ELEMENTS = ['div', 'span', 'section'] as const;
+type NeutralHtmlElement = (typeof NEUTRAL_HTML_ELEMENTS)[number];
+
+function isNeutralElement(name: string): name is NeutralHtmlElement {
+	return (NEUTRAL_HTML_ELEMENTS as readonly string[]).includes(name);
+}
+
 // --- Main migration ---
 
 export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tree): string {
@@ -142,7 +149,7 @@ export function migrateComponent(sourceFile: SourceFile, path: string, tree: Tre
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function migrateGridNode(grid: HtmlGrid, templateUpdate: any): void {
 	const { node, nodeOffset, inputs } = grid;
-	const divLength = node.name.length; // 'div' or 'span'
+	const divLength = node.name.length;
 	const classesNode = node.attributes.find((attr) => attr.name === 'class');
 	const styleNode = node.attributes.find((attr) => attr.name === 'style');
 
@@ -201,7 +208,7 @@ function migrateGridNode(grid: HtmlGrid, templateUpdate: any): void {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function migrateGridColumnNode(col: HtmlGridColumn, templateUpdate: any): void {
 	const { node, nodeOffset, inputs, remainingStyle, extraClasses } = col;
-	const divLength = node.name.length; // 'div' or 'span'
+	const divLength = node.name.length;
 	const classesNode = node.attributes.find((attr) => attr.name === 'class');
 	const styleNode = node.attributes.find((attr) => attr.name === 'style');
 
@@ -275,7 +282,7 @@ function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): Ht
 	ngTemplates.forEach((template) => {
 		const htmlAst = new HtmlAst(template.content);
 		htmlAst.visitNodes((node) => {
-			if (!isInterestingNode(node) || (node.name !== 'div' && node.name !== 'span')) {
+			if (!isInterestingNode(node) || !isNeutralElement(node.name)) {
 				return;
 			}
 			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
@@ -314,12 +321,21 @@ function findHTMLGridColumns(sourceFile: SourceFile, basePath: string, tree: Tre
 
 	ngTemplates.forEach((template) => {
 		const htmlAst = new HtmlAst(template.content);
-		htmlAst.visitNodes((node) => {
-			if (!isInterestingNode(node) || (node.name !== 'div' && node.name !== 'span')) {
+		htmlAst.visitNodes((node, parent) => {
+			if (!isInterestingNode(node) || !isNeutralElement(node.name)) {
 				return;
 			}
 			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
 			if (!classes?.match(/(^|\s)grid-column(\s|$)/)) {
+				return;
+			}
+
+			// Only migrate grid-column if its parent grid container is also being migrated
+			if (!isInterestingNode(parent) || !isNeutralElement(parent.name)) {
+				return;
+			}
+			const parentClasses = parent.attributes.find((attr) => attr.name === 'class')?.value;
+			if (!parentClasses?.match(/(^|\s)grid(\s|$)/)) {
 				return;
 			}
 

--- a/packages/ng/schematics/lu-grid/migration.utils.ts
+++ b/packages/ng/schematics/lu-grid/migration.utils.ts
@@ -1,0 +1,104 @@
+import type { TmplAstElement } from '@angular/compiler';
+import { SourceFile } from 'typescript';
+
+// --- Grid container ---
+
+export interface GridInputs {
+	mode?: string;
+	columns?: string;
+	extraClasses?: string;
+}
+
+export interface HtmlGrid {
+	node: TmplAstElement;
+	inputs: GridInputs;
+	nodeOffset: number;
+	filePath: string;
+	componentTS: SourceFile;
+}
+
+// --- Grid column ---
+
+interface GridColumnInputs {
+	colspan?: string;
+	rowspan?: string;
+	column?: string;
+	row?: string;
+	justify?: string;
+	align?: string;
+	responsive?: Record<string, string>;
+}
+
+export interface HtmlGridColumn {
+	node: TmplAstElement;
+	inputs: GridColumnInputs;
+	remainingStyle?: string;
+	extraClasses?: string;
+	nodeOffset: number;
+	filePath: string;
+	componentTS: SourceFile;
+}
+
+// --- CSS custom properties helpers ---
+
+export function parseCssCustomProperties(style: string): Record<string, string> {
+	const result: Record<string, string> = {};
+	style.split(';').map((p) => p.trim()).filter(Boolean).forEach((part) => {
+		const colonIdx = part.indexOf(':');
+		if (colonIdx === -1) {
+			return;
+		}
+		const prop = part.substring(0, colonIdx).trim();
+		const value = part.substring(colonIdx + 1).trim();
+		result[prop] = value;
+	});
+	return result;
+}
+
+// CSS custom properties that map directly to GridColumnComponent inputs
+const GRID_COLUMN_DIRECT_PROPS: Record<string, string> = {
+	'--grid-colspan': 'colspan',
+	'--grid-rowspan': 'rowspan',
+	'--grid-column': 'column',
+	'--grid-row': 'row',
+	'--grid-justify': 'justify',
+	'--grid-align': 'align',
+};
+
+// Prefix for responsive CSS custom properties
+const RESPONSIVE_PREFIX = '--grid-';
+
+export function extractGridColumnInputs(style: string): { inputs: GridColumnInputs; remainingStyle: string } {
+	const cssProps = parseCssCustomProperties(style);
+	const inputs: GridColumnInputs = {};
+	const responsive: Record<string, string> = {};
+	const remaining: string[] = [];
+
+	for (const [prop, value] of Object.entries(cssProps)) {
+		if (GRID_COLUMN_DIRECT_PROPS[prop]) {
+			(inputs as Record<string, string>)[GRID_COLUMN_DIRECT_PROPS[prop]] = value;
+		} else if (prop.startsWith(RESPONSIVE_PREFIX) && prop.includes('AtMedia')) {
+			// e.g. --grid-colspanAtMediaMinXS → colspanAtMediaMinXS
+			const key = prop.substring(RESPONSIVE_PREFIX.length);
+			responsive[key] = value;
+		} else if (prop.startsWith('--grid-')) {
+			// Unknown grid property — drop it (it was grid-specific)
+		} else {
+			remaining.push(`${prop}: ${value}`);
+		}
+	}
+
+	if (Object.keys(responsive).length > 0) {
+		inputs.responsive = responsive;
+	}
+
+	return { inputs, remainingStyle: remaining.join('; ') };
+}
+
+const NEUTRAL_HTML_ELEMENTS = ['div', 'span', 'section'] as const;
+type NeutralHtmlElement = (typeof NEUTRAL_HTML_ELEMENTS)[number];
+
+export function isNeutralElement(name: string): name is NeutralHtmlElement {
+	return (NEUTRAL_HTML_ELEMENTS as readonly string[]).includes(name);
+}
+

--- a/packages/ng/schematics/lu-grid/migration.utils.ts
+++ b/packages/ng/schematics/lu-grid/migration.utils.ts
@@ -37,6 +37,7 @@ export interface HtmlGridColumn {
 	nodeOffset: number;
 	filePath: string;
 	componentTS: SourceFile;
+
 }
 
 // --- CSS custom properties helpers ---
@@ -101,4 +102,3 @@ type NeutralHtmlElement = (typeof NEUTRAL_HTML_ELEMENTS)[number];
 export function isNeutralElement(name: string): name is NeutralHtmlElement {
 	return (NEUTRAL_HTML_ELEMENTS as readonly string[]).includes(name);
 }
-

--- a/packages/ng/schematics/lu-grid/tests/input/mixed-elements.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/input/mixed-elements.component.ts
@@ -1,0 +1,28 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<div class="grid">
+			<div class="grid-column" style="--grid-colspan: 6">div migrated</div>
+			<span class="grid-column" style="--grid-colspan: 6">span migrated</span>
+			<button class="grid-column" style="--grid-colspan: 6">button skipped</button>
+		</div>
+		<span class="grid mod-auto">
+			<span class="grid-column">span auto migrated</span>
+		</span>
+		<label class="grid">
+			<span class="grid-column">span in label skipped</span>
+		</label>
+		<label class="grid">
+			<li class="grid-column">label skipped, li skipped</li>
+		</label>
+	`,
+	imports: [
+		ButtonComponent
+	]
+})
+export class MixedElementsComponent {
+}

--- a/packages/ng/schematics/lu-grid/tests/input/neutral-elements-only.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/input/neutral-elements-only.component.ts
@@ -1,0 +1,24 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<div class="grid">
+			<div class="grid-column" style="--grid-colspan: 6">div col</div>
+			<span class="grid-column" style="--grid-colspan: 6">span col</span>
+		</div>
+		<span class="grid mod-auto">
+			<span class="grid-column">span auto</span>
+		</span>
+		<button class="grid">
+			<li class="grid-column">should not migrate</li>
+		</button>
+	`,
+	imports: [
+		ButtonComponent
+	]
+})
+export class NeutralElementsOnlyComponent {
+}

--- a/packages/ng/schematics/lu-grid/tests/output/mixed-elements.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/output/mixed-elements.component.ts
@@ -7,11 +7,11 @@ import { GridColumnComponent } from '@lucca-front/ng/grid';
 	selector: 'lu-test',
 	standalone: true,
 	template: `
-		<lu-grid>
-			<lu-grid-column colspan="6">div migrated</lu-grid-column>
-			<lu-grid-column colspan="6">span migrated</lu-grid-column>
+		<div class="grid">
+			<div class="grid-column" style="--grid-colspan: 6">div migrated</div>
+			<span class="grid-column" style="--grid-colspan: 6">span migrated</span>
 			<button class="grid-column" style="--grid-colspan: 6">button skipped</button>
-		</lu-grid>
+		</div>
 		<lu-grid mode="auto">
 			<lu-grid-column>span auto migrated</lu-grid-column>
 		</lu-grid>

--- a/packages/ng/schematics/lu-grid/tests/output/mixed-elements.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/output/mixed-elements.component.ts
@@ -1,0 +1,30 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { GridComponent } from '@lucca-front/ng/grid';
+import { GridColumnComponent } from '@lucca-front/ng/grid';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<lu-grid>
+			<lu-grid-column colspan="6">div migrated</lu-grid-column>
+			<lu-grid-column colspan="6">span migrated</lu-grid-column>
+			<button class="grid-column" style="--grid-colspan: 6">button skipped</button>
+		</lu-grid>
+		<lu-grid mode="auto">
+			<lu-grid-column>span auto migrated</lu-grid-column>
+		</lu-grid>
+		<label class="grid">
+			<span class="grid-column">span in label skipped</span>
+		</label>
+		<label class="grid">
+			<li class="grid-column">label skipped, li skipped</li>
+		</label>
+	`,
+	imports: [
+		ButtonComponent, GridComponent, GridColumnComponent
+	]
+})
+export class MixedElementsComponent {
+}

--- a/packages/ng/schematics/lu-grid/tests/output/neutral-elements-only.component.ts
+++ b/packages/ng/schematics/lu-grid/tests/output/neutral-elements-only.component.ts
@@ -1,0 +1,26 @@
+import { Component } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import { GridComponent } from '@lucca-front/ng/grid';
+import { GridColumnComponent } from '@lucca-front/ng/grid';
+
+@Component({
+	selector: 'lu-test',
+	standalone: true,
+	template: `
+		<lu-grid>
+			<lu-grid-column colspan="6">div col</lu-grid-column>
+			<lu-grid-column colspan="6">span col</lu-grid-column>
+		</lu-grid>
+		<lu-grid mode="auto">
+			<lu-grid-column>span auto</lu-grid-column>
+		</lu-grid>
+		<button class="grid">
+			<li class="grid-column">should not migrate</li>
+		</button>
+	`,
+	imports: [
+		ButtonComponent, GridComponent, GridColumnComponent
+	]
+})
+export class NeutralElementsOnlyComponent {
+}


### PR DESCRIPTION
## Description

## Context

The lu-grid migration schematic was migrating grids even when their children
included non-neutral elements (custom components, directives, etc.), which
could produce incorrect output.

## Changes

- The migration now only runs on `div`/`span` grid containers whose column
  children are exclusively neutral HTML elements (div, span).
- Mixed templates (at least one non-neutral child) are skipped entirely.
- Extracted shared utilities into `migration.utils.ts` to keep the main
  migration file focused.
- Added test cases for both the neutral-only path and the mixed (skipped) path.

## Test plan

- [x] `neutral-elements-only` fixture: grid and columns are migrated to
  `lu-grid` / `lu-grid-column`
- [x] `mixed-elements` fixture: component is left untouched
- [x] Run `ng generate @lucca-front/ng:lu-grid` on a real project to confirm
  no regressions


-----


-----
