### PR TITLE
feat(schematics): add rgba/rgb-with-alpha → color.transparentize migration in CssMapper

### DIFF
--- a/packages/ng/schematics/lib/css-mapper.ts
+++ b/packages/ng/schematics/lib/css-mapper.ts
@@ -7,20 +7,22 @@ import { HtmlAst, HtmlAstVisitor, updateCssClassNames } from './html-ast';
 import { currentSchematicContext } from './lf-schematic-context';
 import { expand } from './schematic.utils';
 import { migrateFile } from './schematics';
-import { PostCssScssLib, PostCssSelectorParserLib, updateCSSClassNamesInRules, updateCSSVariableNames, updateMixinNames } from './scss-ast';
+import { PostCssLib, PostCssScssLib, PostCssSelectorParserLib, updateCSSClassNamesInRules, updateCSSVariableNames, updateMixinNames, updateRgbaToTransparentize } from './scss-ast';
 import { replaceStringLiterals } from './typescript-ast';
 
 interface Mappings {
 	classes: Record<string, string>;
 	variables: Record<string, string>;
 	mixins: Record<string, string>;
+	rgbaVariables?: Record<string, string>;
 }
 
 export class CssMapper {
 	private mappings: Mappings = {
 		classes: expand(this.rawMappings.classes, this.mappingProps),
 		variables: expand(this.rawMappings.variables, this.mappingProps),
-		mixins: expand(this.rawMappings.mixins, this.mappingProps)
+		mixins: expand(this.rawMappings.mixins, this.mappingProps),
+		rgbaVariables: this.rawMappings.rgbaVariables ? expand(this.rawMappings.rgbaVariables, this.mappingProps) : undefined,
 	};
 	private classesToUpdate = new Set(Object.keys(this.mappings.classes));
 	private varsToUpdate = new Set(Object.keys(this.mappings.variables));
@@ -36,12 +38,13 @@ export class CssMapper {
 		const postCssScss = await import('../lib/local-deps/postcss-scss.js');
 		const { postcssValueParser } = await import('../lib/local-deps/postcss-value-parser.js');
 		const { postcssSelectorParser } = await import('../lib/local-deps/postcss-selector-parser.js');
+		const { postCss } = await import('../lib/local-deps/postcss.js');
 		this.tree.visit((path, entry) => {
 			if (path.includes('node_modules') || !entry) {
 				return;
 			}
 			if (path.endsWith('.scss')) {
-				migrateFile(path, entry, this.tree, (content) => this.migrateScssFile(content, postCssScss, postcssValueParser, postcssSelectorParser));
+				migrateFile(path, entry, this.tree, (content) => this.migrateScssFile(content, postCssScss, postcssValueParser, postcssSelectorParser, postCss));
 			}
 			if (path.endsWith('.html')) {
 				migrateFile(path, entry, this.tree, (content) => this.migrateHTMLFile(content));
@@ -52,12 +55,16 @@ export class CssMapper {
 		});
 	}
 
-	private migrateScssFile(content: string, postCssScss: PostCssScssLib, postcssValueParser: ValueParser, postcssSelectorParser: PostCssSelectorParserLib): string {
+	private migrateScssFile(content: string, postCssScss: PostCssScssLib, postcssValueParser: ValueParser, postcssSelectorParser: PostCssSelectorParserLib, postCss: PostCssLib): string {
 		const root = postCssScss.parse(content);
 
 		updateMixinNames(root, this.mappings.mixins);
 		updateCSSVariableNames(root, this.mappings.variables, postcssValueParser);
 		updateCSSClassNamesInRules(root, this.mappings.classes, postcssSelectorParser);
+
+		if (this.mappings.rgbaVariables && Object.keys(this.mappings.rgbaVariables).length) {
+			updateRgbaToTransparentize(root, this.mappings.rgbaVariables, postcssValueParser, postCss);
+		}
 
 		return root.toResult({ syntax: { stringify: postCssScss.stringify } }).css;
 	}

--- a/packages/ng/schematics/lib/scss-ast.ts
+++ b/packages/ng/schematics/lib/scss-ast.ts
@@ -1,5 +1,5 @@
 import type { AtRule, Container, Declaration, Node, Root } from 'postcss';
-import type { Node as ValueNode, ValueParser } from 'postcss-value-parser';
+import type { FunctionNode, Node as ValueNode, ValueParser } from 'postcss-value-parser';
 import { ScssValueAst } from './scss-value-ast.js';
 
 export type PostCssSelectorParserLib = typeof import('./local-deps/postcss-selector-parser.js').postcssSelectorParser;
@@ -229,6 +229,74 @@ export function wrapWithCalcFunctionNode(rootValueNode: ScssValueAst, node: Valu
 		parent.nodes = newNodes;
 	} else {
 		rootValueNode.nodes = newNodes;
+	}
+}
+
+const COLOR_UTILS_IMPORT = '@lucca-front/scss/src/commons/utils/color';
+
+/**
+ * Transforms rgba(var(--x-rgb), alpha) → color.transparentize(var(--palette-x), alpha)
+ * and rgb(var(--x-rgb)) → var(--palette-x).
+ * Adds @use for the color utils if any rgba replacement happened.
+ */
+export function updateRgbaToTransparentize(
+	root: Root,
+	rgbVarMappings: Record<string, string>,
+	postcssValueParser: ValueParser,
+	postCss: PostCssLib,
+): void {
+	let hasRgba = false;
+
+	root.walkDecls((decl) => {
+		const valueAst = new ScssValueAst(decl.value, postcssValueParser);
+		let changed = false;
+
+		valueAst.walkFunction(/^rgba?$/, (funcNode) => {
+			const isRgba = funcNode.value === 'rgba';
+
+			const varNode = funcNode.nodes.find(
+				(n): n is FunctionNode => n.type === 'function' && n.value === 'var',
+			);
+			if (!varNode) {
+				return;
+			}
+
+			const varName = varNode.nodes[0]?.value ?? '';
+			const newVarName = rgbVarMappings[varName];
+			if (!newVarName) {
+				return;
+			}
+
+			if (isRgba) {
+				varNode.nodes = [{ type: 'word', value: newVarName, sourceIndex: 0, sourceEndIndex: newVarName.length }];
+				funcNode.value = 'color.transparentize';
+				hasRgba = true;
+			} else {
+				// rgb(var(--x-rgb)) → var(--palette-x)
+				funcNode.value = 'var';
+				funcNode.nodes = [{ type: 'word', value: newVarName, sourceIndex: 0, sourceEndIndex: newVarName.length }];
+			}
+			changed = true;
+		});
+
+		if (changed) {
+			decl.value = valueAst.toString();
+		}
+	});
+
+	if (!hasRgba) {
+		return;
+	}
+
+	let colorImportExists = false;
+	root.walkAtRules(/(import|use)/, (rule) => {
+		if (rule.params.includes(COLOR_UTILS_IMPORT)) {
+			colorImportExists = true;
+		}
+	});
+
+	if (!colorImportExists) {
+		addMixinImport(root, COLOR_UTILS_IMPORT, postCss);
 	}
 }
 

--- a/packages/ng/schematics/lib/scss-ast.ts
+++ b/packages/ng/schematics/lib/scss-ast.ts
@@ -267,7 +267,9 @@ export function updateRgbaToTransparentize(
 				return;
 			}
 
-			if (isRgba) {
+			const hasAlpha = funcNode.nodes.some((n) => n.type === 'word');
+
+			if (isRgba || hasAlpha) {
 				varNode.nodes = [{ type: 'word', value: newVarName, sourceIndex: 0, sourceEndIndex: newVarName.length }];
 				funcNode.value = 'color.transparentize';
 				hasRgba = true;

--- a/packages/ng/schematics/palettes/index.ts
+++ b/packages/ng/schematics/palettes/index.ts
@@ -39,7 +39,11 @@ export default (options?: SchematicContextOpts): Rule => {
 					'--palettes-error-text': `--palettes-error-0`,
 					'--palettes-critical-text': `--palettes-critical-0`,
 				},
-				mixins: {}
+				mixins: {},
+				rgbaVariables: {
+					'--colors-grey-{val}-rgb': `--palettes-neutral-{val}`,
+					'--colors-white-rgb': '--palettes-neutral-0',
+				}
 			},
 			{
 				val: {

--- a/packages/ng/schematics/palettes/tests/component.input.scss
+++ b/packages/ng/schematics/palettes/tests/component.input.scss
@@ -5,4 +5,13 @@
 	-webkit-text-fill-color: var(--palettes-critical-text);
 }
 
+.rgba-vars {
+	background-color: rgba(var(--colors-grey-900-rgb), 0.04);
+	border-color: rgb(var(--colors-grey-400-rgb), 0.5);
+	color: rgb(var(--colors-grey-400-rgb));
+	text-decoration-color: rgb(var(--colors-white-rgb), 0.3);
+	-webkit-text-fill-color: rgba(var(--colors-neutral-400-rgb), 1);
+	color-scheme: var(--palettes-neutral-400);
+}
+
 

--- a/packages/ng/schematics/palettes/tests/component.output.scss
+++ b/packages/ng/schematics/palettes/tests/component.output.scss
@@ -1,8 +1,19 @@
+@use '@lucca-front/scss/src/commons/utils/color';
+
 .css-vars {
 	background-color: var(--palettes-neutral-25);
 	color: var(--palettes-product-500);
 	text-decoration-color: var(--palettes-lucca-0);
 	-webkit-text-fill-color: var(--palettes-critical-0);
+}
+
+.rgba-vars {
+	background-color: color.transparentize(var(--palettes-neutral-900), 0.04);
+	border-color: color.transparentize(var(--palettes-neutral-400), 0.5);
+	color: var(--palettes-neutral-400);
+	text-decoration-color: color.transparentize(var(--palettes-neutral-0), 0.3);
+	-webkit-text-fill-color: rgba(var(--colors-neutral-400-rgb), 1);
+	color-scheme: var(--palettes-neutral-400);
 }
 
 


### PR DESCRIPTION
## Description

## Summary

Adds support for `rgbaVariables` in the `CssMapper` schematic, which migrates
`rgba`/`rgb`-with-alpha CSS variable usages to the SCSS `color.transparentize()` mixin.

- Introduces `rgbaVariables` config in `CssMapper` to map RGB CSS variables (e.g.
  `--colors-grey-{val}-rgb`) to their palette equivalents (`--palettes-neutral-{val}`)
- `rgba(var(--colors-grey-900-rgb), 0.04)` → `color.transparentize(var(--palettes-neutral-900), 0.04)`
- `rgb(var(--colors-white-rgb), 0.3)` → `color.transparentize(var(--palettes-neutral-0), 0.3)`
- `rgb(var(--colors-grey-400-rgb))` (no alpha) → `var(--palettes-neutral-400)` (unchanged behavior)
- Automatically adds `@use '@lucca-front/scss/src/commons/utils/color'` when replacements occur
- Configures the palettes schematic with the initial `--colors-grey-{val}-rgb` and
  `--colors-white-rgb` mappings


---------

---------

