### PR TITLE
fix(dialogHeader): update id with content

### DIFF
--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -1,5 +1,5 @@
 import { CdkDialogContainer } from '@angular/cdk/dialog';
-import { ChangeDetectionStrategy, Component, contentChild, Directive, ElementRef, inject, input, OnInit, Renderer2, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, contentChild, Directive, DoCheck, ElementRef, inject, Injector, input, OnDestroy, Renderer2, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { intlInputOptions } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -31,7 +31,7 @@ export class DialogHeaderSubtitle {}
 		class: 'dialog-inside-header',
 	},
 })
-export class DialogHeaderComponent implements OnInit {
+export class DialogHeaderComponent implements DoCheck, OnDestroy {
 	#ref = inject(LuDialogRef);
 
 	intl = input(...intlInputOptions(LU_DIALOG_HEADER_TRANSLATIONS));
@@ -42,6 +42,10 @@ export class DialogHeaderComponent implements OnInit {
 
 	#renderer = inject(Renderer2);
 
+	#injector = inject(Injector);
+
+	#registeredAriaLabelledById: string | undefined;
+
 	close(): void {
 		this.#ref.dismiss();
 	}
@@ -50,16 +54,39 @@ export class DialogHeaderComponent implements OnInit {
 
 	optionalSubtitle = contentChild(DialogHeaderSubtitle);
 
-	ngOnInit(): void {
-		// Using setTimeout here to make sure this will be handled in the next Cd cycle, not the current one.
-		setTimeout(() => {
-			const header = this.#elementRef.nativeElement.querySelector('h1');
-			const id = header?.id || `lu-dialog-header-${nextId++}`;
-			if (header) {
-				this.#renderer.setAttribute(header, 'id', id);
-				this.#renderer.addClass(header, 'dialog-inside-header-container-title');
-			}
-			(this.#ref.cdkRef.containerInstance as CdkDialogContainer)?._addAriaLabelledBy(id);
-		});
+	ngDoCheck(): void {
+		// Runs after every check so a title that appears, disappears or gets swapped later (e.g. behind an @if) stays in sync.
+		afterNextRender(() => this.#syncAriaLabelledBy(), { injector: this.#injector });
+	}
+
+	ngOnDestroy(): void {
+		this.#unregisterAriaLabelledBy();
+	}
+
+	#syncAriaLabelledBy(): void {
+		const header = this.#elementRef.nativeElement.querySelector('h1');
+		if (!header) {
+			this.#unregisterAriaLabelledBy();
+			return;
+		}
+
+		const id = header.id || `lu-dialog-header-${nextId++}`;
+		if (id === this.#registeredAriaLabelledById) {
+			return;
+		}
+
+		this.#unregisterAriaLabelledBy();
+		this.#renderer.setAttribute(header, 'id', id);
+		this.#renderer.addClass(header, 'dialog-inside-header-container-title');
+		(this.#ref.cdkRef.containerInstance as CdkDialogContainer)?._addAriaLabelledBy(id);
+		this.#registeredAriaLabelledById = id;
+	}
+
+	#unregisterAriaLabelledBy(): void {
+		if (!this.#registeredAriaLabelledById) {
+			return;
+		}
+		(this.#ref.cdkRef.containerInstance as CdkDialogContainer)?._removeAriaLabelledBy(this.#registeredAriaLabelledById);
+		this.#registeredAriaLabelledById = undefined;
 	}
 }

--- a/packages/ng/dialog/dialog-header/dialog-header.component.ts
+++ b/packages/ng/dialog/dialog-header/dialog-header.component.ts
@@ -1,5 +1,5 @@
 import { CdkDialogContainer } from '@angular/cdk/dialog';
-import { afterNextRender, ChangeDetectionStrategy, Component, contentChild, Directive, DoCheck, ElementRef, inject, Injector, input, OnDestroy, Renderer2, ViewEncapsulation } from '@angular/core';
+import { afterRenderEffect, ChangeDetectionStrategy, Component, contentChild, Directive, ElementRef, inject, input, OnDestroy, Renderer2, ViewEncapsulation } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { intlInputOptions } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
@@ -31,7 +31,7 @@ export class DialogHeaderSubtitle {}
 		class: 'dialog-inside-header',
 	},
 })
-export class DialogHeaderComponent implements DoCheck, OnDestroy {
+export class DialogHeaderComponent implements OnDestroy {
 	#ref = inject(LuDialogRef);
 
 	intl = input(...intlInputOptions(LU_DIALOG_HEADER_TRANSLATIONS));
@@ -42,9 +42,11 @@ export class DialogHeaderComponent implements DoCheck, OnDestroy {
 
 	#renderer = inject(Renderer2);
 
-	#injector = inject(Injector);
-
 	#registeredAriaLabelledById: string | undefined;
+
+	constructor() {
+		afterRenderEffect(() => this.#syncAriaLabelledBy());
+	}
 
 	close(): void {
 		this.#ref.dismiss();
@@ -53,11 +55,6 @@ export class DialogHeaderComponent implements DoCheck, OnDestroy {
 	optionalAction = contentChild(DialogHeaderAction);
 
 	optionalSubtitle = contentChild(DialogHeaderSubtitle);
-
-	ngDoCheck(): void {
-		// Runs after every check so a title that appears, disappears or gets swapped later (e.g. behind an @if) stays in sync.
-		afterNextRender(() => this.#syncAriaLabelledBy(), { injector: this.#injector });
-	}
 
 	ngOnDestroy(): void {
 		this.#unregisterAriaLabelledBy();


### PR DESCRIPTION
## Description

When the title/h1 changes in the dialog, then the aria-labelby is broken.

Example : passing this dialog from "readOnly" to "edit".

<img width="1138" height="1000" alt="image" src="https://github.com/user-attachments/assets/16838538-36f2-4974-b09f-5c9d1c33a98c" />

<img width="1081" height="997" alt="image" src="https://github.com/user-attachments/assets/9f0a883e-74fb-470b-9282-151f57e03744" />

-----
