### PR TITLE
fix(richText): prevent Shift+Enter soft line breaks inside lists

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/list-format/list-format.command.ts
+++ b/packages/ng/forms/rich-text-input/plugins/list-format/list-format.command.ts
@@ -1,4 +1,4 @@
-import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_NORMAL, createCommand, INSERT_PARAGRAPH_COMMAND, LexicalEditor, SELECTION_CHANGE_COMMAND } from 'lexical';
+import { $getSelection, $isRangeSelection, COMMAND_PRIORITY_NORMAL, createCommand, INSERT_PARAGRAPH_COMMAND, KEY_ENTER_COMMAND, LexicalEditor, SELECTION_CHANGE_COMMAND } from 'lexical';
 import { $handleListInsertParagraph, $insertList, $removeList, ListNode, ListType } from '@lexical/list';
 import { $getNearestNodeOfType, mergeRegister } from '@lexical/utils';
 import { getSelectedNode } from '../../utils';
@@ -29,6 +29,27 @@ export function registerListsGlobal(editor: LexicalEditor) {
 		),
 		// end list with enter key on an empty list item node
 		editor.registerCommand(INSERT_PARAGRAPH_COMMAND, () => $handleListInsertParagraph(), COMMAND_PRIORITY_NORMAL),
+		// Shift+Enter (soft line break) inside a list cannot be represented in Markdown,
+		// so redirect it to a new list item, matching the plain Enter behaviour.
+		editor.registerCommand(
+			KEY_ENTER_COMMAND,
+			(event) => {
+				if (!event?.shiftKey) {
+					return false;
+				}
+				const selection = $getSelection();
+				if (!$isRangeSelection(selection)) {
+					return false;
+				}
+				const parent = $getNearestNodeOfType(getSelectedNode(selection), ListNode);
+				if (!parent) {
+					return false;
+				}
+				event.preventDefault();
+				return editor.dispatchCommand(INSERT_PARAGRAPH_COMMAND, undefined);
+			},
+			COMMAND_PRIORITY_NORMAL,
+		),
 	);
 }
 


### PR DESCRIPTION
## Description

In the Rich Text editor, pressing Shift+Enter inside a list item used to insert a soft line break. This break could not be represented in Markdown, producing a broken/ambiguous list structure on export. Shift+Enter inside a list now creates a new list item (same as Enter), guaranteeing valid Markdown. Shift+Enter keeps its normal behaviour outside of lists.

-----

Added a `KEY_ENTER_COMMAND` handler in the list-format plugin (priority `NORMAL`, so it runs before `registerRichText`'s `EDITOR`-priority handler). It only acts when `shiftKey` is pressed **and** the selection is inside a `ListNode`; it then calls `preventDefault()` and redirects to `INSERT_PARAGRAPH_COMMAND`, consuming the event so no `LineBreakNode` is inserted. All other cases return `false` and fall through to default behaviour.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [x] All related impacted functionalities are manually tested and show no regression

-----
