### PR TITLE
core(ng): replace setTimeout with afterNextRender for post-render DOM updates

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -1,5 +1,6 @@
 import { OverlayConfig, OverlayContainer } from '@angular/cdk/overlay';
 import {
+	afterNextRender,
 	booleanAttribute,
 	ChangeDetectorRef,
 	computed,
@@ -7,6 +8,7 @@ import {
 	ElementRef,
 	EventEmitter,
 	inject,
+	Injector,
 	input,
 	linkedSignal,
 	model,
@@ -49,6 +51,7 @@ export const coreSelectDefaultOptionKey: (option: unknown) => unknown = (option)
 export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDestroy, OnInit, ControlValueAccessor, FilterPillInputComponent {
 	public parentInput = inject(FILTER_PILL_INPUT_COMPONENT, { optional: true, skipSelf: true });
 	protected changeDetectorRef = inject(ChangeDetectorRef);
+	readonly #injector = inject(Injector);
 	protected overlayContainerRef: HTMLElement = inject(OverlayContainer).getContainerElement();
 
 	protected labelElement: HTMLElement | undefined = inject(SELECT_LABEL);
@@ -259,15 +262,16 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 			if (isNotNil(options)) {
 				this.options$.next(options);
 				if (this.panelRef) {
-					// We have to put it in a setTimeout so it'll be triggered AFTER the DOM is updated and not right now,
-					// which is before the panel size has been modified by the arrival of the new options
-					const timeoutId = setTimeout(() => {
-						this.panelRef?.updatePosition();
-						this.updatePositionFn?.();
-						// If no fixes are found, last resort fix is here
-						// window.dispatchEvent(new Event('resize'));
-					});
-					onCleanup(() => clearTimeout(timeoutId));
+					const ref = afterNextRender(
+						() => {
+							this.panelRef?.updatePosition();
+							this.updatePositionFn?.();
+							// If no fixes are found, last resort fix is here
+							// window.dispatchEvent(new Event('resize'));
+						},
+						{ injector: this.#injector },
+					);
+					onCleanup(() => ref.destroy());
 				}
 			}
 		});

--- a/packages/ng/date2/date-input/date-input.component.ts
+++ b/packages/ng/date2/date-input/date-input.component.ts
@@ -1,6 +1,7 @@
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { NgTemplateOutlet } from '@angular/common';
 import {
+	afterNextRender,
 	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
@@ -248,9 +249,12 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 			}
 			if (!this.isNavigationButtonFocused && !this.inputFocused()) {
 				this.calendar()?.blurTabbableDate();
-				setTimeout(() => {
-					this.calendar()?.focusTabbableDate();
-				});
+				afterNextRender(
+					() => {
+						this.calendar()?.focusTabbableDate();
+					},
+					{ injector: this.#injector },
+				);
 			}
 		});
 	}
@@ -284,10 +288,12 @@ export class DateInputComponent extends AbstractDateComponent implements OnInit,
 		if (!this.isFilterPill) {
 			ref.openPopover(true, true);
 			// Once popover is opened, aka in the next CD cycle, focus current tabbable date
-
-			setTimeout(() => {
-				this.calendar()?.focusTabbableDate();
-			});
+			afterNextRender(
+				() => {
+					this.calendar()?.focusTabbableDate();
+				},
+				{ injector: this.#injector },
+			);
 		}
 	}
 

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -2,6 +2,7 @@ import { BreakpointObserver, LayoutModule } from '@angular/cdk/layout';
 import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { NgTemplateOutlet } from '@angular/common';
 import {
+	afterNextRender,
 	booleanAttribute,
 	ChangeDetectionStrategy,
 	Component,
@@ -282,9 +283,12 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 			}
 			if (!this.isNavigationButtonFocused && !this.inputFocused()) {
 				this.focusedCalendar()?.blurTabbableDate();
-				setTimeout(() => {
-					this.focusedCalendar()?.focusTabbableDate();
-				});
+				afterNextRender(
+					() => {
+						this.focusedCalendar()?.focusTabbableDate();
+					},
+					{ injector: this.#injector },
+				);
 			}
 		});
 	}
@@ -349,28 +353,31 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 			ref.openPopover(true, true);
 		}
 		// Once popover is opened, aka in the next CD cycle, focus current tabbable date
-		setTimeout(() => {
-			this.focusedCalendarIndex.set(0);
-			const selectedRange = this.selectedRange();
-			if (propertyToFocus && selectedRange && selectedRange[propertyToFocus]) {
-				// Specific case: if range is on a single month, focus on it on left calendar
-				// Same goes for focus on start date, we want it on left panel
-				if (propertyToFocus === 'start' || (selectedRange.end && compareCalendarPeriods(this.mode(), selectedRange.start, selectedRange.end))) {
-					this.currentDate.set(selectedRange[propertyToFocus]);
-					this.tabbableDate.set(selectedRange[propertyToFocus]);
-				} else {
-					// Compute the date to use for proper focus on left panel, minus one calendar on focus date basically
-					const leftPanelFocus = selectedRange.end;
-					if (leftPanelFocus) {
-						this.currentDate.set(leftPanelFocus);
-						this.tabbableDate.set(leftPanelFocus);
+		afterNextRender(
+			() => {
+				this.focusedCalendarIndex.set(0);
+				const selectedRange = this.selectedRange();
+				if (propertyToFocus && selectedRange && selectedRange[propertyToFocus]) {
+					// Specific case: if range is on a single month, focus on it on left calendar
+					// Same goes for focus on start date, we want it on left panel
+					if (propertyToFocus === 'start' || (selectedRange.end && compareCalendarPeriods(this.mode(), selectedRange.start, selectedRange.end))) {
+						this.currentDate.set(selectedRange[propertyToFocus]);
+						this.tabbableDate.set(selectedRange[propertyToFocus]);
+					} else {
+						// Compute the date to use for proper focus on left panel, minus one calendar on focus date basically
+						const leftPanelFocus = selectedRange.end;
+						if (leftPanelFocus) {
+							this.currentDate.set(leftPanelFocus);
+							this.tabbableDate.set(leftPanelFocus);
+						}
 					}
 				}
-			}
-			if (focusTabbableDate) {
-				this.focusedCalendar()?.focusTabbableDate();
-			}
-		});
+				if (focusTabbableDate) {
+					this.focusedCalendar()?.focusTabbableDate();
+				}
+			},
+			{ injector: this.#injector },
+		);
 	}
 
 	dateClicked(date: Date, popoverRef: PopoverDirective): void {

--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -1,5 +1,5 @@
 import { CdkDialogContainer } from '@angular/cdk/dialog';
-import { ChangeDetectionStrategy, Component, contentChild, Directive, ElementRef, inject, input, OnInit, Renderer2, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, contentChild, Directive, ElementRef, inject, Injector, input, OnInit, Renderer2, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { intlInputOptions } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -41,6 +41,7 @@ export class DialogHeaderComponent implements OnInit {
 	#elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
 
 	#renderer = inject(Renderer2);
+	#injector = inject(Injector);
 
 	close(): void {
 		this.#ref.dismiss();
@@ -51,15 +52,17 @@ export class DialogHeaderComponent implements OnInit {
 	readonly optionalSubtitle = contentChild(DialogHeaderSubtitle);
 
 	ngOnInit(): void {
-		// Using setTimeout here to make sure this will be handled in the next Cd cycle, not the current one.
-		setTimeout(() => {
-			const header = this.#elementRef.nativeElement.querySelector('h1');
-			const id = header?.id || `lu-dialog-header-${nextId++}`;
-			if (header) {
-				this.#renderer.setAttribute(header, 'id', id);
-				this.#renderer.addClass(header, 'dialog-inside-header-container-title');
-			}
-			(this.#ref.cdkRef.containerInstance as CdkDialogContainer)?._addAriaLabelledBy(id);
-		});
+		afterNextRender(
+			() => {
+				const header = this.#elementRef.nativeElement.querySelector('h1');
+				const id = header?.id || `lu-dialog-header-${nextId++}`;
+				if (header) {
+					this.#renderer.setAttribute(header, 'id', id);
+					this.#renderer.addClass(header, 'dialog-inside-header-container-title');
+				}
+				(this.#ref.cdkRef.containerInstance as CdkDialogContainer)?._addAriaLabelledBy(id);
+			},
+			{ injector: this.#injector },
+		);
 	}
 }

--- a/packages/ng/form-field/form-field.component.ts
+++ b/packages/ng/form-field/form-field.component.ts
@@ -31,9 +31,9 @@ import { InlineMessageComponent, InlineMessageState } from '@lucca-front/ng/inli
 import { LuTooltipModule } from '@lucca-front/ng/tooltip';
 import { BehaviorSubject } from 'rxjs';
 import { FormFieldSize } from './form-field-size';
-import { FormFieldLayout, FormFieldWidth } from './form-field.type';
 import { FORM_FIELD_INSTANCE } from './form-field.token';
 import { LU_FORM_FIELD_TRANSLATIONS } from './form-field.translate';
+import { FormFieldLayout, FormFieldWidth } from './form-field.type';
 import { InputDirective } from './input.directive';
 import { INPUT_FRAMED_INSTANCE } from './public-api';
 
@@ -155,12 +155,12 @@ export class FormFieldComponent implements OnDestroy, DoCheck {
 
 	public addInput(input: InputDirective) {
 		this.#inputs.push(input);
-		/* We have to put this in the next cycle to make sure it'll be applied properly
-		 * and that it won't trigger a change detection error
-		 */
-		setTimeout(() => {
-			this.prepareInput();
-		});
+		afterNextRender(
+			() => {
+				this.prepareInput();
+			},
+			{ injector: this.#injector },
+		);
 	}
 
 	public get inputs(): InputDirective[] {

--- a/packages/ng/multi-select/displayer/default-displayer.component.ts
+++ b/packages/ng/multi-select/displayer/default-displayer.component.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, input, OnInit, viewChild } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, DestroyRef, ElementRef, inject, Injector, input, OnInit, viewChild } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ChipComponent } from '@lucca-front/ng/chip';
@@ -54,6 +54,7 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 	valueID = `value-${++nextID}`;
 
 	protected destroyRef = inject(DestroyRef);
+	readonly #injector = inject(Injector);
 
 	readonly inputElementRef = viewChild<ElementRef<HTMLInputElement>>('inputElement');
 
@@ -87,12 +88,15 @@ export class LuMultiSelectDefaultDisplayerComponent<T> implements OnInit {
 			this.value.filter((o) => o !== option),
 			true,
 		);
-		setTimeout(() => {
-			this.select.panelRef?.updatePosition();
-			this.select.updatePosition();
-			this.inputElementRef()?.nativeElement.focus();
-			this.select.panelRef?.updateSelectedOptions(this.value);
-		});
+		afterNextRender(
+			() => {
+				this.select.panelRef?.updatePosition();
+				this.select.updatePosition();
+				this.inputElementRef()?.nativeElement.focus();
+				this.select.panelRef?.updateSelectedOptions(this.value);
+			},
+			{ injector: this.#injector },
+		);
 	}
 
 	inputBackspace(): void {

--- a/packages/ng/multi-select/input/select-all/multi-select-all-displayer.component.ts
+++ b/packages/ng/multi-select/input/select-all/multi-select-all-displayer.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, ElementRef, inject, input, viewChild } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, computed, ElementRef, inject, Injector, input, viewChild } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ChipComponent } from '@lucca-front/ng/chip';
 import { intlInputOptions } from '@lucca-front/ng/core';
@@ -49,14 +49,18 @@ export class LuMultiSelectAllDisplayerComponent<TValue> {
 	readonly disabled = toSignal(this.select.disabled$);
 
 	readonly inputElementRef = viewChild.required<LuMultiSelectDisplayerInputDirective<TValue>, ElementRef<HTMLInputElement>>(LuMultiSelectDisplayerInputDirective, { read: ElementRef });
+	readonly #injector = inject(Injector);
 
 	unselectOption(option: TValue, $event: Event): void {
 		$event.stopPropagation();
 		$event.preventDefault();
 		this.select.updateValue(this.select.value?.filter((o) => o !== option) ?? [], true);
-		setTimeout(() => {
-			this.select.panelRef?.updatePosition();
-			this.inputElementRef().nativeElement.focus();
-		});
+		afterNextRender(
+			() => {
+				this.select.panelRef?.updatePosition();
+				this.inputElementRef().nativeElement.focus();
+			},
+			{ injector: this.#injector },
+		);
 	}
 }

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,6 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
+import { afterNextRender, AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, Injector, signal, TrackByFunction } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { isNotNil, PortalDirective } from '@lucca-front/ng/core';
@@ -85,6 +85,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	readonly pointerNavigation = signal(false);
 
 	readonly keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
+	readonly #injector = inject(Injector);
 
 	onKeydown(): void {
 		this.pointerNavigation.set(false);
@@ -138,7 +139,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		const matchingOption = this.selectedOptions.find((o) => this.optionComparer()(o, option));
 		this.selectedOptions = matchingOption && option ? this.selectedOptions.filter((o) => o !== matchingOption) : [...this.selectedOptions, option];
 		this.panelRef.emitValue(this.selectedOptions);
-		setTimeout(() => this.panelRef.updatePosition());
+		afterNextRender(() => this.panelRef.updatePosition(), { injector: this.#injector });
 	}
 
 	toggleOptions(notSelectedOptions: T[], groupOptions: T[]): void {
@@ -160,7 +161,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 		}
 
 		this.panelRef.emitValue(this.selectedOptions);
-		setTimeout(() => this.panelRef.updatePosition());
+		afterNextRender(() => this.panelRef.updatePosition(), { injector: this.#injector });
 	}
 
 	protected initKeyManager(): void {


### PR DESCRIPTION
## Description

- Replace `setTimeout(() => ...)` deferred DOM operations with `afterNextRender(..., { injector })` across 9 components
- Affected packages: `multi-select`, `core-select`, `dialog`, `form-field`, `date2`

---------

---------
