### PR TITLE
fix(error-page): Fix layout when used inside dialogs

### DIFF
--- a/packages/scss/src/components/errorPage/index.scss
+++ b/packages/scss/src/components/errorPage/index.scss
@@ -16,8 +16,8 @@
 			@include narrow;
 		}
 
-		.appLayout & {
-			@include inAppLayout;
+		:is(.appLayout, .dialog) & {
+			@include nested;
 		}
 	}
 }

--- a/packages/scss/src/components/errorPage/mods.scss
+++ b/packages/scss/src/components/errorPage/mods.scss
@@ -26,7 +26,7 @@
 	}
 }
 
-@mixin inAppLayout {
+@mixin nested {
 	&,
 	.errorPage-section {
 		block-size: 100%;


### PR DESCRIPTION
## Description

Fix Error page layout inside dialogs.

-----

I tried to rename the mixin with a more generic term. A quick search across repositories shows no use of it in any other project, so it should be safe to edit.

-----
