### PR TITLE
fix(stylelint): Make LF version handling numeric and normalise lookups

### DIFF
--- a/packages/stylelint-config/stylelintForLF.mjs
+++ b/packages/stylelint-config/stylelintForLF.mjs
@@ -71,8 +71,16 @@ function isValidDate(date) {
  * @return {Date|undefined}
  */
 function getDateForVersion(version) {
-	if (version && version in LFVersions) {
-		const date = new Date(LFVersions[version]);
+	if (!version) {
+		return;
+	}
+
+	// LFVersions keys are normalised to a patch version (e.g. `22.0` → `22.0.0`) in LFVersions.mjs,
+	// so normalise the lookup the same way; otherwise a two-part version silently misses the map.
+	const normalizedVersion = version.split('.').length === 2 ? `${version}.0` : version;
+
+	if (normalizedVersion in LFVersions) {
+		const date = new Date(LFVersions[normalizedVersion]);
 
 		if (isValidDate(date)) {
 			return date;
@@ -130,6 +138,36 @@ function getMessage(objectData) {
 }
 
 /**
+ * Is the current version at or past the deletion version?
+ * Compares dot-separated versions component by component so the most significant
+ * difference decides — a plain string comparison would misorder them (e.g. `9.0.0` > `22.0.0`).
+ *
+ * @param {string} currentVersion - The current LF version
+ * @param {string} deletedVersion - The version the element is deleted in
+ * @return {boolean} - true if currentVersion >= deletedVersion
+ */
+function isDeleted(currentVersion, deletedVersion) {
+	const currentParts = currentVersion.split('.');
+	const deletedParts = deletedVersion.split('.');
+	const length = Math.max(currentParts.length, deletedParts.length);
+
+	for (let i = 0; i < length; i++) {
+		const diff = (parseInt(currentParts[i], 10) || 0) - (parseInt(deletedParts[i], 10) || 0);
+
+		if (diff < 0) {
+			return false;
+		}
+
+		if (diff > 0) {
+			return true;
+		}
+	}
+
+	// Current version equals the deleted version.
+	return true;
+}
+
+/**
  * Get severity based on version used.
  *
  * @param {String} objectData
@@ -144,7 +182,7 @@ function getSeverity(objectData) {
 		return 'warning';
 	}
 
-	if (currentLFVersion < objectData.versionDeleted) {
+	if (!isDeleted(currentLFVersion, objectData.versionDeleted)) {
 		return 'warning';
 	}
 


### PR DESCRIPTION
## Description

Fix incorrect severities on deprecated CSS tokens: the linter compared Lucca Front versions as plain strings, so a token deleted several versions ago could still be reported as a warning instead of an error, and the deprecation/deletion date could be missing from the message.

-----

`stylelintForLF.mjs` handled versions with string operations:

- `getSeverity` used `currentLFVersion < versionDeleted`, a lexicographic comparison that misorders versions (`'9.0.0' > '22.0.0'`) and, more importantly, keeps a token deleted in e.g. `20.1.0` at `warning` on a `22.x` release instead of escalating to `error`. Added `isDeleted()`, which compares dot-separated versions component by component so the most significant difference decides.
- `getDateForVersion` looked up the raw version string in `LFVersions`, whose keys are normalised to a patch version. A two-part version (`22.0`) missed the map and silently dropped the date from the message. It now normalises the lookup the same way.

Found while reviewing #5095. Both bugs are pre-existing on `master`.

-----
