### PR TITLE
refactor(file-upload): align single file upload with multi

### DIFF
--- a/docs/file-upload.md
+++ b/docs/file-upload.md
@@ -33,21 +33,22 @@ Once the files are sent, the display management changes depending on the approac
 
 ### Single File Upload
 
-Just like the multi variant, you render the `lu-file-entry` yourself and project it into
-`lu-single-file-upload`. When a `lu-file-entry` is projected, the dropzone is hidden and replaced
-by the entry.
+Just like the multi variant, you render the `lu-file-entry` yourself, as a sibling of
+`lu-single-file-upload` rather than projected inside it. The single variant only ever holds one
+file, so once it's uploaded you hide the dropzone and show the entry in its place — you own that
+toggle, the component does not do it for you.
 
 ```html
 
 <lu-form-field label="Label">
   @let fileUpload = fileUploadFeature.fileUploads()[0];
-  <lu-single-file-upload [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
-    @if (fileUpload) {
-      <lu-file-entry [entry]="fileUpload | luFileEntry" [state]="fileUpload.state"
-                     [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail"
-                     (deleteFile)="deleteFile(fileUpload)" />
-    }
-  </lu-single-file-upload>
+  @if (fileUpload) {
+    <lu-file-entry [entry]="fileUpload | luFileEntry" [state]="fileUpload.state"
+                   [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail"
+                   (deleteFile)="deleteFile(fileUpload)" />
+  } @else {
+    <lu-single-file-upload [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])" />
+  }
 </lu-form-field>
 ```
 

--- a/docs/file-upload.md
+++ b/docs/file-upload.md
@@ -33,14 +33,21 @@ Once the files are sent, the display management changes depending on the approac
 
 ### Single File Upload
 
+Just like the multi variant, you render the `lu-file-entry` yourself and project it into
+`lu-single-file-upload`. When a `lu-file-entry` is projected, the dropzone is hidden and replaced
+by the entry.
+
 ```html
 
 <lu-form-field label="Label">
   @let fileUpload = fileUploadFeature.fileUploads()[0];
-  <lu-single-file-upload [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])"
-                         [entry]="fileUpload | luFileEntry" [state]="fileUpload?.state"
-                         [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload?.error?.detail"
-                         (deleteFile)="deleteFile(fileUpload)" />
+  <lu-single-file-upload [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
+    @if (fileUpload) {
+      <lu-file-entry [entry]="fileUpload | luFileEntry" [state]="fileUpload.state"
+                     [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail"
+                     (deleteFile)="deleteFile(fileUpload)" />
+    }
+  </lu-single-file-upload>
 </lu-form-field>
 ```
 

--- a/packages/ng/file-upload/single/single-file-upload.component.html
+++ b/packages/ng/file-upload/single/single-file-upload.component.html
@@ -2,7 +2,7 @@
 	class="fileUpload"
 	[class.is-droppable]="droppable"
 	[class.mod-L]="size() === 'L'"
-	[class.is-hidden]="!!entry()"
+	[class.is-hidden]="!!fileEntry()"
 	[class.mod-structure]="structure()"
 >
 	<input
@@ -14,7 +14,7 @@
 		(dragenter)="droppable = true"
 		(dragleave)="droppable = false"
 		(change)="filesChange($event)"
-		[attr.disabled]="!!entry() ? 'disabled' : null"
+		[attr.disabled]="!!fileEntry() ? 'disabled' : null"
 		[attr.aria-describedby]="'fileUpload-instruction-' + idSuffix"
 	/>
 	<div class="fileUpload-status">
@@ -42,16 +42,4 @@
 	</div>
 	<span class="fileUpload-button button" [class.mod-filled]="buttonFilled()" aria-hidden="true">{{ intl().selectFile.one }}</span>
 </div>
-@if (entry()) {
-	<lu-file-entry
-		[media]="size() === 'L'"
-		[size]="'L'"
-		[previewUrl]="previewUrl()"
-		[entry]="entry()"
-		[state]="state()"
-		(deleteFile)="deleteFile.emit()"
-		[inlineMessageError]="inlineMessageError()"
-		[displayFileName]="displayFileName()"
-		[structure]="structure()"
-	/>
-}
+<ng-content select="lu-file-entry" />

--- a/packages/ng/file-upload/single/single-file-upload.component.html
+++ b/packages/ng/file-upload/single/single-file-upload.component.html
@@ -1,10 +1,4 @@
-<div
-	class="fileUpload"
-	[class.is-droppable]="droppable"
-	[class.mod-L]="size() === 'L'"
-	[class.is-hidden]="!!fileEntry()"
-	[class.mod-structure]="structure()"
->
+<div class="fileUpload" [class.is-droppable]="droppable" [class.mod-L]="size() === 'L'" [class.mod-structure]="structure()">
 	<input
 		class="fileUpload-input"
 		type="file"
@@ -14,7 +8,6 @@
 		(dragenter)="droppable = true"
 		(dragleave)="droppable = false"
 		(change)="filesChange($event)"
-		[attr.disabled]="!!fileEntry() ? 'disabled' : null"
 		[attr.aria-describedby]="'fileUpload-instruction-' + idSuffix"
 	/>
 	<div class="fileUpload-status">
@@ -42,4 +35,3 @@
 	</div>
 	<span class="fileUpload-button button" [class.mod-filled]="buttonFilled()" aria-hidden="true">{{ intl().selectFile.one }}</span>
 </div>
-<ng-content select="lu-file-entry" />

--- a/packages/ng/file-upload/single/single-file-upload.component.ts
+++ b/packages/ng/file-upload/single/single-file-upload.component.ts
@@ -1,9 +1,8 @@
-import { ChangeDetectionStrategy, Component, contentChild, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
 import { BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration';
 import { IntlParamsPipe } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.component';
-import { FileEntryComponent } from '../file-entry/file-entry.component';
 
 @Component({
 	selector: 'lu-single-file-upload',
@@ -13,15 +12,4 @@ import { FileEntryComponent } from '../file-entry/file-entry.component';
 	imports: [InputDirective, IntlParamsPipe, BubbleIllustrationComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SingleFileUploadComponent extends BaseFileUploadComponent {
-	/**
-	 * The `lu-file-entry` projected by the consumer. When present, the dropzone
-	 * is hidden and replaced in-place by the entry.
-	 *
-	 * Like `lu-multi-file-upload`, the consumer owns the `lu-file-entry` rather than
-	 * the upload component rendering it. Multi renders its entries as a sibling list
-	 * (the dropzone stays visible), so it needs no query; single's entry takes the
-	 * dropzone's place, so we detect it here to toggle the dropzone off.
-	 */
-	readonly fileEntry = contentChild(FileEntryComponent);
-}
+export class SingleFileUploadComponent extends BaseFileUploadComponent {}

--- a/packages/ng/file-upload/single/single-file-upload.component.ts
+++ b/packages/ng/file-upload/single/single-file-upload.component.ts
@@ -1,30 +1,27 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, input, output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChild, ViewEncapsulation } from '@angular/core';
 import { BubbleIllustrationComponent } from '@lucca-front/ng/bubble-illustration';
 import { IntlParamsPipe } from '@lucca-front/ng/core';
 import { InputDirective } from '@lucca-front/ng/form-field';
 import { BaseFileUploadComponent } from '../base-file-upload/base-file-upload.component';
 import { FileEntryComponent } from '../file-entry/file-entry.component';
-import { FileEntry } from '../file-upload-entry';
-import { FileUploadState } from '../file-upload.type';
 
 @Component({
 	selector: 'lu-single-file-upload',
 	templateUrl: './single-file-upload.component.html',
 	styleUrl: './single-file-upload.component.scss',
 	encapsulation: ViewEncapsulation.None,
-	imports: [InputDirective, FileEntryComponent, IntlParamsPipe, BubbleIllustrationComponent],
+	imports: [InputDirective, IntlParamsPipe, BubbleIllustrationComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SingleFileUploadComponent extends BaseFileUploadComponent {
-	readonly entry = input<FileEntry | null>(null);
-
-	readonly state = input<FileUploadState>('default');
-
-	readonly inlineMessageError = input<string | null>(null);
-
-	readonly previewUrl = input<string | null>(null);
-
-	readonly deleteFile = output<void>();
-
-	readonly displayFileName = input(false, { transform: booleanAttribute });
+	/**
+	 * The `lu-file-entry` projected by the consumer. When present, the dropzone
+	 * is hidden and replaced in-place by the entry.
+	 *
+	 * Like `lu-multi-file-upload`, the consumer owns the `lu-file-entry` rather than
+	 * the upload component rendering it. Multi renders its entries as a sibling list
+	 * (the dropzone stays visible), so it needs no query; single's entry takes the
+	 * dropzone's place, so we detect it here to toggle the dropzone off.
+	 */
+	readonly fileEntry = contentChild(FileEntryComponent);
 }

--- a/stories/documentation/forms/file-upload/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-upload/angular/basic.stories.ts
@@ -345,6 +345,7 @@ export const Single = {
 		],
 		fileMaxSize: 5000000,
 		illustration: 'invoice',
+		media: false,
 		displayFileName: false,
 		structure: false,
 		buttonFilled: false,

--- a/stories/documentation/forms/file-upload/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-upload/angular/basic.stories.ts
@@ -302,12 +302,13 @@ export const Multi = {
 export const Single = {
 	render: (args, { argTypes }) => {
 		const multi = Multi.render(args, { argTypes });
-		const { media, size, displayFileName, accept, ...mainArgs } = args;
-		const mediaParam = media ? ` media` : ``;
-		const displayFileNameParam = displayFileName && media ? ` displayFileName` : ``;
+		const { size, displayFileName, accept, ...mainArgs } = args;
+
+		// En Single, le FileEntry est toujours en taille L ; l'aperçu média n'existe qu'à size="L".
+		const isLarge = !!size;
+		const entryAttrs = `size="L"${isLarge ? ` media` : ``}${isLarge && displayFileName ? ` displayFileName` : ``}`;
 		const sizeLFileUploadParam = size ? ` size="L"` : ``;
-		const sizeLFileEntryParam = media ? `` : sizeLFileUploadParam;
-		const fileEntry = `<lu-file-entry${sizeLFileEntryParam}${displayFileNameParam}${mediaParam} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />`;
+		const fileEntry = `<lu-file-entry ${entryAttrs} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />`;
 		if (args.AItag) {
 			return {
 				props: { ...multi.props, accept },
@@ -336,6 +337,10 @@ export const Single = {
 			};
 		}
 	},
+	argTypes: {
+		// En Single, le mode media découle de la taille : le contrôle n'a pas lieu d'être.
+		media: { table: { disable: true } },
+	},
 	args: {
 		accept: [
 			{
@@ -345,7 +350,6 @@ export const Single = {
 		],
 		fileMaxSize: 5000000,
 		illustration: 'invoice',
-		media: false,
 		displayFileName: false,
 		structure: false,
 		buttonFilled: false,

--- a/stories/documentation/forms/file-upload/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-upload/angular/basic.stories.ts
@@ -307,18 +307,19 @@ export const Single = {
 		const displayFileNameParam = displayFileName && media ? ` displayFileName` : ``;
 		const sizeLFileUploadParam = size ? ` size="L"` : ``;
 		const sizeLFileEntryParam = media ? `` : sizeLFileUploadParam;
-		const fileEntry = `@if (fileUpload) {
-			<lu-file-entry${sizeLFileEntryParam}${displayFileNameParam}${mediaParam} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
-		}`;
+		const fileEntry = `<lu-file-entry${sizeLFileEntryParam}${displayFileNameParam}${mediaParam} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />`;
 		if (args.AItag) {
 			return {
 				props: { ...multi.props, accept },
 				template: `@let fileUpload = fileUploadFeature.fileUploads()[0];
 <lu-form-field label="Label">
-	<lu-single-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
-		<lu-tag icon="weatherStars" label="Scan intelligent" AI />
+	@if (fileUpload) {
 		${fileEntry}
-	</lu-single-file-upload>
+	} @else {
+		<lu-single-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
+			<lu-tag icon="weatherStars" label="Scan intelligent" AI />
+		</lu-single-file-upload>
+	}
 </lu-form-field>`,
 			};
 		} else {
@@ -326,9 +327,11 @@ export const Single = {
 				props: { ...multi.props, accept },
 				template: `@let fileUpload = fileUploadFeature.fileUploads()[0];
 <lu-form-field label="Label">
-	<lu-single-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
+	@if (fileUpload) {
 		${fileEntry}
-	</lu-single-file-upload>
+	} @else {
+		<lu-single-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])" />
+	}
 </lu-form-field>`,
 			};
 		}

--- a/stories/documentation/forms/file-upload/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-upload/angular/basic.stories.ts
@@ -302,15 +302,22 @@ export const Multi = {
 export const Single = {
 	render: (args, { argTypes }) => {
 		const multi = Multi.render(args, { argTypes });
-		const { accept, ...mainArgs } = args;
+		const { media, size, displayFileName, accept, ...mainArgs } = args;
+		const mediaParam = media ? ` media` : ``;
+		const displayFileNameParam = displayFileName && media ? ` displayFileName` : ``;
+		const sizeLFileUploadParam = size ? ` size="L"` : ``;
+		const sizeLFileEntryParam = media ? `` : sizeLFileUploadParam;
+		const fileEntry = `@if (fileUpload) {
+			<lu-file-entry${sizeLFileEntryParam}${displayFileNameParam}${mediaParam} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
+		}`;
 		if (args.AItag) {
 			return {
 				props: { ...multi.props, accept },
 				template: `@let fileUpload = fileUploadFeature.fileUploads()[0];
 <lu-form-field label="Label">
-	<lu-single-file-upload ${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])"
-		[entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload?.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload?.error?.detail" (deleteFile)="deleteFile(fileUpload)">
+	<lu-single-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
 		<lu-tag icon="weatherStars" label="Scan intelligent" AI />
+		${fileEntry}
 	</lu-single-file-upload>
 </lu-form-field>`,
 			};
@@ -319,8 +326,9 @@ export const Single = {
 				props: { ...multi.props, accept },
 				template: `@let fileUpload = fileUploadFeature.fileUploads()[0];
 <lu-form-field label="Label">
-	<lu-single-file-upload ${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])"
-		[entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload?.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload?.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
+	<lu-single-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])">
+		${fileEntry}
+	</lu-single-file-upload>
 </lu-form-field>`,
 			};
 		}


### PR DESCRIPTION
## Description

Refactor lu-single-file-upload so it renders exactly like lu-multi-file-upload: the component is now just the dropzone, and the consumer owns the lu-file-entry and the toggle between the two.

Previously, SingleFileUploadComponent rendered the entry itself and exposed a set of pass-through inputs/outputs (entry, state, inlineMessageError, previewUrl, displayFileName, deleteFile). These are all removed. The single variant only ever holds one file, so once it's uploaded the consumer hides the dropzone and shows the lu-file-entry in its place — the consumer owns that toggle, the component does not do it anymore.

Changes
Remove the entry / state / inlineMessageError / previewUrl / displayFileName inputs and the deleteFile output from SingleFileUploadComponent.
Drop the entry rendering (@if (entry()) { <lu-file-entry ... /> }) and the is-hidden / disabled toggling from the template.
The component now reduces to the bare dropzone, keeping only the unnamed <ng-content /> (rendered in size="L") for in-dropzone projection (e.g. the AI tag) — same template shape as multi-file-upload.
Update the documentation and Storybook stories to the new sibling-entry usage (@if (fileUpload) { <lu-file-entry .../> } @else { <lu-single-file-upload .../> }).
Breaking change
Consumers must now render the lu-file-entry themselves as a sibling of lu-single-file-upload and toggle between the two, instead of binding [entry], [state], [previewUrl], [inlineMessageError], [displayFileName] and the (deleteFile) output.

Before

```
<lu-single-file-upload
  [accept]="accept"
  (filePicked)="uploadFiles([$event])"
  [entry]="fileUpload | luFileEntry"
  [state]="fileUpload?.state"
  [previewUrl]="getPreviewUrl(fileUpload)"
  [inlineMessageError]="fileUpload?.error?.detail"
  (deleteFile)="deleteFile(fileUpload)" />
```

After

```
@if (fileUpload) {
  <lu-file-entry
    [entry]="fileUpload | luFileEntry"
    [state]="fileUpload.state"
    [previewUrl]="getPreviewUrl(fileUpload)"
    [inlineMessageError]="fileUpload.error?.detail"
    (deleteFile)="deleteFile(fileUpload)" />
} @else {
  <lu-single-file-upload [accept]="accept" (filePicked)="uploadFiles([$event])" />
}
```
