### PR TITLE
[button] fix loading state

### DIFF
--- a/packages/prisme/button/button.component.ts
+++ b/packages/prisme/button/button.component.ts
@@ -14,6 +14,7 @@ import { ButtonSize, ButtonState, ButtonType } from './button.type';
 	host: {
 		class: 'button',
 		'[class.is-error]': 'notifyError()',
+		'[attr.disabled]': "isDisabled() ? '' : null",
 		'(click)': 'triggerErrorIfNeeded()',
 		'(animationend)': 'notifyError.set(false)',
 	},
@@ -33,6 +34,11 @@ export class ButtonComponent {
 	 * Apply block display
 	 */
 	readonly block = input(false, { transform: booleanAttribute });
+
+	/**
+	 * Disables the Button. Also applied automatically when `state` is `loading`
+	 */
+	readonly disabled = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Indicates an action with significant or irreversible consequences on hover and focus. Only compatible with outlined and ghost
@@ -68,6 +74,8 @@ export class ButtonComponent {
 	readonly prButton = input<ButtonType>('');
 
 	readonly buttonType = computed(() => this.luButton() || this.prButton());
+
+	readonly isDisabled = computed(() => this.disabled() || this.state() === 'loading');
 
 	readonly iconComponentRef = contentChild<IconComponent, ElementRef<HTMLElement>>(IconComponent, { read: ElementRef });
 

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -21,7 +21,6 @@
 
 @mixin loading {
 	--components-button-pointerEvents: none;
-	--components-button-color: transparent;
 	--components-button-userSelect: none;
 	--components-button-boxShadow: none;
 	--components-button-backgroundColor: var(--palettes-500, var(--palettes-product-500));
@@ -29,6 +28,7 @@
 
 	@include loading.spinner(var(--pr-t-font-body-M-lineHeight));
 
+	&,
 	&:disabled {
 		--components-button-color: transparent;
 	}

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -29,6 +29,10 @@
 
 	@include loading.spinner(var(--pr-t-font-body-M-lineHeight));
 
+	&:disabled {
+		--components-button-color: transparent;
+	}
+
 	.numericBadge {
 		@include numericBadge.state;
 	}

--- a/stories/documentation/actions/button/html&css/button-states.stories.ts
+++ b/stories/documentation/actions/button/html&css/button-states.stories.ts
@@ -8,7 +8,7 @@ export default {
 
 function getTemplate(args: ButtonStatesStory): string {
 	return `<div class="pr-u-displayFlex pr-u-gap100 pr-u-alignItemsCenter">
-	<button type="button" class="button is-loading">Button</button>
+	<button type="button" class="button is-loading" disabled="disabled">Button</button>
 	<button type="button" class="button is-success">Button</button>
 	<button type="button" class="button is-error">Button</button>
 </div>`;

--- a/stories/qa/button/button.stories.html
+++ b/stories/qa/button/button.stories.html
@@ -243,19 +243,19 @@
 			<td>States</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<button type="button" class="button is-loading">Loading</button>
-					<button type="button" class="button mod-outlined is-loading">Loading</button>
-					<button type="button" class="button mod-ghost is-loading">Loading</button>
+					<button type="button" disabled="disabled" class="button is-loading">Loading</button>
+					<button type="button" disabled="disabled" class="button mod-outlined is-loading">Loading</button>
+					<button type="button" disabled="disabled" class="button mod-ghost is-loading">Loading</button>
 					<button type="button" class="button is-success">Success</button>
 					<button type="button" class="button mod-outlined is-success">Success</button>
 					<button type="button" class="button mod-ghost is-success">Success</button>
 					<button type="button" class="button is-error">Error (reset .is-error class)</button>
-					<button type="button" class="button is-loading mod-AI mod-withIcon">
+					<button type="button" disabled="disabled" class="button is-loading mod-AI mod-withIcon">
 						<span aria-hidden="true" class="lucca-icon icon-heart"></span>Loading
 					</button>
-					<button type="button" class="button is-loading mod-S">Loading S</button>
+					<button type="button" disabled="disabled" class="button is-loading mod-S">Loading S</button>
 					<button type="button" class="button is-success mod-S">Success S</button>
-					<button type="button" class="button is-loading mod-XS">Loading XS</button>
+					<button type="button" disabled="disabled" class="button is-loading mod-XS">Loading XS</button>
 					<button type="button" class="button is-success mod-XS">Success XS</button>
 				</div>
 			</td>


### PR DESCRIPTION
## Description

Adds a `disabled` state to the buttons when they are loading.

-----

So now we handle interactions using `pointer-events: none` for the mouse and `disabled` for the keyboard.
The visual display should not be affected.

-----

<img width="97" height="65" alt="Capture d’écran 2026-07-06 à 11 57 44" src="https://github.com/user-attachments/assets/84872b11-e228-4d7f-985f-802c4318bb02" />
