### PR TITLE
fix(teardown): ResizeObserver and unmanaged RxJS subscriptions to prevent memory leaks

### DIFF
--- a/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
+++ b/packages/ng/data-table/data-table-cell-header/data-table-cell-header.component.ts
@@ -1,5 +1,5 @@
 import { NgTemplateOutlet } from '@angular/common';
-import { AfterContentInit, ChangeDetectionStrategy, Component, computed, ElementRef, forwardRef, inject, input, model, ViewEncapsulation } from '@angular/core';
+import { AfterContentInit, ChangeDetectionStrategy, Component, computed, DestroyRef, ElementRef, forwardRef, inject, input, model, ViewEncapsulation } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ButtonComponent } from '@lucca-front/ng/button';
@@ -43,6 +43,7 @@ const SORT_VALUES = ['none', 'ascending', 'descending'] as const;
 })
 export class DataTableRowCellHeaderComponent extends BaseDataTableCell implements AfterContentInit {
 	elementRef = inject<ElementRef<HTMLTableCellElement>>(ElementRef);
+	#destroyRef = inject(DestroyRef);
 
 	sort = model<DataTableSort | null>(null);
 	fixedWidth = input<string | null>(null);
@@ -83,9 +84,9 @@ export class DataTableRowCellHeaderComponent extends BaseDataTableCell implement
 	inlineSizePx = toSignal(this.#inlineSizePx$);
 
 	ngAfterContentInit(): void {
-		new ResizeObserver(() => {
-			this.#inlineSizePx$.next(this.elementRef.nativeElement.clientWidth);
-		}).observe(this.elementRef.nativeElement);
+		const observer = new ResizeObserver(() => this.#inlineSizePx$.next(this.elementRef.nativeElement.clientWidth));
+		observer.observe(this.elementRef.nativeElement);
+		this.#destroyRef.onDestroy(() => observer.disconnect());
 	}
 
 	toggleSort(): void {

--- a/packages/ng/data-table/data-table.component.ts
+++ b/packages/ng/data-table/data-table.component.ts
@@ -6,6 +6,7 @@ import {
 	computed,
 	contentChild,
 	contentChildren,
+	DestroyRef,
 	ElementRef,
 	forwardRef,
 	inject,
@@ -43,6 +44,7 @@ import { DataTableVerticalAlign } from './data-table.type';
 })
 export class DataTableComponent implements OnInit {
 	#elementRef = inject<ElementRef<Element>>(ElementRef);
+	#destroyRef = inject(DestroyRef);
 	tableRef = viewChild<ElementRef<Element>>('tableRef');
 
 	readonly hover = input(false, { transform: booleanAttribute });
@@ -124,8 +126,8 @@ export class DataTableComponent implements OnInit {
 	}
 
 	ngOnInit(): void {
-		new ResizeObserver(() => {
-			this.scroll();
-		}).observe(this.tableRef().nativeElement);
+		const observer = new ResizeObserver(() => this.scroll());
+		observer.observe(this.tableRef().nativeElement);
+		this.#destroyRef.onDestroy(() => observer.disconnect());
 	}
 }

--- a/packages/ng/input/input.directive.ts
+++ b/packages/ng/input/input.directive.ts
@@ -1,4 +1,5 @@
-import { Directive, ElementRef, OnInit, Renderer2 } from '@angular/core';
+import { DestroyRef, Directive, ElementRef, inject, OnInit, Renderer2 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { NgControl } from '@angular/forms';
 
 /**
@@ -8,6 +9,8 @@ import { NgControl } from '@angular/forms';
 	selector: '[luInput]',
 })
 export class LuInputDirective implements OnInit {
+	protected _destroyRef = inject(DestroyRef);
+
 	constructor(
 		protected _elementRef: ElementRef,
 		protected _renderer: Renderer2,
@@ -27,7 +30,7 @@ export class LuInputDirective implements OnInit {
 		}
 	}
 	ngOnInit() {
-		this._ngControl.valueChanges.subscribe((v) => this.applyClasses(v));
+		this._ngControl.valueChanges.pipe(takeUntilDestroyed(this._destroyRef)).subscribe((v) => this.applyClasses(v));
 		const val: unknown = this._ngControl.value;
 		this.applyClasses(val);
 	}

--- a/packages/ng/scroll/scroll.directive.ts
+++ b/packages/ng/scroll/scroll.directive.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
-import { Directive, ElementRef, input, OnInit, output } from '@angular/core';
+import { DestroyRef, Directive, ElementRef, inject, input, OnInit, output } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { ILuScrollable } from './scroll.model';
@@ -22,6 +23,8 @@ export class LuScrollDirective implements ILuScrollable, OnInit {
 	readonly onScrollLeft = output<Event>();
 	readonly onScrollRight = output<Event>();
 
+	#destroyRef = inject(DestroyRef);
+
 	#scrollSubject = new Subject<Event>();
 	#scroll$ = this.#scrollSubject.asObservable().pipe(debounceTime(this.debounceTime()));
 
@@ -30,7 +33,7 @@ export class LuScrollDirective implements ILuScrollable, OnInit {
 	}
 
 	ngOnInit(): void {
-		this.#scroll$.subscribe((scrollEvent) => this.emitScrollEvents(scrollEvent));
+		this.#scroll$.pipe(takeUntilDestroyed(this.#destroyRef)).subscribe((scrollEvent) => this.emitScrollEvents(scrollEvent));
 	}
 	private emitScrollEvents($event: Event) {
 		this.onScroll.emit($event);

--- a/packages/ng/title/title.service.ts
+++ b/packages/ng/title/title.service.ts
@@ -1,4 +1,5 @@
-import { Inject, Injectable } from '@angular/core';
+import { DestroyRef, Inject, inject, Injectable } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, ActivationEnd, Router } from '@angular/router';
 import { BehaviorSubject, combineLatest, ObservableInput, of } from 'rxjs';
@@ -11,6 +12,8 @@ import { PageTitle, TitleSeparator } from './title.model';
  */
 @Injectable()
 export class LuTitleService {
+	private destroyRef = inject(DestroyRef);
+
 	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>(['Lucca']);
 	titleParts$ = this.titlePartsSubject.asObservable();
 	title$ = this.titleParts$.pipe(
@@ -36,10 +39,16 @@ export class LuTitleService {
 				map((titleParts: Array<string>) => [...titleParts, this.translateService.translate(applicationNameTranslationKey, {}), 'Lucca'].filter((x) => !!x)),
 				distinctUntilChanged(),
 				tap((titleParts) => this.titlePartsSubject.next(titleParts)),
+				takeUntilDestroyed(this.destroyRef),
 			)
 			.subscribe();
 
-		this.title$.pipe(tap((title) => this.title.setTitle(title))).subscribe();
+		this.title$
+			.pipe(
+				tap((title) => this.title.setTitle(title)),
+				takeUntilDestroyed(this.destroyRef),
+			)
+			.subscribe();
 	}
 
 	prependTitle(title: string | ObservableInput<string>) {


### PR DESCRIPTION
## Description

- Fix a memory leak in `DataTableComponent` and `DataTableRowCellHeaderComponent` where `ResizeObserver` instances were created inline and never disconnected — each mount/unmount cycle accumulated a live observer on the DOM.
- Fix four RxJS subscriptions that were never torn down:
  - `LuInputDirective`: `_ngControl.valueChanges` subscription now uses `takeUntilDestroyed`.
  - `LuScrollDirective`: `#scroll$` subscription now uses `takeUntilDestroyed`.
  - `LuTitleService.init()`: both the `router.events` and `title$` subscriptions now use `takeUntilDestroyed`.

## Why

None of these had any teardown mechanism (`OnDestroy`, `DestroyRef`, `takeUntilDestroyed`, or subscription bag), so each component/directive instance leaked its observer/subscription on destroy, retaining DOM references and closures for the lifetime of the app.


-----


-----
