### PR TITLE
feat(data-table/index-table): add mixed checkbox state

### DIFF
--- a/packages/ng/data-table/data-table-row/data-table-row.component.html
+++ b/packages/ng/data-table/data-table-row/data-table-row.component.html
@@ -22,7 +22,7 @@
 <ng-template #input>
 	@if (!footRef && selectedLabel()) {
 		<lu-form-field [label]="selectedLabel()" hiddenLabel>
-			<lu-checkbox-input [(ngModel)]="selected" [disabled]="disabled()" />
+			<lu-checkbox-input [(ngModel)]="selected" [disabled]="disabled()" [mixed]="mixed()" />
 		</lu-form-field>
 	}
 </ng-template>

--- a/packages/ng/data-table/data-table-row/data-table-row.component.ts
+++ b/packages/ng/data-table/data-table-row/data-table-row.component.ts
@@ -49,5 +49,6 @@ export class DataTableRowComponent {
 
 	readonly selected = model<boolean>(false);
 	readonly selectedLabel = input<string | null>(null);
+	readonly mixed = input(false, { transform: booleanAttribute });
 	readonly disabled = input(false, { transform: booleanAttribute });
 }

--- a/packages/ng/index-table/index-table-row/index-table-row.component.html
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.html
@@ -12,7 +12,7 @@
 <ng-template #input>
 	@if (!footRef && selectedLabel()) {
 		<lu-form-field [label]="selectedLabel()" hiddenLabel>
-			<lu-checkbox-input class="indexTable-head-row-cell-checkbox" [(ngModel)]="selected" [disabled]="disabled()" />
+			<lu-checkbox-input class="indexTable-head-row-cell-checkbox" [(ngModel)]="selected" [disabled]="disabled()" [mixed]="mixed()" />
 		</lu-form-field>
 	}
 </ng-template>

--- a/packages/ng/index-table/index-table-row/index-table-row.component.ts
+++ b/packages/ng/index-table/index-table-row/index-table-row.component.ts
@@ -52,5 +52,6 @@ export class IndexTableRowComponent implements LuTooltipAnchorRef {
 	readonly selected = model<boolean>(false);
 	readonly selectedLabel = input<string | null>(null);
 	readonly disabled = input(false, { transform: booleanAttribute });
+	readonly mixed = input(false, { transform: booleanAttribute });
 	readonly stack = input(1, { transform: numberAttribute });
 }

--- a/stories/documentation/listings/data-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/data-table/angular/basic.stories.ts
@@ -69,6 +69,7 @@ export default {
 		},
 		mixed: {
 			if: { arg: 'selectable', truthy: true },
+			description: "Applique un état de sélection mixte (-) à la checkbox d'une ligne.",
 		},
 		disabled: {
 			if: { arg: 'selectable', truthy: true },

--- a/stories/documentation/listings/data-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/data-table/angular/basic.stories.ts
@@ -67,6 +67,9 @@ export default {
 			if: { arg: 'selectable', truthy: true },
 			description: 'Texte alternatif restitué à la sélection de l’ensemble des lignes.',
 		},
+		mixed: {
+			if: { arg: 'selectable', truthy: true },
+		},
 		disabled: {
 			if: { arg: 'selectable', truthy: true },
 		},
@@ -194,6 +197,7 @@ export default {
 			cellBorder,
 			inlineSize,
 			inlineSizeValue,
+			mixed,
 			selectable,
 			lines,
 			nested,
@@ -216,6 +220,7 @@ export default {
 		const selectedAttr = selected ? ` [selected]="true"` : ``;
 		const selectableLabelAttr = selectable ? ` selectedLabel="${selectedLabel}"` : ``;
 		const selectableLabelHeadAttr = selectable ? ` selectedLabel="${selectedLabelHead}"` : ``;
+		const mixedAttr = mixed ? ` mixed` : ``;
 		const disabledAttr = disabled ? ` disabled` : ``;
 		const groupAttr = group ? ` groupButtonAlt="${groupButtonAlt}" [group]="samplePortalContent"` : ``;
 		const expandedAttr = expanded ? ` [expanded]="true"` : ``;
@@ -310,7 +315,7 @@ export default {
 			props: { example: text },
 			template: `<lu-data-table${layoutFixedAttr}${hoverAttr}${cellBorderAttr}${selectableAttr}${verticalAlignAttr}${nestedAttr}${draggable}${emptyAttr}>
 	<thead luDataTableHead>
-		<tr luDataTableRow${selectableLabelHeadAttr}>
+		<tr luDataTableRow${selectableLabelHeadAttr}${mixedAttr}>
 			<th luDataTableCell>${textHeader}</th>${colsHeaderContent}
 			<th luDataTableCell${inlineSizeAttr}${sortAttr}${alignAttr}>${textHeader}</th>
 		</tr>
@@ -340,6 +345,7 @@ export const Basic: StoryObj = {
 		inlineSizeValue: '6rem',
 		selectable: false,
 		selected: false,
+		mixed: false,
 		disabled: false,
 		selectedLabel: 'Sélectionner cette ligne',
 		selectedLabelHead: 'Sélectionner toutes les lignes',

--- a/stories/documentation/listings/index-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/index-table/angular/basic.stories.ts
@@ -23,25 +23,6 @@ import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/an
 import { HiddenArgType } from 'stories/helpers/common-arg-types';
 import { setStoryOptions } from 'stories/helpers/stories';
 
-interface BasicStory {
-	action: string;
-	pagination: boolean;
-	selectable: boolean;
-	stack: number;
-	group: boolean;
-	groupButtonAlt: string;
-	expanded: boolean;
-	footer: boolean;
-	intermediateFooter: boolean;
-	allowSelection: boolean;
-	allowAction: boolean;
-	hiddenLabel: boolean;
-	sort: string;
-	align: string;
-	layoutFixed: boolean;
-	empty: boolean;
-}
-
 export default {
 	title: 'Documentation/Listings/Index Table/Angular/Basic',
 	argTypes: {
@@ -54,6 +35,12 @@ export default {
 		},
 		selectable: {
 			description: 'Rend les lignes du tableau sélectionnables via des checkbox.',
+		},
+		mixed: {
+			if: { arg: 'selectable', truthy: true },
+		},
+		disabled: {
+			if: { arg: 'selectable', truthy: true },
 		},
 		action: {
 			options: ['link', 'button', 'user', 'file'],
@@ -136,62 +123,83 @@ export default {
 			providers: [provideAnimations(), provideHttpClient()],
 		}),
 	],
-} as Meta;
+	render: (args, { argTypes }) => {
+		const {
+			stack,
+			selectable,
+			mixed,
+			disabled,
+			group,
+			allowAction,
+			allowSelection,
+			groupButtonAlt,
+			intermediateFooter,
+			action,
+			hiddenLabel,
+			sort,
+			align,
+			expanded,
+			pagination,
+			layoutFixed,
+			empty,
+			footer,
+		} = args;
 
-function getTemplate(args: BasicStory): string {
-	const stackParam = args.stack >= 2 ? ` stack="${args.stack}"` : ``;
-	const selectableAttr = args.selectable ? ` selectable` : ``;
-	const selectableParam = args.selectable ? ` selectedLabel="Sélectionner cette ligne"` : ``;
-	const selectableAllParam = args.selectable ? ` selectedLabel="Sélectionner toutes les lignes"` : ``;
-	const groupAttr = args.group ? ` [group]="samplePortalContent"` : ``;
-	const allowSelectionAttr = args.allowSelection ? ` allowTextSelection` : ``;
-	const allowActionTpl = args.allowAction ? `<a href="#">Content</a>` : `Content`;
-	const intermediateFooterAttr = args.intermediateFooter ? ` tfoot` : ``;
-	const hiddenLabelAttr = args.hiddenLabel ? ` hiddenLabel` : ``;
-	const sortAttr = args.sort ? ` sort="${args.sort}"` : ``;
-	const alignAttr = args.align ? ` align="${args.align}"` : ``;
-	const groupExpandedAttr = args.expanded && args.group ? ` [expanded]="true"` : ``;
-	const groupButtonAltAttr = args.group ? ` groupButtonAlt="${args.groupButtonAlt}"` : ``;
-	const layoutFixedAttr = args.layoutFixed ? ` layoutFixed` : ``;
-	const emptyAttr = args.empty ? ` empty` : ``;
-	const footerTpl = args.footer
-		? `
+		const stackParam = stack >= 2 ? ` stack="${stack}"` : ``;
+		const selectableAttr = selectable ? ` selectable` : ``;
+		const disabledAttr = disabled ? ` disabled` : ``;
+		const mixedAttr = mixed ? ` mixed` : ``;
+		const selectableParam = selectable ? ` selectedLabel="Sélectionner cette ligne"` : ``;
+		const selectableAllParam = selectable ? ` selectedLabel="Sélectionner toutes les lignes"` : ``;
+		const groupAttr = group ? ` [group]="samplePortalContent"` : ``;
+		const allowSelectionAttr = allowSelection ? ` allowTextSelection` : ``;
+		const allowActionTpl = allowAction ? `<a href="#">Content</a>` : `Content`;
+		const intermediateFooterAttr = intermediateFooter ? ` tfoot` : ``;
+		const hiddenLabelAttr = hiddenLabel ? ` hiddenLabel` : ``;
+		const sortAttr = sort ? ` sort="${sort}"` : ``;
+		const alignAttr = align ? ` align="${align}"` : ``;
+		const groupExpandedAttr = expanded && group ? ` [expanded]="true"` : ``;
+		const groupButtonAltAttr = group ? ` groupButtonAlt="${groupButtonAlt}"` : ``;
+		const layoutFixedAttr = layoutFixed ? ` layoutFixed` : ``;
+		const emptyAttr = empty ? ` empty` : ``;
+		const footerTpl = footer
+			? `
 	<tfoot luIndexTableFoot>
 		<tr luIndexTableRow>
 			<td colspan="3" luIndexTableCell>Content</td>
 		</tr>
 	</tfoot>`
-		: ``;
-	const paginationTpl = args.pagination
-		? `
+			: ``;
+		const paginationTpl = pagination
+			? `
 	<lu-pagination indexTablePagination from="1" to="20" itemsCount="27" isFirstPage />`
-		: ``;
-	let actionTpl = ``;
-	switch (args.action) {
-		case 'button':
-			actionTpl = `
+			: ``;
+		let actionTpl = ``;
+		switch (action) {
+			case 'button':
+				actionTpl = `
 				<button luIndexTableAction type="button">button</button>
 			`;
-			break;
-		case 'user':
-			actionTpl = `
+				break;
+			case 'user':
+				actionTpl = `
 				<button luIndexTableAction type="button" class="pr-u-mask">{{ bob | luUserDisplay:'lf' }}</button>
 				<button class="userPopover_trigger" [luUserPopover]="bob">user</button>
 			`;
-			break;
-		case 'file':
-			actionTpl = `
+				break;
+			case 'file':
+				actionTpl = `
 				<label luIndexTableAction for="myInput">file</label>
 				<input luIndexTableAction id="myInput" type="file" />
 			`;
-			break;
-		default:
-			actionTpl = `
+				break;
+			default:
+				actionTpl = `
 				<a luIndexTableAction href="#">link</a>
 			`;
-	}
-	const tbodyTpl = args.empty
-		? `<tr luIndexTableRow>
+		}
+		const tbodyTpl = empty
+			? `<tr luIndexTableRow>
 			<th luIndexTableCell colspan="3">
 				<lu-empty-state-section
 					hx="3"
@@ -201,12 +209,12 @@ function getTemplate(args: BasicStory): string {
 				/>
 			</th>
 		</tr>`
-		: `<tr luIndexTableRow${selectableParam}${stackParam}>
+			: `<tr luIndexTableRow${selectableParam}${stackParam}>
 			<th luIndexTableCell>${actionTpl}</th>
 			<td luIndexTableCell>Content</td>
 			<td luIndexTableCell>Content</td>
 		</tr>
-		<tr luIndexTableRow${selectableParam}>
+		<tr luIndexTableRow${selectableParam}${disabledAttr}>
 			<td luIndexTableCell colspan="3"${alignAttr}${intermediateFooterAttr}>Content</td>
 		</tr>
 		<tr luIndexTableRow${selectableParam}>
@@ -214,17 +222,18 @@ function getTemplate(args: BasicStory): string {
 			<td luIndexTableCell${allowSelectionAttr}>${allowActionTpl}</td>
 			<td luIndexTableCell>Content Content Content</td>
 		</tr>`;
-	const samplePortalContentTpl = args.group
-		? `
+		const samplePortalContentTpl = group
+			? `
 <ng-template #samplePortalContent>
 	Group label
 	<lu-numeric-badge [value]="8" />
 </ng-template>`
-		: ``;
+			: ``;
 
-	return `<lu-index-table${selectableAttr}${layoutFixedAttr}${emptyAttr}>
+		return {
+			template: `<lu-index-table${selectableAttr}${layoutFixedAttr}${emptyAttr}>
 	<thead luIndexTableHead>
-		<tr luIndexTableRow${selectableAllParam}>
+		<tr luIndexTableRow${selectableAllParam}${mixedAttr}>
 			<th luIndexTableCell>Label</th>
 			<th luIndexTableCell${hiddenLabelAttr}>Label</th>
 			<th luIndexTableCell${alignAttr}${sortAttr}>Label</th>
@@ -234,19 +243,18 @@ function getTemplate(args: BasicStory): string {
 		${tbodyTpl}
 	</tbody>${footerTpl}${paginationTpl}
 </lu-index-table>${samplePortalContentTpl}
-`;
-}
+`,
+		};
+	},
+} as Meta;
 
-const Template = (args: BasicStory) => ({
-	props: args,
-	template: getTemplate(args),
-});
-
-export const Basic: StoryObj<BasicStory> = {
+export const Basic: StoryObj = {
 	args: {
 		empty: false,
 		layoutFixed: false,
 		selectable: false,
+		disabled: false,
+		mixed: false,
 
 		sort: '',
 		align: '',
@@ -266,5 +274,4 @@ export const Basic: StoryObj<BasicStory> = {
 		footer: false,
 		pagination: false,
 	},
-	render: Template,
 };

--- a/stories/documentation/listings/index-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/index-table/angular/basic.stories.ts
@@ -38,6 +38,7 @@ export default {
 		},
 		mixed: {
 			if: { arg: 'selectable', truthy: true },
+			description: "Applique un état de sélection mixte (-) à la checkbox d'une ligne.",
 		},
 		disabled: {
 			if: { arg: 'selectable', truthy: true },


### PR DESCRIPTION
## Description

- Add support for mixed (indeterminate) checkbox state on data-table-row and index-table-row components.
- Add corresponding disabled checkbox state handling.
- Update Angular Storybook stories for both data-table and index-table with examples showcasing mixed and disabled check states.


---------

---------

