### PR TITLE
fix(appLayout): Wire navSide overflow variables to matching axes

### DIFF
--- a/packages/scss/src/components/appLayout/component.scss
+++ b/packages/scss/src/components/appLayout/component.scss
@@ -23,8 +23,8 @@
 		.appLayout-navSide {
 			min-inline-size: 0;
 			grid-area: navSide;
-			overflow-y: var(--components-appLayout-navSide-overflowX);
-			overflow-x: var(--components-appLayout-navSide-overflowY);
+			overflow-x: var(--components-appLayout-navSide-overflowX);
+			overflow-y: var(--components-appLayout-navSide-overflowY);
 
 			&:focus-visible {
 				@include a11y.focusVisible($offset: -4px);


### PR DESCRIPTION
## Description

Not entirely sure about this one since the sidebar is indeed scrolling, but it seems like the right move.

Found while reviewing #5095.

-----

`.appLayout-navSide` read `--components-appLayout-navSide-overflowX` onto `overflow-y` and `--components-appLayout-navSide-overflowY` onto `overflow-x`.

* With the defaults (`overflowX: hidden`, `overflowY: auto`) this produced `overflow-y: hidden` / `overflow-x: auto` — the opposite of the intended behaviour.
* Each variable is now read onto its matching axis.
* The `mods.scss` variant sets both variables to `visible`, so it is unaffected.

-----
