### PR TITLE
fix(link): render href on external router links for keyboard accessibility

### DIFF
--- a/packages/ng/link/link.component.ts
+++ b/packages/ng/link/link.component.ts
@@ -1,5 +1,5 @@
 import { Location } from '@angular/common';
-import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, inject, Injector, input, ViewEncapsulation } from '@angular/core';
+import { afterNextRender, booleanAttribute, ChangeDetectionStrategy, Component, effect, ElementRef, inject, Injector, input, ViewEncapsulation } from '@angular/core';
 import { Router, UrlTree } from '@angular/router';
 import { intlInputOptions } from '@lucca-front/ng/core';
 import { LU_INDEX_TABLE_INSTANCE } from '@lucca-front/ng/index-table';
@@ -39,6 +39,7 @@ export class LinkComponent {
 	intl = input(...intlInputOptions(LU_LINK_TRANSLATIONS));
 	routerLink = inject(LuRouterLink);
 	#injector = inject(Injector);
+	#elementRef = inject(ElementRef);
 	router = inject(Router);
 	location = inject(Location);
 	insideIndexTable = inject(LU_INDEX_TABLE_INSTANCE, { optional: true });
@@ -94,6 +95,11 @@ export class LinkComponent {
 				// We need to do this in order to have `routerLink` update the value for `href`:
 				// See https://github.com/angular/angular/blob/main/packages/router/src/directives/router_link.ts#L281
 				this.routerLink.ngOnChanges({});
+			} else if (this.routerLinkCommands() && this.external()) {
+				// External router links must not wire up the `RouterLink` directive (it would navigate in-place),
+				// but they still need an `href` so the anchor is keyboard-focusable and its destination is previewable.
+				// Actual navigation is handled natively by `target="_blank"` (anchors) or by `redirect()` (buttons).
+				this.routerLink.publicReactiveHref.set(this.#serializeExternalUrl());
 			} else if (!href() && this.hrefBackup) {
 				this.routerLink.publicReactiveHref.set(this.hrefBackup);
 			}
@@ -101,20 +107,33 @@ export class LinkComponent {
 	}
 
 	redirect(): void {
-		const routerLinkCommands = this.routerLinkCommands();
-		if (!this.disabled() && routerLinkCommands && this.external()) {
-			const urlTree =
-				routerLinkCommands instanceof UrlTree
-					? routerLinkCommands
-					: this.router.createUrlTree(Array.isArray(routerLinkCommands) ? routerLinkCommands : [routerLinkCommands], {
-							queryParams: this.routerLink.queryParams,
-							fragment: this.routerLink.fragment,
-							queryParamsHandling: this.routerLink.queryParamsHandling,
-							preserveFragment: this.routerLink.preserveFragment,
-						});
-			const serializedUrl = this.router.serializeUrl(urlTree);
-			const externalUrl = Array.isArray(routerLinkCommands) ? this.location.prepareExternalUrl(serializedUrl) : serializedUrl;
+		// Anchors carry an `href` with `target="_blank"`, so the browser opens the new tab natively.
+		// Only non-anchor hosts (e.g. `button[luLink]`) need us to open the window programmatically.
+		if (!this.disabled() && this.routerLinkCommands() && this.external() && !this.#isAnchor()) {
+			const externalUrl = this.#serializeExternalUrl();
 			afterNextRender(() => window.open(externalUrl, '_blank'), { injector: this.#injector });
 		}
+	}
+
+	#isAnchor(): boolean {
+		return (this.#elementRef.nativeElement as HTMLElement).tagName === 'A';
+	}
+
+	#serializeExternalUrl(): string | null {
+		const routerLinkCommands = this.routerLinkCommands();
+		if (!routerLinkCommands) {
+			return null;
+		}
+		const urlTree =
+			routerLinkCommands instanceof UrlTree
+				? routerLinkCommands
+				: this.router.createUrlTree(Array.isArray(routerLinkCommands) ? routerLinkCommands : [routerLinkCommands], {
+						queryParams: this.routerLink.queryParams,
+						fragment: this.routerLink.fragment,
+						queryParamsHandling: this.routerLink.queryParamsHandling,
+						preserveFragment: this.routerLink.preserveFragment,
+					});
+		const serializedUrl = this.router.serializeUrl(urlTree);
+		return Array.isArray(routerLinkCommands) ? this.location.prepareExternalUrl(serializedUrl) : serializedUrl;
 	}
 }


### PR DESCRIPTION
## Description

External router links (`<a luLink="…" external>`) now expose an `href` attribute. They are reachable via keyboard navigation and their destination is shown when hovering over them.

-----

External router links never set `publicReactiveHref`, so no `href` was rendered on the anchor: the `effect` only wired up an href for internal router links (`routerLinkCommands && !external`). An `<a>` without `href` is skipped by the tab order and shows no URL preview — navigation only happened through the `(click)` → `window.open()` handler, unreachable by keyboard.

The effect now has a dedicated branch for external router links that serializes the target URL (extracted into `#serializeExternalUrl()`) and sets it as the `href`. Combined with the existing `target="_blank"`/`rel` host bindings, the browser handles opening in a new tab natively (including on Enter).

`redirect()` now only calls `window.open()` for non-anchor hosts (`button[luLink]`), since anchors carry a real `href` with `target="_blank"` and would otherwise open a duplicate tab.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [ ] `npm run build` is OK
- [ ] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
