### PR TITLE
fix(forms): handle signal-forms field errors in injectNgControl

### DIFF
--- a/packages/ng/forms/inject-ng-control.spec.ts
+++ b/packages/ng/forms/inject-ng-control.spec.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, computed, ElementRef, Signal, signal, Type, viewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { form, FormField } from '@angular/forms/signals';
+import { form, FormField, validate } from '@angular/forms/signals';
 import { injectNgControl } from './inject-ng-control';
 import { NoopValueAccessorDirective } from './noop-value-accessor.directive';
 
@@ -136,5 +136,37 @@ describe('injectNgControl', () => {
 		// Assert
 		expect(initialValue).toBe('Initial');
 		expect(host.value()).toBe('Changed');
+	});
+
+	it('should mirror field validity into the control when using formField', () => {
+		// Arrange: field starts with a valid (non-empty) value
+		@Component({
+			selector: 'lu-form-field-validity-host',
+			imports: [CustomControl, FormField],
+			template: `<lu-custom-control [formField]="form" />`,
+			changeDetection: ChangeDetectionStrategy.OnPush,
+		})
+		class FormFieldValidityHost {
+			readonly value = signal('Bob');
+			readonly form = form(this.value, (path) => {
+				validate(path, ({ value }) => (value() ? null : [{ kind: 'required' as const, message: 'Required' }]));
+			});
+			readonly customControl = viewChild(CustomControl);
+		}
+
+		const { fixture, host } = createHost(FormFieldValidityHost);
+		const control = host.customControl().ngControl.control;
+
+		// Assert: a valid field leaves the control VALID (regression: setErrors([]) used to force INVALID)
+		expect(control.valid).toBe(true);
+		expect(control.errors).toBeNull();
+
+		// Act: clear the field so the required validator fails
+		host.value.set('');
+		fixture.detectChanges();
+
+		// Assert: the error is mirrored as a keyed ValidationErrors object, not a raw array
+		expect(control.invalid).toBe(true);
+		expect(control.errors).toEqual({ required: 'Required' });
 	});
 });

--- a/packages/ng/forms/inject-ng-control.ts
+++ b/packages/ng/forms/inject-ng-control.ts
@@ -2,8 +2,8 @@
 // Heavily modified to handle ngModel properly
 import { DestroyRef, effect, inject } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { FormControl, FormControlDirective, FormControlName, NgControl, NgModel } from '@angular/forms';
-import { FormField } from '@angular/forms/signals';
+import { FormControl, FormControlDirective, FormControlName, NgControl, NgModel, type ValidationErrors } from '@angular/forms';
+import { FormField, type ValidationError } from '@angular/forms/signals';
 import { distinctUntilChanged, map } from 'rxjs';
 
 export function injectNgControl() {
@@ -84,7 +84,10 @@ function generateMirrorControl(_ngControl: NgControl, field: FormField<unknown>)
 	effect(() => (field.state().disabled() ? control.disable() : control.enable()));
 
 	// Error | Field -> Control
-	effect(() => control.setErrors(field.state().errors()));
+	effect(() => {
+		const errors = field.state().errors();
+		control.setErrors(errors.length ? toValidationErrors(errors) : null);
+	});
 
 	ngControl.registerOnChange ??= () => {};
 	ngControl.markAsTouched ??= () => {};
@@ -96,4 +99,11 @@ function generateMirrorControl(_ngControl: NgControl, field: FormField<unknown>)
 
 	// eslint-disable-next-line
 	return ngControl as NgControl & { control: FormControl<any> };
+}
+
+/** Maps signal-forms ValidationError[] to reactive-forms' flat ValidationErrors map. */
+function toValidationErrors(errors: readonly ValidationError[]): ValidationErrors {
+	// Keyed by `kind`; the message (or `true` when absent) is the value. Duplicate kinds are
+	// last-wins, matching reactive-forms' single-value-per-key error map.
+	return Object.fromEntries(errors.map((error) => [error.kind, error.message ?? true]));
 }


### PR DESCRIPTION
## Description

The [formField] bridge in generateMirrorControl fed field.state().errors() straight into FormControl.setErrors(). errors() is a ValidationError[] (signals format) whereas setErrors() expects a ValidationErrors map or null: an empty array is non-null, so the mirror control stayed INVALID forever and CVA-based controls (e.g. lu-text-input) were stuck ng-invalid even when the field was valid.

Map the array to a flat ValidationErrors object keyed by `kind`, falling back to null when there are no errors. Adds a regression test covering the valid and invalid field states.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
