### PR TITLE
fix(overlay): keep connected overlays out of the pushPanel zone

### DIFF
--- a/packages/ng/core/overlay/index.ts
+++ b/packages/ng/core/overlay/index.ts
@@ -1,0 +1,1 @@
+export * from './push-panel';

--- a/packages/ng/core/overlay/push-panel.spec.ts
+++ b/packages/ng/core/overlay/push-panel.spec.ts
@@ -6,7 +6,7 @@ describe('push-panel overlay helpers', () => {
 	function withPushPanelValue(value: string): Document {
 		getComputedStyleSpy.mockReturnValue({
 			getPropertyValue: (prop: string) => (prop === '--commons-pushPanel-inlineSize' ? value : ''),
-		} as unknown as CSSStyleDeclaration);
+		});
 		return { documentElement: {} } as unknown as Document;
 	}
 

--- a/packages/ng/core/overlay/push-panel.spec.ts
+++ b/packages/ng/core/overlay/push-panel.spec.ts
@@ -3,11 +3,11 @@ import { getPushPanelInlineSize, getPushPanelViewportMargin } from './push-panel
 describe('push-panel overlay helpers', () => {
 	let getComputedStyleSpy: jest.SpyInstance;
 
-	function withPushPanelValue(value: string): Document {
+	function withPushPanelValue(value: string): Element {
 		getComputedStyleSpy.mockReturnValue({
 			getPropertyValue: (prop: string) => (prop === '--commons-pushPanel-inlineSize' ? value : ''),
 		});
-		return { documentElement: {} } as unknown as Document;
+		return {} as unknown as Element;
 	}
 
 	beforeEach(() => {

--- a/packages/ng/core/overlay/push-panel.spec.ts
+++ b/packages/ng/core/overlay/push-panel.spec.ts
@@ -23,6 +23,18 @@ describe('push-panel overlay helpers', () => {
 			expect(getPushPanelInlineSize(withPushPanelValue('200px'))).toBe(200);
 		});
 
+		it('resolves a flat calc() sum of pixels', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('calc(32px + 348px)'))).toBe(380);
+		});
+
+		it('resolves a calc() difference of pixels', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('calc(400px - 20px)'))).toBe(380);
+		});
+
+		it('returns 0 for a calc() mixing non-pixel units', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('calc(2rem + 348px)'))).toBe(0);
+		});
+
 		it('returns 0 when the token is unset', () => {
 			expect(getPushPanelInlineSize(withPushPanelValue(''))).toBe(0);
 		});

--- a/packages/ng/core/overlay/push-panel.spec.ts
+++ b/packages/ng/core/overlay/push-panel.spec.ts
@@ -30,6 +30,14 @@ describe('push-panel overlay helpers', () => {
 		it('returns 0 when the token is not parseable', () => {
 			expect(getPushPanelInlineSize(withPushPanelValue('var(--whatever)'))).toBe(0);
 		});
+
+		it('returns 0 for a non-pixel unit', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('2rem'))).toBe(0);
+		});
+
+		it('returns 0 for a negative pixel value', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('-200px'))).toBe(0);
+		});
 	});
 
 	describe('getPushPanelViewportMargin', () => {

--- a/packages/ng/core/overlay/push-panel.spec.ts
+++ b/packages/ng/core/overlay/push-panel.spec.ts
@@ -1,0 +1,48 @@
+import { getPushPanelInlineSize, getPushPanelViewportMargin } from './push-panel';
+
+describe('push-panel overlay helpers', () => {
+	let getComputedStyleSpy: jest.SpyInstance;
+
+	function withPushPanelValue(value: string): Document {
+		getComputedStyleSpy.mockReturnValue({
+			getPropertyValue: (prop: string) => (prop === '--commons-pushPanel-inlineSize' ? value : ''),
+		} as unknown as CSSStyleDeclaration);
+		return { documentElement: {} } as unknown as Document;
+	}
+
+	beforeEach(() => {
+		getComputedStyleSpy = jest.spyOn(window, 'getComputedStyle');
+	});
+
+	afterEach(() => {
+		getComputedStyleSpy.mockRestore();
+	});
+
+	describe('getPushPanelInlineSize', () => {
+		it('parses a pixel value', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('200px'))).toBe(200);
+		});
+
+		it('returns 0 when the token is unset', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue(''))).toBe(0);
+		});
+
+		it('returns 0 when the token is not parseable', () => {
+			expect(getPushPanelInlineSize(withPushPanelValue('var(--whatever)'))).toBe(0);
+		});
+	});
+
+	describe('getPushPanelViewportMargin', () => {
+		it('reserves the push size on the inline-end only', () => {
+			expect(getPushPanelViewportMargin(withPushPanelValue('200px'))).toEqual({ start: 0, end: 200, top: 0, bottom: 0 });
+		});
+
+		it('adds the base margin to every side and the push on top of the inline-end', () => {
+			expect(getPushPanelViewportMargin(withPushPanelValue('200px'), 8)).toEqual({ start: 8, end: 208, top: 8, bottom: 8 });
+		});
+
+		it('falls back to the base margin when no push is set', () => {
+			expect(getPushPanelViewportMargin(withPushPanelValue('0px'), 8)).toEqual({ start: 8, end: 8, top: 8, bottom: 8 });
+		});
+	});
+});

--- a/packages/ng/core/overlay/push-panel.ts
+++ b/packages/ng/core/overlay/push-panel.ts
@@ -5,7 +5,24 @@
  */
 export function getPushPanelInlineSize(element: Element): number {
 	const raw = getComputedStyle(element).getPropertyValue('--commons-pushPanel-inlineSize').trim();
-	const match = /^(\d+(?:\.\d+)?)px$/.exec(raw);
+	if (raw === '') {
+		return 0;
+	}
+
+	// Custom properties aren't resolved by the browser (getComputedStyle returns them verbatim), so a
+	// value like `calc(32px + 348px)` never matches a plain px regex. Assign it to a real <length>
+	// property on a probe element and read back the computed value, which the browser always resolves to px.
+	const probe = document.createElement('div');
+	probe.style.position = 'absolute';
+	probe.style.width = raw;
+	// `element` may be a void element (e.g. an <input> carrying the trigger) that can't hold children,
+	// so probe from its parent: custom properties inherit, so the resolution context is the same.
+	const host = element.parentElement ?? element.ownerDocument.body;
+	host.appendChild(probe);
+	const computed = getComputedStyle(probe).width;
+	probe.remove();
+
+	const match = /^(\d+(?:\.\d+)?)px$/.exec(computed);
 	return match ? Number.parseFloat(match[1]) : 0;
 }
 

--- a/packages/ng/core/overlay/push-panel.ts
+++ b/packages/ng/core/overlay/push-panel.ts
@@ -1,0 +1,21 @@
+/**
+ * Reads the `--commons-pushPanel-inlineSize` design token — the inline-end space reserved for a
+ * docked panel that shrinks the page content — from the document root, in pixels.
+ * Returns 0 when the token is unset or cannot be parsed as a pixel length.
+ */
+export function getPushPanelInlineSize(document: Document): number {
+	const raw = getComputedStyle(document.documentElement).getPropertyValue('--commons-pushPanel-inlineSize').trim();
+	const px = Number.parseFloat(raw);
+	return Number.isFinite(px) ? px : 0;
+}
+
+/**
+ * Builds a per-side viewport margin for a CDK `FlexibleConnectedPositionStrategy` so connected
+ * overlays (popovers, tooltips, selects…) are pushed out of the reserved pushPanel zone on the
+ * inline-end instead of overflowing into it. `base` is added to every side so an existing uniform
+ * margin is preserved.
+ */
+export function getPushPanelViewportMargin(document: Document, base = 0): { start: number; end: number; top: number; bottom: number } {
+	const push = getPushPanelInlineSize(document);
+	return { start: base, end: base + push, top: base, bottom: base };
+}

--- a/packages/ng/core/overlay/push-panel.ts
+++ b/packages/ng/core/overlay/push-panel.ts
@@ -5,8 +5,8 @@
  */
 export function getPushPanelInlineSize(element: Element): number {
 	const raw = getComputedStyle(element).getPropertyValue('--commons-pushPanel-inlineSize').trim();
-	const px = Number.parseFloat(raw);
-	return Number.isFinite(px) ? px : 0;
+	const match = /^(\d+(?:\.\d+)?)px$/.exec(raw);
+	return match ? Number.parseFloat(match[1]) : 0;
 }
 
 /**

--- a/packages/ng/core/overlay/push-panel.ts
+++ b/packages/ng/core/overlay/push-panel.ts
@@ -5,25 +5,23 @@
  */
 export function getPushPanelInlineSize(element: Element): number {
 	const raw = getComputedStyle(element).getPropertyValue('--commons-pushPanel-inlineSize').trim();
-	if (raw === '') {
+	return parsePxExpression(raw);
+}
+
+/**
+ * Resolves a CSS length restricted to pixels: either a bare `<px>` value or a flat `calc(...)`
+ * summing/subtracting px terms — since custom properties are returned verbatim by getComputedStyle,
+ * a token like `calc(32px + 348px)` never resolves on its own. Returns 0 (clamped, non-negative)
+ * for anything outside that grammar, including relative units this parser deliberately doesn't handle.
+ */
+function parsePxExpression(raw: string): number {
+	const inner = (/^calc\((.*)\)$/.exec(raw)?.[1] ?? raw).replace(/\s+/g, '');
+	const terms = inner.match(/[+-]?\d+(?:\.\d+)?px/g);
+	if (!terms || terms.join('') !== inner) {
 		return 0;
 	}
-
-	// Custom properties aren't resolved by the browser (getComputedStyle returns them verbatim), so a
-	// value like `calc(32px + 348px)` never matches a plain px regex. Assign it to a real <length>
-	// property on a probe element and read back the computed value, which the browser always resolves to px.
-	const probe = document.createElement('div');
-	probe.style.position = 'absolute';
-	probe.style.width = raw;
-	// `element` may be a void element (e.g. an <input> carrying the trigger) that can't hold children,
-	// so probe from its parent: custom properties inherit, so the resolution context is the same.
-	const host = element.parentElement ?? element.ownerDocument.body;
-	host.appendChild(probe);
-	const computed = getComputedStyle(probe).width;
-	probe.remove();
-
-	const match = /^(\d+(?:\.\d+)?)px$/.exec(computed);
-	return match ? Number.parseFloat(match[1]) : 0;
+	const sum = terms.reduce((acc, term) => acc + Number.parseFloat(term), 0);
+	return Math.max(0, sum);
 }
 
 /**

--- a/packages/ng/core/overlay/push-panel.ts
+++ b/packages/ng/core/overlay/push-panel.ts
@@ -3,8 +3,8 @@
  * docked panel that shrinks the page content — from the document root, in pixels.
  * Returns 0 when the token is unset or cannot be parsed as a pixel length.
  */
-export function getPushPanelInlineSize(document: Document): number {
-	const raw = getComputedStyle(document.documentElement).getPropertyValue('--commons-pushPanel-inlineSize').trim();
+export function getPushPanelInlineSize(element: Element): number {
+	const raw = getComputedStyle(element).getPropertyValue('--commons-pushPanel-inlineSize').trim();
 	const px = Number.parseFloat(raw);
 	return Number.isFinite(px) ? px : 0;
 }
@@ -15,7 +15,7 @@ export function getPushPanelInlineSize(document: Document): number {
  * inline-end instead of overflowing into it. `base` is added to every side so an existing uniform
  * margin is preserved.
  */
-export function getPushPanelViewportMargin(document: Document, base = 0): { start: number; end: number; top: number; bottom: number } {
-	const push = getPushPanelInlineSize(document);
+export function getPushPanelViewportMargin(element: Element, base = 0): { start: number; end: number; top: number; bottom: number } {
+	const push = getPushPanelInlineSize(element);
 	return { start: base, end: base + push, top: base, bottom: base };
 }

--- a/packages/ng/core/public-api.ts
+++ b/packages/ng/core/public-api.ts
@@ -3,6 +3,7 @@ export * from './event/index';
 export * from './group/index';
 export * from './id/index';
 export * from './misc';
+export * from './overlay/index';
 export * from './portal/index';
 export * from './route';
 export * from './signal';

--- a/packages/ng/multi-select/input/panel-ref.factory.ts
+++ b/packages/ng/multi-select/input/panel-ref.factory.ts
@@ -1,6 +1,7 @@
 import { ConnectedPosition, Overlay, OverlayConfig, OverlayPositionBuilder, OverlayRef, PositionStrategy, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ChangeDetectorRef, ComponentRef, ElementRef, inject, Injectable, Injector, ViewContainerRef } from '@angular/core';
+import { getPushPanelViewportMargin } from '@lucca-front/ng/core';
 import { addAttributesOnCdkContainer, SELECT_ID, SELECT_LABEL_ID } from '@lucca-front/ng/core-select';
 import { takeUntil } from 'rxjs';
 import { LuMultiSelectPanelComponent } from '../panel';
@@ -141,7 +142,7 @@ export class LuMultiSelectPanelRefFactory {
 			.flexibleConnectedTo(this.elementRef)
 			.withGrowAfterOpen(true)
 			.withLockedPosition(false)
-			.withViewportMargin(8)
+			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement.ownerDocument, 8))
 			.withPositions([
 				this.buildPosition('bottom', 'right', config),
 				this.buildPosition('bottom', 'left', config),

--- a/packages/ng/multi-select/input/panel-ref.factory.ts
+++ b/packages/ng/multi-select/input/panel-ref.factory.ts
@@ -142,7 +142,7 @@ export class LuMultiSelectPanelRefFactory {
 			.flexibleConnectedTo(this.elementRef)
 			.withGrowAfterOpen(true)
 			.withLockedPosition(false)
-			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement.ownerDocument, 8))
+			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement, 8))
 			.withPositions([
 				this.buildPosition('bottom', 'right', config),
 				this.buildPosition('bottom', 'left', config),

--- a/packages/ng/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/popover/trigger/popover-trigger.model.ts
@@ -532,7 +532,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 		return this._overlay
 			.position()
 			.flexibleConnectedTo(element)
-			.withViewportMargin(getPushPanelViewportMargin((element.nativeElement as HTMLElement).ownerDocument))
+			.withViewportMargin(getPushPanelViewportMargin(element.nativeElement))
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/packages/ng/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/popover/trigger/popover-trigger.model.ts
@@ -12,7 +12,7 @@ import {
 } from '@angular/cdk/overlay';
 import { ComponentPortal, TemplatePortal } from '@angular/cdk/portal';
 import { ElementRef, ViewContainerRef } from '@angular/core';
-import { generateId } from '@lucca-front/ng/core';
+import { generateId, getPushPanelViewportMargin } from '@lucca-front/ng/core';
 import { Observable, Subject, Subscription, timer } from 'rxjs';
 import { debounce, distinctUntilChanged, map } from 'rxjs/operators';
 import { ILuPopoverPanel, LuPopoverScrollStrategy } from '../panel/index';
@@ -532,6 +532,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 		return this._overlay
 			.position()
 			.flexibleConnectedTo(element)
+			.withViewportMargin(getPushPanelViewportMargin((element.nativeElement as HTMLElement).ownerDocument))
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/packages/ng/popover/trigger/popover-trigger.model.ts
+++ b/packages/ng/popover/trigger/popover-trigger.model.ts
@@ -532,7 +532,7 @@ export abstract class ALuPopoverTrigger<TPanel extends ILuPopoverPanel = ILuPopo
 		return this._overlay
 			.position()
 			.flexibleConnectedTo(element)
-			.withViewportMargin(getPushPanelViewportMargin(element.nativeElement))
+			.withViewportMargin(getPushPanelViewportMargin(element.nativeElement as Element))
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -247,7 +247,7 @@ export class PopoverDirective implements OnDestroy {
 				positionStrategy: this.overlay
 					.position()
 					.flexibleConnectedTo(this.luPopoverAnchor())
-					.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement.ownerDocument))
+					.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement))
 					.withPositions(this.customPositions || this.#buildPositions()),
 				scrollStrategy: this.overlay.scrollStrategies[this.overlayScrollStrategy ?? 'reposition'](),
 				hasBackdrop: withBackdrop,

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -24,7 +24,7 @@ import {
 	ViewContainerRef,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { intlInputOptions, isNotNil } from '@lucca-front/ng/core';
+import { getPushPanelViewportMargin, intlInputOptions, isNotNil } from '@lucca-front/ng/core';
 import { combineLatest, debounce, filter, map, merge, Subject, switchMap, take, timer } from 'rxjs';
 import { PopoverContentComponent } from './content/popover-content/popover-content.component';
 import { POPOVER_CONFIG, PopoverConfig } from './popover-tokens';
@@ -247,6 +247,7 @@ export class PopoverDirective implements OnDestroy {
 				positionStrategy: this.overlay
 					.position()
 					.flexibleConnectedTo(this.luPopoverAnchor())
+					.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement.ownerDocument))
 					.withPositions(this.customPositions || this.#buildPositions()),
 				scrollStrategy: this.overlay.scrollStrategies[this.overlayScrollStrategy ?? 'reposition'](),
 				hasBackdrop: withBackdrop,

--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -121,7 +121,7 @@ export class LuSimpleSelectPanelRefFactory {
 		const overlayConfig: OverlayConfig = overlayConfigOverride || {};
 		overlayConfig.positionStrategy = this.positionBuilder
 			.flexibleConnectedTo(this.elementRef)
-			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement.ownerDocument, 8))
+			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement, 8))
 			.withPositions([
 				{
 					originX: 'start',

--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -1,6 +1,7 @@
 import { Overlay, OverlayConfig, OverlayPositionBuilder, OverlayRef, ScrollStrategyOptions } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { ComponentRef, ElementRef, inject, Injectable, Injector, ViewContainerRef } from '@angular/core';
+import { getPushPanelViewportMargin } from '@lucca-front/ng/core';
 import { addAttributesOnCdkContainer, LuSelectPanelRef, SELECT_ID, SELECT_LABEL_ID } from '@lucca-front/ng/core-select';
 import { takeUntil } from 'rxjs';
 import { LuSelectPanelComponent } from '../panel';
@@ -120,7 +121,7 @@ export class LuSimpleSelectPanelRefFactory {
 		const overlayConfig: OverlayConfig = overlayConfigOverride || {};
 		overlayConfig.positionStrategy = this.positionBuilder
 			.flexibleConnectedTo(this.elementRef)
-			.withViewportMargin(8)
+			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement.ownerDocument, 8))
 			.withPositions([
 				{
 					originX: 'start',

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -438,7 +438,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 		return this.#overlay
 			.position()
 			.flexibleConnectedTo(this.#resolveAnchor())
-			.withViewportMargin(getPushPanelViewportMargin(this.#host.nativeElement.ownerDocument))
+			.withViewportMargin(getPushPanelViewportMargin(this.#host.nativeElement))
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -30,7 +30,7 @@ import {
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { SafeHtml } from '@angular/platform-browser';
-import { isNil, isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
+import { getPushPanelViewportMargin, isNil, isNotNil, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuPopoverPosition } from '@lucca-front/ng/popover';
 import { startWith, timer } from 'rxjs';
 import { debounce, filter, map, tap } from 'rxjs/operators';
@@ -438,6 +438,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 		return this.#overlay
 			.position()
 			.flexibleConnectedTo(this.#resolveAnchor())
+			.withViewportMargin(getPushPanelViewportMargin(this.#host.nativeElement.ownerDocument))
 			.withPositions([
 				{
 					originX: connectionPosition.originX,

--- a/stories/qa/push-panel/push-panel.stories.html
+++ b/stories/qa/push-panel/push-panel.stories.html
@@ -17,6 +17,27 @@
 					</button>
 					<button luButton="outlined" size="S" (click)="showToast()">Show Toast</button>
 				</div>
+
+				<!-- Connected overlays anchored to the inline-end edge: they must be pushed out of the pushPanel zone, never overflow into it -->
+				<div class="pr-u-marginTop400 pr-u-displayFlex pr-u-flexDirectionColumn pr-u-alignItemsFlexEnd pr-u-gap100 connectedOverlays">
+					<div class="pr-u-displayFlex pr-u-gap100">
+						<button luButton="outlined" size="S" [luPopover2]="popover" luPopoverPosition="below">Open Popover</button>
+						<button
+							luButton="outlined"
+							size="S"
+							luTooltip="This tooltip is intentionally long so it spans a wide box and would overflow into the push panel zone unless it gets pushed back to the inline-start."
+							luTooltipPosition="below"
+						>
+							Hover for Tooltip
+						</button>
+					</div>
+					<lu-form-field label="Simple select">
+						<lu-simple-select placeholder="Placeholder" clearable [options]="allLegumes" [(ngModel)]="simpleExample" />
+					</lu-form-field>
+					<lu-form-field label="Multi select">
+						<lu-multi-select placeholder="Placeholder" clearable [options]="allLegumes" [(ngModel)]="multiExample" />
+					</lu-form-field>
+				</div>
 			</lu-container>
 		</lu-main-layout-block>
 	</lu-main-layout>
@@ -79,6 +100,10 @@
 			</div>
 		</lu-dialog-footer>
 	</lu-dialog>
+</ng-template>
+
+<ng-template #popover>
+	<p style="inline-size: 24rem">This popover is intentionally wide so it would overflow into the push panel zone unless it gets pushed back to the inline-start.</p>
 </ng-template>
 
 <!-- To tell the ui-diff tool that the page has finished rendering -->

--- a/stories/qa/push-panel/push-panel.stories.html
+++ b/stories/qa/push-panel/push-panel.stories.html
@@ -21,12 +21,12 @@
 				<!-- Connected overlays anchored to the inline-end edge: they must be pushed out of the pushPanel zone, never overflow into it -->
 				<div class="pr-u-marginTop400 pr-u-displayFlex pr-u-flexDirectionColumn pr-u-alignItemsFlexEnd pr-u-gap100 connectedOverlays">
 					<div class="pr-u-displayFlex pr-u-gap100">
-						<button luButton="outlined" size="S" [luPopover2]="popover" luPopoverPosition="below">Open Popover</button>
+						<button luButton="outlined" size="S" [luPopover2]="popover" luPopoverPosition="after">Open Popover</button>
 						<button
 							luButton="outlined"
 							size="S"
 							luTooltip="This tooltip is intentionally long so it spans a wide box and would overflow into the push panel zone unless it gets pushed back to the inline-start."
-							luTooltipPosition="below"
+							luTooltipPosition="after"
 						>
 							Hover for Tooltip
 						</button>

--- a/stories/qa/push-panel/push-panel.stories.ts
+++ b/stories/qa/push-panel/push-panel.stories.ts
@@ -1,3 +1,4 @@
+import { allLegumes } from '@/stories/forms/select/select.utils';
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { AppLayoutComponent } from '@lucca-front/ng/app-layout';
@@ -7,7 +8,11 @@ import { DialogComponent, DialogContentComponent, DialogFooterComponent, DialogH
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { SwitchInputComponent } from '@lucca-front/ng/forms';
 import { MainLayoutBlockComponent, MainLayoutComponent } from '@lucca-front/ng/main-layout';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { PopoverDirective } from '@lucca-front/ng/popover2';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { LuToastsComponent, LuToastsService } from '@lucca-front/ng/toast';
+import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { Meta } from '@storybook/angular';
 
 @Component({
@@ -28,6 +33,10 @@ import { Meta } from '@storybook/angular';
 		FormFieldComponent,
 		SwitchInputComponent,
 		FormsModule,
+		PopoverDirective,
+		LuTooltipTriggerDirective,
+		LuSimpleSelectInputComponent,
+		LuMultiSelectInputComponent,
 	],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	styles: [
@@ -113,6 +122,10 @@ import { Meta } from '@storybook/angular';
 						--commons-container-maxWidth: 50rem;
 					}
 
+					.connectedOverlays lu-form-field {
+						inline-size: 16rem;
+					}
+
 					.fakeContent {
 						background-color: var(--pr-t-elevation-surface-raised);
 						border: 1px solid var(--palettes-neutral-50);
@@ -132,6 +145,10 @@ import { Meta } from '@storybook/angular';
 })
 class PushPanelStory {
 	private toasts = inject(LuToastsService);
+
+	allLegumes = allLegumes;
+	simpleExample = allLegumes[0];
+	multiExample = allLegumes;
 
 	showPushPanel = false;
 


### PR DESCRIPTION
## Description

Connected overlays (popover, popover2 → dropdown, tooltip, simple-select, multi-select) could overflow into the inline-end space reserved by `--commons-pushPanel-inlineSize` (docked panel). They now respect that zone and stay within the content area.

-----

CDK positions connected overlays through `FlexibleConnectedPositionStrategy`, which relies on the full viewport (`ViewportRuler`) and ignores the shrinking applied by `--commons-pushPanel-inlineSize` (the SCSS only constrained `.cdk-overlay-container` and the backdrop, with no effect on connected positioning).

Added a shared `getPushPanelViewportMargin(document, base?)` helper in `@lucca-front/ng/core`:
- reads the `--commons-pushPanel-inlineSize` token from `documentElement` (px, falls back to 0);
- returns a per-side viewport margin `{ start, end, top, bottom }` reserving only the inline-end (`end`), with an optional `base` added to every side to preserve existing margins.

Applied via `withViewportMargin(...)` on each connected position strategy. The object form of `ViewportMargin` is supported since `@angular/cdk@21.0.0` (typings + runtime), so it is compatible with the whole `^21.0.0` range. `document` is resolved via `element.nativeElement.ownerDocument` (no DI, works outside an injection context — needed for the popover v1 model). The selects' hardcoded `withViewportMargin(8)` becomes `getPushPanelViewportMargin(..., 8)`.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
