### PR TITLE
feat(core-select): add legal units directive with archived support

### DIFF
--- a/packages/ng/core-select/legal-units/archived-legal-units.component.scss
+++ b/packages/ng/core-select/legal-units/archived-legal-units.component.scss
@@ -1,0 +1,15 @@
+@use '../../styles/definitions';
+
+@include definitions.optionItemStyle;
+
+@layer components {
+	:host {
+		display: block;
+		background-color: var(--palettes-neutral-0);
+		border-block-end: 1px solid var(--commons-border-200);
+		padding-block: 0 var(--components-options-item-padding-vertical);
+		padding-inline: var(--pr-t-spacings-50);
+		margin-block: 0 var(--components-options-item-padding-vertical);
+		margin-inline: calc(-1 * var(--pr-t-spacings-50));
+	}
+}

--- a/packages/ng/core-select/legal-units/archived-legal-units.component.ts
+++ b/packages/ng/core-select/legal-units/archived-legal-units.component.ts
@@ -1,0 +1,42 @@
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, WritableSignal } from '@angular/core';
+import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ɵCoreSelectPanelElement } from '@lucca-front/ng/core-select';
+
+export interface ArchivedLegalUnitsContext {
+	includeArchivedLegalUnits: WritableSignal<boolean>;
+}
+
+export const ARCHIVED_LEGAL_UNITS_CONTEXT = new InjectionToken<ArchivedLegalUnitsContext>('ArchivedLegalUnitsContext');
+
+@Component({
+	selector: 'lu-core-select-archived-legal-units',
+	styleUrl: './archived-legal-units.component.scss',
+	imports: [FormsModule],
+	hostDirectives: [ɵCoreSelectPanelElement],
+	template: `
+		<div class="archivedLegalUnitsDisplayer optionItem">
+			<div class="optionItem-value" [class.is-selected]="context.includeArchivedLegalUnits()" (mousedown)="onMouseDown($event)">Inclure les unités légales archivées</div>
+		</div>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LuCoreSelectArchivedLegalUnitsComponent {
+	readonly context = inject(ARCHIVED_LEGAL_UNITS_CONTEXT);
+	readonly #selectableItem = inject(ɵCoreSelectPanelElement);
+
+	constructor() {
+		this.#selectableItem.id.set('select-archived-legal-units');
+		outputToObservable(this.#selectableItem.selected)
+			.pipe(takeUntilDestroyed())
+			.subscribe(() => {
+				this.context.includeArchivedLegalUnits.set(!this.context.includeArchivedLegalUnits());
+			});
+	}
+
+	onMouseDown($event: MouseEvent): void {
+		this.context.includeArchivedLegalUnits.set(!this.context.includeArchivedLegalUnits());
+		$event.preventDefault();
+		$event.stopPropagation();
+	}
+}

--- a/packages/ng/core-select/legal-units/archived-legal-units.component.ts
+++ b/packages/ng/core-select/legal-units/archived-legal-units.component.ts
@@ -1,7 +1,9 @@
-import { ChangeDetectionStrategy, Component, inject, InjectionToken, WritableSignal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, InjectionToken, input, WritableSignal } from '@angular/core';
 import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
+import { intlInputOptions } from '@lucca-front/ng/core';
 import { ɵCoreSelectPanelElement } from '@lucca-front/ng/core-select';
+import { LU_CORE_SELECT_LEGAL_UNITS_TRANSLATIONS } from './legal-units.translate';
 
 export interface ArchivedLegalUnitsContext {
 	includeArchivedLegalUnits: WritableSignal<boolean>;
@@ -16,12 +18,13 @@ export const ARCHIVED_LEGAL_UNITS_CONTEXT = new InjectionToken<ArchivedLegalUnit
 	hostDirectives: [ɵCoreSelectPanelElement],
 	template: `
 		<div class="archivedLegalUnitsDisplayer optionItem">
-			<div class="optionItem-value" [class.is-selected]="context.includeArchivedLegalUnits()" (mousedown)="onMouseDown($event)">Inclure les unités légales archivées</div>
+			<div class="optionItem-value" [class.is-selected]="context.includeArchivedLegalUnits()" (mousedown)="onMouseDown($event)">{{ intl().includeArchivedLegalUnits }}</div>
 		</div>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LuCoreSelectArchivedLegalUnitsComponent {
+	readonly intl = input(...intlInputOptions(LU_CORE_SELECT_LEGAL_UNITS_TRANSLATIONS));
 	readonly context = inject(ARCHIVED_LEGAL_UNITS_CONTEXT);
 	readonly #selectableItem = inject(ɵCoreSelectPanelElement);
 

--- a/packages/ng/core-select/legal-units/legal-units.directive.ts
+++ b/packages/ng/core-select/legal-units/legal-units.directive.ts
@@ -1,9 +1,11 @@
 import { HttpClient } from '@angular/common/http';
-import { Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
+import { Directive, OnInit, booleanAttribute, computed, forwardRef, inject, input, signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { ARCHIVED_LEGAL_UNITS_CONTEXT, LuCoreSelectArchivedLegalUnitsComponent } from './archived-legal-units.component';
 import { LuCoreSelectLegalUnit } from './models';
 
 @Directive({
@@ -16,6 +18,10 @@ import { LuCoreSelectLegalUnit } from './models';
 			provide: CORE_SELECT_API_TOTAL_COUNT_PROVIDER,
 			useExisting: forwardRef(() => LuCoreSelectLegalUnitsDirective),
 		},
+		{
+			provide: ARCHIVED_LEGAL_UNITS_CONTEXT,
+			useExisting: forwardRef(() => LuCoreSelectLegalUnitsDirective),
+		},
 	],
 })
 export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = LuCoreSelectLegalUnit> extends ALuCoreSelectApiDirective<T> implements OnInit, CoreSelectApiTotalCountProvider {
@@ -25,8 +31,16 @@ export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = L
 	readonly filters = input<Record<string, string | number | boolean> | null>(null);
 	readonly uniqueOperationIds = input<readonly number[] | null>(null);
 	readonly searchDelimiter = input<string>(' ');
+	readonly enableArchivedLegalUnits = input(false, { transform: booleanAttribute });
+
+	readonly includeArchivedLegalUnits = signal(false);
 
 	protected readonly clue = toSignal(this.clue$);
+
+	constructor() {
+		super();
+		ɵeffectWithDeps([this.enableArchivedLegalUnits], (enableArchivedLegalUnits) => this.select.panelHeaderTpl.set(enableArchivedLegalUnits ? LuCoreSelectArchivedLegalUnitsComponent : undefined));
+	}
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
 		return this.httpClient
@@ -44,11 +58,13 @@ export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = L
 		computed(() => {
 			const uniqueOperationIds = this.uniqueOperationIds();
 			const clue = this.clue();
+			const includeArchivedLegalUnits = this.includeArchivedLegalUnits();
 			return {
 				...this.filters(),
 				sort: 'name',
 				...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()) } : {}),
 				...(uniqueOperationIds ? { uniqueOperations: uniqueOperationIds.join(',') } : {}),
+				...(includeArchivedLegalUnits ? { isArchived: true } : {}),
 			};
 		}),
 	);

--- a/packages/ng/core-select/legal-units/legal-units.directive.ts
+++ b/packages/ng/core-select/legal-units/legal-units.directive.ts
@@ -1,0 +1,70 @@
+import { HttpClient } from '@angular/common/http';
+import { Directive, OnInit, computed, forwardRef, inject, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
+import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
+import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { LuCoreSelectLegalUnit } from './models';
+
+@Directive({
+	// The attribute is already prefixed with "lu-simple-select" / "lu-multi-select"
+	// eslint-disable-next-line @angular-eslint/directive-selector
+	selector: 'lu-simple-select[legalUnits],lu-multi-select[legalUnits]',
+	exportAs: 'luLegalUnits',
+	providers: [
+		{
+			provide: CORE_SELECT_API_TOTAL_COUNT_PROVIDER,
+			useExisting: forwardRef(() => LuCoreSelectLegalUnitsDirective),
+		},
+	],
+})
+export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = LuCoreSelectLegalUnit> extends ALuCoreSelectApiDirective<T> implements OnInit, CoreSelectApiTotalCountProvider {
+	protected httpClient = inject(HttpClient);
+
+	readonly url = input<string>('/organization/structure/api/legal-units');
+	readonly filters = input<Record<string, string | number | boolean> | null>(null);
+	readonly uniqueOperationIds = input<readonly number[] | null>(null);
+	readonly searchDelimiter = input<string>(' ');
+
+	protected readonly clue = toSignal(this.clue$);
+
+	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
+		return this.httpClient
+			.get<{ items: T[] }>(this.url(), {
+				params: {
+					...params,
+					page: page + 1,
+					limit: this.pageSize,
+				},
+			})
+			.pipe(map((res) => res?.items ?? []));
+	}
+
+	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
+		computed(() => {
+			const uniqueOperationIds = this.uniqueOperationIds();
+			const clue = this.clue();
+			return {
+				...this.filters(),
+				sort: 'name',
+				...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()) } : {}),
+				...(uniqueOperationIds ? { uniqueOperations: uniqueOperationIds.join(',') } : {}),
+			};
+		}),
+	);
+
+	public readonly totalCount$ = toObservable(computed(() => ({ url: this.url(), filters: this.filters() }))).pipe(
+		debounceTime(250),
+		switchMap(({ url, filters }) =>
+			this.httpClient.get<{ count: number }>(url, {
+				params: {
+					...filters,
+					['fields.root']: 'count',
+				},
+			}),
+		),
+		map((res) => res?.count ?? 0),
+	);
+
+	protected override optionKey = (option: T) => option.id;
+}

--- a/packages/ng/core-select/legal-units/legal-units.translate.ts
+++ b/packages/ng/core-select/legal-units/legal-units.translate.ts
@@ -1,0 +1,13 @@
+import { InjectionToken } from '@angular/core';
+import { LuTranslation } from '@lucca-front/ng/core';
+import { Translations } from './translations';
+
+export const LU_CORE_SELECT_LEGAL_UNITS_TRANSLATIONS = new InjectionToken('LuCoreSelectLegalUnitsTranslations', {
+	factory: () => luCoreSelectLegalUnitsTranslations,
+});
+
+export interface LuCoreSelectLegalUnitsTranslations {
+	includeArchivedLegalUnits: string;
+}
+
+export const luCoreSelectLegalUnitsTranslations: LuTranslation<LuCoreSelectLegalUnitsTranslations> = Translations;

--- a/packages/ng/core-select/legal-units/models.ts
+++ b/packages/ng/core-select/legal-units/models.ts
@@ -1,0 +1,10 @@
+import { ILuApiItem } from '@lucca-front/ng/api';
+
+export interface LuCoreSelectLegalUnit extends ILuApiItem {
+	code: string | null;
+	legalIdentificationNumber: string | null;
+	activityCode: string | null;
+	countryId: number;
+	headquartersId: number;
+	isArchived: boolean;
+}

--- a/packages/ng/core-select/legal-units/ng-package.json
+++ b/packages/ng/core-select/legal-units/ng-package.json
@@ -1,0 +1,7 @@
+{
+	"$schema": "../../../../node_modules/ng-packagr/ng-package.schema.json",
+	"lib": {
+		"entryFile": "public-api.ts",
+		"styleIncludePaths": ["../../styles"]
+	}
+}

--- a/packages/ng/core-select/legal-units/public-api.ts
+++ b/packages/ng/core-select/legal-units/public-api.ts
@@ -1,2 +1,3 @@
+export * from './archived-legal-units.component';
 export * from './legal-units.directive';
 export * from './models';

--- a/packages/ng/core-select/legal-units/public-api.ts
+++ b/packages/ng/core-select/legal-units/public-api.ts
@@ -1,0 +1,2 @@
+export * from './legal-units.directive';
+export * from './models';

--- a/packages/ng/core-select/legal-units/translations.ts
+++ b/packages/ng/core-select/legal-units/translations.ts
@@ -1,0 +1,29 @@
+﻿export const Translations = {
+	"pl": {
+		'includeArchivedLegalUnits': "Include archived legal units",
+	},
+	"nl-BE": {
+		'includeArchivedLegalUnits': "Gearchiveerde wettelijke eenheden opnemen",
+	},
+	"fr": {
+		'includeArchivedLegalUnits': "Inclure les unités légales archivées",
+	},
+	"de": {
+		'includeArchivedLegalUnits': "Archivierte gesetzliche Einheiten einbeziehen",
+	},
+	"en": {
+		'includeArchivedLegalUnits': "Include archived legal units",
+	},
+	"es": {
+		'includeArchivedLegalUnits': "Incluir las unidades legales archivadas",
+	},
+	"it": {
+		'includeArchivedLegalUnits': "Includere le unità giuridiche archiviate",
+	},
+	"nl": {
+		'includeArchivedLegalUnits': "Gearchiveerde wettelijke eenheden opnemen",
+	},
+	"pt": {
+		'includeArchivedLegalUnits': "Incluir as unidades legais arquivadas",
+	},
+};

--- a/packages/ng/core-select/legal-units/translations.ts
+++ b/packages/ng/core-select/legal-units/translations.ts
@@ -1,29 +1,29 @@
 ﻿export const Translations = {
-	"pl": {
-		'includeArchivedLegalUnits': "Include archived legal units",
+	pl: {
+		includeArchivedLegalUnits: 'Include archived legal units',
 	},
-	"nl-BE": {
-		'includeArchivedLegalUnits': "Gearchiveerde wettelijke eenheden opnemen",
+	'nl-BE': {
+		includeArchivedLegalUnits: 'Gearchiveerde wettelijke eenheden opnemen',
 	},
-	"fr": {
-		'includeArchivedLegalUnits': "Inclure les unités légales archivées",
+	fr: {
+		includeArchivedLegalUnits: 'Inclure les unités légales archivées',
 	},
-	"de": {
-		'includeArchivedLegalUnits': "Archivierte gesetzliche Einheiten einbeziehen",
+	de: {
+		includeArchivedLegalUnits: 'Archivierte gesetzliche Einheiten einbeziehen',
 	},
-	"en": {
-		'includeArchivedLegalUnits': "Include archived legal units",
+	en: {
+		includeArchivedLegalUnits: 'Include archived legal units',
 	},
-	"es": {
-		'includeArchivedLegalUnits': "Incluir las unidades legales archivadas",
+	es: {
+		includeArchivedLegalUnits: 'Incluir las unidades legales archivadas',
 	},
-	"it": {
-		'includeArchivedLegalUnits': "Includere le unità giuridiche archiviate",
+	it: {
+		includeArchivedLegalUnits: 'Includere le unità giuridiche archiviate',
 	},
-	"nl": {
-		'includeArchivedLegalUnits': "Gearchiveerde wettelijke eenheden opnemen",
+	nl: {
+		includeArchivedLegalUnits: 'Gearchiveerde wettelijke eenheden opnemen',
 	},
-	"pt": {
-		'includeArchivedLegalUnits': "Incluir as unidades legais arquivadas",
+	pt: {
+		includeArchivedLegalUnits: 'Incluir as unidades legais arquivadas',
 	},
 };

--- a/packages/ng/styles/definitions/option/_option-item.scss
+++ b/packages/ng/styles/definitions/option/_option-item.scss
@@ -120,7 +120,8 @@
 	}
 
 	:host-context(.mod-multiple),
-	.formerEmployeeDisplayer {
+	.formerEmployeeDisplayer,
+	.archivedLegalUnitsDisplayer {
 		.optionItem-value {
 			@layer mods {
 				position: relative;

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -17,7 +17,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
-import { LuCoreSelectLegalUnitsDirective } from '@lucca-front/ng/core-select/legal-units';
+import { LuCoreSelectArchivedLegalUnitsComponent, LuCoreSelectLegalUnitsDirective } from '@lucca-front/ng/core-select/legal-units';
 import { LuCoreSelectOccupationCategoriesDirective } from '@lucca-front/ng/core-select/occupation-category';
 import { LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
 import {
@@ -649,6 +649,27 @@ export const LegalUnits = generateStory({
 	},
 });
 
+export const LegalUnitsWithArchived = generateStory({
+	name: 'LegalUnit Select with Archived',
+	description: 'Utiliser l’input `enableArchivedLegalUnits` pour afficher un bouton dans le panel permettant d’inclure les entités légales archivées.',
+	template: `<lu-multi-select
+	legalUnits
+	[enableArchivedLegalUnits]="true"
+	[(ngModel)]="selectedLegalUnits"
+	[keepSearchAfterSelection]="keepSearchAfterSelection"
+/>
+<pr-story-model-display>{{ selectedLegalUnits | json }}</pr-story-model-display>`,
+	neededImports: {
+		'@lucca-front/ng/multi-select': ['LuMultiSelectInputComponent'],
+		'@lucca-front/ng/core-select/legal-units': ['LuCoreSelectLegalUnitsDirective'],
+	},
+	storyPartial: {
+		args: {
+			selectedLegalUnits: [],
+		},
+	},
+});
+
 export const GroupBy = generateStory({
 	name: 'Group options',
 	description: 'Pour grouper les options, il suffit d’utiliser la directive `luOptionGroup`.',
@@ -884,6 +905,7 @@ const meta: Meta<InputAlias<LuMultiSelectInputStoryComponent, SelectCommonAliasI
 				LuCoreSelectUsersDirective,
 				LuCoreSelectJobQualificationsDirective,
 				LuCoreSelectLegalUnitsDirective,
+				LuCoreSelectArchivedLegalUnitsComponent,
 				LuCoreSelectOccupationCategoriesDirective,
 				LuCoreSelectPanelHeaderDirective,
 				LuDisabledOptionDirective,

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -661,7 +661,7 @@ export const LegalUnitsWithArchived = generateStory({
 <pr-story-model-display>{{ selectedLegalUnits | json }}</pr-story-model-display>`,
 	neededImports: {
 		'@lucca-front/ng/multi-select': ['LuMultiSelectInputComponent'],
-		'@lucca-front/ng/core-select/legal-units': ['LuCoreSelectLegalUnitsDirective'],
+		'@lucca-front/ng/core-select/legal-units': ['LuCoreSelectLegalUnitsDirective', 'LuCoreSelectArchivedLegalUnitsComponent'],
 	},
 	storyPartial: {
 		args: {

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -50,7 +50,7 @@ type LuMultiSelectInputStoryComponent = LuCoreSelectInputStoryComponent & {
 	selectedAxisSection: LuMultiSelection<{ id: number; name: string }>;
 	selectedEstablishment: LuMultiSelection<{ id: number; name: string }>;
 	selectedDepartments: LuMultiSelection<{ id: number; name: string }>;
-	selectedLegalUnits: LuMultiSelection<{ id: number; name: string }>;
+	selectedLegalUnits: { id: number; name: string }[];
 	selectLegume(legume: ILegume, legumes: ILegume[]): ILegume[];
 	groupingFn?: TreeGroupingFn<ILegume>;
 } & LuMultiSelectInputComponent<ILegume>;
@@ -644,7 +644,7 @@ export const LegalUnits = generateStory({
 	},
 	storyPartial: {
 		args: {
-			selectedLegalUnits: { mode: 'none' },
+			selectedLegalUnits: [],
 		},
 	},
 });

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -17,6 +17,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
+import { LuCoreSelectLegalUnitsDirective } from '@lucca-front/ng/core-select/legal-units';
 import { LuCoreSelectOccupationCategoriesDirective } from '@lucca-front/ng/core-select/occupation-category';
 import { LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
 import {
@@ -49,6 +50,7 @@ type LuMultiSelectInputStoryComponent = LuCoreSelectInputStoryComponent & {
 	selectedAxisSection: LuMultiSelection<{ id: number; name: string }>;
 	selectedEstablishment: LuMultiSelection<{ id: number; name: string }>;
 	selectedDepartments: LuMultiSelection<{ id: number; name: string }>;
+	selectedLegalUnits: LuMultiSelection<{ id: number; name: string }>;
 	selectLegume(legume: ILegume, legumes: ILegume[]): ILegume[];
 	groupingFn?: TreeGroupingFn<ILegume>;
 } & LuMultiSelectInputComponent<ILegume>;
@@ -627,6 +629,26 @@ export const OccupationCategory = generateStory({
 	},
 });
 
+export const LegalUnits = generateStory({
+	name: 'LegalUnit Select',
+	description: 'Pour saisir une entité légale, il suffit d’utiliser la directive `legalUnits`',
+	template: `<lu-multi-select
+	legalUnits
+	[(ngModel)]="selectedLegalUnits"
+	[keepSearchAfterSelection]="keepSearchAfterSelection"
+/>
+<pr-story-model-display>{{ selectedLegalUnits | json }}</pr-story-model-display>`,
+	neededImports: {
+		'@lucca-front/ng/multi-select': ['LuMultiSelectInputComponent'],
+		'@lucca-front/ng/core-select/legal-units': ['LuCoreSelectLegalUnitsDirective'],
+	},
+	storyPartial: {
+		args: {
+			selectedLegalUnits: { mode: 'none' },
+		},
+	},
+});
+
 export const GroupBy = generateStory({
 	name: 'Group options',
 	description: 'Pour grouper les options, il suffit d’utiliser la directive `luOptionGroup`.',
@@ -861,6 +883,7 @@ const meta: Meta<InputAlias<LuMultiSelectInputStoryComponent, SelectCommonAliasI
 				LuCoreSelectDepartmentsDirective,
 				LuCoreSelectUsersDirective,
 				LuCoreSelectJobQualificationsDirective,
+				LuCoreSelectLegalUnitsDirective,
 				LuCoreSelectOccupationCategoriesDirective,
 				LuCoreSelectPanelHeaderDirective,
 				LuDisabledOptionDirective,

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -15,7 +15,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
-import { LuCoreSelectLegalUnitsDirective } from '@lucca-front/ng/core-select/legal-units';
+import { LuCoreSelectArchivedLegalUnitsComponent, LuCoreSelectLegalUnitsDirective } from '@lucca-front/ng/core-select/legal-units';
 import { LuCoreSelectOccupationCategoriesDirective } from '@lucca-front/ng/core-select/occupation-category';
 import { LuCoreSelectUserOptionDirective, LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -620,6 +620,20 @@ export const LegalUnits = generateStory({
 	},
 });
 
+export const LegalUnitsWithArchived = generateStory({
+	name: 'LegalUnit Select with Archived',
+	description: 'Utiliser l’input `enableArchivedLegalUnits` pour afficher un bouton dans le panel permettant d’inclure les entités légales archivées.',
+	template: `<lu-simple-select
+	legalUnits
+	[enableArchivedLegalUnits]="true"
+	[(ngModel)]="selectedLegalUnit"
+></lu-simple-select>`,
+	neededImports: {
+		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
+		'@lucca-front/ng/core-select/legal-units': ['LuCoreSelectLegalUnitsDirective', 'LuCoreSelectArchivedLegalUnitsComponent'],
+	},
+});
+
 export const GroupBy = generateStory({
 	name: 'Group options',
 	description: 'Pour grouper les options, il suffit d’utiliser la directive `luOptionGroup`.',
@@ -784,6 +798,7 @@ const meta: Meta<InputAlias<LuSimpleSelectInputStoryComponent, SelectCommonAlias
 				LuCoreSelectUserOptionDirective,
 				LuCoreSelectJobQualificationsDirective,
 				LuCoreSelectLegalUnitsDirective,
+				LuCoreSelectArchivedLegalUnitsComponent,
 				LuCoreSelectOccupationCategoriesDirective,
 				LuCoreSelectPanelHeaderDirective,
 				LuDisabledOptionDirective,

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -15,6 +15,7 @@ import { LuCoreSelectApiV3Directive, LuCoreSelectApiV4Directive } from '@lucca-f
 import { LuCoreSelectDepartmentsDirective } from '@lucca-front/ng/core-select/department';
 import { LuCoreSelectEstablishmentsDirective } from '@lucca-front/ng/core-select/establishment';
 import { LuCoreSelectJobQualificationsDirective } from '@lucca-front/ng/core-select/job-qualification';
+import { LuCoreSelectLegalUnitsDirective } from '@lucca-front/ng/core-select/legal-units';
 import { LuCoreSelectOccupationCategoriesDirective } from '@lucca-front/ng/core-select/occupation-category';
 import { LuCoreSelectUserOptionDirective, LuCoreSelectUsersDirective, provideCoreSelectCurrentUserId } from '@lucca-front/ng/core-select/user';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -606,6 +607,19 @@ export const OccupationCategory = generateStory({
 	},
 });
 
+export const LegalUnits = generateStory({
+	name: 'LegalUnit Select',
+	description: 'Pour saisir une entité légale, il suffit d’utiliser la directive `legalUnits`',
+	template: `<lu-simple-select
+	legalUnits
+	[(ngModel)]="selectedLegalUnit"
+></lu-simple-select>`,
+	neededImports: {
+		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
+		'@lucca-front/ng/core-select/legal-units': ['LuCoreSelectLegalUnitsDirective'],
+	},
+});
+
 export const GroupBy = generateStory({
 	name: 'Group options',
 	description: 'Pour grouper les options, il suffit d’utiliser la directive `luOptionGroup`.',
@@ -769,6 +783,7 @@ const meta: Meta<InputAlias<LuSimpleSelectInputStoryComponent, SelectCommonAlias
 				LuCoreSelectUsersDirective,
 				LuCoreSelectUserOptionDirective,
 				LuCoreSelectJobQualificationsDirective,
+				LuCoreSelectLegalUnitsDirective,
 				LuCoreSelectOccupationCategoriesDirective,
 				LuCoreSelectPanelHeaderDirective,
 				LuDisabledOptionDirective,


### PR DESCRIPTION
## Description

- Adds a new LegalUnitsDirective under `packages/ng/core-select/legal-units/` to fetch and display legal units via the API, following the same pattern as existing directives (users, departments, establishments).
- Introduces an ArchivedLegalUnitsComponent that displays a "Show archived" toggle inside the option panel.
- Wires the archived displayer into the mixin option item so consumers can opt into archived visibility.
- Adds i18n translations for the archived state label.
- Adds Storybook stories for both the basic and archived variants, for simple-select and the multi-select.

---------

---------

