### PR TITLE
docs: add interaction testing plan for non-deprecated components

### DIFF
--- a/docs/testing-plan/00-conventions.md
+++ b/docs/testing-plan/00-conventions.md
@@ -1,0 +1,148 @@
+# Shared conventions — read fully before writing any test
+
+You are writing tests for **lucca-front**, Lucca's Angular design system. This file defines
+the stack, the patterns to copy, and the rules. The task file you received alongside this
+one defines the scope. Follow both exactly.
+
+## Repository facts
+
+- Angular 21. All components are **standalone**, use **OnPush** change detection, and are
+  increasingly **signal-based** (`input()`, `signal()`, `computed()`).
+- Library code lives in `packages/ng/<entry-point>/`, each with a `public-api.ts`.
+- Unit tests: **Jest** (jsdom) via `jest-preset-angular`. Config: `jest.config.json`,
+  setup: `setup-jest.ts` (already loads `@testing-library/jest-dom`, `jest-axe`, and
+  polyfills for ResizeObserver/IntersectionObserver/MutationObserver).
+- Interaction tests in a real browser: **Storybook play functions** run by
+  `@storybook/test-runner` (Playwright). Stories live in `stories/documentation/**`.
+- Path alias in tests: `@lucca-front/ng/<entry>` resolves to that entry point's public API.
+
+## Choosing the test layer
+
+Write a **Jest spec** (`packages/ng/<entry>/**/*.spec.ts`) when the behavior is observable
+in jsdom: form value changes, outputs emitted, ARIA attribute changes, DOM content changes,
+keydown handling, focus moves within the component's own template.
+
+Write a **Storybook play-function story** (`stories/documentation/**`) when the behavior
+needs a real browser: overlay positioning, focus trapping across an overlay boundary,
+hover-triggered behavior, scrolling, anything where jsdom's lack of layout would make the
+test lie. The repo already has 141 play-function stories — always look at neighbors first.
+
+If a behavior works in both layers, prefer Jest (faster, runs in `ci-test`).
+
+## Jest spec pattern (copy this style)
+
+Reference example to read before writing anything:
+`packages/ng/date2/date-input/date-input.component.spec.ts`
+
+```ts
+import { registerLocaleData } from '@angular/common';
+import localeFr from '@angular/common/locales/fr';
+import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+
+registerLocaleData(localeFr, 'fr-FR');
+
+@Component({
+	template: `<lu-some-input [formControl]="formControl" />`,
+	imports: [ReactiveFormsModule, SomeInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {
+	formControl = new FormControl<SomeType | null>(null);
+}
+
+describe('SomeInputComponent', () => {
+	// TestBed.configureTestingModule({ imports: [HostComponent], providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }] })
+	// fixture = TestBed.createComponent(HostComponent); fixture.detectChanges();
+});
+```
+
+Rules for Jest specs:
+
+- **Always test through a host component** binding the public API (inputs, outputs,
+  `formControl`), never by poking private fields.
+- **Locale**: always `registerLocaleData(localeFr, 'fr-FR')` at module top and provide
+  `{ provide: LOCALE_ID, useValue: 'fr-FR' }`. This is a repo-wide convention.
+- Interactions: prefer `userEvent` from `@testing-library/user-event` (already a dependency)
+  for clicks and typing; for raw key handling on a specific element, dispatching a
+  `KeyboardEvent('keydown', { key: '...' })` and awaiting `fixture.whenStable()` is the
+  established pattern (see `packages/ng/core-select/input/select-input.component.spec.ts`).
+- You may also use `render`/`screen` from `@testing-library/angular`
+  (see `packages/ng/api/api.spec.ts` for that style). Either style is fine; match whichever
+  the entry point already uses.
+- Query the DOM by **role or data-testid**, in that order of preference. Add a
+  `data-testid` to the component template only if there is truly no accessible query.
+- Add exactly **one** `jest-axe` accessibility test per component (render a representative
+  state, `expect(await axe(element)).toHaveNoViolations()`), not one per scenario.
+- Async/animations: `fakeAsync` + `tick()` where timers are involved; otherwise
+  `await fixture.whenStable()`.
+
+## Storybook play-function pattern (copy this style)
+
+Reference examples to read before writing anything:
+`stories/documentation/forms/select/simple-select.stories.ts` and
+`stories/helpers/stories.ts` / `stories/helpers/test.ts`.
+
+- Create test variants with `createTestStory(existingStory, playFn)` from
+  `stories/helpers/stories.ts` — it clones a story, appends " TEST" to its name, and
+  provides `LOCALE_ID: 'fr-FR'`.
+- Import `expect, screen, userEvent, within` from `'storybook/test'`.
+- After every interaction that triggers Angular change detection, call
+  `await waitForAngular()` from `stories/helpers/test.ts`.
+- Structure keyboard coverage in a `step('Keyboard interactions', async () => { ... })`
+  block inside the same play function as the mouse coverage.
+- Overlay content usually renders in a CDK overlay container **outside** `canvasElement`:
+  query it with the global `screen`, not `within(canvasElement)`.
+
+## What every interactive component must cover
+
+For each component in scope, cover both input modalities **when the component supports
+them** (check the source; do not invent behavior):
+
+**Mouse**: click to activate/open/select/toggle; click outside or on close affordances to
+dismiss; click on a disabled control does nothing (value unchanged, no output emitted).
+
+**Keyboard**: Tab reaches the control and focus is visible on the right element; the
+documented keys work (typically Enter/Space to activate, Escape to dismiss, arrow keys to
+navigate options, Home/End where lists are involved); focus goes somewhere sensible after
+close (usually back to the trigger); a disabled control is skipped or inert.
+
+**Forms contract** (only for ControlValueAccessor components): user interaction updates the
+bound `FormControl` value (assert the actual value, including edge cases like clearing to
+`null`); `setValue` from code updates the DOM; `disable()` prevents interaction and DOM
+reflects it; the control reports `touched` after blur; `registerOnChange` is not fired by
+programmatic `writeValue`.
+
+## Hard rules — tests that will be rejected
+
+- No "component exists" / "should create" tests. No asserting a CSS class is present
+  unless the class change *is* the observable behavior of an interaction.
+- No snapshot tests.
+- No testing of private members, internal signals, or implementation details. Assert only:
+  FormControl values, emitted outputs, DOM/ARIA state, focus location, rendered text.
+- No duplicating existing coverage. **Before writing, list the existing `*.spec.ts` files
+  in the entry point and any existing `play` functions in its stories, read them, and only
+  add what's missing.** Extending an existing spec file is preferred over creating a
+  parallel one.
+- Every test must fail if the behavior it describes breaks. If you cannot articulate the
+  user-visible failure a test guards against, do not write it.
+- Do not add new dependencies. Do not modify component source except to add a
+  `data-testid` or fix an *actual bug* the test exposes — and if you find a bug, stop and
+  report it instead of silently changing behavior.
+
+## Definition of done (run these, report output)
+
+```bash
+# fast loop while writing (scope to the entry point):
+npx jest packages/ng/<entry-point> --isolatedModules=true
+
+# full unit suite must stay green:
+npm run ci-test
+
+# only if you added/changed stories — needs a served Storybook:
+npm run build-storybook
+npx concurrently -k -s first "npx http-server storybook-static --port 6006 --silent" "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook"
+```
+
+Also run `npm run lint` if you touched any non-spec file.

--- a/docs/testing-plan/01-simple-multi-select.md
+++ b/docs/testing-plan/01-simple-multi-select.md
@@ -1,0 +1,71 @@
+# Task 01 — Simple select & multi select
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/simple-select` — `LuSimpleSelectInputComponent` (`lu-simple-select`)
+- `packages/ng/multi-select` — `LuMultiSelectInputComponent` (`lu-multi-select`) and its
+  displayer/counter sub-components
+- Shared behavior lives in `packages/ng/core-select` (do **not** test core-select directly;
+  test it through the two public components)
+
+**Out of scope**: the deprecated `ALuSimpleSelectApiDirective` / `LuSimpleSelectApiV4Directive`
+aliases in `packages/ng/simple-select/api/`; the legacy `select` entry point; API-backed
+directives (grouped data sources are fine to use as fixtures, HTTP directives are not the
+subject here).
+
+## Before writing
+
+1. Read `packages/ng/core-select/input/select-input.component.spec.ts` — there is an
+   existing **shared test-suite factory** `runALuSelectInputComponentTestSuite(...)`.
+   Extend this factory for behaviors common to both selects; put component-specific tests
+   in each component's own spec.
+2. Read existing specs and stories:
+   `packages/ng/simple-select/**/*.spec.ts`, `packages/ng/multi-select/**/*.spec.ts`,
+   `stories/documentation/forms/select/*.stories.ts` (several already have play functions —
+   list them and do not duplicate).
+3. Read both components' templates to get the real roles/testids (the trigger is a
+   `combobox`, the panel a `listbox` with `option` children).
+
+## Behaviors to cover (Jest, via the shared factory where common)
+
+Mouse — both selects:
+- Click on the trigger opens the panel; click again closes it.
+- Click on an option: simple select sets the FormControl to that entity and closes the
+  panel; multi select toggles the entity in the array value and keeps the panel open.
+- Click on the clearer (when `clearable`) resets to the empty value (`null` / `[]`) and
+  does not open the panel.
+- Click outside the open panel closes it without changing the value.
+- Disabled select: click opens nothing, value unchanged.
+
+Keyboard — both selects:
+- ArrowDown/ArrowUp on the closed trigger opens the panel (an existing test covers
+  ArrowDown-opens — check before adding).
+- Arrow keys move the active option (assert via `aria-activedescendant` or the visually
+  active option's attribute, whichever the template exposes).
+- Enter selects the active option (simple: sets value + closes; multi: toggles, stays open).
+- Escape closes the panel without changing the value and returns focus to the trigger.
+- Tab from the open combobox: panel closes, value untouched.
+- Typing in the search input (when a searcher/clue is enabled) filters options; check the
+  source for the clue input/output name and assert the filtered option list.
+
+Multi select specific:
+- Selected values render as chips/displayers in the trigger; clicking a chip's remove
+  affordance removes only that entity from the value.
+- The "select all" behavior if the component or an official directive provides one.
+
+Forms contract (both, per conventions): value updates, `writeValue`, `disable()`,
+`touched` on blur, clearing to empty value.
+
+## Storybook play functions (real browser)
+
+Only where jsdom lies: panel positioning is not testable here — skip it. Add/extend play
+stories in `stories/documentation/forms/select/` for: focus returning to the combobox after
+Escape and after option selection (already partially covered — extend, don't duplicate),
+and multi-select chip removal via keyboard.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/simple-select packages/ng/multi-select packages/ng/core-select --isolatedModules=true`

--- a/docs/testing-plan/02-date2.md
+++ b/docs/testing-plan/02-date2.md
@@ -1,0 +1,65 @@
+# Task 02 — date2: date input, date range input, calendar
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/date2` — `LuDateInputComponent` (`lu-date-input`),
+  `LuDateRangeInputComponent` (`lu-date-range-input`), `LuCalendar2Component`
+  (`lu-calendar2`), and their granularity/week-mode options.
+
+**Out of scope**: the legacy `packages/ng/date` entry point (fully deprecated).
+
+**Warning**: this area has recent activity (week-mode handling, branch `feat/calendar-week`)
+and the best existing spec coverage in the repo. Read
+`packages/ng/date2/**/*.spec.ts` completely first and only fill gaps — much of the
+value-parsing behavior is already tested.
+
+## Before writing
+
+1. Read all existing specs under `packages/ng/date2/` and list what they already cover
+   (typing partial dates, clearing, min/max, granularity — verify).
+2. Read `stories/documentation/forms/date2/*.stories.ts` and note existing play functions;
+   `stories/helpers/test.ts` already has a `pickDay()` helper — reuse it.
+3. Read the calendar template for the real grid roles (`grid`, `gridcell`) and the
+   navigation button labels.
+
+## Behaviors to cover
+
+Mouse (Jest where jsdom suffices, otherwise play stories):
+- Clicking the input's calendar affordance opens the calendar popover; picking a day sets
+  the FormControl to that date and closes the popover.
+- Month navigation (prev/next buttons) changes the displayed month without changing the
+  value; year/month zoom-out views (if the calendar has them) navigate correctly on click.
+- Range input: clicking a start day then an end day produces a `{start, end}` range value
+  (check the exact value shape in the source); clicking an end day before the start
+  reorders or restarts the range per the implementation — assert whichever the code does.
+- Week mode (if `mode`/week-picking input exists — verify in source, it is recent): clicking
+  any day selects the whole week; assert the emitted value.
+- Days outside min/max are disabled: clicking them does nothing.
+
+Keyboard:
+- Typing a full date into the text input updates the FormControl; typing an invalid or
+  partial date sets the control invalid/null per existing spec conventions (extend, don't
+  duplicate — this is the best-covered area already).
+- With the calendar open: arrow keys move day focus in the grid (left/right ±1 day,
+  up/down ±7 days), PageUp/PageDown change month (verify these bindings exist in the
+  source before testing; test exactly the keys the component handles).
+- Enter/Space on a focused day selects it; Escape closes the calendar without changing the
+  value and returns focus to the input.
+- Tab order: input → calendar trigger → (open) calendar, and focus restoration on close.
+
+Forms contract for both inputs per conventions, with date-specific edge cases: clearing
+the text to empty → `null` (already covered for date-input — check), timezone-stable
+values (assert with explicit UTC dates like the existing specs do).
+
+## Storybook play functions
+
+The calendar popover's focus management and grid keyboard navigation are the priority for
+real-browser coverage. Extend `stories/documentation/forms/date2/` test stories using
+`createTestStory` + `pickDay`.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/date2 --isolatedModules=true`

--- a/docs/testing-plan/03-time.md
+++ b/docs/testing-plan/03-time.md
@@ -1,0 +1,55 @@
+# Task 03 — time: time picker & time range picker
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/time` — `TimePickerComponent` and `TimeRangePickerComponent`
+  (verify exact selectors in `packages/ng/time/public-api.ts`).
+
+## Before writing
+
+1. Read `packages/ng/time/**/*.spec.ts` — time specs exist; list current coverage and only
+   fill gaps.
+2. Read the component source to establish: the value type (ISO duration string? `{hours,
+   minutes}`? — assert the real one), whether fields are separate hour/minute segments or
+   one masked input, and which keys the component explicitly handles.
+3. Check `stories/documentation/forms/time*/` for existing play functions.
+
+## Behaviors to cover
+
+Mouse:
+- Clicking a segment (hours/minutes) focuses/selects it.
+- If there are increment/decrement affordances or an options dropdown, clicking them
+  changes the value accordingly (wrap-around at 23→0 hours and 59→0 minutes if the
+  implementation wraps — assert what the code does).
+- Disabled picker ignores clicks.
+
+Keyboard (the core of this component — be thorough):
+- Typing digits fills the focused segment and auto-advances to the next segment when the
+  segment is complete (e.g. typing "9" vs "09" in hours — check the source for the
+  auto-advance rule and test it precisely).
+- ArrowUp/ArrowDown increment/decrement the focused segment, respecting any `step` input;
+  assert wrap-around behavior at boundaries.
+- ArrowLeft/ArrowRight move between segments; Backspace/Delete clears the segment.
+- Invalid input (e.g. "77" minutes) is rejected or clamped per the implementation — assert
+  the actual behavior.
+- Tab moves out of the whole control, not between inner segments, unless the
+  implementation deliberately does otherwise — assert whichever it is.
+
+Range picker:
+- Start/end interaction updates the combined range value; whether end < start is possible,
+  rejected, or marks the control invalid — read the validator and assert it.
+- Everything above applies to both sub-pickers.
+
+Forms contract per conventions (both components are CVAs): FormControl value shape,
+`writeValue` renders segments, `disable()`, `null` handling on clear.
+
+## Storybook play functions
+
+Only needed if the picker uses an overlay for option lists; otherwise Jest covers this
+component fully.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop: `npx jest packages/ng/time --isolatedModules=true`

--- a/docs/testing-plan/04-form-inputs.md
+++ b/docs/testing-plan/04-form-inputs.md
@@ -1,0 +1,80 @@
+# Task 04 — Basic form inputs
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope (all in `packages/ng/forms` unless noted)
+
+- `CheckboxInputComponent` (`lu-checkbox-input`)
+- `RadioGroupInputComponent` (`lu-radio-group-input`)
+- `SwitchInputComponent` (`lu-switch-input`)
+- `NumberInputComponent` (`lu-number-input`)
+- `PhoneNumberInputComponent` (`lu-phone-number-input`)
+- `ColorInputComponent` (`lu-color-input`)
+- `TextInputComponent` / `TextareaInputComponent` (only their non-trivial behaviors:
+  clearability, suffix/prefix interactions if any — plain text pass-through is not worth a test)
+- `NumberFormatDirective` (`input[luNumberFormatInput]`) in `packages/ng/number-format`
+- `InputFramedComponent` and `form-field` integration (`packages/ng/form-field`): inputs
+  wired through `lu-form-field` get label association and error display
+
+**Out of scope**: the deprecated `input` entry point; rich-text and multilanguage inputs
+(separate task 05).
+
+## Before writing
+
+Read existing specs in `packages/ng/forms/**/*.spec.ts` and `packages/ng/form-field/**/*.spec.ts`;
+several inputs already have specs. List coverage per component, fill gaps only. Wrap each
+host in `lu-form-field` the way the stories do (see `stories/documentation/forms/`), since
+that is the supported usage.
+
+## Behaviors to cover (all Jest — nothing here needs a real browser)
+
+Checkbox / Switch:
+- Click toggles the FormControl between `true`/`false`; Space toggles it when focused;
+  Enter does **not** toggle a native checkbox (assert only if the component customizes this).
+- Indeterminate state, if the checkbox supports it: what click does from indeterminate.
+- Disabled: click and Space do nothing; control value unchanged.
+- Label click toggles the input (form-field association working).
+
+Radio group:
+- Click on an option sets the FormControl to that option's value; clicking the selected
+  option keeps it selected.
+- Arrow keys move selection between radios (native roving behavior — assert selection
+  follows focus, i.e. ArrowDown from option 1 both focuses and selects option 2).
+- Tab enters the group on the checked (or first) radio and a second Tab leaves the group.
+- Disabled single option is skipped; fully disabled group is inert.
+
+Number input:
+- Typing digits updates the FormControl as a **number** (not string); clearing → `null`.
+- Non-numeric input is rejected/ignored per implementation; assert what happens.
+- min/max/step inputs: values outside range mark the control invalid or are clamped —
+  read the source, assert the real behavior.
+- ArrowUp/ArrowDown stepping if implemented.
+
+NumberFormatDirective:
+- Typing `1234.5` displays the fr-FR formatted value (e.g. narrow-space grouping, comma
+  decimal) while the FormControl holds the raw number — assert both sides.
+- Pasting a formatted string parses back to a number.
+
+Phone number input:
+- Typing a national number produces the expected FormControl value (check the value type —
+  string vs structured — in the source) and formats the display.
+- Country/prefix selection (if a country selector exists): changing country reformats and
+  updates the value.
+- Invalid numbers mark the control invalid.
+
+Color input:
+- Selecting/typing a color updates the FormControl with the expected format (hex?);
+  invalid strings rejected per implementation.
+
+Form-field wiring (one small suite, not per input):
+- The label is associated: clicking the `lu-form-field` label focuses the input;
+  `aria-describedby` points at the error/hint when the control is invalid+touched.
+- Required state is conveyed (`aria-required` or required marker) when the control has a
+  required validator.
+
+Forms contract per conventions for every CVA in scope.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/forms packages/ng/form-field packages/ng/number-format --isolatedModules=true`

--- a/docs/testing-plan/05-rich-text-multilanguage.md
+++ b/docs/testing-plan/05-rich-text-multilanguage.md
@@ -1,0 +1,59 @@
+# Task 05 — Rich text input & multilanguage input
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `RichTextInputComponent` (`lu-rich-text-input`) in `packages/ng/forms` — including its
+  toolbar plugins (bold/italic/lists/link — enumerate from the source)
+- `MultilanguageInputComponent` (`lu-multilanguage-input`) in `packages/ng/forms`
+
+These are the two heaviest form inputs; they get their own task so the agent can spend its
+whole budget here.
+
+## Before writing
+
+1. Read the rich-text component source to identify the underlying editor engine (check
+   imports — likely a contenteditable wrapper or a lib like Lexical/ProseMirror). **The
+   editor engine's internals are out of scope** — test the component's contract: toolbar
+   actions, FormControl value, keyboard shortcuts the component itself wires.
+2. Read existing specs/stories: `packages/ng/forms/rich-text-input/**/*.spec.ts` (if any),
+   `stories/documentation/forms/rich-text*/*.stories.ts` (play functions may exist).
+3. jsdom warning: contenteditable support in jsdom is poor. Expect most rich-text
+   interaction coverage to live in **Storybook play functions**, with Jest reserved for
+   the CVA contract (writeValue renders HTML, disable works, value emitted on change).
+
+## Behaviors to cover
+
+Rich text — mouse (play functions):
+- Clicking a toolbar button (bold, italic, list…) applies the format to the selection and
+  the button reflects active state (`aria-pressed` or equivalent).
+- Link plugin: selecting text and clicking the link button opens the link editor overlay;
+  confirming inserts a link into the value; Escape cancels without modifying content.
+- Disabled editor: toolbar inert, content not editable.
+
+Rich text — keyboard (play functions):
+- Typing text updates the FormControl value (assert the serialized format the CVA emits —
+  read the source for HTML vs JSON).
+- Standard shortcuts the component wires (Ctrl+B / Ctrl+I — verify in source which exist)
+  toggle formatting.
+- Tab behavior: whether Tab leaves the editor or indents (lists) — assert what the
+  implementation does; focus must never be trapped with no keyboard exit.
+- Toolbar is reachable by keyboard (Tab or arrow-key pattern — assert the actual pattern).
+
+Rich text — Jest (CVA contract only):
+- `writeValue` renders the given content; user edit → FormControl value; `disable()`;
+  empty content → the empty value the component emits (`null` or `''` — assert the real one).
+
+Multilanguage input:
+- Renders one input per configured language/translation entry; typing in one language
+  updates only that entry in the FormControl value (assert the value shape from source).
+- Language switching UI (tabs? dropdown? — read the template): mouse click and keyboard
+  activation both switch the visible language input.
+- Required/invalid state when a mandatory translation is empty, if validators exist.
+- Full CVA contract per conventions.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop: `npx jest packages/ng/forms --isolatedModules=true`,
+plus the Storybook test-runner flow since most rich-text coverage lands there.

--- a/docs/testing-plan/06-dialog.md
+++ b/docs/testing-plan/06-dialog.md
@@ -1,0 +1,55 @@
+# Task 06 — Dialog (modern LuDialog)
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/dialog` — `LuDialogService` (open/close API), `lu-dialog`,
+  `lu-dialog-content/-header/-footer`, `lu-dialog-routing-container`, sidepanel mode.
+
+**Out of scope**: legacy `modal`, `popup`, `sidepanel` entry points (all deprecated).
+The `defaultOnClosedFn<_C>` generic overload is deprecated — don't use it in fixtures.
+
+## Before writing
+
+1. Read `packages/ng/dialog/**/*.spec.ts` — service-level specs may exist; list coverage.
+2. Read the service API: config options (dismissability, size, mode, data injection,
+   result typing) from `packages/ng/dialog/dialog.models.ts` (or equivalent — locate it).
+3. This is a CDK Dialog wrapper: focus trapping and backdrop behavior come from CDK and
+   work partially in jsdom. Test the **wiring**, not CDK itself: put behaviors that need
+   real focus-trap semantics into Storybook play functions
+   (`stories/documentation/overlays/dialog*` — check for existing play functions first).
+
+## Behaviors to cover
+
+Service contract (Jest):
+- `open()` renders the component/template in an overlay with the injected data available;
+  the returned ref's `closed` (or equivalent — check the API) emits the result passed to
+  `close(result)`.
+- A dialog opened with `canClose`/dismissible disabled (find the real option name) does
+  not close on backdrop click or Escape.
+- Opening a second dialog stacks; closing the top one leaves the first open.
+- Routing container: navigating to a dialog route opens it; closing navigates back
+  (testable with RouterTestingHarness — only if the wiring is non-trivial; skip if it
+  reduces to CDK passthrough).
+
+Mouse:
+- Backdrop click closes a dismissible dialog and the ref resolves with the dismissed
+  result (check what value dismissal produces — `undefined`? a sentinel?).
+- Close button in `lu-dialog-header` closes the dialog.
+- Clicks inside the dialog content do not close it.
+
+Keyboard (Storybook play functions for the focus behaviors):
+- Escape closes a dismissible dialog; with dismiss disabled, Escape does nothing.
+- On open, focus moves into the dialog (to the configured auto-focus target — check config).
+- Tab cycles within the dialog (focus trap) — real browser only.
+- On close, focus returns to the element that had focus before opening — real browser only.
+
+A11y (Jest, one test): the dialog container has `role="dialog"`, `aria-modal="true"`, and
+is labelled by the header (`aria-labelledby` or `aria-label`) — assert the actual wiring,
+plus the standard single axe check.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop: `npx jest packages/ng/dialog --isolatedModules=true`,
+plus the Storybook test-runner flow for the focus-trap stories.

--- a/docs/testing-plan/07-popover2-tooltip.md
+++ b/docs/testing-plan/07-popover2-tooltip.md
@@ -1,0 +1,59 @@
+# Task 07 — Popover2 & Tooltip
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/popover2` — `LuPopover2Directive` (`[luPopover2]`) + `lu-popover-content`
+- `packages/ng/tooltip` — `LuTooltipTriggerDirective` (`[luTooltip]`) +
+  `LuTooltipPanelComponent`
+
+**Out of scope**: the legacy `popover` (v1) and `popup` entry points; the deprecated
+tooltip **NgModules** (`LuTooltipModule`, `LuTooltipTriggerModule`) — use the standalone
+directive in fixtures.
+
+Note: popover2 is the foundation for several other components (date2 calendar, callout
+popover, user-popover). Solid coverage here de-risks all of them.
+
+## Before writing
+
+1. Read both directives' sources to enumerate: trigger modes (click? hover? focus?),
+   open/close delays, disabled input, position inputs, and any outputs.
+2. Read existing specs (`packages/ng/popover2/**/*.spec.ts`,
+   `packages/ng/tooltip/**/*.spec.ts`) and stories with play functions
+   (`stories/documentation/overlays/`).
+3. jsdom rule of thumb: open/close state and ARIA wiring are Jest-testable; positioning
+   and hover with delays are Storybook material. Hover in jsdom via `userEvent.hover`
+   works for simple cases — use `fakeAsync`/`tick` for delay logic.
+
+## Behaviors to cover
+
+Popover2 — mouse (Jest):
+- Trigger click opens the popover (content rendered in the overlay container); second
+  click closes it; click outside closes it; click inside content does not.
+- Disabled trigger opens nothing.
+
+Popover2 — keyboard (Jest + play stories):
+- Trigger is focusable; Enter/Space opens (if click-triggered — match the real trigger
+  events); Escape closes and returns focus to the trigger (focus return in a play story).
+- If the popover content contains focusables: Tab from the trigger reaches them (play
+  story — real sequential focus navigation).
+
+Tooltip — mouse (Jest with fakeAsync):
+- Hover shows the panel after the configured delay; unhover hides it (tick through both
+  delays); moving from trigger onto the panel keeps it open if the implementation
+  supports that — check.
+- Tooltip does not open on hover when disabled or when content is empty (check the
+  directive's guard conditions — empty-content suppression is common; assert what exists).
+
+Tooltip — keyboard/a11y (Jest):
+- Focusing the trigger (keyboard focus, not click) shows the tooltip; blur hides it.
+- Escape while visible hides it.
+- The trigger gets `aria-describedby` pointing at the panel content while open —
+  assert the actual ARIA strategy from the source.
+- Standard single axe check with an open tooltip.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/popover2 packages/ng/tooltip --isolatedModules=true`

--- a/docs/testing-plan/08-tree-select-listbox.md
+++ b/docs/testing-plan/08-tree-select-listbox.md
@@ -1,0 +1,60 @@
+# Task 08 — Tree select & Listbox
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+**Prerequisite task**: 01 (select suite) should be merged first — reuse its patterns and,
+where applicable, the shared `runALuSelectInputComponentTestSuite` factory.
+
+## Scope
+
+- `packages/ng/tree-select` — `LuTreeSelectDirective` (verify export list in
+  `public-api.ts`; overlay-based hierarchical select)
+- `packages/ng/listbox` — `LuListboxComponent` (`lu-listbox`)
+
+**Out of scope**: legacy `option`/`tree-option` entry points (deprecated).
+
+## Before writing
+
+1. Read both sources: tree-select builds on core-select — identify what is tree-specific
+   (expand/collapse, parent/child selection propagation) vs inherited (already covered by
+   task 01; do not re-test inherited basics beyond one smoke path).
+2. Read existing specs and stories (`stories/documentation/forms/tree-select*`,
+   `stories/documentation/listbox*`) — list play functions before writing.
+3. Get the real roles from the templates (`tree`/`treeitem` with `aria-expanded`, or
+   listbox/option with `aria-level` — assert whichever pattern is implemented).
+
+## Behaviors to cover
+
+Tree select — mouse:
+- Clicking a parent node's expander expands/collapses its children without selecting.
+- Clicking a leaf selects it (single mode: sets value + closes; multi mode: toggles).
+- Multi mode parent selection: does selecting a parent select all descendants? Read the
+  source and assert the actual propagation, including the parent's indeterminate state
+  when only some children are selected (if implemented).
+
+Tree select — keyboard:
+- ArrowUp/ArrowDown move through **visible** nodes only (collapsed children skipped).
+- ArrowRight expands a collapsed parent / moves to first child if already expanded;
+  ArrowLeft collapses / moves to parent — the standard tree pattern; verify against the
+  implementation and test exactly what it handles.
+- Enter/Space selects the active node; Escape closes without value change, focus returns
+  to the trigger.
+- Search/clue typing filters the tree; matching children keep their parents visible
+  (assert the actual filtering semantics from the source).
+
+Listbox — mouse:
+- Click selects an option (and toggles in multi mode, if it has one — check).
+- Disabled options are not selectable.
+
+Listbox — keyboard:
+- Arrow keys move the active option; Home/End jump to first/last (verify these are
+  handled); Enter/Space select; type-ahead (first-letter jump) if implemented.
+- Selection state exposed via `aria-selected`; active option via focus or
+  `aria-activedescendant` — assert the mechanism used.
+
+Forms contract per conventions for each CVA in scope (tree-select value type is
+entity-or-array; listbox — check whether it's a CVA at all before assuming).
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/tree-select packages/ng/listbox --isolatedModules=true`

--- a/docs/testing-plan/09-filter-pills.md
+++ b/docs/testing-plan/09-filter-pills.md
@@ -1,0 +1,51 @@
+# Task 09 — Filter pills & filter bar
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/filter-pills` — `LuFilterBarComponent`, `LuFilterPillComponent`, and the
+  pill-type directives/components exported from `public-api.ts` (enumerate them: there are
+  typically select-pill, date-pill, checkbox-pill variants — list what actually exists).
+
+## Before writing
+
+1. Read `packages/ng/filter-pills/**/*.spec.ts` and
+   `stories/documentation/filter-pills/*.stories.ts` (play functions likely exist — list
+   them, extend rather than duplicate).
+2. Pills wrap other in-scope components (selects, date inputs) inside a popover2-based
+   panel. Do **not** re-test the inner components' behavior (tasks 01/02 own that); test
+   the **pill layer**: open/close, value summary display, clearing, and the bar's
+   composition behavior.
+
+## Behaviors to cover
+
+Pill — mouse:
+- Clicking a pill opens its editing panel; choosing a value closes it (if the pill type
+  auto-closes — assert per type) and the pill label reflects the chosen value summary.
+- Clearing a pill (its clear affordance) empties the bound control and resets the label
+  to the placeholder.
+- Click outside the open panel closes it, keeping the previously committed value.
+
+Pill — keyboard:
+- Tab reaches each pill in the bar in order; Enter/Space opens the focused pill's panel.
+- Escape closes the panel without committing in-progress changes (verify: does Escape
+  revert or commit? assert the implemented semantics) and returns focus to the pill.
+- A cleared/removed pill does not break the Tab sequence.
+
+Filter bar:
+- The bar renders one pill per configured filter and emits its combined filter
+  value/output when any pill changes (check the output API in the source — this is the
+  bar's core contract; assert emitted payloads precisely).
+- "Additional filters" / overflow behavior if the bar has one (a "more filters" affordance
+  is common — check): opening it by mouse and keyboard, and pills chosen from it join the bar.
+- Resetting the bar (if a reset API/affordance exists) clears all pills and emits the
+  empty state.
+
+Forms/controls contract: pills bind to FormControls or an equivalent filter model — assert
+values flow both ways (programmatic set updates pill labels).
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/filter-pills --isolatedModules=true`

--- a/docs/testing-plan/10-tables-pagination-sortable.md
+++ b/docs/testing-plan/10-tables-pagination-sortable.md
@@ -1,0 +1,55 @@
+# Task 10 — Data table, index table, sortable list, pagination
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/data-table` — `lu-data-table` + body/row/cell directives
+- `packages/ng/index-table` — index table row/components
+- `packages/ng/sortable-list` — `lu-sortable-list` (drag-reorderable list)
+- `packages/ng/pagination` — `lu-pagination`
+
+Skip purely presentational aspects (column layout, styling). Only interactive behavior.
+
+## Before writing
+
+Read each entry point's source and existing specs/stories. For each component, first
+enumerate its **outputs and interactive inputs** — those define what to test. If a
+component turns out to have no interactive behavior (pure rendering), write nothing for it
+and say so in your report.
+
+## Behaviors to cover
+
+Data table / index table (test only what the source actually implements):
+- Sortable column headers: click toggles sort direction and emits the sort output with the
+  right column/direction payload; `aria-sort` reflects state. Keyboard: header is a button
+  (or focusable) and Enter/Space triggers the same sort.
+- Row selection if implemented (checkbox column, row click): mouse click and Space on the
+  row checkbox toggle selection; select-all header checkbox selects all rows and shows
+  indeterminate for partial selection; the selection output emits the selected set.
+- Row actions/expansion if implemented: mouse + Enter/Space parity.
+
+Sortable list — mouse (Storybook play function; jsdom cannot do real drag):
+- Dragging an item to a new position emits the reorder output with the correct
+  from/to indices (CDK DragDrop-based, most likely — check; the test-runner's Playwright
+  can do pointer sequences, or use the CDK drop-list events if the play API is too coarse).
+
+Sortable list — keyboard (Jest, this is the important a11y path):
+- Check the source for keyboard reordering support (grab with Space/Enter, move with
+  arrows). If it exists, test the full cycle: grab → ArrowDown → drop → output emitted
+  with new order. **If it does not exist, report it as an accessibility gap** in your
+  final summary instead of inventing coverage.
+
+Pagination:
+- Clicking next/prev/a page number emits the page-change output with the correct page;
+  current page is marked (`aria-current="page"` or equivalent).
+- Prev is disabled on the first page, next on the last: clicks emit nothing.
+- Keyboard: page controls are real buttons/links reachable by Tab and activated by
+  Enter/Space (assert activation emits, not just focusability).
+- Page-size selector if present: changing it emits the size output (it may reuse a select
+  from task 01 — don't re-test the select itself, just the emitted wiring).
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/data-table packages/ng/index-table packages/ng/sortable-list packages/ng/pagination --isolatedModules=true`

--- a/docs/testing-plan/11-navigation.md
+++ b/docs/testing-plan/11-navigation.md
@@ -1,0 +1,55 @@
+# Task 11 — Navigation components
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `packages/ng/segmented-control` — `lu-segmented-control`
+- `packages/ng/segmented-control-tabs` — `lu-segmented-control-tabs`
+- `packages/ng/breadcrumbs` — `lu-breadcrumbs`
+- `packages/ng/horizontal-navigation`, `packages/ng/vertical-navigation`
+
+## Before writing
+
+Read each source and its stories. Distinguish two families: **value selectors** (segmented
+control is likely a CVA or has a selection model) and **link containers** (breadcrumbs,
+navigations render router links — their "interaction" is mostly link semantics plus any
+collapse/overflow behavior). Enumerate outputs first; test only real behavior.
+
+## Behaviors to cover
+
+Segmented control (value selector):
+- Click on a segment selects it: FormControl/output gets the segment's value, previous
+  segment deselects, ARIA state updates (`aria-pressed`/`aria-checked`/`aria-selected` —
+  assert the pattern used).
+- Keyboard: the implemented pattern — either roving arrows (radio-like: arrows move+select,
+  one tab stop) or tab-through buttons (Enter/Space selects). Read the source, assert
+  exactly that pattern, including that the non-implemented alternative isn't half-present.
+- Disabled segment: not selectable by mouse, skipped or inert for keyboard.
+- CVA contract if it's a CVA (writeValue selects the right segment, disable, etc.).
+
+Segmented control tabs:
+- Same interaction checks as above, plus: selecting a tab shows the associated panel
+  (assert panel content swap) and wires `role="tab"` / `aria-selected` /
+  `aria-controls` → `role="tabpanel"` if implemented.
+
+Breadcrumbs:
+- Items render as links with correct hrefs (use RouterTestingHarness or provideRouter with
+  test routes; assert navigation on click).
+- Overflow/collapse behavior if implemented (an ellipsis item expanding hidden crumbs):
+  mouse click and Enter both expand; hidden crumbs become reachable by Tab.
+- The current page item is not a link (or is `aria-current="page"`) — assert the pattern.
+
+Horizontal / vertical navigation:
+- Active item tracking: the item matching the active route/value is marked
+  (`aria-current` or active class-as-behavior).
+- Expand/collapse of sub-sections (vertical nav commonly has collapsible groups): mouse
+  click and Enter/Space parity; `aria-expanded` reflects state; collapsed children are
+  removed from Tab order.
+- Any overflow "more" menu in horizontal nav: open by mouse and keyboard, items inside
+  are activatable.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/segmented-control packages/ng/segmented-control-tabs packages/ng/breadcrumbs packages/ng/horizontal-navigation packages/ng/vertical-navigation --isolatedModules=true`

--- a/docs/testing-plan/12-actions-feedback.md
+++ b/docs/testing-plan/12-actions-feedback.md
@@ -1,0 +1,78 @@
+# Task 12 — Actions & feedback components
+
+**Prerequisite reading**: `00-conventions.md` (provided alongside this file). Follow it.
+
+## Scope
+
+- `button` (prisme/ng `LuButtonDirective` — `button[luButton]`, `a[luButton]`)
+- `chip` (`lu-chip`, `button[luChip]`)
+- `clear` (`lu-clear`)
+- `toast` — **only** `LuToastsComponent` (the `LuToastModule` is deprecated)
+- `callout` — `LuCalloutDisclosureComponent`, `LuCalloutPopoverComponent`,
+  `LuCalloutActionsComponent` (the static callout body is presentational — skip it)
+- `read-more` (`lu-read-more`)
+- `user-popover` (`[luUserPopover]` — active parts only; skip `@deprecated` APIs inside)
+- `impersonation` (`lu-impersonation`)
+- `file-upload` — `LuFileDropzoneComponent`, `LuFileEntryComponent` (skip the
+  `@deprecated` invoice-related API)
+
+These are small; the task is one agent-session covering all of them. For each, enumerate
+outputs/interactive inputs first; skip any that turn out non-interactive and say so.
+
+## Behaviors to cover
+
+Button directive:
+- Loading/busy state if the directive has one (check inputs): while loading, clicks emit
+  nothing and the button is `aria-busy`/disabled; keyboard activation equally blocked.
+- Only behaviors the **directive adds** — do not test native button semantics.
+
+Chip:
+- Dismissible chip: clicking the remove affordance emits the dismiss output; Delete/
+  Backspace or Enter on the remove button does the same (assert the keys actually handled).
+- Clickable chip (`button[luChip]`): click and Enter/Space emit; disabled chip inert.
+
+Clear:
+- Click emits the clear output/clears the associated control; reachable and activatable
+  by keyboard; hidden when there is nothing to clear (if the source implements that guard).
+
+Toasts (`LuToastsComponent`):
+- Adding a toast through the service/input API renders it in the live region
+  (`role="status"`/`aria-live` — assert the wiring); the dismiss button removes that toast
+  and emits.
+- Auto-dismiss timers (`fakeAsync`): toast disappears after its duration; hover pausing
+  the timer if implemented.
+- Keyboard: dismiss button reachable and Enter/Space works; multiple toasts each dismissible.
+
+Callout disclosure:
+- Click on the disclosure toggle expands/collapses the extra content; `aria-expanded`
+  updates; Enter/Space parity; collapsed content out of the accessibility tree/Tab order.
+
+Callout popover / user popover:
+- Built on popover2 (task 07 owns the overlay mechanics) — test only the wiring: trigger
+  opens with the right content (e.g. user data rendered), Escape closes. One mouse + one
+  keyboard path each.
+
+Read more:
+- Click on the "read more" affordance expands the full text and the affordance updates
+  ("read less" or disappears — assert actual behavior); keyboard activation parity;
+  content beyond the clamp is hidden from screen readers when collapsed if implemented.
+
+Impersonation:
+- There is an existing play-function story (`impersonation-basic.stories.ts` was cited as a
+  play-function example) — read it first. Cover its action affordances (stop impersonation
+  button → output emitted) by mouse and keyboard if not already done.
+
+File dropzone / entry:
+- Dropping a file (dispatch a `drop` event with a `DataTransfer` containing a `File`)
+  emits the file output; the hidden input path (click → file picker) emits the same output
+  when the input's `change` fires with files.
+- Rejected files (wrong type/size, if validation inputs exist) emit the rejection output
+  or error state — assert the real API.
+- Keyboard: the dropzone's browse affordance is focusable and Enter/Space opens the file
+  input (assert the input's click is triggered).
+- File entry: delete/retry affordances emit their outputs by mouse and keyboard.
+
+## Definition of done
+
+Per `00-conventions.md`. Fast loop:
+`npx jest packages/ng/chip packages/ng/clear packages/ng/toast packages/ng/callout packages/ng/read-more packages/ng/user-popover packages/ng/impersonation packages/ng/file-upload packages/prisme/button --isolatedModules=true`

--- a/docs/testing-plan/README.md
+++ b/docs/testing-plan/README.md
@@ -1,0 +1,66 @@
+# lucca-front — Interaction Testing Plan
+
+A component-by-component testing plan for the non-deprecated parts of `@lucca-front/ng`.
+Each numbered file in this folder is a **self-contained prompt** designed to be given to a
+coding agent (including smaller models) as a single task.
+
+## How to use
+
+1. Always provide **two files** to the agent: `00-conventions.md` + one numbered task file.
+   The conventions file is the shared preamble (stack, patterns, rules, definition of done);
+   the task file is the scope.
+2. Run one task file per agent/session. Task files are independent of each other and can run
+   in parallel, **except** 01 must land before 08 (tree-select reuses the select test suite
+   factory conventions).
+3. Each task tells the agent to read the component source and existing tests first. Do not
+   skip that step when relaying the prompt.
+
+## Scope rules (already applied — do not re-litigate in tasks)
+
+**Excluded as deprecated/legacy** (do not write tests for these entry points):
+`api`*, `core`, `core-select` (tested indirectly via selects), `date`, `department`,
+`dialog` legacy `LuModal*`, `divider`, `dropdown` (panel component is `@deprecated`,
+replaced by the new menu approach), `empty-state`, `establishment`, `formly`, `input`,
+`modal`, `number` (module), `option` (all of it), `popover` (v1), `popup`, `safe-content`,
+`scroll`, `select` (legacy `lu-select`), `sidepanel`, `simple-select/api` directive aliases,
+`title`, `toast` module (the `LuToastsComponent` itself is active), `tooltip` NgModules
+(the directive/panel are active), `user` modules.
+
+\* deprecated NgModules only — where a standalone component inside the entry point is not
+deprecated, it stays in scope and is listed in a task file.
+
+**Excluded as non-interactive** (no tests wanted — rendering-only components would only get
+"it exists" tests, which this plan forbids): `icon`, `software-icon`, `bubble-icon`,
+`bubble-illustration`, `skeleton`, `loading`, `status-badge`, `numeric-badge`, `new-badge`,
+`tag`, `box`, `container`, `fancy-box`, `grid`, `footer`, `page-header`, `error-page`,
+`code`, `highlight-text`, `highlight-data`, `resource-card`, `comment`, `activity-feed`,
+`gauge`, `progress-bar`, `progress-stepper`, `inline-message`, `app-layout`/`main-layout`
+(layout shells), `form-header`, `form-label`.
+
+## Task files and priority
+
+| # | File | Scope | Priority |
+|---|------|-------|----------|
+| 01 | `01-simple-multi-select.md` | `simple-select`, `multi-select` (shared core-select behavior) | P1 |
+| 02 | `02-date2.md` | `date2`: date-input, date-range-input, calendar2 | P1 |
+| 03 | `03-time.md` | `time`: time-picker, time-range-picker | P1 |
+| 04 | `04-form-inputs.md` | `forms`: checkbox, radio-group, switch, number, phone-number, color, text, textarea + `number-format` directive + `form-field` wiring | P1 |
+| 05 | `05-rich-text-multilanguage.md` | `forms`: rich-text-input, multilanguage-input | P2 |
+| 06 | `06-dialog.md` | `dialog`: LuDialogService, dialog component, routing container | P1 |
+| 07 | `07-popover2-tooltip.md` | `popover2`, `tooltip` (directive + panel) | P1 |
+| 08 | `08-tree-select-listbox.md` | `tree-select`, `listbox` | P2 |
+| 09 | `09-filter-pills.md` | `filter-pills`: filter-bar + pill types | P2 |
+| 10 | `10-tables-pagination-sortable.md` | `data-table`, `index-table`, `sortable-list`, `pagination` | P2 |
+| 11 | `11-navigation.md` | `breadcrumbs`, `segmented-control`, `segmented-control-tabs`, `horizontal-navigation`, `vertical-navigation` | P3 |
+| 12 | `12-actions-feedback.md` | `button`, `chip`, `clear`, `toast` (LuToastsComponent), `callout` (disclosure + popover), `read-more`, `user-popover`, `impersonation`, `file-upload` (dropzone/entry, active parts) | P3 |
+
+P1 = form controls and overlays with the richest mouse/keyboard contracts — highest
+regression risk. P3 = simpler click/focus contracts.
+
+## What "done" means for the whole plan
+
+- Every in-scope interactive behavior has either a Jest spec (jsdom-compatible behavior) or
+  a Storybook play-function test story (geometry/focus-trap/real-browser behavior), per the
+  layer-selection rule in `00-conventions.md`.
+- `npm run ci-test` passes; `npm run test-storybook` passes against a built Storybook.
+- No test asserts mere existence, class names without behavior, or private component state.


### PR DESCRIPTION
## Description

14 self-contained prompt files under docs/testing-plan, designed to be fed to coding agents two at a time (shared conventions + one scoped task). Covers mouse and keyboard interaction testing for all active entry points, excluding deprecated/legacy packages and purely presentational components.

Created with Claude.

-----

I tols him to create prompts for other, smaller models to generate tests in order to increase coverage without creating useless tests.

This branch's goal is to hold the progress around this, with smaller models doing the job.

-----
