### PR TITLE
fix(navside): break long labels with hyphens

### DIFF
--- a/packages/scss/src/components/navside/component.scss
+++ b/packages/scss/src/components/navside/component.scss
@@ -117,6 +117,7 @@
 		}
 
 		.navSide-item-link-title {
+			hyphens: auto;
 			overflow-wrap: anywhere;
 		}
 


### PR DESCRIPTION
## Description

Allow long module labels to be broken up with hyphens when necessary.

-----

**Before**
<img width="224" height="64" alt="Capture d’écran 2026-07-07 à 15 26 18" src="https://github.com/user-attachments/assets/a6cdb48f-1cac-48cf-8305-42eb5c9ef68f" />

**After**
<img width="224" height="64" alt="Capture d’écran 2026-07-07 à 15 26 05" src="https://github.com/user-attachments/assets/3174f55c-6e7a-4141-a57a-a608ceda42d9" />

-----
