### PR TITLE
fix(stories): MSW mock response format for users totalCount

### DIFF
--- a/.storybook/msw/handlers.ts
+++ b/.storybook/msw/handlers.ts
@@ -20,6 +20,7 @@ const usersSearchHandler = genericHandler(
 		paging: (p) => p,
 		clue: (clue) => clue.toLowerCase(),
 		id: (ids) => ids.split(',').map((id) => parseInt(id)),
+		fields: (f) => f,
 	},
 	{
 		// Apply filters to items
@@ -28,12 +29,17 @@ const usersSearchHandler = genericHandler(
 		// Then paging/limiting
 		paging: applyV3Paging,
 	},
-	(items) => ({
-		data: {
-			items: items.map((item) => ({ relevance: 1, item })),
-		},
-		count: items.length,
-	}),
+	(items, params) => {
+		if (params.fields === 'collection.count') {
+			return { data: { count: items.length } };
+		}
+		return {
+			data: {
+				items: items.map((item) => ({ relevance: 1, item })),
+			},
+			count: items.length,
+		};
+	},
 );
 
 export const handlers = [


### PR DESCRIPTION
## Description

The mock now parses the `fields` query param and returns `{ data: { count: N } }` when `fields: 'collection.count'` is requested, matching the shape the production API actually returns.


-----


-----
