### PR TITLE
fix(core-select): allow Ctrl/Cmd+V paste in the search field

### DIFF
--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -337,6 +337,12 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 				}
 				break;
 			default:
+				// Let the browser handle modifier chords like Ctrl/Cmd+V (paste) or Ctrl/Cmd+C (copy)
+				// instead of treating the chord's letter (e.g. the "v" of Ctrl+V) as typeahead input.
+				// AltGr (Ctrl+Alt on Windows) is excluded so accented/special characters still work.
+				if (($event.ctrlKey || $event.metaKey) && !$event.altKey) {
+					return;
+				}
 				// For any other key, forward it to the panel if it's open
 				if (this.isPanelOpen) {
 					this.panelRef?.handleKeyManagerEvent($event);


### PR DESCRIPTION
## Description

Fix the select search field (both simple and multi select) which, on Windows, treated the `Ctrl+V` paste shortcut as typing the letter "V" instead of letting the native paste happen. The search was then run on "v" (simple select only inserted "V" on the first attempt, multi select displayed the pasted string but filtered on "v").

-----

The `default` case of `onKeyDownNavigation` (`core-select`) treated any single-character key (`$event.key.length === 1`) as search input, without checking modifier keys. The `v` keydown from `Ctrl+V` was therefore captured before the paste occurred.

We now return early when `ctrlKey` or `metaKey` is held, excluding the AltGr case (`ctrlKey && altKey`) so typing `@ { } [ ] \` on European keyboards still works.

-----

### Contribution

- [ ] Root cause of the bug is identified and understood
- [ ] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [ ] `npm run build` is OK
- [ ] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
