### PR TITLE
docs(toasts): préciser que <lu-toasts /> doit être hors de <lu-app-layout />

### DIFF
--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -5,9 +5,6 @@ import { defaultToastDuration, LuToastInput, LuToastsComponent, LuToastsService,
 import { applicationConfig, Meta, StoryObj } from '@storybook/angular';
 import { Observable, ReplaySubject, Subject } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { createTestStory } from 'stories/helpers/stories';
-import { waitForAngular } from 'stories/helpers/test';
-import { expect, userEvent, within } from 'storybook/test';
 
 @Component({
 	selector: 'toasts-stories',
@@ -84,11 +81,7 @@ const template = (args: ToastsStory) => ({
 });
 
 const code = `
-/* Ajouter l'encre <lu-toasts /> dans le app.component.html.
-   ⚠️ Le <lu-toasts /> doit se trouver EN DEHORS du <lu-app-layout />.
-   Le host .appLayout a \`isolation: isolate\`, ce qui enfermerait le z-index
-   du toast dans un stacking context, sous le .cdk-overlay-container des overlays
-   (dialogs) : les toasts passeraient alors derrière les dialogs. */
+/* Ajouter l'encre <lu-toasts /> dans app.component.html, en dessous de <lu-app-layout />, afin que les toasts soient affichés au-dessus de tous les overlays (voir la structure complète sur la page AppLayout).*/
 <lu-toasts [bottom]="true" [sources]="[]" />
 
 /* Ajouter un toast avec la méthode addToast(..) du LuToastsService */

--- a/stories/documentation/overlays/toasts/toasts.stories.ts
+++ b/stories/documentation/overlays/toasts/toasts.stories.ts
@@ -84,7 +84,11 @@ const template = (args: ToastsStory) => ({
 });
 
 const code = `
-/* Ajouter l'encre <lu-toasts /> dans le app.component.html */
+/* Ajouter l'encre <lu-toasts /> dans le app.component.html.
+   ⚠️ Le <lu-toasts /> doit se trouver EN DEHORS du <lu-app-layout />.
+   Le host .appLayout a \`isolation: isolate\`, ce qui enfermerait le z-index
+   du toast dans un stacking context, sous le .cdk-overlay-container des overlays
+   (dialogs) : les toasts passeraient alors derrière les dialogs. */
 <lu-toasts [bottom]="true" [sources]="[]" />
 
 /* Ajouter un toast avec la méthode addToast(..) du LuToastsService */

--- a/stories/documentation/structure/main-layout/angular/inAppLayout.stories.ts
+++ b/stories/documentation/structure/main-layout/angular/inAppLayout.stories.ts
@@ -216,7 +216,9 @@ export default {
 		${content}
 		${footerContainer}
 	</lu-main-layout>
-</lu-app-layout>`,
+</lu-app-layout>
+<!-- <lu-toasts /> -->
+`,
 		};
 	},
 } as Meta;

--- a/stories/documentation/structure/main-layout/html&css/inAppLayout.stories.ts
+++ b/stories/documentation/structure/main-layout/html&css/inAppLayout.stories.ts
@@ -198,6 +198,7 @@ export default {
 		</main>
 	</div>
 </div>
+<!-- <lu-toasts /> -->
 `,
 		};
 	},


### PR DESCRIPTION
## Description

Le host `.appLayout` de `<lu-app-layout />` a `isolation: isolate`, ce qui enferme le z-index du toast dans un stacking context, sous le `.cdk-overlay-container` des overlays (dialogs).

Placé **à l'intérieur** de `<lu-app-layout />`, le `<lu-toasts />` passe donc derrière les dialogs (CDK 21 rend en plus les overlays dans la top layer via l'API Popover).

Cette PR met à jour le snippet d'exemple de la doc des toasts (`stories/documentation/overlays/toasts/toasts.stories.ts`) pour indiquer que le `<lu-toasts />` doit se trouver **en dehors** de `<lu-app-layout />`.

Voir le fix appliqué côté apps : LuccaSA/Poplee.Talent#12505.

-----