### PR TITLE
tech(scss): single machine-readable deprecation registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,5 +21,7 @@ jobs:
           node-version: 24.13.0
       - run: npm install
       - run: npm run build --if-present
+      - name: Check deprecations.json is up to date
+        run: npm run scss:deprecations -- --check
       - run: npm run ci-test
       - run: npm run lint

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,3 @@ scripts/generate-skills/generate-skills-config.json
 /coverage/
 
 *storybook.log
-
-# scss deprecation size audit (generated evidence, pasted into PRs)
-scss-size-audit.md

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ scripts/generate-skills/generate-skills-config.json
 /coverage/
 
 *storybook.log
+
+# scss deprecation size audit (generated evidence, pasted into PRs)
+scss-size-audit.md

--- a/build.js
+++ b/build.js
@@ -39,7 +39,7 @@ runTask('Lucca Front compilation', async () => {
 	await runTask('@lucca-front/scss compilation', () => compileScss(lfScssInput, lfScssOutput));
 	await runTask('@lucca-front/scss copy', () => {
 		copyFiles({
-			patterns: ['package.json', 'src/**/*.scss'],
+			patterns: ['package.json', 'src/**/*.scss', 'css-api/deprecations.json'],
 			context: SCSS,
 			output: OUTPUT_SCSS,
 		});

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "lint:fix": "npm run lint:es -- --fix && npm run lint:style -- --fix",
     "lint:es": "eslint --quiet packages/",
     "lint:style": "stylelint \"packages/**/*.scss\" --report-needless-disables --report-unscoped-disables --report-invalid-scope-disables",
+    "scss:deprecations": "node packages/scss/css-api/extract-deprecations.js",
+    "scss:audit": "node packages/scss/tools/audit-size.js",
     "icons:update": "node ./packages/icons/update-icons.js",
     "i18n:update": "lucca translate && prettier --write 'packages/ng/**/translations.ts'",
     "skills:generate": "ts-node --project scripts/generate-skills/tsconfig.json scripts/generate-skills/index.ts"

--- a/packages/scss/README.md
+++ b/packages/scss/README.md
@@ -150,3 +150,59 @@ Below is the current list of all available components. Import only the ones you 
 ```
 
 
+
+## Marking something as deprecated
+
+Deprecation metadata for this package lives in **one** place: the registry module
+`src/commons/deprecated.scss`. Its mixins record what is deprecated while emitting
+**zero CSS**, so the shipped stylesheet is unaffected. A build step reads the registry
+out to a committed JSON manifest (`css-api/deprecations.json`) that powers the Storybook
+"Deprecations" page and downstream tooling (VS Code IntelliSense, stylelint, codemods).
+
+Register a deprecation at the declaration site, colocated with the thing it documents:
+
+```scss
+@use '@lucca-front/scss/src/commons/deprecated';
+
+// A utility/component class (bare name, no dot)
+@include deprecated.class('pr-u-textLeft', $replacement: 'pr-u-textAlignStart', $scope: 'commons/utils');
+
+// A CSS custom property (with leading dashes)
+@include deprecated.cssVariable('--commons-font-family', $replacement: '--pr-t-font-family', $scope: 'commons/vars');
+
+// A compound/legacy selector (full selector, with dots)
+@include deprecated.selector('.box.mod-grey', $replacement: '.box.mod-neutral', $scope: 'component:box');
+
+// A Sass API surface (variable, mixin, config flag)
+@include deprecated.sassApi('config.$borderRadius', $replacement: 'config.$borderRadiusVars', $scope: 'commons/config');
+```
+
+For loop-generated names, register inside the loop using the same interpolation that
+builds the emitted name, so the recorded name is exact by construction. Use `$note`
+instead of `$replacement` when there is no one-to-one modern equivalent. `$scope` must be
+`commons/<file>` or `component:<name>`.
+
+Rule of thumb: **a deprecation is not a deprecation until it is registered.** Plain
+`// deprecated` comments are invisible to tooling.
+
+### Regenerating the manifest
+
+```
+npm run scss:deprecations          # rewrite css-api/deprecations.json from the sources
+npm run scss:deprecations -- --check   # CI: fail if the committed manifest is stale
+```
+
+The manifest is committed so Storybook and typecheck work from a clean checkout; CI runs
+`--check` to catch drift.
+
+### Auditing size impact
+
+Registry calls must never change compiled output. To prove a change is size-neutral:
+
+```
+npm run scss:audit                 # compare bundle + every module vs the rc merge-base
+npm run scss:audit -- --base <ref> # compare against a specific commit
+```
+
+It writes `scss-size-audit.md` with per-module before/after compressed + gzip sizes, a
+sha256 byte-identity summary, and the before/after deprecation inventory.

--- a/packages/scss/css-api/deprecations.json
+++ b/packages/scss/css-api/deprecations.json
@@ -1,0 +1,5478 @@
+{
+	"version": 1,
+	"package": "@lucca-front/scss",
+	"entries": [
+		{
+			"kind": "sass-api",
+			"name": "config palette: grey",
+			"replacement": null,
+			"note": "Deprecated palette name.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config palette: lucca",
+			"replacement": null,
+			"note": "Deprecated palette name.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config palette: primary",
+			"replacement": null,
+			"note": "Deprecated palette name.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config palette: secondary",
+			"replacement": null,
+			"note": "Deprecated palette name.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config.$borderRadius",
+			"replacement": "config.$borderRadiusVars",
+			"note": null,
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config.$colors",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config.$colorsRgb",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config.$deprecatedCardBoxMargin",
+			"replacement": null,
+			"note": "Escape-hatch flag for legacy card/box margins.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config.$deprecatedSpacings",
+			"replacement": null,
+			"note": "Escape-hatch flag for legacy element spacing.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "config.$deprecatedUtilityPrefix",
+			"replacement": null,
+			"note": "Escape-hatch flag; the u- prefix will be removed.",
+			"since": null,
+			"scope": "commons/config"
+		},
+		{
+			"kind": "sass-api",
+			"name": "core.borderRadius",
+			"replacement": "core.borderRadiusTokens",
+			"note": null,
+			"since": null,
+			"scope": "commons/core"
+		},
+		{
+			"kind": "sass-api",
+			"name": "core.sizes",
+			"replacement": null,
+			"note": "Use the typography utilities/tokens instead.",
+			"since": null,
+			"scope": "commons/core"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottom0",
+			"replacement": "pr-u-borderBlockEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomLeftRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomLeftRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomLeftRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomLeftRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomRightRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomRightRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomRightRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderBottomRightRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndEndRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndEndRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndEndRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndEndRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndStartRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndStartRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndStartRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderEndStartRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderLeft0",
+			"replacement": "pr-u-borderInlineStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderRight0",
+			"replacement": "pr-u-borderInlineEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartEndRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartEndRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartEndRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartEndRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartStartRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartStartRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartStartRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderStartStartRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTop0",
+			"replacement": "pr-u-borderBlockStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopLeftRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopLeftRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopLeftRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopLeftRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopRightRadiusFull",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopRightRadiusL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopRightRadiusM",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-borderTopRightRadiusXL",
+			"replacement": null,
+			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-bottom0",
+			"replacement": "pr-u-insetBlockEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-bottomReset",
+			"replacement": "pr-u-insetBlockEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-clear",
+			"replacement": "pr-u-clearBoth",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-clearLeft",
+			"replacement": "pr-u-clearInlineStart",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-clearRight",
+			"replacement": "pr-u-clearInlineEnd",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-floatLeft",
+			"replacement": "pr-u-floatInlineStart",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-floatRight",
+			"replacement": "pr-u-floatInlineEnd",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-h5",
+			"replacement": null,
+			"note": "Use pr-u-h1 through pr-u-h4 or body utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-h6",
+			"replacement": null,
+			"note": "Use pr-u-h1 through pr-u-h4 or body utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-insetReset",
+			"replacement": "pr-u-inset0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-left0",
+			"replacement": "pr-u-insetInlineStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-leftReset",
+			"replacement": "pr-u-insetInlineStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom0",
+			"replacement": "pr-u-marginBlockEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom100",
+			"replacement": "pr-u-marginBlockEnd100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom150",
+			"replacement": "pr-u-marginBlockEnd150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom200",
+			"replacement": "pr-u-marginBlockEnd200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom25",
+			"replacement": "pr-u-marginBlockEnd25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom250",
+			"replacement": "pr-u-marginBlockEnd250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom300",
+			"replacement": "pr-u-marginBlockEnd300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom400",
+			"replacement": "pr-u-marginBlockEnd400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom50",
+			"replacement": "pr-u-marginBlockEnd50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom500",
+			"replacement": "pr-u-marginBlockEnd500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom600",
+			"replacement": "pr-u-marginBlockEnd600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom700",
+			"replacement": "pr-u-marginBlockEnd700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom75",
+			"replacement": "pr-u-marginBlockEnd75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottom800",
+			"replacement": "pr-u-marginBlockEnd800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginBottomAuto",
+			"replacement": "pr-u-marginBlockEndAuto",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft0",
+			"replacement": "pr-u-marginInlineStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft100",
+			"replacement": "pr-u-marginInlineStart100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft150",
+			"replacement": "pr-u-marginInlineStart150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft200",
+			"replacement": "pr-u-marginInlineStart200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft25",
+			"replacement": "pr-u-marginInlineStart25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft250",
+			"replacement": "pr-u-marginInlineStart250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft300",
+			"replacement": "pr-u-marginInlineStart300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft400",
+			"replacement": "pr-u-marginInlineStart400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft50",
+			"replacement": "pr-u-marginInlineStart50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft500",
+			"replacement": "pr-u-marginInlineStart500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft600",
+			"replacement": "pr-u-marginInlineStart600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft700",
+			"replacement": "pr-u-marginInlineStart700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft75",
+			"replacement": "pr-u-marginInlineStart75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeft800",
+			"replacement": "pr-u-marginInlineStart800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginLeftAuto",
+			"replacement": "pr-u-marginInlineStartAuto",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight0",
+			"replacement": "pr-u-marginInlineEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight100",
+			"replacement": "pr-u-marginInlineEnd100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight150",
+			"replacement": "pr-u-marginInlineEnd150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight200",
+			"replacement": "pr-u-marginInlineEnd200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight25",
+			"replacement": "pr-u-marginInlineEnd25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight250",
+			"replacement": "pr-u-marginInlineEnd250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight300",
+			"replacement": "pr-u-marginInlineEnd300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight400",
+			"replacement": "pr-u-marginInlineEnd400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight50",
+			"replacement": "pr-u-marginInlineEnd50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight500",
+			"replacement": "pr-u-marginInlineEnd500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight600",
+			"replacement": "pr-u-marginInlineEnd600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight700",
+			"replacement": "pr-u-marginInlineEnd700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight75",
+			"replacement": "pr-u-marginInlineEnd75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRight800",
+			"replacement": "pr-u-marginInlineEnd800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginRightAuto",
+			"replacement": "pr-u-marginInlineEndAuto",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop0",
+			"replacement": "pr-u-marginBlockStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop100",
+			"replacement": "pr-u-marginBlockStart100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop150",
+			"replacement": "pr-u-marginBlockStart150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop200",
+			"replacement": "pr-u-marginBlockStart200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop25",
+			"replacement": "pr-u-marginBlockStart25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop250",
+			"replacement": "pr-u-marginBlockStart250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop300",
+			"replacement": "pr-u-marginBlockStart300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop400",
+			"replacement": "pr-u-marginBlockStart400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop50",
+			"replacement": "pr-u-marginBlockStart50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop500",
+			"replacement": "pr-u-marginBlockStart500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop600",
+			"replacement": "pr-u-marginBlockStart600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop700",
+			"replacement": "pr-u-marginBlockStart700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop75",
+			"replacement": "pr-u-marginBlockStart75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTop800",
+			"replacement": "pr-u-marginBlockStart800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-marginTopAuto",
+			"replacement": "pr-u-marginBlockStartAuto",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom0",
+			"replacement": "pr-u-paddingBlockEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom100",
+			"replacement": "pr-u-paddingBlockEnd100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom150",
+			"replacement": "pr-u-paddingBlockEnd150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom200",
+			"replacement": "pr-u-paddingBlockEnd200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom25",
+			"replacement": "pr-u-paddingBlockEnd25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom250",
+			"replacement": "pr-u-paddingBlockEnd250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom300",
+			"replacement": "pr-u-paddingBlockEnd300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom400",
+			"replacement": "pr-u-paddingBlockEnd400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom50",
+			"replacement": "pr-u-paddingBlockEnd50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom500",
+			"replacement": "pr-u-paddingBlockEnd500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom600",
+			"replacement": "pr-u-paddingBlockEnd600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom700",
+			"replacement": "pr-u-paddingBlockEnd700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom75",
+			"replacement": "pr-u-paddingBlockEnd75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingBottom800",
+			"replacement": "pr-u-paddingBlockEnd800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft0",
+			"replacement": "pr-u-paddingInlineStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft100",
+			"replacement": "pr-u-paddingInlineStart100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft150",
+			"replacement": "pr-u-paddingInlineStart150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft200",
+			"replacement": "pr-u-paddingInlineStart200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft25",
+			"replacement": "pr-u-paddingInlineStart25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft250",
+			"replacement": "pr-u-paddingInlineStart250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft300",
+			"replacement": "pr-u-paddingInlineStart300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft400",
+			"replacement": "pr-u-paddingInlineStart400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft50",
+			"replacement": "pr-u-paddingInlineStart50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft500",
+			"replacement": "pr-u-paddingInlineStart500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft600",
+			"replacement": "pr-u-paddingInlineStart600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft700",
+			"replacement": "pr-u-paddingInlineStart700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft75",
+			"replacement": "pr-u-paddingInlineStart75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingLeft800",
+			"replacement": "pr-u-paddingInlineStart800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight0",
+			"replacement": "pr-u-paddingInlineEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight100",
+			"replacement": "pr-u-paddingInlineEnd100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight150",
+			"replacement": "pr-u-paddingInlineEnd150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight200",
+			"replacement": "pr-u-paddingInlineEnd200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight25",
+			"replacement": "pr-u-paddingInlineEnd25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight250",
+			"replacement": "pr-u-paddingInlineEnd250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight300",
+			"replacement": "pr-u-paddingInlineEnd300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight400",
+			"replacement": "pr-u-paddingInlineEnd400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight50",
+			"replacement": "pr-u-paddingInlineEnd50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight500",
+			"replacement": "pr-u-paddingInlineEnd500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight600",
+			"replacement": "pr-u-paddingInlineEnd600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight700",
+			"replacement": "pr-u-paddingInlineEnd700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight75",
+			"replacement": "pr-u-paddingInlineEnd75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingRight800",
+			"replacement": "pr-u-paddingInlineEnd800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop0",
+			"replacement": "pr-u-paddingBlockStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop100",
+			"replacement": "pr-u-paddingBlockStart100",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop150",
+			"replacement": "pr-u-paddingBlockStart150",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop200",
+			"replacement": "pr-u-paddingBlockStart200",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop25",
+			"replacement": "pr-u-paddingBlockStart25",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop250",
+			"replacement": "pr-u-paddingBlockStart250",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop300",
+			"replacement": "pr-u-paddingBlockStart300",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop400",
+			"replacement": "pr-u-paddingBlockStart400",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop50",
+			"replacement": "pr-u-paddingBlockStart50",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop500",
+			"replacement": "pr-u-paddingBlockStart500",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop600",
+			"replacement": "pr-u-paddingBlockStart600",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop700",
+			"replacement": "pr-u-paddingBlockStart700",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop75",
+			"replacement": "pr-u-paddingBlockStart75",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-paddingTop800",
+			"replacement": "pr-u-paddingBlockStart800",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-right0",
+			"replacement": "pr-u-insetInlineEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-rightReset",
+			"replacement": "pr-u-insetInlineEnd0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textAlignLeft",
+			"replacement": "pr-u-textAlignStart",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textAlignRight",
+			"replacement": "pr-u-textAlignEnd",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textBlueberry",
+			"replacement": "pr-u-colorTextBlueberry",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textBrand",
+			"replacement": "pr-u-colorTextBrand",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textBrandContrasted",
+			"replacement": "pr-u-colorTextBrandContrasted",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textCc",
+			"replacement": "pr-u-colorTextCc",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textCenter",
+			"replacement": "pr-u-textAlignCenter",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textCleemy",
+			"replacement": "pr-u-colorTextCleemy",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textCoreHR",
+			"replacement": "pr-u-colorTextCoreHR",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textCritical",
+			"replacement": "pr-u-colorTextCritical",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textCucumber",
+			"replacement": "pr-u-colorTextCucumber",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textDefault",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textError",
+			"replacement": "pr-u-colorTextError",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textGlacier",
+			"replacement": "pr-u-colorTextGlacier",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textGrape",
+			"replacement": "pr-u-colorTextGrape",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textGrey",
+			"replacement": "pr-u-colorTextGrey",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textKiwi",
+			"replacement": "pr-u-colorTextKiwi",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textL",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textLagoon",
+			"replacement": "pr-u-colorTextLagoon",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textLavender",
+			"replacement": "pr-u-colorTextLavender",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textLeft",
+			"replacement": "pr-u-textAlignStart",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textLight",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textLime",
+			"replacement": "pr-u-colorTextLime",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textLucca",
+			"replacement": "pr-u-colorTextLucca",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textM",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textMint",
+			"replacement": "pr-u-colorTextMint",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textNavigation",
+			"replacement": "pr-u-colorTextNavigation",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textNeutral",
+			"replacement": "pr-u-colorTextNeutral",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textOrchid",
+			"replacement": "pr-u-colorTextOrchid",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPagga",
+			"replacement": "pr-u-colorTextPagga",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPineapple",
+			"replacement": "pr-u-colorTextPineapple",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPineappleContrasted",
+			"replacement": "pr-u-colorTextPineappleContrasted",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPlaceholder",
+			"replacement": "pr-u-colorInputTextPlaceholder",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPoplee",
+			"replacement": "pr-u-colorTextPoplee",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPrimary",
+			"replacement": "pr-u-colorTextPrimary",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textProduct",
+			"replacement": "pr-u-colorTextProduct",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textPumpkin",
+			"replacement": "pr-u-colorTextPumpkin",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textRight",
+			"replacement": "pr-u-textAlignEnd",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textS",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textSecondary",
+			"replacement": "pr-u-colorTextSecondary",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textSuccess",
+			"replacement": "pr-u-colorTextSuccess",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textSuccessContrasted",
+			"replacement": "pr-u-colorTextSuccessContrasted",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textTimmi",
+			"replacement": "pr-u-colorTextTimmi",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textWarning",
+			"replacement": "pr-u-colorTextWarning",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textWarningContrasted",
+			"replacement": "pr-u-colorTextWarningContrasted",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textWatermelon",
+			"replacement": "pr-u-colorTextWatermelon",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textXL",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textXS",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textXXL",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-textXXXL",
+			"replacement": null,
+			"note": "Use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-top0",
+			"replacement": "pr-u-insetBlockStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "pr-u-topReset",
+			"replacement": "pr-u-insetBlockStart0",
+			"note": null,
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignItemsBaseline",
+			"replacement": "pr-u-alignItemsBaseline",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignItemsCenter",
+			"replacement": "pr-u-alignItemsCenter",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignItemsFlexEnd",
+			"replacement": "pr-u-alignItemsFlexEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignItemsFlexStart",
+			"replacement": "pr-u-alignItemsFlexStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignItemsStretch",
+			"replacement": "pr-u-alignItemsStretch",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignSelfBaseline",
+			"replacement": "pr-u-alignSelfBaseline",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignSelfCenter",
+			"replacement": "pr-u-alignSelfCenter",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignSelfFlexEnd",
+			"replacement": "pr-u-alignSelfFlexEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignSelfFlexStart",
+			"replacement": "pr-u-alignSelfFlexStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-alignSelfStretch",
+			"replacement": "pr-u-alignSelfStretch",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-animated",
+			"replacement": "pr-u-animated",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-blockSize100\\%",
+			"replacement": "pr-u-blockSize100\\%",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-blockSizeFitContent",
+			"replacement": "pr-u-blockSizeFitContent",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-bodyM",
+			"replacement": "pr-u-bodyM",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-bodyS",
+			"replacement": "pr-u-bodyS",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-bodyXS",
+			"replacement": "pr-u-bodyXS",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomLeftRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomLeftRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomLeftRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomLeftRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomRightRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomRightRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomRightRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderBottomRightRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndEndRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndEndRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndEndRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndEndRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndStartRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndStartRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndStartRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderEndStartRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartEndRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartEndRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartEndRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartEndRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartStartRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartStartRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartStartRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderStartStartRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopLeftRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopLeftRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopLeftRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopLeftRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopRightRadiusFull",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopRightRadiusL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopRightRadiusM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-borderTopRightRadiusXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use border-radius token utilities instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-bottom0",
+			"replacement": "pr-u-insetBlockEnd0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-bottomReset",
+			"replacement": "pr-u-insetBlockEnd0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-buttonReset",
+			"replacement": "pr-u-buttonReset",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clear",
+			"replacement": "pr-u-clearBoth",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clearBoth",
+			"replacement": "pr-u-clearBoth",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clearfix",
+			"replacement": "pr-u-clearfix",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clearInlineEnd",
+			"replacement": "pr-u-clearInlineEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clearInlineStart",
+			"replacement": "pr-u-clearInlineStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clearLeft",
+			"replacement": "pr-u-clearInlineStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-clearRight",
+			"replacement": "pr-u-clearInlineEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-cursorAuto",
+			"replacement": "pr-u-cursorAuto",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-cursorDefault",
+			"replacement": "pr-u-cursorDefault",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-cursorPointer",
+			"replacement": "pr-u-cursorPointer",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-cursorText",
+			"replacement": "pr-u-cursorText",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-descriptionListReset",
+			"replacement": "pr-u-descriptionListReset",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayBlock",
+			"replacement": "pr-u-displayBlock",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayContents",
+			"replacement": "pr-u-displayContents",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayFlex",
+			"replacement": "pr-u-displayFlex",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayGrid",
+			"replacement": "pr-u-displayGrid",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayInline",
+			"replacement": "pr-u-displayInline",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayInlineBlock",
+			"replacement": "pr-u-displayInlineBlock",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayInlineFlex",
+			"replacement": "pr-u-displayInlineFlex",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayInlineGrid",
+			"replacement": "pr-u-displayInlineGrid",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-displayNone",
+			"replacement": "pr-u-displayNone",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-ellipsis",
+			"replacement": "pr-u-ellipsis",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexBasis0",
+			"replacement": "pr-u-flexBasis0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexBasisAuto",
+			"replacement": "pr-u-flexBasisAuto",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexDirectionColumn",
+			"replacement": "pr-u-flexDirectionColumn",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexDirectionColumnReverse",
+			"replacement": "pr-u-flexDirectionColumnReverse",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexDirectionRow",
+			"replacement": "pr-u-flexDirectionRow",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexDirectionRowReverse",
+			"replacement": "pr-u-flexDirectionRowReverse",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexGrow0",
+			"replacement": "pr-u-flexGrow0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexGrow1",
+			"replacement": "pr-u-flexGrow1",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexShrink0",
+			"replacement": "pr-u-flexShrink0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexShrink1",
+			"replacement": "pr-u-flexShrink1",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexWrapNowrap",
+			"replacement": "pr-u-flexWrapNowrap",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexWrapWrap",
+			"replacement": "pr-u-flexWrapWrap",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-flexWrapWrapReverse",
+			"replacement": "pr-u-flexWrapWrapReverse",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-floatInlineEnd",
+			"replacement": "pr-u-floatInlineEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-floatInlineStart",
+			"replacement": "pr-u-floatInlineStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-floatLeft",
+			"replacement": "pr-u-floatInlineStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-floatRight",
+			"replacement": "pr-u-floatInlineEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontFamily",
+			"replacement": "pr-u-fontFamily",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontFamilyBrand",
+			"replacement": "pr-u-fontFamilyBrand",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontFamilyCursive",
+			"replacement": "pr-u-fontFamilyCursive",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontStyleItalic",
+			"replacement": "pr-u-fontStyleItalic",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontStyleNormal",
+			"replacement": "pr-u-fontStyleNormal",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeight400",
+			"replacement": "pr-u-fontWeight400",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeight600",
+			"replacement": "pr-u-fontWeight600",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeight700",
+			"replacement": "pr-u-fontWeight700",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeight900",
+			"replacement": "pr-u-fontWeight900",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeightBold",
+			"replacement": "pr-u-fontWeightBold",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeightNormal",
+			"replacement": "pr-u-fontWeightNormal",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeightRegular",
+			"replacement": "pr-u-fontWeightRegular",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-fontWeightSemiBold",
+			"replacement": "pr-u-fontWeightSemiBold",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-h1",
+			"replacement": "pr-u-h1",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-h2",
+			"replacement": "pr-u-h2",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-h3",
+			"replacement": "pr-u-h3",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-h4",
+			"replacement": "pr-u-h4",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-h5",
+			"replacement": null,
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-h6",
+			"replacement": null,
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-height100\\%",
+			"replacement": "pr-u-height100\\%",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-heightFitContent",
+			"replacement": "pr-u-heightFitContent",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-inlineSize100\\%",
+			"replacement": "pr-u-inlineSize100\\%",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-inlineSizeFitContent",
+			"replacement": "pr-u-inlineSizeFitContent",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-inset0",
+			"replacement": "pr-u-inset0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetBlock-end0",
+			"replacement": "pr-u-insetBlock-end0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetBlock-start0",
+			"replacement": "pr-u-insetBlock-start0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetBlock0",
+			"replacement": "pr-u-insetBlock0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetInline-end0",
+			"replacement": "pr-u-insetInline-end0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetInline-start0",
+			"replacement": "pr-u-insetInline-start0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetInline0",
+			"replacement": "pr-u-insetInline0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-insetReset",
+			"replacement": "pr-u-inset0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-justifyContentCenter",
+			"replacement": "pr-u-justifyContentCenter",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-justifyContentFlexEnd",
+			"replacement": "pr-u-justifyContentFlexEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-justifyContentFlexStart",
+			"replacement": "pr-u-justifyContentFlexStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-justifyContentSpaceAround",
+			"replacement": "pr-u-justifyContentSpaceAround",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-justifyContentSpaceBetween",
+			"replacement": "pr-u-justifyContentSpaceBetween",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-justifyContentSpaceEvenly",
+			"replacement": "pr-u-justifyContentSpaceEvenly",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-left0",
+			"replacement": "pr-u-insetInlineStart0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-leftReset",
+			"replacement": "pr-u-insetInlineStart0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-listReset",
+			"replacement": "pr-u-listReset",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-marginBlock-end0",
+			"replacement": "pr-u-marginBlock-end0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-marginBlock-start0",
+			"replacement": "pr-u-marginBlock-start0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-marginBlock0",
+			"replacement": "pr-u-marginBlock0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-marginInline-end0",
+			"replacement": "pr-u-marginInline-end0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-marginInline-start0",
+			"replacement": "pr-u-marginInline-start0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-marginInline0",
+			"replacement": "pr-u-marginInline0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-mask",
+			"replacement": "pr-u-mask",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-maxInlineSize100\\%",
+			"replacement": "pr-u-maxInlineSize100\\%",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-maxInlineSizeFitContent",
+			"replacement": "pr-u-maxInlineSizeFitContent",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-minBlockSize0",
+			"replacement": "pr-u-minBlockSize0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-minHeight0",
+			"replacement": "pr-u-minHeight0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-minInlineSize0",
+			"replacement": "pr-u-minInlineSize0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-minWidth0",
+			"replacement": "pr-u-minWidth0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-noSpinButtons",
+			"replacement": "pr-u-noSpinButtons",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayBlock",
+			"replacement": "pr-u-onlyPrintDisplayBlock",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayContents",
+			"replacement": "pr-u-onlyPrintDisplayContents",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayFlex",
+			"replacement": "pr-u-onlyPrintDisplayFlex",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayGrid",
+			"replacement": "pr-u-onlyPrintDisplayGrid",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayInline",
+			"replacement": "pr-u-onlyPrintDisplayInline",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayInlineBlock",
+			"replacement": "pr-u-onlyPrintDisplayInlineBlock",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayInlineFlex",
+			"replacement": "pr-u-onlyPrintDisplayInlineFlex",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayInlineGrid",
+			"replacement": "pr-u-onlyPrintDisplayInlineGrid",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-onlyPrintDisplayNone",
+			"replacement": "pr-u-onlyPrintDisplayNone",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-order1",
+			"replacement": "pr-u-order1",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-orderMinus1",
+			"replacement": "pr-u-orderMinus1",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-overflowAuto",
+			"replacement": "pr-u-overflowAuto",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-overflowHidden",
+			"replacement": "pr-u-overflowHidden",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-overflowScroll",
+			"replacement": "pr-u-overflowScroll",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-overflowVisible",
+			"replacement": "pr-u-overflowVisible",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-paddingBlock-end0",
+			"replacement": "pr-u-paddingBlock-end0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-paddingBlock-start0",
+			"replacement": "pr-u-paddingBlock-start0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-paddingBlock0",
+			"replacement": "pr-u-paddingBlock0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-paddingInline-end0",
+			"replacement": "pr-u-paddingInline-end0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-paddingInline-start0",
+			"replacement": "pr-u-paddingInline-start0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-paddingInline0",
+			"replacement": "pr-u-paddingInline0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-pointerEventsAuto",
+			"replacement": "pr-u-pointerEventsAuto",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-pointerEventsNone",
+			"replacement": "pr-u-pointerEventsNone",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-positionAbsolute",
+			"replacement": "pr-u-positionAbsolute",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-positionFixed",
+			"replacement": "pr-u-positionFixed",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-positionRelative",
+			"replacement": "pr-u-positionRelative",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-positionStatic",
+			"replacement": "pr-u-positionStatic",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-positionSticky",
+			"replacement": "pr-u-positionSticky",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-right0",
+			"replacement": "pr-u-insetInlineEnd0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-rightReset",
+			"replacement": "pr-u-insetInlineEnd0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-scrollBehaviorAuto",
+			"replacement": "pr-u-scrollBehaviorAuto",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-scrollBehaviorSmooth",
+			"replacement": "pr-u-scrollBehaviorSmooth",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-summaryReset",
+			"replacement": "pr-u-summaryReset",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textAlignCenter",
+			"replacement": "pr-u-textAlignCenter",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textAlignEnd",
+			"replacement": "pr-u-textAlignEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textAlignLeft",
+			"replacement": "pr-u-textAlignStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textAlignRight",
+			"replacement": "pr-u-textAlignEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textAlignStart",
+			"replacement": "pr-u-textAlignStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textBlueberry",
+			"replacement": "pr-u-colorTextBlueberry",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textBrand",
+			"replacement": "pr-u-colorTextBrand",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textBrandContrasted",
+			"replacement": "pr-u-colorTextBrandContrasted",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textCc",
+			"replacement": "pr-u-colorTextCc",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textCenter",
+			"replacement": "pr-u-textAlignCenter",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textCleemy",
+			"replacement": "pr-u-colorTextCleemy",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textCoreHR",
+			"replacement": "pr-u-colorTextCoreHR",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textCritical",
+			"replacement": "pr-u-colorTextCritical",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textCucumber",
+			"replacement": "pr-u-colorTextCucumber",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textDecorationLineThrough",
+			"replacement": "pr-u-textDecorationLineThrough",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textDecorationNone",
+			"replacement": "pr-u-textDecorationNone",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textDecorationUnderline",
+			"replacement": "pr-u-textDecorationUnderline",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textDefault",
+			"replacement": null,
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textError",
+			"replacement": "pr-u-colorTextError",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textGlacier",
+			"replacement": "pr-u-colorTextGlacier",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textGrape",
+			"replacement": "pr-u-colorTextGrape",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textGrey",
+			"replacement": "pr-u-colorTextGrey",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textKiwi",
+			"replacement": "pr-u-colorTextKiwi",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textLagoon",
+			"replacement": "pr-u-colorTextLagoon",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textLavender",
+			"replacement": "pr-u-colorTextLavender",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textLeft",
+			"replacement": "pr-u-textAlignStart",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textLight",
+			"replacement": null,
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textLime",
+			"replacement": "pr-u-colorTextLime",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textLucca",
+			"replacement": "pr-u-colorTextLucca",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textM",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textMint",
+			"replacement": "pr-u-colorTextMint",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textNavigation",
+			"replacement": "pr-u-colorTextNavigation",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textNeutral",
+			"replacement": "pr-u-colorTextNeutral",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textOrchid",
+			"replacement": "pr-u-colorTextOrchid",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPagga",
+			"replacement": "pr-u-colorTextPagga",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPineapple",
+			"replacement": "pr-u-colorTextPineapple",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPineappleContrasted",
+			"replacement": "pr-u-colorTextPineappleContrasted",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPlaceholder",
+			"replacement": "pr-u-colorInputTextPlaceholder",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPoplee",
+			"replacement": "pr-u-colorTextPoplee",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPrimary",
+			"replacement": "pr-u-colorTextPrimary",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textProduct",
+			"replacement": "pr-u-colorTextProduct",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textPumpkin",
+			"replacement": "pr-u-colorTextPumpkin",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textRight",
+			"replacement": "pr-u-textAlignEnd",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textS",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textSecondary",
+			"replacement": "pr-u-colorTextSecondary",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textSuccess",
+			"replacement": "pr-u-colorTextSuccess",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textSuccessContrasted",
+			"replacement": "pr-u-colorTextSuccessContrasted",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textTimmi",
+			"replacement": "pr-u-colorTextTimmi",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textWarning",
+			"replacement": "pr-u-colorTextWarning",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textWarningContrasted",
+			"replacement": "pr-u-colorTextWarningContrasted",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textWatermelon",
+			"replacement": "pr-u-colorTextWatermelon",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textXS",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textXXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-textXXXL",
+			"replacement": null,
+			"note": "The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-top0",
+			"replacement": "pr-u-insetBlockStart0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-topReset",
+			"replacement": "pr-u-insetBlockStart0",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignBaseline",
+			"replacement": "pr-u-verticalAlignBaseline",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignBottom",
+			"replacement": "pr-u-verticalAlignBottom",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignMiddle",
+			"replacement": "pr-u-verticalAlignMiddle",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignSub",
+			"replacement": "pr-u-verticalAlignSub",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignSuper",
+			"replacement": "pr-u-verticalAlignSuper",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignTextBottom",
+			"replacement": "pr-u-verticalAlignTextBottom",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignTextTop",
+			"replacement": "pr-u-verticalAlignTextTop",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-verticalAlignTop",
+			"replacement": "pr-u-verticalAlignTop",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-visibilityCollapse",
+			"replacement": "pr-u-visibilityCollapse",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-visibilityHidden",
+			"replacement": "pr-u-visibilityHidden",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-visibilityVisible",
+			"replacement": "pr-u-visibilityVisible",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-whiteSpaceNormal",
+			"replacement": "pr-u-whiteSpaceNormal",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-whiteSpaceNowrap",
+			"replacement": "pr-u-whiteSpaceNowrap",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-whiteSpacePreLine",
+			"replacement": "pr-u-whiteSpacePreLine",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-width100\\%",
+			"replacement": "pr-u-width100\\%",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-widthFitContent",
+			"replacement": "pr-u-widthFitContent",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/utils"
+		},
+		{
+			"kind": "class",
+			"name": "u-prefersContrastMore",
+			"replacement": "pr-u-prefersContrastMore",
+			"note": "The u- prefix is deprecated.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-black-color",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-grey-400-rgb",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-grey-900-rgb",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-neutral-400-rgb",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-neutral-900-rgb",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-white-color",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--colors-white-rgb",
+			"replacement": null,
+			"note": "Use palette custom properties (--palettes-*) instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--commons-background-base",
+			"replacement": "--pr-t-elevation-surface-default",
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--commons-divider-color",
+			"replacement": null,
+			"note": "Use --palettes-neutral-200 instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--commons-font-family",
+			"replacement": "--pr-t-font-family",
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--commons-font-family-brand",
+			"replacement": "--pr-t-font-family-brand",
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--commons-font-family-cursive",
+			"replacement": "--pr-t-font-family-cursive",
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-blueberry-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-brand-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-brandContrasted-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-cc-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-cleemy-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-coreHR-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-critical-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-cucumber-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-error-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-glacier-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grape-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-0",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-100",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-200",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-25",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-300",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-400",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-50",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-500",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-600",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-700",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-800",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-900",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-grey-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-kiwi-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lagoon-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lavender-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lime-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-0",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-100",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-200",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-300",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-400",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-50",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-500",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-600",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-700",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-800",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-900",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-lucca-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-mint-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-navigation-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-neutral-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-orchid-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-pagga-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-pineapple-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-pineappleContrasted-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-poplee-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-0",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-100",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-200",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-300",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-400",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-50",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-500",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-600",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-700",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-800",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-900",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-primary-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-product-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-pumpkin-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-0",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-100",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-200",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-300",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-400",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-50",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-500",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-600",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-700",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-800",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-900",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-secondary-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-success-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-successContrasted-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-timmi-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-warning-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-warningContrasted-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--palettes-watermelon-text",
+			"replacement": null,
+			"note": null,
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-L-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-L-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-L-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-M-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-M-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-M-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-S-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-S-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-S-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XL-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XL-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XL-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XS-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XS-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XS-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XXL-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XXL-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XXL-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XXXL-fontSize",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XXXL-lineHeight",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--sizes-XXXL-verticalPadding",
+			"replacement": null,
+			"note": "Use --pr-t-font-* tokens instead.",
+			"since": null,
+			"scope": "commons/vars"
+		},
+		{
+			"kind": "selector",
+			"name": ".lu-user-picture",
+			"replacement": ".avatar",
+			"note": null,
+			"since": null,
+			"scope": "component:avatar"
+		},
+		{
+			"kind": "selector",
+			"name": ".box.mod-grey",
+			"replacement": ".box.mod-neutral",
+			"note": null,
+			"since": null,
+			"scope": "component:box"
+		},
+		{
+			"kind": "selector",
+			"name": ".box.mod-toggle",
+			"replacement": null,
+			"note": "The toggle box variant is deprecated.",
+			"since": null,
+			"scope": "component:box"
+		},
+		{
+			"kind": "selector",
+			"name": ".active",
+			"replacement": ".is-active",
+			"note": null,
+			"since": null,
+			"scope": "component:breadcrumbs"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-compact",
+			"replacement": null,
+			"note": "The compact breadcrumbs variant is deprecated.",
+			"since": null,
+			"scope": "component:breadcrumbs"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-button-font-size",
+			"replacement": "--components-button-font",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-button-line-height",
+			"replacement": "--components-button-font",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".button.disabled",
+			"replacement": ".button.is-disabled",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".button.error",
+			"replacement": ".button.is-error",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".button.loading",
+			"replacement": ".button.is-loading",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".button.success",
+			"replacement": ".button.is-success",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-delete",
+			"replacement": ".mod-critical",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-invert",
+			"replacement": ".mod-inverted",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-link",
+			"replacement": ".mod-ghost",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-outline",
+			"replacement": ".mod-outlined",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-text",
+			"replacement": ".mod-ghost",
+			"note": null,
+			"since": null,
+			"scope": "component:button"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-callout-fontSize",
+			"replacement": "--components-callout-font",
+			"note": null,
+			"since": null,
+			"scope": "component:callout"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-callout-lineHeight",
+			"replacement": "--components-callout-font",
+			"note": null,
+			"since": null,
+			"scope": "component:callout"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-calloutFeedbackList-fontSize",
+			"replacement": "--components-calloutFeedbackList-font",
+			"note": null,
+			"since": null,
+			"scope": "component:calloutFeedbackList"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-calloutFeedbackList-lineHeight",
+			"replacement": "--components-calloutFeedbackList-font",
+			"note": null,
+			"since": null,
+			"scope": "component:calloutFeedbackList"
+		},
+		{
+			"kind": "selector",
+			"name": ".card.mod-grey",
+			"replacement": ".card.mod-neutral",
+			"note": null,
+			"since": null,
+			"scope": "component:card"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-chip-fontSize",
+			"replacement": "--components-chip-font",
+			"note": null,
+			"since": null,
+			"scope": "component:chip"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-chip-lineHeight",
+			"replacement": "--components-chip-font",
+			"note": null,
+			"since": null,
+			"scope": "component:chip"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-comment-text-fontSize",
+			"replacement": "--components-comment-text-font",
+			"note": null,
+			"since": null,
+			"scope": "component:comment"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-comment-text-lineHeight",
+			"replacement": "--components-comment-text-font",
+			"note": null,
+			"since": null,
+			"scope": "component:comment"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-container-max-width",
+			"replacement": "--commons-container-maxWidth",
+			"note": null,
+			"since": null,
+			"scope": "component:container"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-container-padding",
+			"replacement": "--commons-container-padding",
+			"note": null,
+			"since": null,
+			"scope": "component:container"
+		},
+		{
+			"kind": "selector",
+			"name": ".dialog-form",
+			"replacement": ".dialog-inside-formOptional",
+			"note": null,
+			"since": null,
+			"scope": "component:dialog"
+		},
+		{
+			"kind": "selector",
+			"name": ".dialog-formOptional",
+			"replacement": ".dialog-inside-formOptional",
+			"note": null,
+			"since": null,
+			"scope": "component:dialog"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-divider-fontSize",
+			"replacement": "--components-divider-font",
+			"note": null,
+			"since": null,
+			"scope": "component:divider"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-divider-lineHeight",
+			"replacement": "--components-divider-font",
+			"note": null,
+			"since": null,
+			"scope": "component:divider"
+		},
+		{
+			"kind": "selector",
+			"name": ".lu-dropdown-content",
+			"replacement": ".dropdown",
+			"note": null,
+			"since": null,
+			"scope": "component:dropdown"
+		},
+		{
+			"kind": "selector",
+			"name": ".lu-dropdown-options",
+			"replacement": ".dropdown-list",
+			"note": null,
+			"since": null,
+			"scope": "component:dropdown"
+		},
+		{
+			"kind": "selector",
+			"name": ".lu-dropdown-options-item",
+			"replacement": ".dropdown-list-option",
+			"note": null,
+			"since": null,
+			"scope": "component:dropdown"
+		},
+		{
+			"kind": "selector",
+			"name": ".lu-dropdown-options-item-action",
+			"replacement": ".dropdown-list-option-action",
+			"note": null,
+			"since": null,
+			"scope": "component:dropdown"
+		},
+		{
+			"kind": "selector",
+			"name": ".filterBarDeprecated",
+			"replacement": null,
+			"note": "Entire component is deprecated, including all .filterBarDeprecated-* descendants.",
+			"since": null,
+			"scope": "component:filterBarDeprecated"
+		},
+		{
+			"kind": "sass-api",
+			"name": "form.componentDeprecated",
+			"replacement": null,
+			"note": "The legacy form component mixin is deprecated.",
+			"since": null,
+			"scope": "component:form"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-formLabel-fontSize",
+			"replacement": "--components-formLabel-font",
+			"note": null,
+			"since": null,
+			"scope": "component:formLabel"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-formLabel-lineHeight",
+			"replacement": "--components-formLabel-font",
+			"note": null,
+			"since": null,
+			"scope": "component:formLabel"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-gauge-height",
+			"replacement": "--components-gauge-blockSize",
+			"note": null,
+			"since": null,
+			"scope": "component:gauge"
+		},
+		{
+			"kind": "sass-api",
+			"name": "gauge.vertical",
+			"replacement": null,
+			"note": "The vertical gauge mixin is deprecated.",
+			"since": null,
+			"scope": "component:gauge"
+		},
+		{
+			"kind": "sass-api",
+			"name": "gauge.verticalThin",
+			"replacement": null,
+			"note": "The verticalThin gauge mixin is deprecated.",
+			"since": null,
+			"scope": "component:gauge"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-vertical",
+			"replacement": null,
+			"note": "The vertical gauge variant is deprecated.",
+			"since": null,
+			"scope": "component:gauge"
+		},
+		{
+			"kind": "selector",
+			"name": ".disabled",
+			"replacement": ".is-disabled",
+			"note": null,
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".menu",
+			"replacement": ".horizontalNavigation",
+			"note": null,
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".menu-containerOptional",
+			"replacement": null,
+			"note": "Legacy .menu-* selector; use the .horizontalNavigation-* equivalent.",
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".menu-link",
+			"replacement": null,
+			"note": "Legacy .menu-* selector; use the .horizontalNavigation-* equivalent.",
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".menu-link-placeholder",
+			"replacement": null,
+			"note": "Legacy .menu-* selector; use the .horizontalNavigation-* equivalent.",
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".menu-list",
+			"replacement": ".horizontalNavigation-list",
+			"note": null,
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".menu-list-item-action",
+			"replacement": ".horizontalNavigation-list-item-action",
+			"note": null,
+			"since": null,
+			"scope": "component:horizontalNavigation"
+		},
+		{
+			"kind": "selector",
+			"name": ".indexTable-body-row-cell-action",
+			"replacement": null,
+			"note": "The indexTable row cell action selector is deprecated.",
+			"since": null,
+			"scope": "component:indexTable"
+		},
+		{
+			"kind": "selector",
+			"name": ".lucca-icon:first-child",
+			"replacement": ".inlineMessage-statusIcon",
+			"note": null,
+			"since": null,
+			"scope": "component:inlineMessage"
+		},
+		{
+			"kind": "selector",
+			"name": ".label",
+			"replacement": null,
+			"note": "The .label component is deprecated.",
+			"since": null,
+			"scope": "component:label"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-dialog",
+			"replacement": ".mod-popin",
+			"note": null,
+			"since": null,
+			"scope": "component:loading"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-sidePanel",
+			"replacement": ".mod-drawer",
+			"note": null,
+			"since": null,
+			"scope": "component:loading"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-navSide-fullwidth-palette-alert-color",
+			"replacement": null,
+			"note": "Use the selected-alert palette custom properties instead.",
+			"since": null,
+			"scope": "component:navside"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-navSide-fullwidth-palette-alert-text",
+			"replacement": null,
+			"note": "Use the selected-alert palette custom properties instead.",
+			"since": null,
+			"scope": "component:navside"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-withMenuCompact",
+			"replacement": ".navSide.mod-compact",
+			"note": null,
+			"since": null,
+			"scope": "component:navside"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-withMenu",
+			"replacement": ".mod-withHorizontalNavigation",
+			"note": null,
+			"since": null,
+			"scope": "component:pageHeader"
+		},
+		{
+			"kind": "selector",
+			"name": ".section.mod-grey",
+			"replacement": ".section.mod-neutral",
+			"note": null,
+			"since": null,
+			"scope": "component:section"
+		},
+		{
+			"kind": "selector",
+			"name": ".viewTabs",
+			"replacement": ".segmentedControl",
+			"note": null,
+			"since": null,
+			"scope": "component:segmentedControl"
+		},
+		{
+			"kind": "selector",
+			"name": ".viewTabs_panel",
+			"replacement": ".segmentedControl_panel",
+			"note": null,
+			"since": null,
+			"scope": "component:segmentedControl"
+		},
+		{
+			"kind": "selector",
+			"name": ".viewTabs-item",
+			"replacement": ".segmentedControl-item",
+			"note": null,
+			"since": null,
+			"scope": "component:segmentedControl"
+		},
+		{
+			"kind": "selector",
+			"name": ".viewTabs-item-tab",
+			"replacement": ".segmentedControl-item-action",
+			"note": null,
+			"since": null,
+			"scope": "component:segmentedControl"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-sortableList-description-fontSize",
+			"replacement": "--components-sortableList-description-font",
+			"note": null,
+			"since": null,
+			"scope": "component:sortableList"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-sortableList-description-lineHeight",
+			"replacement": "--components-sortableList-description-font",
+			"note": null,
+			"since": null,
+			"scope": "component:sortableList"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-actionsHidden",
+			"replacement": null,
+			"note": "Hidden table actions are deprecated.",
+			"since": null,
+			"scope": "component:table"
+		},
+		{
+			"kind": "selector",
+			"name": ".table.mod-layoutFixed",
+			"replacement": null,
+			"note": "Entire tableFixedDeprecated component is deprecated, including all its descendant selectors.",
+			"since": null,
+			"scope": "component:tableFixedDeprecated"
+		},
+		{
+			"kind": "selector",
+			"name": ".table.mod-stickyColumn",
+			"replacement": null,
+			"note": "Entire tableStickedDeprecated component is deprecated, including all its descendant selectors.",
+			"since": null,
+			"scope": "component:tableStickedDeprecated"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-tag-fontSize",
+			"replacement": "--components-tag-font",
+			"note": null,
+			"since": null,
+			"scope": "component:tag"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-tag-lineHeight",
+			"replacement": "--components-tag-font",
+			"note": null,
+			"since": null,
+			"scope": "component:tag"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-clickable",
+			"replacement": null,
+			"note": "Clickable tags are inferred from the a/button element; the modifier is deprecated.",
+			"since": null,
+			"scope": "component:tag"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--component-textField-fontSize",
+			"replacement": "--component-textField-font",
+			"note": null,
+			"since": null,
+			"scope": "component:textField"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--component-textField-lineHeight",
+			"replacement": "--component-textField-font",
+			"note": null,
+			"since": null,
+			"scope": "component:textField"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-toasts-background",
+			"replacement": null,
+			"note": "Toast background is no longer customizable.",
+			"since": null,
+			"scope": "component:toast"
+		},
+		{
+			"kind": "css-variable",
+			"name": "--components-toasts-padding",
+			"replacement": null,
+			"note": "Toast padding is no longer customizable.",
+			"since": null,
+			"scope": "component:toast"
+		},
+		{
+			"kind": "sass-api",
+			"name": "userTile.XL",
+			"replacement": null,
+			"note": "The XL userTile size mixin is deprecated.",
+			"since": null,
+			"scope": "component:userTile"
+		},
+		{
+			"kind": "sass-api",
+			"name": "userTile.XXL",
+			"replacement": null,
+			"note": "The XXL userTile size mixin is deprecated.",
+			"since": null,
+			"scope": "component:userTile"
+		},
+		{
+			"kind": "sass-api",
+			"name": "userTile.XXXL",
+			"replacement": null,
+			"note": "The XXXL userTile size mixin is deprecated.",
+			"since": null,
+			"scope": "component:userTile"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-XL",
+			"replacement": null,
+			"note": "The XL userTile size is deprecated.",
+			"since": null,
+			"scope": "component:userTile"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-XXL",
+			"replacement": null,
+			"note": "The XXL userTile size is deprecated.",
+			"since": null,
+			"scope": "component:userTile"
+		},
+		{
+			"kind": "selector",
+			"name": ".mod-XXXL",
+			"replacement": null,
+			"note": "The XXXL userTile size is deprecated.",
+			"since": null,
+			"scope": "component:userTile"
+		}
+	]
+}

--- a/packages/scss/css-api/deprecations.json
+++ b/packages/scss/css-api/deprecations.json
@@ -110,7 +110,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomLeftRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -118,7 +118,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomLeftRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -126,7 +126,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomLeftRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -134,7 +134,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomLeftRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -142,7 +142,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomRightRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -150,7 +150,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomRightRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -158,7 +158,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomRightRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -166,7 +166,7 @@
 			"kind": "class",
 			"name": "pr-u-borderBottomRightRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -174,7 +174,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndEndRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -182,7 +182,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndEndRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -190,7 +190,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndEndRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -198,7 +198,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndEndRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -206,7 +206,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndStartRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -214,7 +214,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndStartRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -222,7 +222,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndStartRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -230,7 +230,7 @@
 			"kind": "class",
 			"name": "pr-u-borderEndStartRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -246,7 +246,7 @@
 			"kind": "class",
 			"name": "pr-u-borderRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -254,7 +254,7 @@
 			"kind": "class",
 			"name": "pr-u-borderRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -262,7 +262,7 @@
 			"kind": "class",
 			"name": "pr-u-borderRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -278,7 +278,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartEndRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -286,7 +286,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartEndRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -294,7 +294,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartEndRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -302,7 +302,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartEndRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -310,7 +310,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartStartRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -318,7 +318,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartStartRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -326,7 +326,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartStartRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -334,7 +334,7 @@
 			"kind": "class",
 			"name": "pr-u-borderStartStartRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -350,7 +350,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopLeftRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -358,7 +358,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopLeftRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -366,7 +366,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopLeftRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -374,7 +374,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopLeftRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -382,7 +382,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopRightRadiusFull",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -390,7 +390,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopRightRadiusL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -398,7 +398,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopRightRadiusM",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},
@@ -406,7 +406,7 @@
 			"kind": "class",
 			"name": "pr-u-borderTopRightRadiusXL",
 			"replacement": null,
-			"note": "Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.",
+			"note": "Use border-radius token utilities such as pr-u-borderRadiusDefault instead.",
 			"since": null,
 			"scope": "commons/utils"
 		},

--- a/packages/scss/css-api/extract-deprecations.js
+++ b/packages/scss/css-api/extract-deprecations.js
@@ -1,0 +1,169 @@
+/**
+ * Extracts the SCSS deprecation registry (packages/scss/src/commons/deprecated.scss)
+ * to a committed JSON manifest that Storybook, CI and downstream tooling consume.
+ *
+ * The registry emits no CSS: we compile a synthetic entry point that turns on every
+ * deprecation-gated branch, `@include deprecated.dump()`, and read the module-level map
+ * back through a custom Sass function. No CSS parsing is involved.
+ *
+ * Usage:
+ *   node packages/scss/css-api/extract-deprecations.js           # write deprecations.json
+ *   node packages/scss/css-api/extract-deprecations.js --check   # fail if out of date
+ */
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const sass = require('sass');
+
+const ROOT = path.join(__dirname, '..', '..', '..');
+const OUTPUT = path.join(__dirname, 'deprecations.json');
+
+// Maximal config: enable every $deprecated* branch so gated registrations run.
+// If a new $deprecated* flag is added to commons/config.scss, add it here.
+const CONFIG = `@use '@lucca-front/scss/src/commons/config' with (
+	$deprecatedSpacings: true,
+	$deprecatedCardBoxMargin: true,
+	$deprecatedUtilityPrefix: true,
+	$palettesOtherProduct: 'all',
+	$fontFamilyCursive: 'Caveat'
+);
+@use '@lucca-front/scss/src/main-all';
+`;
+
+function toJs(value) {
+	if (value === null || value.equals(sass.sassNull)) {
+		return null;
+	}
+	if (value instanceof sass.SassString) {
+		return value.text;
+	}
+	if (value instanceof sass.SassBoolean) {
+		return value.value;
+	}
+	if (value instanceof sass.SassNumber) {
+		return value.value;
+	}
+	if (value instanceof sass.SassMap) {
+		const out = {};
+		value.contents.forEach((v, k) => {
+			out[toJs(k)] = toJs(v);
+		});
+		return out;
+	}
+	return value.toString();
+}
+
+function compile(source, functions = {}) {
+	return sass.compileString(source, {
+		style: 'compressed',
+		loadPaths: [path.join(ROOT, 'node_modules')],
+		functions,
+	});
+}
+
+function extract() {
+	let registry = null;
+	const withDump = compile(`${CONFIG}@use '@lucca-front/scss/src/commons/deprecated';\n@include deprecated.dump();`, {
+		'lf-dump-deprecations($registry)': (args) => {
+			registry = toJs(args[0].assertMap('registry'));
+			return sass.sassNull;
+		},
+	});
+
+	// Reliability invariant: the registry mechanism must never change CSS output.
+	const withoutDump = compile(CONFIG);
+	if (withDump.css !== withoutDump.css) {
+		throw new Error('deprecated.dump() altered CSS output — the registry must be output-neutral.');
+	}
+
+	if (!registry) {
+		throw new Error('lf-dump-deprecations was never called — did deprecated.dump() run?');
+	}
+
+	const entries = Object.values(registry)
+		.map(({ kind, name, replacement, note, since, scope }) => ({ kind, name, replacement, note, since, scope }))
+		.sort((a, b) => a.scope.localeCompare(b.scope) || a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name));
+
+	return { version: 1, package: '@lucca-front/scss', entries };
+}
+
+function selfCheck(manifest) {
+	const { entries } = manifest;
+	const byKind = (kind) => entries.filter((e) => e.kind === kind);
+	const find = (kind, name) => entries.find((e) => e.kind === kind && e.name === name);
+
+	const problems = [];
+
+	// Minimum counts — guard against a broken compile silently dropping registrations.
+	const minimums = { class: 200, 'css-variable': 20, selector: 5, 'sass-api': 5 };
+	for (const [kind, min] of Object.entries(minimums)) {
+		const count = byKind(kind).length;
+		if (count < min) {
+			problems.push(`expected >= ${min} "${kind}" entries, found ${count}`);
+		}
+	}
+
+	// Sentinel entries with exact replacements.
+	const sentinels = [
+		['class', 'pr-u-marginTop100', 'pr-u-marginBlockStart100'],
+		['class', 'pr-u-textLeft', 'pr-u-textAlignStart'],
+		['css-variable', '--commons-font-family', '--pr-t-font-family'],
+	];
+	for (const [kind, name, replacement] of sentinels) {
+		const entry = find(kind, name);
+		if (!entry) {
+			problems.push(`missing sentinel ${kind} "${name}"`);
+		} else if (entry.replacement !== replacement) {
+			problems.push(`sentinel ${kind} "${name}" replacement is "${entry.replacement}", expected "${replacement}"`);
+		}
+	}
+	if (!find('class', 'u-textLeft')) {
+		problems.push('missing u- prefixed sentinel "u-textLeft"');
+	}
+	if (!find('selector', '.filterBarDeprecated')) {
+		problems.push('missing wholly-deprecated component sentinel ".filterBarDeprecated"');
+	}
+
+	// A class/css-variable replacement must not itself be a deprecated name (chains must terminate).
+	const deprecatedNames = new Set(entries.filter((e) => e.kind === 'class' || e.kind === 'css-variable').map((e) => `${e.kind}|${e.name}`));
+	for (const entry of entries) {
+		if ((entry.kind === 'class' || entry.kind === 'css-variable') && entry.replacement) {
+			if (deprecatedNames.has(`${entry.kind}|${entry.replacement}`)) {
+				problems.push(`${entry.kind} "${entry.name}" points at deprecated replacement "${entry.replacement}"`);
+			}
+		}
+	}
+
+	if (problems.length) {
+		throw new Error(`deprecations self-check failed:\n  - ${problems.join('\n  - ')}`);
+	}
+}
+
+function serialize(manifest) {
+	return JSON.stringify(manifest, null, '\t') + '\n';
+}
+
+function main() {
+	const manifest = extract();
+	selfCheck(manifest);
+	const json = serialize(manifest);
+
+	if (process.argv.includes('--check')) {
+		const current = fs.existsSync(OUTPUT) ? fs.readFileSync(OUTPUT, 'utf-8') : '';
+		if (current !== json) {
+			const hash = (s) => crypto.createHash('sha256').update(s).digest('hex').slice(0, 8);
+			console.error(`deprecations.json is out of date (${hash(current)} != ${hash(json)}). Run: npm run scss:deprecations`);
+			process.exit(1);
+		}
+		console.log(`deprecations.json is up to date (${manifest.entries.length} entries).`);
+	} else {
+		fs.writeFileSync(OUTPUT, json);
+		console.log(`Wrote ${manifest.entries.length} deprecation entries to ${path.relative(ROOT, OUTPUT)}`);
+	}
+}
+
+if (require.main === module) {
+	main();
+}
+
+module.exports = { extract, selfCheck, serialize };

--- a/packages/scss/src/commons/config.scss
+++ b/packages/scss/src/commons/config.scss
@@ -1,6 +1,7 @@
 @use 'sass:list';
 @use 'sass:map';
 
+@use '@lucca-front/scss/src/commons/deprecated';
 @use '@lucca-front/scss/src/commons/function';
 
 $layers: 'reset, base, components, mods, product, utils';
@@ -789,13 +790,11 @@ $textLink: (
 
 // Deprecated
 
-// $colors are deprecated
 $colors: (
 	'white': #ffffff,
 	'black': #121212,
 );
 
-// $colorsRgb are deprecated
 $colorsRgb: (
 	'white': '255, 255, 255',
 	'neutral-400': '172, 187, 215',
@@ -804,10 +803,22 @@ $colorsRgb: (
 	'grey-900': '19, 29, 53',
 ) !default;
 
-// $borderRadius are deprecated
 $borderRadius: (
 	'M': 4px,
 	'L': 8px,
 	'XL': 12px,
 	'full': 9999px,
 ) !default;
+
+// Register the deprecated Sass API surface (flags, maps, deprecated palette names).
+// Emits no CSS.
+@include deprecated.sassApi('config.$deprecatedSpacings', $note: 'Escape-hatch flag for legacy element spacing.', $scope: 'commons/config');
+@include deprecated.sassApi('config.$deprecatedCardBoxMargin', $note: 'Escape-hatch flag for legacy card/box margins.', $scope: 'commons/config');
+@include deprecated.sassApi('config.$deprecatedUtilityPrefix', $note: 'Escape-hatch flag; the u- prefix will be removed.', $scope: 'commons/config');
+@include deprecated.sassApi('config.$colors', $note: 'Use palette custom properties (--palettes-*) instead.', $scope: 'commons/config');
+@include deprecated.sassApi('config.$colorsRgb', $note: 'Use palette custom properties (--palettes-*) instead.', $scope: 'commons/config');
+@include deprecated.sassApi('config.$borderRadius', $replacement: 'config.$borderRadiusVars', $scope: 'commons/config');
+
+@each $deprecatedPalette in $palettesDeprecated {
+	@include deprecated.sassApi('config palette: #{$deprecatedPalette}', $note: 'Deprecated palette name.', $scope: 'commons/config');
+}

--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -1,13 +1,15 @@
+@use 'sass:map';
 @use 'sass:meta';
 @use 'sass:string';
 
 @use '@lucca-front/scss/src/commons/config';
+@use '@lucca-front/scss/src/commons/deprecated';
 @use '@lucca-front/icons/src/commons/core' as transform;
 
 $contents: '100\\%', 'fit-content';
 $boxModel: 'margin', 'padding', 'border', 'inset';
-$boxDirection: '', 'top', 'bottom', 'left', 'right', 'inline', 'block', 'block-start', 'block-end', 'inline-start', 'inline-end'; // top, bottom, left and right are deprecated
-$corners: '', 'top-left-', 'top-right-', 'bottom-left-', 'bottom-right-', 'start-start-', 'start-end-', 'end-start-', 'end-end-'; // top-left, top-right, bottom-left and bottom-right are deprecated
+$boxDirection: '', 'top', 'bottom', 'left', 'right', 'inline', 'block', 'block-start', 'block-end', 'inline-start', 'inline-end';
+$corners: '', 'top-left-', 'top-right-', 'bottom-left-', 'bottom-right-', 'start-start-', 'start-end-', 'end-start-', 'end-end-';
 $gaps: 'column-gap', 'row-gap', 'gap';
 $displays: 'block', 'flex', 'grid', 'inline', 'inline-flex', 'inline-block', 'inline-grid', 'contents', 'none';
 $direction: 'column', 'column-reverse', 'row', 'row-reverse';
@@ -17,14 +19,37 @@ $align: 'flex-start', 'flex-end', 'baseline', 'stretch', 'center';
 $flex: '0', '1';
 $basis: '0', 'auto';
 $order: '-1', '1';
-$textAlign: 'left', 'center', 'right', 'start', 'end'; // left and right are deprecated
+$textAlign: 'left', 'center', 'right', 'start', 'end';
 $visibility: 'visible', 'hidden', 'collapse';
 $fontWeight: '400', '600', '700', '900', 'normal', 'bold';
 $fontStyle: 'normal', 'italic';
 $pointerEvents: 'none', 'auto';
 $scrollBehavior: 'auto', 'smooth';
 $whiteSpace: 'normal', 'nowrap', 'pre-line';
-$float: 'left', 'right', 'inline-start', 'inline-end'; // left and right are deprecated
+$float: 'left', 'right', 'inline-start', 'inline-end';
+
+// Deprecation data: physical values superseded by logical equivalents. Colocated with the
+// value lists above; consumed by the mixins below and by utils to register deprecations.
+$physicalDirectionToLogical: (
+	'top': 'block-start',
+	'bottom': 'block-end',
+	'left': 'inline-start',
+	'right': 'inline-end',
+);
+$textAlignDeprecated: (
+	'left': 'start',
+	'right': 'end',
+);
+$floatDeprecated: (
+	'left': 'inline-start',
+	'right': 'inline-end',
+);
+$cornersDeprecated: (
+	'top-left-': 'start-start-',
+	'top-right-': 'start-end-',
+	'bottom-left-': 'end-start-',
+	'bottom-right-': 'end-end-',
+);
 $verticalAlign: 'baseline', 'sub', 'super', 'text-top', 'text-bottom', 'middle', 'top', 'bottom';
 $position: 'absolute', 'relative', 'static', 'fixed', 'sticky';
 $decoration: 'underline', 'line-through', 'none';
@@ -41,7 +66,14 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 	}
 
 	@if $boxModel != 'inset' or ($boxDirection != 'top' and $boxDirection != 'bottom' and $boxDirection != 'left' and $boxDirection != 'right') {
-		.pr-u-#{transform.camelize($boxModel)}#{transform.capitalize(transform.camelize($boxDirection))}#{transform.capitalize($key)} {
+		$class: 'pr-u-#{transform.camelize($boxModel)}#{transform.capitalize(transform.camelize($boxDirection))}#{transform.capitalize($key)}';
+
+		@if map.has-key($physicalDirectionToLogical, $boxDirection) {
+			$logical: map.get($physicalDirectionToLogical, $boxDirection);
+			@include deprecated.class($class, $replacement: 'pr-u-#{transform.camelize($boxModel)}#{transform.capitalize(transform.camelize($logical))}#{transform.capitalize($key)}', $scope: 'commons/utils');
+		}
+
+		.#{$class} {
 			#{$boxModel}#{$boxDirectionString}#{$boxDirection}: var(--pr-t-spacings-#{$key}) #{$suffix};
 		}
 	}
@@ -91,7 +123,7 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 	}
 }
 
-@mixin classes($name, $properties, $suffix: '!important', $prefix: '') {
+@mixin classes($name, $properties, $suffix: '!important', $prefix: '', $deprecated: ()) {
 	@each $property in $properties {
 		$minusString: '';
 
@@ -100,24 +132,40 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 		}
 
 		@if $prefix == '' {
-			.pr-u-#{transform.camelize($name)}#{$minusString}#{transform.capitalize(transform.camelize($property))} {
+			$prName: 'pr-u-#{transform.camelize($name)}#{$minusString}#{transform.capitalize(transform.camelize($property))}';
+			$modern: $prName;
+
+			@if map.has-key($deprecated, $property) {
+				$modern: 'pr-u-#{transform.camelize($name)}#{transform.capitalize(transform.camelize(map.get($deprecated, $property)))}';
+				@include deprecated.class($prName, $replacement: $modern, $scope: 'commons/utils');
+			}
+
+			.#{$prName} {
 				#{$name}: #{transform.replace($property, '\\', '')} #{$suffix};
 			}
 
 			// Deprecated .u- utilities
 			@if config.$deprecatedUtilityPrefix {
-				.u-#{transform.camelize($name)}#{$minusString}#{transform.capitalize(transform.camelize($property))} {
+				$uName: 'u-#{transform.camelize($name)}#{$minusString}#{transform.capitalize(transform.camelize($property))}';
+				@include deprecated.class($uName, $replacement: $modern, $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+
+				.#{$uName} {
 					#{$name}: #{transform.replace($property, '\\', '')} #{$suffix};
 				}
 			}
 		} @else {
-			.pr-u-#{$prefix}#{transform.capitalize(transform.camelize($name))}#{$minusString}#{transform.capitalize(transform.camelize($property))} {
+			$prName: 'pr-u-#{$prefix}#{transform.capitalize(transform.camelize($name))}#{$minusString}#{transform.capitalize(transform.camelize($property))}';
+
+			.#{$prName} {
 				#{$name}: #{transform.replace($property, '\\', '')} #{$suffix};
 			}
 
 			// Deprecated .u- utilities
 			@if config.$deprecatedUtilityPrefix {
-				.u-#{$prefix}#{transform.capitalize(transform.camelize($name))}#{$minusString}#{transform.capitalize(transform.camelize($property))} {
+				$uName: 'u-#{$prefix}#{transform.capitalize(transform.camelize($name))}#{$minusString}#{transform.capitalize(transform.camelize($property))}';
+				@include deprecated.class($uName, $replacement: $prName, $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+
+				.#{$uName} {
 					#{$name}: #{transform.replace($property, '\\', '')} #{$suffix};
 				}
 			}
@@ -126,14 +174,17 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 }
 
 @mixin palettes($suffix: '!important') {
-	// .pr-u-text is deprecated
 	@each $palette in config.$palettesAll {
+		@include deprecated.class('pr-u-text#{transform.capitalize($palette)}', $replacement: 'pr-u-colorText#{transform.capitalize($palette)}', $scope: 'commons/utils');
+
 		.pr-u-text#{transform.capitalize($palette)}, .pr-u-colorText#{transform.capitalize($palette)} {
 			color: var(--palettes-#{$palette}-700) #{$suffix};
 		}
 
 		// Deprecated .u- utilities
 		@if config.$deprecatedUtilityPrefix {
+			@include deprecated.class('u-text#{transform.capitalize($palette)}', $replacement: 'pr-u-colorText#{transform.capitalize($palette)}', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+
 			.u-text#{transform.capitalize($palette)} {
 				color: var(--palettes-#{$palette}-700) #{$suffix};
 			}
@@ -187,8 +238,13 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 
 // DEPRECATED
 
+@include deprecated.sassApi('core.sizes', $note: 'Use the typography utilities/tokens instead.', $scope: 'commons/core');
+@include deprecated.sassApi('core.borderRadius', $replacement: 'core.borderRadiusTokens', $scope: 'commons/core');
+
 @mixin sizes($suffix: '!important') {
 	@each $key, $value in config.$sizes {
+		@include deprecated.class('pr-u-text#{transform.capitalize($key)}', $note: 'Use typography utilities (pr-u-body*, pr-u-h*) instead.', $scope: 'commons/utils');
+
 		.pr-u-text#{transform.capitalize($key)} {
 			font-size: var(--sizes-#{$key}-fontSize) #{$suffix};
 			line-height: var(--sizes-#{$key}-lineHeight) #{$suffix};
@@ -196,6 +252,8 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 
 		// Deprecated .u- utilities
 		@if config.$deprecatedUtilityPrefix {
+			@include deprecated.class('u-text#{transform.capitalize($key)}', $note: 'The u- prefix is deprecated; use typography utilities (pr-u-body*, pr-u-h*) instead.', $scope: 'commons/utils');
+
 			.u-text#{transform.capitalize($key)} {
 				font-size: var(--sizes-#{$key}-fontSize) #{$suffix};
 				line-height: var(--sizes-#{$key}-lineHeight) #{$suffix};
@@ -207,12 +265,22 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 @mixin borderRadius($suffix: '!important') {
 	@each $corner in $corners {
 		@each $key, $value in config.$borderRadius {
-			.pr-u-border#{transform.capitalize(transform.camelize($corner))}Radius#{transform.capitalize($key)} {
+			$class: 'pr-u-border#{transform.capitalize(transform.camelize($corner))}Radius#{transform.capitalize($key)}';
+			// pr-u-borderRadiusFull (plain corner) is a live border-radius token utility, not deprecated.
+			$isTokenAlias: $corner == '' and $key == 'full';
+
+			@if not $isTokenAlias {
+				@include deprecated.class($class, $note: 'Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.', $scope: 'commons/utils');
+			}
+
+			.#{$class} {
 				border-#{$corner}radius: var(--commons-borderRadius-#{$key}) #{$suffix};
 			}
 
 			// Deprecated .u- utilities
 			@if config.$deprecatedUtilityPrefix {
+				@include deprecated.class('u-border#{transform.capitalize(transform.camelize($corner))}Radius#{transform.capitalize($key)}', $note: 'The u- prefix is deprecated; use border-radius token utilities instead.', $scope: 'commons/utils');
+
 				.u-border#{transform.capitalize(transform.camelize($corner))}Radius#{transform.capitalize($key)} {
 					border-#{$corner}radius: var(--commons-borderRadius-#{$key}) #{$suffix};
 				}

--- a/packages/scss/src/commons/core.scss
+++ b/packages/scss/src/commons/core.scss
@@ -70,6 +70,7 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 
 		@if map.has-key($physicalDirectionToLogical, $boxDirection) {
 			$logical: map.get($physicalDirectionToLogical, $boxDirection);
+
 			@include deprecated.class($class, $replacement: 'pr-u-#{transform.camelize($boxModel)}#{transform.capitalize(transform.camelize($logical))}#{transform.capitalize($key)}', $scope: 'commons/utils');
 		}
 
@@ -137,6 +138,7 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 
 			@if map.has-key($deprecated, $property) {
 				$modern: 'pr-u-#{transform.camelize($name)}#{transform.capitalize(transform.camelize(map.get($deprecated, $property)))}';
+
 				@include deprecated.class($prName, $replacement: $modern, $scope: 'commons/utils');
 			}
 
@@ -147,6 +149,7 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 			// Deprecated .u- utilities
 			@if config.$deprecatedUtilityPrefix {
 				$uName: 'u-#{transform.camelize($name)}#{$minusString}#{transform.capitalize(transform.camelize($property))}';
+
 				@include deprecated.class($uName, $replacement: $modern, $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 
 				.#{$uName} {
@@ -163,6 +166,7 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 			// Deprecated .u- utilities
 			@if config.$deprecatedUtilityPrefix {
 				$uName: 'u-#{$prefix}#{transform.capitalize(transform.camelize($name))}#{$minusString}#{transform.capitalize(transform.camelize($property))}';
+
 				@include deprecated.class($uName, $replacement: $prName, $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 
 				.#{$uName} {
@@ -266,11 +270,12 @@ $cursor: 'pointer', 'auto', 'default', 'text';
 	@each $corner in $corners {
 		@each $key, $value in config.$borderRadius {
 			$class: 'pr-u-border#{transform.capitalize(transform.camelize($corner))}Radius#{transform.capitalize($key)}';
+
 			// pr-u-borderRadiusFull (plain corner) is a live border-radius token utility, not deprecated.
 			$isTokenAlias: $corner == '' and $key == 'full';
 
 			@if not $isTokenAlias {
-				@include deprecated.class($class, $note: 'Use border-radius token utilities (pr-u-borderRadius{Structure,Default,Small,Full,Input}) instead.', $scope: 'commons/utils');
+				@include deprecated.class($class, $note: 'Use border-radius token utilities such as pr-u-borderRadiusDefault instead.', $scope: 'commons/utils');
 			}
 
 			.#{$class} {

--- a/packages/scss/src/commons/deprecated.scss
+++ b/packages/scss/src/commons/deprecated.scss
@@ -1,0 +1,71 @@
+// Machine-readable deprecation registry.
+//
+// This module is the single authoritative source of deprecation metadata for
+// `@lucca-front/scss`. Call sites register a deprecated public API surface
+// (utility class, custom property, selector contract or Sass API) right where
+// it is declared; the registration accumulates into a module-level map and
+// EMITS NO CSS. A build-time extractor (packages/scss/css-api/extract-deprecations.js)
+// includes `dump()` to read the registry out as JSON.
+//
+// HARD RULE: this file must only `@use` sass built-ins. Depending on any other
+// module would risk a dependency cycle, since config.scss / core.scss /
+// component files all `@use` this module.
+
+@use 'sass:map';
+@use 'sass:meta';
+
+// stylelint-disable-next-line scss/dollar-variable-pattern -- private module state
+$-registry: ();
+
+// stylelint-disable-next-line scss/at-mixin-pattern -- private helper
+@mixin -register($kind, $name, $replacement, $note, $since, $scope) {
+	$key: '#{$kind}|#{$name}';
+	$entry: (
+		kind: $kind,
+		name: $name,
+		replacement: $replacement,
+		note: $note,
+		since: $since,
+		scope: $scope,
+	);
+	$existing: map.get($-registry, $key);
+
+	@if $existing != null and $existing != $entry {
+		@error 'Conflicting deprecation registration for "#{$name}" (#{$kind}).';
+	}
+
+	// stylelint-disable-next-line scss/dollar-variable-pattern
+	$-registry: map.set($-registry, $key, $entry) !global;
+}
+
+// A deprecated emitted class name (utility or component class), bare, no leading dot.
+@mixin class($name, $replacement: null, $note: null, $since: null, $scope: 'commons') {
+	@include -register('class', $name, $replacement, $note, $since, $scope);
+}
+
+// A deprecated compound / contextual selector, written as it appears in CSS ('.box.mod-grey').
+@mixin selector($name, $replacement: null, $note: null, $since: null, $scope: 'commons') {
+	@include -register('selector', $name, $replacement, $note, $since, $scope);
+}
+
+// A deprecated CSS custom property, with leading dashes ('--commons-font-family').
+@mixin cssVariable($name, $replacement: null, $note: null, $since: null, $scope: 'commons') {
+	@include -register('css-variable', $name, $replacement, $note, $since, $scope);
+}
+
+// A deprecated Sass API surface: variable ('config.$colors'), mixin ('core.sizes'),
+// list/map member or config flag ('config.$deprecatedUtilityPrefix').
+@mixin sassApi($name, $replacement: null, $note: null, $since: null, $scope: 'commons') {
+	@include -register('sass-api', $name, $replacement, $note, $since, $scope);
+}
+
+// Reads the registry out through the `lf-dump-deprecations` custom JS function.
+// Only ever included by packages/scss/css-api/extract-deprecations.js.
+@mixin dump {
+	@if not meta.function-exists('lf-dump-deprecations') {
+		@error 'deprecated.dump() must be compiled through packages/scss/css-api/extract-deprecations.js';
+	}
+
+	// stylelint-disable-next-line scss/dollar-variable-pattern
+	$-result: meta.call(meta.get-function('lf-dump-deprecations'), $-registry);
+}

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -409,18 +409,21 @@
 	}
 
 	@include deprecated.class('pr-u-clear', $replacement: 'pr-u-clearBoth', $scope: 'commons/utils');
+
 	.pr-u-clearBoth,
 	.pr-u-clear {
 		@extend %clearBoth;
 	}
 
 	@include deprecated.class('pr-u-clearLeft', $replacement: 'pr-u-clearInlineStart', $scope: 'commons/utils');
+
 	.pr-u-clearInlineStart,
 	.pr-u-clearLeft {
 		@extend %clearInlineStart;
 	}
 
 	@include deprecated.class('pr-u-clearRight', $replacement: 'pr-u-clearInlineEnd', $scope: 'commons/utils');
+
 	.pr-u-clearInlineEnd,
 	.pr-u-clearRight {
 		@extend %clearInlineEnd;
@@ -463,11 +466,13 @@
 	}
 
 	@include deprecated.class('pr-u-h5', $note: 'Use pr-u-h1 through pr-u-h4 or body utilities instead.', $scope: 'commons/utils');
+
 	.pr-u-h5 {
 		@extend %h5;
 	}
 
 	@include deprecated.class('pr-u-h6', $note: 'Use pr-u-h1 through pr-u-h4 or body utilities instead.', $scope: 'commons/utils');
+
 	.pr-u-h6 {
 		@extend %h6;
 	}
@@ -485,32 +490,38 @@
 	}
 
 	@include deprecated.class('pr-u-textLeft', $replacement: 'pr-u-textAlignStart', $scope: 'commons/utils');
+
 	.pr-u-textLeft {
 		@extend %textLeft;
 	}
 
 	@include deprecated.class('pr-u-textRight', $replacement: 'pr-u-textAlignEnd', $scope: 'commons/utils');
+
 	.pr-u-textRight {
 		@extend %textRight;
 	}
 
 	@include deprecated.class('pr-u-textCenter', $replacement: 'pr-u-textAlignCenter', $scope: 'commons/utils');
+
 	.pr-u-textCenter {
 		@extend %textCenter;
 	}
 
 	@include deprecated.class('pr-u-textLight', $scope: 'commons/utils');
+
 	.pr-u-textLight {
 		@extend %textLight;
 	}
 
 	@include deprecated.class('pr-u-textPlaceholder', $replacement: 'pr-u-colorInputTextPlaceholder', $scope: 'commons/utils');
+
 	.pr-u-textPlaceholder,
 	.pr-u-colorInputTextPlaceholder {
 		@extend %textPlaceholder;
 	}
 
 	@include deprecated.class('pr-u-textDefault', $scope: 'commons/utils');
+
 	.pr-u-textDefault {
 		@extend %textDefault;
 	}
@@ -645,12 +656,14 @@
 	@each $direction in core.$boxDirection {
 		@if $direction == '' {
 			@include deprecated.class('pr-u-insetReset', $replacement: 'pr-u-inset0', $scope: 'commons/utils');
+
 			.pr-u-inset0,
 			.pr-u-insetReset {
 				@extend %inset0;
 			}
 		} @else if $direction == 'top' or $direction == 'bottom' or $direction == 'left' or $direction == 'right' {
 			$logical: map.get(core.$physicalDirectionToLogical, $direction);
+
 			@include deprecated.class('pr-u-#{$direction}0', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $scope: 'commons/utils');
 			@include deprecated.class('pr-u-#{$direction}Reset', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $scope: 'commons/utils');
 			.pr-u-#{$direction}0,
@@ -877,12 +890,14 @@
 			@if $direction == '' {
 				@include deprecated.class('u-inset0', $replacement: 'pr-u-inset0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 				@include deprecated.class('u-insetReset', $replacement: 'pr-u-inset0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+
 				.u-inset0,
 				.u-insetReset {
 					@extend %inset0;
 				}
 			} @else if $direction == 'top' or $direction == 'bottom' or $direction == 'left' or $direction == 'right' {
 				$logical: map.get(core.$physicalDirectionToLogical, $direction);
+
 				@include deprecated.class('u-#{$direction}0', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 				@include deprecated.class('u-#{$direction}Reset', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 				.u-#{$direction}0,

--- a/packages/scss/src/commons/utils/index.scss
+++ b/packages/scss/src/commons/utils/index.scss
@@ -1,6 +1,8 @@
 @use 'sass:list';
+@use 'sass:map';
 
 @use '@lucca-front/scss/src/commons/config';
+@use '@lucca-front/scss/src/commons/deprecated';
 @use '@lucca-front/icons/src/commons/core' as transform;
 @use '@lucca-front/scss/src/commons/core';
 
@@ -406,19 +408,19 @@
 		@extend %clearfix;
 	}
 
-	// clear is deprecated
+	@include deprecated.class('pr-u-clear', $replacement: 'pr-u-clearBoth', $scope: 'commons/utils');
 	.pr-u-clearBoth,
 	.pr-u-clear {
 		@extend %clearBoth;
 	}
 
-	// clearLeft is deprecated
+	@include deprecated.class('pr-u-clearLeft', $replacement: 'pr-u-clearInlineStart', $scope: 'commons/utils');
 	.pr-u-clearInlineStart,
 	.pr-u-clearLeft {
 		@extend %clearInlineStart;
 	}
 
-	// clearRight is deprecated
+	@include deprecated.class('pr-u-clearRight', $replacement: 'pr-u-clearInlineEnd', $scope: 'commons/utils');
 	.pr-u-clearInlineEnd,
 	.pr-u-clearRight {
 		@extend %clearInlineEnd;
@@ -460,13 +462,13 @@
 		@extend %h4;
 	}
 
+	@include deprecated.class('pr-u-h5', $note: 'Use pr-u-h1 through pr-u-h4 or body utilities instead.', $scope: 'commons/utils');
 	.pr-u-h5 {
-		// Deprecated
 		@extend %h5;
 	}
 
+	@include deprecated.class('pr-u-h6', $note: 'Use pr-u-h1 through pr-u-h4 or body utilities instead.', $scope: 'commons/utils');
 	.pr-u-h6 {
-		// Deprecated
 		@extend %h6;
 	}
 
@@ -482,33 +484,33 @@
 		@extend %bodyXS;
 	}
 
-	// textLeft is deprecated
+	@include deprecated.class('pr-u-textLeft', $replacement: 'pr-u-textAlignStart', $scope: 'commons/utils');
 	.pr-u-textLeft {
 		@extend %textLeft;
 	}
 
-	// textRight is deprecated
+	@include deprecated.class('pr-u-textRight', $replacement: 'pr-u-textAlignEnd', $scope: 'commons/utils');
 	.pr-u-textRight {
 		@extend %textRight;
 	}
 
-	// textCenter is deprecated
+	@include deprecated.class('pr-u-textCenter', $replacement: 'pr-u-textAlignCenter', $scope: 'commons/utils');
 	.pr-u-textCenter {
 		@extend %textCenter;
 	}
 
-	// textLight is deprecated
+	@include deprecated.class('pr-u-textLight', $scope: 'commons/utils');
 	.pr-u-textLight {
 		@extend %textLight;
 	}
 
-	// textPlaceholder is deprecated
+	@include deprecated.class('pr-u-textPlaceholder', $replacement: 'pr-u-colorInputTextPlaceholder', $scope: 'commons/utils');
 	.pr-u-textPlaceholder,
 	.pr-u-colorInputTextPlaceholder {
 		@extend %textPlaceholder;
 	}
 
-	// textDefault is deprecated
+	@include deprecated.class('pr-u-textDefault', $scope: 'commons/utils');
 	.pr-u-textDefault {
 		@extend %textDefault;
 	}
@@ -545,7 +547,7 @@
 		@extend %placeItemsCenter;
 	}
 
-	@include core.classes('float', core.$float);
+	@include core.classes('float', core.$float, $deprecated: core.$floatDeprecated);
 	@include core.classes('vertical-align', core.$verticalAlign);
 	@include core.classes('white-space', core.$whiteSpace);
 	@include core.classes('display', core.$displays);
@@ -576,7 +578,7 @@
 	@include core.classes('font-style', core.$fontStyle);
 	@include core.classes('pointer-events', core.$pointerEvents);
 	@include core.classes('cursor', core.$cursor);
-	@include core.classes('text-align', core.$textAlign);
+	@include core.classes('text-align', core.$textAlign, $deprecated: core.$textAlignDeprecated);
 	@include core.classes('text-decoration', core.$decoration);
 	@include core.classes('overflow', core.$overflow);
 
@@ -642,13 +644,15 @@
 
 	@each $direction in core.$boxDirection {
 		@if $direction == '' {
-			// insetReset is deprecated
+			@include deprecated.class('pr-u-insetReset', $replacement: 'pr-u-inset0', $scope: 'commons/utils');
 			.pr-u-inset0,
 			.pr-u-insetReset {
 				@extend %inset0;
 			}
 		} @else if $direction == 'top' or $direction == 'bottom' or $direction == 'left' or $direction == 'right' {
-			// Reset is deprecated
+			$logical: map.get(core.$physicalDirectionToLogical, $direction);
+			@include deprecated.class('pr-u-#{$direction}0', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $scope: 'commons/utils');
+			@include deprecated.class('pr-u-#{$direction}Reset', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $scope: 'commons/utils');
 			.pr-u-#{$direction}0,
 			.pr-u-#{$direction}Reset {
 				#{$direction}: 0 !important;
@@ -673,6 +677,48 @@
 	// Deprecated .u- utilities
 	// Delete when all utilities are prefixed in .pr-u-
 	@if config.$deprecatedUtilityPrefix {
+		// The whole u- prefix is deprecated in favour of pr-u-. Register the hand-written
+		// members here (loop-generated ones register inside their loops below). Emits no CSS.
+		@each $uName, $replacement in (
+			'u-animated': 'pr-u-animated',
+			'u-mask': 'pr-u-mask',
+			'u-clearfix': 'pr-u-clearfix',
+			'u-clearBoth': 'pr-u-clearBoth',
+			'u-clear': 'pr-u-clearBoth',
+			'u-clearInlineStart': 'pr-u-clearInlineStart',
+			'u-clearLeft': 'pr-u-clearInlineStart',
+			'u-clearInlineEnd': 'pr-u-clearInlineEnd',
+			'u-clearRight': 'pr-u-clearInlineEnd',
+			'u-listReset': 'pr-u-listReset',
+			'u-descriptionListReset': 'pr-u-descriptionListReset',
+			'u-summaryReset': 'pr-u-summaryReset',
+			'u-buttonReset': 'pr-u-buttonReset',
+			'u-ellipsis': 'pr-u-ellipsis',
+			'u-h1': 'pr-u-h1',
+			'u-h2': 'pr-u-h2',
+			'u-h3': 'pr-u-h3',
+			'u-h4': 'pr-u-h4',
+			'u-h5': null,
+			'u-h6': null,
+			'u-bodyM': 'pr-u-bodyM',
+			'u-bodyS': 'pr-u-bodyS',
+			'u-bodyXS': 'pr-u-bodyXS',
+			'u-textLeft': 'pr-u-textAlignStart',
+			'u-textRight': 'pr-u-textAlignEnd',
+			'u-textCenter': 'pr-u-textAlignCenter',
+			'u-textLight': null,
+			'u-textPlaceholder': 'pr-u-colorInputTextPlaceholder',
+			'u-textDefault': null,
+			'u-fontWeightRegular': 'pr-u-fontWeightRegular',
+			'u-fontWeightSemiBold': 'pr-u-fontWeightSemiBold',
+			'u-noSpinButtons': 'pr-u-noSpinButtons',
+			'u-fontFamily': 'pr-u-fontFamily',
+			'u-fontFamilyCursive': 'pr-u-fontFamilyCursive',
+			'u-fontFamilyBrand': 'pr-u-fontFamilyBrand'
+		) {
+			@include deprecated.class($uName, $replacement: $replacement, $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+		}
+
 		[class*='u-animated'] {
 			@extend %animatedAll;
 		}
@@ -819,6 +865,8 @@
 
 		@each $display in core.$displays {
 			@if $display != 'none' {
+				@include deprecated.class('u-onlyPrintDisplay#{transform.capitalize(transform.camelize($display))}', $replacement: 'pr-u-onlyPrintDisplay#{transform.capitalize(transform.camelize($display))}', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+
 				.u-onlyPrintDisplay#{transform.capitalize(transform.camelize($display))} {
 					@extend %displayNone;
 				}
@@ -827,13 +875,16 @@
 
 		@each $direction in core.$boxDirection {
 			@if $direction == '' {
-				// insetReset is deprecated
+				@include deprecated.class('u-inset0', $replacement: 'pr-u-inset0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+				@include deprecated.class('u-insetReset', $replacement: 'pr-u-inset0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 				.u-inset0,
 				.u-insetReset {
 					@extend %inset0;
 				}
 			} @else if $direction == 'top' or $direction == 'bottom' or $direction == 'left' or $direction == 'right' {
-				// Reset is deprecated
+				$logical: map.get(core.$physicalDirectionToLogical, $direction);
+				@include deprecated.class('u-#{$direction}0', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+				@include deprecated.class('u-#{$direction}Reset', $replacement: 'pr-u-inset#{transform.capitalize(transform.camelize($logical))}0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
 				.u-#{$direction}0,
 				.u-#{$direction}Reset {
 					#{$direction}: 0 !important;
@@ -841,6 +892,8 @@
 			} @else {
 				@each $boxModel in core.$boxModel {
 					@if $boxModel != 'border' {
+						@include deprecated.class('u-#{$boxModel}#{transform.capitalize($direction)}0', $replacement: 'pr-u-#{$boxModel}#{transform.capitalize($direction)}0', $note: 'The u- prefix is deprecated.', $scope: 'commons/utils');
+
 						.u-#{$boxModel}#{transform.capitalize($direction)}0 {
 							#{$boxModel}-#{$direction}: 0 !important;
 						}

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -94,9 +94,11 @@
 	@each $key, $value in config.$colors {
 		@include deprecated.cssVariable('--colors-#{$key}-color', $note: 'Use palette custom properties (--palettes-*) instead.', $scope: 'commons/vars');
 	}
+
 	@each $key, $value in config.$colorsRgb {
 		@include deprecated.cssVariable('--colors-#{$key}-rgb', $note: 'Use palette custom properties (--palettes-*) instead.', $scope: 'commons/vars');
 	}
+
 	@include core.cssvars('colors', config.$colors, '-color');
 	@include core.cssvars('colors', config.$colorsRgb, '-rgb');
 
@@ -125,6 +127,7 @@
 	// Deprecated
 	@include deprecated.cssVariable('--commons-font-family', $replacement: '--pr-t-font-family', $scope: 'commons/vars');
 	--commons-font-family: '#{config.$fontFamily}', Tahoma, sans-serif;
+
 	@include deprecated.cssVariable('--commons-font-family-brand', $replacement: '--pr-t-font-family-brand', $scope: 'commons/vars');
 	--commons-font-family-brand: '#{config.$fontFamilyBrand}', sans-serif;
 
@@ -152,6 +155,7 @@
 		@each $property, $value in $map {
 			@include deprecated.cssVariable('--sizes-#{$key}-#{$property}', $note: 'Use --pr-t-font-* tokens instead.', $scope: 'commons/vars');
 		}
+
 		@include core.cssvars('sizes-#{$key}', $map);
 	}
 

--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -3,6 +3,7 @@
 
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/core';
+@use '@lucca-front/scss/src/commons/deprecated';
 @use '@lucca-front/scss/src/commons/function';
 @use '@lucca-front/scss/src/commons/utils/color';
 @use '@lucca-front/scss/src/commons/utils/media';
@@ -65,6 +66,17 @@
 	@include core.cssvars('breakpoints', config.$breakpoints, '-breakAt');
 
 	@each $palette in config.$palettesAll {
+		// The `text` shade is deprecated across every palette.
+		@include deprecated.cssVariable('--palettes-#{$palette}-text', $scope: 'commons/vars');
+
+		// Deprecated palette names (lucca, grey, primary, secondary) are still emitted for
+		// backwards compatibility; every shade of them is deprecated.
+		@if list.index(config.$palettesDeprecated, $palette) {
+			@each $shade, $value in map.get(config.$palettesInterpolation, $palette) {
+				@include deprecated.cssVariable('--palettes-#{$palette}-#{$shade}', $scope: 'commons/vars');
+			}
+		}
+
 		@include core.cssvars('palettes-#{$palette}', map.get(config.$palettesInterpolation, $palette));
 	}
 
@@ -79,6 +91,12 @@
 	--palettes-assets-secondary-light: var(--palettes-#{map.get(map.get(config.$palettesAssets, config.$product), 'secondary')}-100);
 	// stylelint-enable custom-property-pattern
 
+	@each $key, $value in config.$colors {
+		@include deprecated.cssVariable('--colors-#{$key}-color', $note: 'Use palette custom properties (--palettes-*) instead.', $scope: 'commons/vars');
+	}
+	@each $key, $value in config.$colorsRgb {
+		@include deprecated.cssVariable('--colors-#{$key}-rgb', $note: 'Use palette custom properties (--palettes-*) instead.', $scope: 'commons/vars');
+	}
 	@include core.cssvars('colors', config.$colors, '-color');
 	@include core.cssvars('colors', config.$colorsRgb, '-rgb');
 
@@ -105,11 +123,15 @@
 	--commons-pushPanel-inlineSize: 0px;
 
 	// Deprecated
+	@include deprecated.cssVariable('--commons-font-family', $replacement: '--pr-t-font-family', $scope: 'commons/vars');
 	--commons-font-family: '#{config.$fontFamily}', Tahoma, sans-serif;
+	@include deprecated.cssVariable('--commons-font-family-brand', $replacement: '--pr-t-font-family-brand', $scope: 'commons/vars');
 	--commons-font-family-brand: '#{config.$fontFamilyBrand}', sans-serif;
 
+	@include deprecated.cssVariable('--commons-background-base', $replacement: '--pr-t-elevation-surface-default', $scope: 'commons/vars');
 	--commons-background-base: var(--pr-t-elevation-surface-default);
 
+	@include deprecated.cssVariable('--commons-divider-color', $note: 'Use --palettes-neutral-200 instead.', $scope: 'commons/vars');
 	--commons-divider-color: var(--palettes-neutral-200);
 
 	--commons-container-padding: 0 var(--pr-t-spacings-200);
@@ -122,10 +144,14 @@
 	--commons-navSide-mobile-toggle-height: 3.5rem;
 
 	@if (config.$fontFamilyCursive) {
+		@include deprecated.cssVariable('--commons-font-family-cursive', $replacement: '--pr-t-font-family-cursive', $scope: 'commons/vars');
 		--commons-font-family-cursive: '#{config.$fontFamilyCursive}', cursive;
 	}
 
 	@each $key, $map in config.$sizes {
+		@each $property, $value in $map {
+			@include deprecated.cssVariable('--sizes-#{$key}-#{$property}', $note: 'Use --pr-t-font-* tokens instead.', $scope: 'commons/vars');
+		}
 		@include core.cssvars('sizes-#{$key}', $map);
 	}
 
@@ -169,6 +195,8 @@
 
 	// Deprecated .u- utilities
 	@if config.$deprecatedUtilityPrefix {
+		@include deprecated.class('u-prefersContrastMore', $replacement: 'pr-u-prefersContrastMore', $note: 'The u- prefix is deprecated.', $scope: 'commons/vars');
+
 		.u-prefersContrastMore {
 			@extend %prefersContrastMore;
 		}

--- a/packages/scss/src/components/avatar/index.scss
+++ b/packages/scss/src/components/avatar/index.scss
@@ -2,6 +2,7 @@
 @use '@lucca-front/scss/src/commons/deprecated';
 
 @include deprecated.selector('.lu-user-picture', $replacement: '.avatar', $scope: 'component:avatar');
+
 .avatar,
 .lu-user-picture {
 	@layer components {

--- a/packages/scss/src/components/avatar/index.scss
+++ b/packages/scss/src/components/avatar/index.scss
@@ -1,6 +1,7 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
-// lu-user-picture is deprecated
+@include deprecated.selector('.lu-user-picture', $replacement: '.avatar', $scope: 'component:avatar');
 .avatar,
 .lu-user-picture {
 	@layer components {

--- a/packages/scss/src/components/box/index.scss
+++ b/packages/scss/src/components/box/index.scss
@@ -9,6 +9,7 @@
 
 	@layer mods {
 		@include deprecated.selector('.box.mod-grey', $replacement: '.box.mod-neutral', $scope: 'component:box');
+
 		&.mod-neutral,
 		&.mod-grey {
 			@include neutral;
@@ -19,6 +20,7 @@
 		}
 
 		@include deprecated.selector('.box.mod-toggle', $note: 'The toggle box variant is deprecated.', $scope: 'component:box');
+
 		&.mod-toggle {
 			@include toggle;
 		}

--- a/packages/scss/src/components/box/index.scss
+++ b/packages/scss/src/components/box/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .box {
 	@layer components {
@@ -7,7 +8,7 @@
 	}
 
 	@layer mods {
-		// .mod-grey is deprecated
+		@include deprecated.selector('.box.mod-grey', $replacement: '.box.mod-neutral', $scope: 'component:box');
 		&.mod-neutral,
 		&.mod-grey {
 			@include neutral;
@@ -17,7 +18,7 @@
 			@include withArrow;
 		}
 
-		// .mod-toggle is deprecated
+		@include deprecated.selector('.box.mod-toggle', $note: 'The toggle box variant is deprecated.', $scope: 'component:box');
 		&.mod-toggle {
 			@include toggle;
 		}

--- a/packages/scss/src/components/breadcrumbs/index.scss
+++ b/packages/scss/src/components/breadcrumbs/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .breadcrumbs {
 	@layer components {
@@ -7,7 +8,7 @@
 	}
 
 	@layer mods {
-		// .mod-compact is deprecated
+		@include deprecated.selector('.mod-compact', $note: 'The compact breadcrumbs variant is deprecated.', $scope: 'component:breadcrumbs');
 		&.mod-compact {
 			@include compact;
 		}
@@ -18,7 +19,7 @@
 .breadcrumbs-list-item-action,
 .breadcrumbs-list-item > a {
 	@layer mods {
-		// .active is deprecated
+		@include deprecated.selector('.active', $replacement: '.is-active', $scope: 'component:breadcrumbs');
 		&.active,
 		&.is-active,
 		&[aria-current='page'] {

--- a/packages/scss/src/components/breadcrumbs/index.scss
+++ b/packages/scss/src/components/breadcrumbs/index.scss
@@ -9,6 +9,7 @@
 
 	@layer mods {
 		@include deprecated.selector('.mod-compact', $note: 'The compact breadcrumbs variant is deprecated.', $scope: 'component:breadcrumbs');
+
 		&.mod-compact {
 			@include compact;
 		}
@@ -20,6 +21,7 @@
 .breadcrumbs-list-item > a {
 	@layer mods {
 		@include deprecated.selector('.active', $replacement: '.is-active', $scope: 'component:breadcrumbs');
+
 		&.active,
 		&.is-active,
 		&[aria-current='page'] {

--- a/packages/scss/src/components/button/index.scss
+++ b/packages/scss/src/components/button/index.scss
@@ -43,6 +43,7 @@
 		}
 
 		@include deprecated.selector('.mod-outline', $replacement: '.mod-outlined', $scope: 'component:button');
+
 		&.mod-outline,
 		&.mod-outlined {
 			&:where(:not(.is-success, .is-error)) {
@@ -52,6 +53,7 @@
 
 		@include deprecated.selector('.mod-link', $replacement: '.mod-ghost', $scope: 'component:button');
 		@include deprecated.selector('.mod-text', $replacement: '.mod-ghost', $scope: 'component:button');
+
 		&.mod-link,
 		&.mod-text,
 		&.mod-ghost {
@@ -111,6 +113,7 @@
 		}
 
 		@include deprecated.selector('.mod-delete', $replacement: '.mod-critical', $scope: 'component:button');
+
 		&.mod-delete,
 		&.mod-critical {
 			@include critical;
@@ -127,6 +130,7 @@
 		}
 
 		@include deprecated.selector('.mod-invert', $replacement: '.mod-inverted', $scope: 'component:button');
+
 		&.mod-invert,
 		&.mod-inverted {
 			@include inverted;
@@ -145,6 +149,7 @@
 		}
 
 		@include deprecated.selector('.button.loading', $replacement: '.button.is-loading', $scope: 'component:button');
+
 		&.loading,
 		&.is-loading {
 			@include loading;
@@ -167,12 +172,14 @@
 		}
 
 		@include deprecated.selector('.button.error', $replacement: '.button.is-error', $scope: 'component:button');
+
 		&.error,
 		&.is-error {
 			@include error;
 		}
 
 		@include deprecated.selector('.button.success', $replacement: '.button.is-success', $scope: 'component:button');
+
 		&.success,
 		&.is-success {
 			@include success;
@@ -188,6 +195,7 @@
 		}
 
 		@include deprecated.selector('.button.disabled', $replacement: '.button.is-disabled', $scope: 'component:button');
+
 		&.disabled,
 		&.is-disabled,
 		&[aria-disabled='true'] {

--- a/packages/scss/src/components/button/index.scss
+++ b/packages/scss/src/components/button/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .button {
 	@layer components {
@@ -41,7 +42,7 @@
 			@include disclosure;
 		}
 
-		// .mod-outline is deprecated
+		@include deprecated.selector('.mod-outline', $replacement: '.mod-outlined', $scope: 'component:button');
 		&.mod-outline,
 		&.mod-outlined {
 			&:where(:not(.is-success, .is-error)) {
@@ -49,7 +50,8 @@
 			}
 		}
 
-		// .mod-link .mod-text deprecated
+		@include deprecated.selector('.mod-link', $replacement: '.mod-ghost', $scope: 'component:button');
+		@include deprecated.selector('.mod-text', $replacement: '.mod-ghost', $scope: 'component:button');
 		&.mod-link,
 		&.mod-text,
 		&.mod-ghost {
@@ -108,25 +110,23 @@
 			}
 		}
 
-		// .mod-delete is deprecated
+		@include deprecated.selector('.mod-delete', $replacement: '.mod-critical', $scope: 'component:button');
 		&.mod-delete,
 		&.mod-critical {
 			@include critical;
 
-			// .mod-link is deprecated
 			&.mod-link,
 			&.mod-text {
 				@include criticalGhost;
 			}
 
-			// .mod-outline is deprecated
 			&.mod-outline,
 			&.mod-outlined {
 				@include criticalOutlined;
 			}
 		}
 
-		// .mod-invert is deprecated
+		@include deprecated.selector('.mod-invert', $replacement: '.mod-inverted', $scope: 'component:button');
 		&.mod-invert,
 		&.mod-inverted {
 			@include inverted;
@@ -144,7 +144,7 @@
 			}
 		}
 
-		// .loading is deprecated
+		@include deprecated.selector('.button.loading', $replacement: '.button.is-loading', $scope: 'component:button');
 		&.loading,
 		&.is-loading {
 			@include loading;
@@ -166,13 +166,13 @@
 			}
 		}
 
-		// .error is deprecated
+		@include deprecated.selector('.button.error', $replacement: '.button.is-error', $scope: 'component:button');
 		&.error,
 		&.is-error {
 			@include error;
 		}
 
-		// .success is deprecated
+		@include deprecated.selector('.button.success', $replacement: '.button.is-success', $scope: 'component:button');
 		&.success,
 		&.is-success {
 			@include success;
@@ -187,7 +187,7 @@
 			}
 		}
 
-		// .disabled is deprecated
+		@include deprecated.selector('.button.disabled', $replacement: '.button.is-disabled', $scope: 'component:button');
 		&.disabled,
 		&.is-disabled,
 		&[aria-disabled='true'] {

--- a/packages/scss/src/components/button/vars.scss
+++ b/packages/scss/src/components/button/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-button-font: var(--pr-t-font-body-M);
 	--components-button-borderRadius: var(--pr-t-border-radius-default);
@@ -21,7 +23,8 @@
 	--components-button-arrow-transform: none;
 	--components-button-AI-background-opacity: 25%;
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-button-font-size', $replacement: '--components-button-font', $scope: 'component:button');
 	--components-button-font-size: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--components-button-line-height', $replacement: '--components-button-font', $scope: 'component:button');
 	--components-button-line-height: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/button/vars.scss
+++ b/packages/scss/src/components/button/vars.scss
@@ -25,6 +25,7 @@
 
 	@include deprecated.cssVariable('--components-button-font-size', $replacement: '--components-button-font', $scope: 'component:button');
 	--components-button-font-size: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--components-button-line-height', $replacement: '--components-button-font', $scope: 'component:button');
 	--components-button-line-height: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/callout/vars.scss
+++ b/packages/scss/src/components/callout/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-callout-gap: var(--pr-t-spacings-150);
 	--components-callout-display: flex;
@@ -11,7 +13,8 @@
 	--components-callout-content-description-action-marginBlockEnd: 0;
 	--components-callout-content-description-action-paddingBlock: var(--pr-t-spacings-50);
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-callout-fontSize', $replacement: '--components-callout-font', $scope: 'component:callout');
 	--components-callout-fontSize: inherit;
+	@include deprecated.cssVariable('--components-callout-lineHeight', $replacement: '--components-callout-font', $scope: 'component:callout');
 	--components-callout-lineHeight: inherit;
 }

--- a/packages/scss/src/components/callout/vars.scss
+++ b/packages/scss/src/components/callout/vars.scss
@@ -15,6 +15,7 @@
 
 	@include deprecated.cssVariable('--components-callout-fontSize', $replacement: '--components-callout-font', $scope: 'component:callout');
 	--components-callout-fontSize: inherit;
+
 	@include deprecated.cssVariable('--components-callout-lineHeight', $replacement: '--components-callout-font', $scope: 'component:callout');
 	--components-callout-lineHeight: inherit;
 }

--- a/packages/scss/src/components/calloutFeedbackList/vars.scss
+++ b/packages/scss/src/components/calloutFeedbackList/vars.scss
@@ -6,6 +6,7 @@
 
 	@include deprecated.cssVariable('--components-calloutFeedbackList-fontSize', $replacement: '--components-calloutFeedbackList-font', $scope: 'component:calloutFeedbackList');
 	--components-calloutFeedbackList-fontSize: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--components-calloutFeedbackList-lineHeight', $replacement: '--components-calloutFeedbackList-font', $scope: 'component:calloutFeedbackList');
 	--components-calloutFeedbackList-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/calloutFeedbackList/vars.scss
+++ b/packages/scss/src/components/calloutFeedbackList/vars.scss
@@ -1,8 +1,11 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-calloutFeedbackList-font: var(--pr-t-font-body-M);
 	--components-calloutFeedbackList-gap: var(--pr-t-spacings-150);
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-calloutFeedbackList-fontSize', $replacement: '--components-calloutFeedbackList-font', $scope: 'component:calloutFeedbackList');
 	--components-calloutFeedbackList-fontSize: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--components-calloutFeedbackList-lineHeight', $replacement: '--components-calloutFeedbackList-font', $scope: 'component:calloutFeedbackList');
 	--components-calloutFeedbackList-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/card/index.scss
+++ b/packages/scss/src/components/card/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .card {
 	@layer components {
@@ -7,7 +8,7 @@
 	}
 
 	@layer mods {
-		// .mod-grey is deprecated
+		@include deprecated.selector('.card.mod-grey', $replacement: '.card.mod-neutral', $scope: 'component:card');
 		&.mod-neutral,
 		&.mod-grey {
 			@include neutral;

--- a/packages/scss/src/components/card/index.scss
+++ b/packages/scss/src/components/card/index.scss
@@ -9,6 +9,7 @@
 
 	@layer mods {
 		@include deprecated.selector('.card.mod-grey', $replacement: '.card.mod-neutral', $scope: 'component:card');
+
 		&.mod-neutral,
 		&.mod-grey {
 			@include neutral;

--- a/packages/scss/src/components/chip/vars.scss
+++ b/packages/scss/src/components/chip/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-chip-font: var(--pr-t-font-body-S);
 	--components-chip-backgroundColor: var(--palettes-100, var(--palettes-neutral-100));
@@ -8,7 +10,8 @@
 	--components-chip-kill-cross-color: var(--palettes-text, var(--palettes-neutral-text));
 	--components-chip-kill-background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='16' width='16' fill='none'%3E%3Cpath d='M5.80473 4.86192C5.54438 4.60157 5.12227 4.60157 4.86192 4.86192C4.60157 5.12227 4.60157 5.54438 4.86192 5.80473L7.05718 7.99999L4.86192 10.1953C4.60157 10.4556 4.60157 10.8777 4.86192 11.1381C5.12227 11.3984 5.54438 11.3984 5.80473 11.1381L7.99999 8.9428L10.1953 11.1381C10.4556 11.3984 10.8777 11.3984 11.1381 11.1381C11.3984 10.8777 11.3984 10.4556 11.1381 10.1953L8.9428 7.99999L11.1381 5.80473C11.3984 5.54438 11.3984 5.12227 11.1381 4.86192C10.8777 4.60157 10.4556 4.60157 10.1953 4.86192L7.99999 7.05718L5.80473 4.86192Z' fill='currentColor'/%3E%3C/svg%3E");
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-chip-fontSize', $replacement: '--components-chip-font', $scope: 'component:chip');
 	--components-chip-fontSize: var(--pr-t-font-body-S-fontSize);
+	@include deprecated.cssVariable('--components-chip-lineHeight', $replacement: '--components-chip-font', $scope: 'component:chip');
 	--components-chip-lineHeight: var(--pr-t-font-body-S-lineHeight);
 }

--- a/packages/scss/src/components/chip/vars.scss
+++ b/packages/scss/src/components/chip/vars.scss
@@ -12,6 +12,7 @@
 
 	@include deprecated.cssVariable('--components-chip-fontSize', $replacement: '--components-chip-font', $scope: 'component:chip');
 	--components-chip-fontSize: var(--pr-t-font-body-S-fontSize);
+
 	@include deprecated.cssVariable('--components-chip-lineHeight', $replacement: '--components-chip-font', $scope: 'component:chip');
 	--components-chip-lineHeight: var(--pr-t-font-body-S-lineHeight);
 }

--- a/packages/scss/src/components/comment/vars.scss
+++ b/packages/scss/src/components/comment/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-comment-max-width: 66ch;
 	--components-comment-text-font: var(--pr-t-font-body-M);
@@ -9,7 +11,8 @@
 	--components-comment-align: start;
 	--components-comment-border-radius: var(--pr-t-border-radius-small) var(--pr-t-border-radius-default) var(--pr-t-border-radius-default);
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-comment-text-fontSize', $replacement: '--components-comment-text-font', $scope: 'component:comment');
 	--components-comment-text-fontSize: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--components-comment-text-lineHeight', $replacement: '--components-comment-text-font', $scope: 'component:comment');
 	--components-comment-text-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/comment/vars.scss
+++ b/packages/scss/src/components/comment/vars.scss
@@ -13,6 +13,7 @@
 
 	@include deprecated.cssVariable('--components-comment-text-fontSize', $replacement: '--components-comment-text-font', $scope: 'component:comment');
 	--components-comment-text-fontSize: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--components-comment-text-lineHeight', $replacement: '--components-comment-text-font', $scope: 'component:comment');
 	--components-comment-text-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/container/vars.scss
+++ b/packages/scss/src/components/container/vars.scss
@@ -1,12 +1,13 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
+@use '@lucca-front/scss/src/commons/deprecated';
 
 @mixin vars($atRoot: namespace.$defaultAtRoot) {
 	--components-container-minInlineSize: 0;
 
 	// for this component some variables are placed in root
 
-	// --components-container-max-width is deprecated
-	// --components-container-padding is deprecated
+	@include deprecated.cssVariable('--components-container-max-width', $replacement: '--commons-container-maxWidth', $scope: 'component:container');
 	--components-container-max-width: var(--commons-container-maxWidth);
+	@include deprecated.cssVariable('--components-container-padding', $replacement: '--commons-container-padding', $scope: 'component:container');
 	--components-container-padding: var(--commons-container-padding);
 }

--- a/packages/scss/src/components/container/vars.scss
+++ b/packages/scss/src/components/container/vars.scss
@@ -8,6 +8,7 @@
 
 	@include deprecated.cssVariable('--components-container-max-width', $replacement: '--commons-container-maxWidth', $scope: 'component:container');
 	--components-container-max-width: var(--commons-container-maxWidth);
+
 	@include deprecated.cssVariable('--components-container-padding', $replacement: '--commons-container-padding', $scope: 'component:container');
 	--components-container-padding: var(--commons-container-padding);
 }

--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -3,6 +3,10 @@
 @use '@lucca-front/scss/src/commons/utils/keyframe';
 @use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.dialog-form', $replacement: '.dialog-inside-formOptional', $scope: 'component:dialog');
+@include deprecated.selector('.dialog-formOptional', $replacement: '.dialog-inside-formOptional', $scope: 'component:dialog');
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	animation-name: var(--components-dialog-animationOpening);

--- a/packages/scss/src/components/divider/vars.scss
+++ b/packages/scss/src/components/divider/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-divider-font: var(--pr-t-font-body-M);
 	--components-divider-marginBlock: var(--pr-t-spacings-50);
@@ -9,7 +11,8 @@
 	--components-divider-justify: normal;
 	--components-divider-alignSelf: '';
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-divider-fontSize', $replacement: '--components-divider-font', $scope: 'component:divider');
 	--components-divider-fontSize: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--components-divider-lineHeight', $replacement: '--components-divider-font', $scope: 'component:divider');
 	--components-divider-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/divider/vars.scss
+++ b/packages/scss/src/components/divider/vars.scss
@@ -13,6 +13,7 @@
 
 	@include deprecated.cssVariable('--components-divider-fontSize', $replacement: '--components-divider-font', $scope: 'component:divider');
 	--components-divider-fontSize: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--components-divider-lineHeight', $replacement: '--components-divider-font', $scope: 'component:divider');
 	--components-divider-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/dropdown/index.scss
+++ b/packages/scss/src/components/dropdown/index.scss
@@ -1,4 +1,10 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.lu-dropdown-content', $replacement: '.dropdown', $scope: 'component:dropdown');
+@include deprecated.selector('.lu-dropdown-options', $replacement: '.dropdown-list', $scope: 'component:dropdown');
+@include deprecated.selector('.lu-dropdown-options-item', $replacement: '.dropdown-list-option', $scope: 'component:dropdown');
+@include deprecated.selector('.lu-dropdown-options-item-action', $replacement: '.dropdown-list-option-action', $scope: 'component:dropdown');
 
 // stylelint-disable-next-line selector-disallowed-list -- .lu-dropdown-content is deprecated
 .lu-dropdown-content.lu-popover-content,

--- a/packages/scss/src/components/filterBarDeprecated/index.scss
+++ b/packages/scss/src/components/filterBarDeprecated/index.scss
@@ -1,4 +1,7 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.filterBarDeprecated', $note: 'Entire component is deprecated, including all .filterBarDeprecated-* descendants.', $scope: 'component:filterBarDeprecated');
 
 // stylelint-disable selector-disallowed-list -- Selectors are all deprecated.
 .filterBarDeprecated {

--- a/packages/scss/src/components/form/component.scss
+++ b/packages/scss/src/components/form/component.scss
@@ -2,6 +2,9 @@
 @use '@lucca-front/scss/src/components/formLabel/exports' as formLabel;
 @use '@lucca-front/scss/src/components/inlineMessage/exports' as inlineMessage;
 @use '@lucca-front/scss/src/commons/utils/namespace';
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.sassApi('form.componentDeprecated', $note: 'The legacy form component mixin is deprecated.', $scope: 'component:form');
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;

--- a/packages/scss/src/components/formLabel/vars.scss
+++ b/packages/scss/src/components/formLabel/vars.scss
@@ -12,6 +12,7 @@
 
 	@include deprecated.cssVariable('--components-formLabel-fontSize', $replacement: '--components-formLabel-font', $scope: 'component:formLabel');
 	--components-formLabel-fontSize: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--components-formLabel-lineHeight', $replacement: '--components-formLabel-font', $scope: 'component:formLabel');
 	--components-formLabel-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/formLabel/vars.scss
+++ b/packages/scss/src/components/formLabel/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-formLabel-font: var(--pr-t-font-body-M);
 	--components-formLabel-color: var(--pr-t-color-text);
@@ -8,7 +10,8 @@
 	--components-formLabel-width: fit-content;
 	--components-formLabel-cursor: default;
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-formLabel-fontSize', $replacement: '--components-formLabel-font', $scope: 'component:formLabel');
 	--components-formLabel-fontSize: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--components-formLabel-lineHeight', $replacement: '--components-formLabel-font', $scope: 'component:formLabel');
 	--components-formLabel-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/gauge/index.scss
+++ b/packages/scss/src/components/gauge/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .gauge {
 	@layer components {
@@ -15,7 +16,7 @@
 			@include circular;
 		}
 
-		// .mod-vertical is deprecated
+		@include deprecated.selector('.mod-vertical', $note: 'The vertical gauge variant is deprecated.', $scope: 'component:gauge');
 		&.mod-vertical {
 			@include vertical;
 

--- a/packages/scss/src/components/gauge/index.scss
+++ b/packages/scss/src/components/gauge/index.scss
@@ -17,6 +17,7 @@
 		}
 
 		@include deprecated.selector('.mod-vertical', $note: 'The vertical gauge variant is deprecated.', $scope: 'component:gauge');
+
 		&.mod-vertical {
 			@include vertical;
 

--- a/packages/scss/src/components/gauge/mods.scss
+++ b/packages/scss/src/components/gauge/mods.scss
@@ -1,3 +1,8 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.sassApi('gauge.vertical', $note: 'The vertical gauge mixin is deprecated.', $scope: 'component:gauge');
+@include deprecated.sassApi('gauge.verticalThin', $note: 'The verticalThin gauge mixin is deprecated.', $scope: 'component:gauge');
+
 @mixin thin {
 	--components-gauge-blockSize: var(--pr-t-spacings-50);
 	--components-gauge-circle-strokeWidth: var(--pr-t-spacings-50);

--- a/packages/scss/src/components/gauge/vars.scss
+++ b/packages/scss/src/components/gauge/vars.scss
@@ -1,4 +1,7 @@
-// --components-gauge-height is deprecated
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.cssVariable('--components-gauge-height', $replacement: '--components-gauge-blockSize', $scope: 'component:gauge');
+
 @mixin vars {
 	--components-gauge-blockSize: var(--components-gauge-height, var(--pr-t-spacings-100));
 	--components-gauge-inlineSize: auto;

--- a/packages/scss/src/components/horizontalNavigation/index.scss
+++ b/packages/scss/src/components/horizontalNavigation/index.scss
@@ -1,5 +1,14 @@
 @use '@lucca-front/scss/src/commons/utils/color';
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.menu', $replacement: '.horizontalNavigation', $scope: 'component:horizontalNavigation');
+@include deprecated.selector('.menu-list', $replacement: '.horizontalNavigation-list', $scope: 'component:horizontalNavigation');
+@include deprecated.selector('.menu-list-item-action', $replacement: '.horizontalNavigation-list-item-action', $scope: 'component:horizontalNavigation');
+@include deprecated.selector('.menu-link', $note: 'Legacy .menu-* selector; use the .horizontalNavigation-* equivalent.', $scope: 'component:horizontalNavigation');
+@include deprecated.selector('.menu-containerOptional', $note: 'Legacy .menu-* selector; use the .horizontalNavigation-* equivalent.', $scope: 'component:horizontalNavigation');
+@include deprecated.selector('.menu-link-placeholder', $note: 'Legacy .menu-* selector; use the .horizontalNavigation-* equivalent.', $scope: 'component:horizontalNavigation');
+@include deprecated.selector('.disabled', $replacement: '.is-disabled', $scope: 'component:horizontalNavigation');
 
 // stylelint-disable-next-line selector-disallowed-list -- .menu is deprecated
 .menu,

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -202,6 +202,7 @@
 		}
 
 		@include deprecated.selector('.indexTable-body-row-cell-action', $note: 'The indexTable row cell action selector is deprecated.', $scope: 'component:indexTable');
+
 		.indexTable-body-row-cell-action {
 			@include a11y.mask;
 		}

--- a/packages/scss/src/components/indexTable/component.scss
+++ b/packages/scss/src/components/indexTable/component.scss
@@ -2,6 +2,7 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/reset';
 @use '@lucca-front/scss/src/commons/utils/namespace';
+@use '@lucca-front/scss/src/commons/deprecated';
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	position: relative;
@@ -200,7 +201,7 @@
 			margin: var(--pr-t-spacings-50);
 		}
 
-		// .indexTable-body-row-cell-action is deprecated
+		@include deprecated.selector('.indexTable-body-row-cell-action', $note: 'The indexTable row cell action selector is deprecated.', $scope: 'component:indexTable');
 		.indexTable-body-row-cell-action {
 			@include a11y.mask;
 		}

--- a/packages/scss/src/components/inlineMessage/component.scss
+++ b/packages/scss/src/components/inlineMessage/component.scss
@@ -2,6 +2,9 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
 
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.lucca-icon:first-child', $replacement: '.inlineMessage-statusIcon', $scope: 'component:inlineMessage');
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: flex;

--- a/packages/scss/src/components/label/index.scss
+++ b/packages/scss/src/components/label/index.scss
@@ -1,4 +1,7 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.label', $note: 'The .label component is deprecated.', $scope: 'component:label');
 
 // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated
 .label {

--- a/packages/scss/src/components/loading/index.scss
+++ b/packages/scss/src/components/loading/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .loading {
 	@layer components {
@@ -19,13 +20,13 @@
 			@include fullPage;
 		}
 
-		// .mod-dialog is deprecated
+		@include deprecated.selector('.mod-dialog', $replacement: '.mod-popin', $scope: 'component:loading');
 		&.mod-popin,
 		&.mod-dialog {
 			@include popin;
 		}
 
-		// .mod-sidePanel is deprecated
+		@include deprecated.selector('.mod-sidePanel', $replacement: '.mod-drawer', $scope: 'component:loading');
 		&.mod-drawer,
 		&.mod-sidePanel {
 			@include drawer;

--- a/packages/scss/src/components/loading/index.scss
+++ b/packages/scss/src/components/loading/index.scss
@@ -21,12 +21,14 @@
 		}
 
 		@include deprecated.selector('.mod-dialog', $replacement: '.mod-popin', $scope: 'component:loading');
+
 		&.mod-popin,
 		&.mod-dialog {
 			@include popin;
 		}
 
 		@include deprecated.selector('.mod-sidePanel', $replacement: '.mod-drawer', $scope: 'component:loading');
+
 		&.mod-drawer,
 		&.mod-sidePanel {
 			@include drawer;

--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
 @use '@lucca-front/scss/src/commons/utils/namespace';
+@use '@lucca-front/scss/src/commons/deprecated';
 
 @mixin compact {
 	background-color: var(--components-navSide-compact-palette-bg-color);
@@ -11,7 +12,7 @@
 				--commons-navSide-width: 15rem;
 			}
 
-			// .mod-withMenuCompact is deprecated
+			@include deprecated.selector('.mod-withMenuCompact', $replacement: '.navSide.mod-compact', $scope: 'component:navside');
 			&:has(.navSide.mod-compact, .mod-withMenuCompact) {
 				--commons-navSide-width: 7.5rem;
 			}

--- a/packages/scss/src/components/navside/mods.scss
+++ b/packages/scss/src/components/navside/mods.scss
@@ -13,6 +13,7 @@
 			}
 
 			@include deprecated.selector('.mod-withMenuCompact', $replacement: '.navSide.mod-compact', $scope: 'component:navside');
+
 			&:has(.navSide.mod-compact, .mod-withMenuCompact) {
 				--commons-navSide-width: 7.5rem;
 			}

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -21,6 +21,7 @@
 
 	@include deprecated.cssVariable('--components-navSide-fullwidth-palette-alert-color', $note: 'Use the selected-alert palette custom properties instead.', $scope: 'component:navside');
 	--components-navSide-fullwidth-palette-alert-color: var(--palettes-brand-200);
+
 	@include deprecated.cssVariable('--components-navSide-fullwidth-palette-alert-text', $note: 'Use the selected-alert palette custom properties instead.', $scope: 'component:navside');
 	--components-navSide-fullwidth-palette-alert-text: var(--palettes-brand-800);
 

--- a/packages/scss/src/components/navside/vars.scss
+++ b/packages/scss/src/components/navside/vars.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/commons/utils/media';
+@use '@lucca-front/scss/src/commons/deprecated';
 
 @mixin vars($atRoot: namespace.$defaultAtRoot) {
 	// for this component some variables are placed in common
@@ -18,9 +19,9 @@
 	--components-navSide-fullwidth-palette-selected-alert-color: var(--palettes-brand-200);
 	--components-navSide-fullwidth-palette-selected-alert-text: var(--palettes-brand-800);
 
-	// --components-navSide-fullwidth-palette-alert-color is deprecated
-	// --components-navSide-fullwidth-palette-alert-text is deprecated
+	@include deprecated.cssVariable('--components-navSide-fullwidth-palette-alert-color', $note: 'Use the selected-alert palette custom properties instead.', $scope: 'component:navside');
 	--components-navSide-fullwidth-palette-alert-color: var(--palettes-brand-200);
+	@include deprecated.cssVariable('--components-navSide-fullwidth-palette-alert-text', $note: 'Use the selected-alert palette custom properties instead.', $scope: 'component:navside');
 	--components-navSide-fullwidth-palette-alert-text: var(--palettes-brand-800);
 
 	--components-navSide-compact-palette-bg-color: var(--palettes-navigation-800);

--- a/packages/scss/src/components/pageHeader/index.scss
+++ b/packages/scss/src/components/pageHeader/index.scss
@@ -10,6 +10,7 @@
 
 	@layer mods {
 		@include deprecated.selector('.mod-withMenu', $replacement: '.mod-withHorizontalNavigation', $scope: 'component:pageHeader');
+
 		&.mod-withHorizontalNavigation,
 		&:has(.horizontalNavigation),
 		&.mod-withMenu {

--- a/packages/scss/src/components/pageHeader/index.scss
+++ b/packages/scss/src/components/pageHeader/index.scss
@@ -1,5 +1,6 @@
 @use 'exports' as *;
 @use '@lucca-front/scss/src/commons/utils/media';
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .pageHeader {
 	@layer components {
@@ -8,7 +9,7 @@
 	}
 
 	@layer mods {
-		// .mod-withMenu is deprecated
+		@include deprecated.selector('.mod-withMenu', $replacement: '.mod-withHorizontalNavigation', $scope: 'component:pageHeader');
 		&.mod-withHorizontalNavigation,
 		&:has(.horizontalNavigation),
 		&.mod-withMenu {

--- a/packages/scss/src/components/section/index.scss
+++ b/packages/scss/src/components/section/index.scss
@@ -10,6 +10,7 @@
 
 	@layer mods {
 		@include deprecated.selector('.section.mod-grey', $replacement: '.section.mod-neutral', $scope: 'component:section');
+
 		&.mod-neutral,
 		&.mod-grey {
 			@include neutral;

--- a/packages/scss/src/components/section/index.scss
+++ b/packages/scss/src/components/section/index.scss
@@ -1,5 +1,6 @@
 @use '@lucca-front/scss/src/commons/utils/media';
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .section {
 	@layer components {
@@ -8,7 +9,7 @@
 	}
 
 	@layer mods {
-		// .mod-grey is deprecated
+		@include deprecated.selector('.section.mod-grey', $replacement: '.section.mod-neutral', $scope: 'component:section');
 		&.mod-neutral,
 		&.mod-grey {
 			@include neutral;

--- a/packages/scss/src/components/segmentedControl/component.scss
+++ b/packages/scss/src/components/segmentedControl/component.scss
@@ -28,6 +28,7 @@
 		}
 
 		@include deprecated.selector('.viewTabs-item', $replacement: '.segmentedControl-item', $scope: 'component:segmentedControl');
+
 		.segmentedControl-item,
 		.viewTabs-item {
 			flex-grow: 1;

--- a/packages/scss/src/components/segmentedControl/component.scss
+++ b/packages/scss/src/components/segmentedControl/component.scss
@@ -1,4 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/a11y';
+@use '@lucca-front/scss/src/commons/deprecated';
 
 @mixin component($atRoot: 'without: rule') {
 	padding: 0;
@@ -26,7 +27,7 @@
 			}
 		}
 
-		// .viewTabs-item is deprecated
+		@include deprecated.selector('.viewTabs-item', $replacement: '.segmentedControl-item', $scope: 'component:segmentedControl');
 		.segmentedControl-item,
 		.viewTabs-item {
 			flex-grow: 1;

--- a/packages/scss/src/components/segmentedControl/index.scss
+++ b/packages/scss/src/components/segmentedControl/index.scss
@@ -1,7 +1,8 @@
 @use '@lucca-front/scss/src/commons/utils/media';
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
-// .viewTabs is deprecated
+@include deprecated.selector('.viewTabs', $replacement: '.segmentedControl', $scope: 'component:segmentedControl');
 .segmentedControl,
 .viewTabs {
 	@layer components {
@@ -25,7 +26,7 @@
 }
 
 @layer mods {
-	// .viewTabs-item-tab is deprecated
+	@include deprecated.selector('.viewTabs-item-tab', $replacement: '.segmentedControl-item-action', $scope: 'component:segmentedControl');
 	.segmentedControl-item-action,
 	.viewTabs-item-tab {
 		.segmentedControl-item-input:checked + &,
@@ -39,7 +40,7 @@
 		@include disabled;
 	}
 
-	// .viewTabs_panel is deprecated
+	@include deprecated.selector('.viewTabs_panel', $replacement: '.segmentedControl_panel', $scope: 'component:segmentedControl');
 	.segmentedControl_panel,
 	.viewTabs_panel {
 		// .active is deprecated

--- a/packages/scss/src/components/segmentedControl/index.scss
+++ b/packages/scss/src/components/segmentedControl/index.scss
@@ -3,6 +3,7 @@
 @use '@lucca-front/scss/src/commons/deprecated';
 
 @include deprecated.selector('.viewTabs', $replacement: '.segmentedControl', $scope: 'component:segmentedControl');
+
 .segmentedControl,
 .viewTabs {
 	@layer components {
@@ -27,6 +28,7 @@
 
 @layer mods {
 	@include deprecated.selector('.viewTabs-item-tab', $replacement: '.segmentedControl-item-action', $scope: 'component:segmentedControl');
+
 	.segmentedControl-item-action,
 	.viewTabs-item-tab {
 		.segmentedControl-item-input:checked + &,
@@ -41,6 +43,7 @@
 	}
 
 	@include deprecated.selector('.viewTabs_panel', $replacement: '.segmentedControl_panel', $scope: 'component:segmentedControl');
+
 	.segmentedControl_panel,
 	.viewTabs_panel {
 		// .active is deprecated

--- a/packages/scss/src/components/sortableList/vars.scss
+++ b/packages/scss/src/components/sortableList/vars.scss
@@ -1,10 +1,13 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-sortableList-padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);
 	--components-sortableList-handler-size: var(--pr-t-font-body-M-lineHeight);
 	--components-sortableList-description-font: var(--pr-t-font-body-M);
 	--components-sortableList-helper-font: var(--pr-t-font-body-S);
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-sortableList-description-fontSize', $replacement: '--components-sortableList-description-font', $scope: 'component:sortableList');
 	--components-sortableList-description-fontSize: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--components-sortableList-description-lineHeight', $replacement: '--components-sortableList-description-font', $scope: 'component:sortableList');
 	--components-sortableList-description-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/sortableList/vars.scss
+++ b/packages/scss/src/components/sortableList/vars.scss
@@ -8,6 +8,7 @@
 
 	@include deprecated.cssVariable('--components-sortableList-description-fontSize', $replacement: '--components-sortableList-description-font', $scope: 'component:sortableList');
 	--components-sortableList-description-fontSize: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--components-sortableList-description-lineHeight', $replacement: '--components-sortableList-description-font', $scope: 'component:sortableList');
 	--components-sortableList-description-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/table/index.scss
+++ b/packages/scss/src/components/table/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .table {
 	@layer components {
@@ -103,7 +104,7 @@
 		&.mod-actions {
 			@include actions;
 
-			// .mod-actionsHidden is deprecated
+			@include deprecated.selector('.mod-actionsHidden', $note: 'Hidden table actions are deprecated.', $scope: 'component:table');
 			&.mod-actionsHidden {
 				@include actionsHidden;
 			}

--- a/packages/scss/src/components/table/index.scss
+++ b/packages/scss/src/components/table/index.scss
@@ -105,6 +105,7 @@
 			@include actions;
 
 			@include deprecated.selector('.mod-actionsHidden', $note: 'Hidden table actions are deprecated.', $scope: 'component:table');
+
 			&.mod-actionsHidden {
 				@include actionsHidden;
 			}

--- a/packages/scss/src/components/tableFixedDeprecated/index.scss
+++ b/packages/scss/src/components/tableFixedDeprecated/index.scss
@@ -1,6 +1,9 @@
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/utils/media';
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.table.mod-layoutFixed', $note: 'Entire tableFixedDeprecated component is deprecated, including all its descendant selectors.', $scope: 'component:tableFixedDeprecated');
 
 .table {
 	@layer mods {

--- a/packages/scss/src/components/tableStickedDeprecated/index.scss
+++ b/packages/scss/src/components/tableStickedDeprecated/index.scss
@@ -1,6 +1,9 @@
 @use '@lucca-front/scss/src/commons/config';
 @use '@lucca-front/scss/src/commons/utils/media';
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.selector('.table.mod-stickyColumn', $note: 'Entire tableStickedDeprecated component is deprecated, including all its descendant selectors.', $scope: 'component:tableStickedDeprecated');
 
 .table {
 	@layer components {

--- a/packages/scss/src/components/tag/index.scss
+++ b/packages/scss/src/components/tag/index.scss
@@ -17,6 +17,7 @@
 		}
 
 		@include deprecated.selector('.mod-clickable', $note: 'Clickable tags are inferred from the a/button element; the modifier is deprecated.', $scope: 'component:tag');
+
 		&:is(a, button),
 		&.mod-clickable {
 			@include clickable;

--- a/packages/scss/src/components/tag/index.scss
+++ b/packages/scss/src/components/tag/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .tag {
 	@layer components {
@@ -15,7 +16,7 @@
 			@include L;
 		}
 
-		// .mod-clickable is deprecated
+		@include deprecated.selector('.mod-clickable', $note: 'Clickable tags are inferred from the a/button element; the modifier is deprecated.', $scope: 'component:tag');
 		&:is(a, button),
 		&.mod-clickable {
 			@include clickable;

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -13,6 +13,7 @@
 
 	@include deprecated.cssVariable('--components-tag-fontSize', $replacement: '--components-tag-font', $scope: 'component:tag');
 	--components-tag-fontSize: var(--pr-t-font-body-S-fontSize);
+
 	@include deprecated.cssVariable('--components-tag-lineHeight', $replacement: '--components-tag-font', $scope: 'component:tag');
 	--components-tag-lineHeight: var(--pr-t-font-body-S-lineHeight);
 }

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-tag-background: var(--palettes-100, var(--palettes-neutral-100));
 	--components-tag-color: var(--palettes-800, var(--palettes-neutral-800));
@@ -9,7 +11,8 @@
 	--components-tag-boxShadow: 0 0 0 1px var(--components-tag-shadow);
 	--components-tag-position: static;
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-tag-fontSize', $replacement: '--components-tag-font', $scope: 'component:tag');
 	--components-tag-fontSize: var(--pr-t-font-body-S-fontSize);
+	@include deprecated.cssVariable('--components-tag-lineHeight', $replacement: '--components-tag-font', $scope: 'component:tag');
 	--components-tag-lineHeight: var(--pr-t-font-body-S-lineHeight);
 }

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -19,6 +19,7 @@
 
 	@include deprecated.cssVariable('--component-textField-fontSize', $replacement: '--component-textField-font', $scope: 'component:textField');
 	--component-textField-fontSize: var(--pr-t-font-body-M-fontSize);
+
 	@include deprecated.cssVariable('--component-textField-lineHeight', $replacement: '--component-textField-font', $scope: 'component:textField');
 	--component-textField-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--component-textField-font: var(--pr-t-font-body-M);
 	--component-textField-placeholder: var(--pr-t-color-input-text-placeholder);
@@ -15,7 +17,8 @@
 	--component-textField-borderRadius: var(--pr-t-border-radius-input);
 	--component-textField-width: auto;
 
-	// Deprecated
+	@include deprecated.cssVariable('--component-textField-fontSize', $replacement: '--component-textField-font', $scope: 'component:textField');
 	--component-textField-fontSize: var(--pr-t-font-body-M-fontSize);
+	@include deprecated.cssVariable('--component-textField-lineHeight', $replacement: '--component-textField-font', $scope: 'component:textField');
 	--component-textField-lineHeight: var(--pr-t-font-body-M-lineHeight);
 }

--- a/packages/scss/src/components/toast/vars.scss
+++ b/packages/scss/src/components/toast/vars.scss
@@ -13,6 +13,7 @@
 
 	@include deprecated.cssVariable('--components-toasts-background', $note: 'Toast background is no longer customizable.', $scope: 'component:toast');
 	--components-toasts-background: var(--palettes-neutral-800);
+
 	@include deprecated.cssVariable('--components-toasts-padding', $note: 'Toast padding is no longer customizable.', $scope: 'component:toast');
 	--components-toasts-padding: var(--pr-t-spacings-100) var(--pr-t-spacings-200);
 }

--- a/packages/scss/src/components/toast/vars.scss
+++ b/packages/scss/src/components/toast/vars.scss
@@ -1,3 +1,5 @@
+@use '@lucca-front/scss/src/commons/deprecated';
+
 @mixin vars {
 	--components-toasts-color: var(--pr-t-color-text-reverse);
 	--components-toasts-top: var(--pr-t-spacings-300);
@@ -9,7 +11,8 @@
 	--components-toasts-inset: var(--components-toasts-top) var(--components-toasts-right) auto auto;
 	--components-toasts-footerHeight: 4.5rem;
 
-	// Deprecated
+	@include deprecated.cssVariable('--components-toasts-background', $note: 'Toast background is no longer customizable.', $scope: 'component:toast');
 	--components-toasts-background: var(--palettes-neutral-800);
+	@include deprecated.cssVariable('--components-toasts-padding', $note: 'Toast padding is no longer customizable.', $scope: 'component:toast');
 	--components-toasts-padding: var(--pr-t-spacings-100) var(--pr-t-spacings-200);
 }

--- a/packages/scss/src/components/userTile/index.scss
+++ b/packages/scss/src/components/userTile/index.scss
@@ -21,16 +21,19 @@
 		}
 
 		@include deprecated.selector('.mod-XL', $note: 'The XL userTile size is deprecated.', $scope: 'component:userTile');
+
 		&.mod-XL {
 			@include XL;
 		}
 
 		@include deprecated.selector('.mod-XXL', $note: 'The XXL userTile size is deprecated.', $scope: 'component:userTile');
+
 		&.mod-XXL {
 			@include XXL;
 		}
 
 		@include deprecated.selector('.mod-XXXL', $note: 'The XXXL userTile size is deprecated.', $scope: 'component:userTile');
+
 		&.mod-XXXL {
 			@include XXXL;
 		}

--- a/packages/scss/src/components/userTile/index.scss
+++ b/packages/scss/src/components/userTile/index.scss
@@ -1,4 +1,5 @@
 @use 'exports' as *;
+@use '@lucca-front/scss/src/commons/deprecated';
 
 .userTile {
 	@layer components {
@@ -19,17 +20,17 @@
 			@include L;
 		}
 
-		// .mod-XL is deprecated
+		@include deprecated.selector('.mod-XL', $note: 'The XL userTile size is deprecated.', $scope: 'component:userTile');
 		&.mod-XL {
 			@include XL;
 		}
 
-		// .mod-XXL is deprecated
+		@include deprecated.selector('.mod-XXL', $note: 'The XXL userTile size is deprecated.', $scope: 'component:userTile');
 		&.mod-XXL {
 			@include XXL;
 		}
 
-		// .mod-XXXL is deprecated
+		@include deprecated.selector('.mod-XXXL', $note: 'The XXXL userTile size is deprecated.', $scope: 'component:userTile');
 		&.mod-XXXL {
 			@include XXXL;
 		}

--- a/packages/scss/src/components/userTile/mods.scss
+++ b/packages/scss/src/components/userTile/mods.scss
@@ -1,4 +1,9 @@
 @use '@lucca-front/scss/src/components/avatar/exports' as avatar;
+@use '@lucca-front/scss/src/commons/deprecated';
+
+@include deprecated.sassApi('userTile.XL', $note: 'The XL userTile size mixin is deprecated.', $scope: 'component:userTile');
+@include deprecated.sassApi('userTile.XXL', $note: 'The XXL userTile size mixin is deprecated.', $scope: 'component:userTile');
+@include deprecated.sassApi('userTile.XXXL', $note: 'The XXXL userTile size mixin is deprecated.', $scope: 'component:userTile');
 
 @mixin XS {
 	--components-userTile-gap: var(--pr-t-spacings-100);

--- a/packages/scss/tools/audit-size.js
+++ b/packages/scss/tools/audit-size.js
@@ -1,0 +1,249 @@
+/**
+ * Audits the compiled+compressed size and the deprecation inventory of
+ * @lucca-front/scss before vs after a change, to prove the deprecation-registry
+ * refactor is size-neutral and that every legacy marker was migrated.
+ *
+ * Default (`full`) run:
+ *   1. resolves the merge-base with origin/rc and checks it out into a temp worktree
+ *   2. snapshots sizes (full bundle + every module) and the deprecation inventory of both trees
+ *   3. writes scss-size-audit.md at the repo root and exits non-zero if any output changed bytes
+ *
+ * Usage:
+ *   node packages/scss/tools/audit-size.js                 # full before/after audit
+ *   node packages/scss/tools/audit-size.js --allow-diff    # don't fail on size differences
+ */
+const autoprefixer = require('autoprefixer');
+const crypto = require('crypto');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const postcss = require('postcss');
+const sass = require('sass');
+const { pathToFileURL } = require('url');
+const zlib = require('zlib');
+
+const MAIN_ROOT = path.resolve(__dirname, '..', '..', '..');
+const REPORT = path.join(MAIN_ROOT, 'scss-size-audit.md');
+
+function git(args, cwd = MAIN_ROOT) {
+	return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+
+// node_modules/@lucca-front/* are symlinks into the *main* checkout, so a plain
+// loadPaths compile of a base-commit worktree would resolve @lucca-front/scss to
+// HEAD sources. Pin those prefixes to the tree being measured.
+function workspaceImporter(repoRoot) {
+	const prefixes = {
+		'@lucca-front/scss/': path.join(repoRoot, 'packages', 'scss'),
+		'@lucca-front/icons/': path.join(repoRoot, 'packages', 'icons'),
+	};
+	return {
+		findFileUrl(url) {
+			for (const [prefix, dir] of Object.entries(prefixes)) {
+				if (url.startsWith(prefix)) {
+					return pathToFileURL(path.join(dir, url.slice(prefix.length)));
+				}
+			}
+			return null;
+		},
+	};
+}
+
+function measure(css) {
+	return {
+		raw: Buffer.byteLength(css),
+		gzip: zlib.gzipSync(Buffer.from(css), { level: 9 }).length,
+		sha256: crypto.createHash('sha256').update(css).digest('hex'),
+	};
+}
+
+async function snapshotSizes(repoRoot) {
+	const opts = {
+		style: 'compressed',
+		loadPaths: [path.join(MAIN_ROOT, 'node_modules')],
+		importers: [workspaceImporter(repoRoot)],
+	};
+	const src = path.join(repoRoot, 'packages', 'scss', 'src');
+	const modules = {};
+
+	// Full bundle — replicate build.js compileScss (compressed + autoprefixer) so
+	// numbers match the shipped dist/scss/dist/lucca-front.min.css.
+	const bundleInput = path.join(src, 'main-all.scss');
+	const bundle = sass.compile(bundleInput, opts);
+	const prefixed = await postcss([autoprefixer]).process(bundle.css, { from: bundleInput });
+	modules['bundle (lucca-front.min.css)'] = measure(prefixed.css);
+
+	// Maximal config — every $deprecated* branch on — proves gated u-* paths are neutral too.
+	const maximal = sass.compileString(
+		`@use '@lucca-front/scss/src/commons/config' with ($deprecatedSpacings: true, $deprecatedCardBoxMargin: true, $deprecatedUtilityPrefix: true, $palettesOtherProduct: 'all', $fontFamilyCursive: 'Caveat');\n@use '@lucca-front/scss/src/main-all';`,
+		opts,
+	);
+	modules['bundle (maximal config)'] = measure(maximal.css);
+
+	// Per module — plain compressed (autoprefixer is identical on both sides, so it
+	// adds nothing to a delta and doubles the cost across 125 compiles).
+	modules['commons (main.scss)'] = measure(sass.compile(path.join(src, 'main.scss'), opts).css);
+	const componentsDir = path.join(src, 'components');
+	for (const dirent of fs.readdirSync(componentsDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+		if (!dirent.isDirectory() || dirent.name.startsWith('_')) {
+			continue;
+		}
+		const index = path.join(componentsDir, dirent.name, 'index.scss');
+		if (fs.existsSync(index)) {
+			modules[`components/${dirent.name}`] = measure(sass.compile(index, opts).css);
+		}
+	}
+	return modules;
+}
+
+const DEPRECATION_RE = /deprecated/i;
+
+// BEFORE: heuristic scan of legacy comment markers (the fuzziness being fixed).
+function scanLegacyMarkers(repoRoot) {
+	const srcDir = path.join(repoRoot, 'packages', 'scss', 'src');
+	const markers = [];
+	const walk = (dir) => {
+		for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+			const full = path.join(dir, dirent.name);
+			if (dirent.isDirectory()) {
+				walk(full);
+			} else if (dirent.name.endsWith('.scss')) {
+				const rel = path.relative(repoRoot, full).replace(/\\/g, '/');
+				fs.readFileSync(full, 'utf-8').split('\n').forEach((line, i) => {
+					const isComment = line.includes('//') || line.includes('/*');
+					if (isComment && DEPRECATION_RE.test(line)) {
+						markers.push({ file: rel, line: i + 1, text: line.trim() });
+					}
+				});
+			}
+		}
+	};
+	walk(srcDir);
+	return markers;
+}
+
+// AFTER: exact registry entries, if the manifest exists in the tree.
+function readManifest(repoRoot) {
+	const file = path.join(repoRoot, 'packages', 'scss', 'css-api', 'deprecations.json');
+	if (!fs.existsSync(file)) {
+		return null;
+	}
+	return JSON.parse(fs.readFileSync(file, 'utf-8'));
+}
+
+function fmtBytes(n) {
+	return n.toLocaleString('en-US');
+}
+
+function buildReport({ base, head, before, after, beforeMarkers, afterManifest }) {
+	const keys = [...new Set([...Object.keys(before), ...Object.keys(after)])];
+	let identical = 0;
+	let changed = 0;
+	const rows = [];
+	for (const key of keys) {
+		const b = before[key];
+		const a = after[key];
+		if (b && a) {
+			const same = b.sha256 === a.sha256;
+			same ? identical++ : changed++;
+			if (!same || process.argv.includes('--full')) {
+				rows.push(`| \`${key}\` | ${fmtBytes(b.raw)} | ${fmtBytes(a.raw)} | ${a.raw - b.raw} | ${fmtBytes(b.gzip)} | ${fmtBytes(a.gzip)} | ${same ? '✅' : '⚠️ changed'} |`);
+			}
+		} else {
+			changed++;
+			rows.push(`| \`${key}\` | ${b ? fmtBytes(b.raw) : '—'} | ${a ? fmtBytes(a.raw) : '—'} | ${b && a ? a.raw - b.raw : 'n/a'} | ${b ? fmtBytes(b.gzip) : '—'} | ${a ? fmtBytes(a.gzip) : '—'} | ${b ? '➖ removed' : '➕ added'} |`);
+		}
+	}
+
+	const out = [];
+	out.push('# SCSS deprecation refactor — size & inventory audit', '');
+	out.push(`- **Base** (before): \`${base}\``);
+	out.push(`- **Head** (after): \`${head}\``);
+	out.push('');
+	out.push('## Compiled + compressed size', '');
+	out.push(`**${identical}/${identical + changed} outputs are byte-identical** (sha256).`, '');
+	out.push('| Module | Before (B) | After (B) | Δ raw | gzip before | gzip after | Status |');
+	out.push('| --- | ---: | ---: | ---: | ---: | ---: | :---: |');
+	out.push(...(rows.length ? rows : ['| _(all modules byte-identical; run with `--full` to list)_ | | | | | | |']));
+	out.push('');
+
+	// Deprecation inventory.
+	out.push('## Deprecated elements — before vs after', '');
+	out.push(`- **Before**: ${beforeMarkers.length} legacy comment markers found by heuristic scan (no single machine-readable source).`);
+	out.push(`- **After**: ${afterManifest ? afterManifest.entries.length : 0} exact registry entries in \`deprecations.json\`.`, '');
+
+	if (afterManifest) {
+		const byKind = {};
+		for (const e of afterManifest.entries) {
+			byKind[e.kind] = (byKind[e.kind] || 0) + 1;
+		}
+		out.push('### After — registry entries by kind', '');
+		out.push('| Kind | Count |', '| --- | ---: |');
+		for (const [kind, count] of Object.entries(byKind).sort()) {
+			out.push(`| ${kind} | ${count} |`);
+		}
+		out.push('');
+		out.push('### After — full deprecated inventory', '');
+		out.push('| Kind | Name | Replacement | Scope |', '| --- | --- | --- | --- |');
+		for (const e of afterManifest.entries) {
+			out.push(`| ${e.kind} | \`${e.name}\` | ${e.replacement ? `\`${e.replacement}\`` : '—'} | ${e.scope || ''} |`);
+		}
+		out.push('');
+	}
+
+	out.push('### Before — legacy comment markers', '');
+	out.push('| File | Line | Marker |', '| --- | ---: | --- |');
+	for (const m of beforeMarkers) {
+		out.push(`| ${m.file} | ${m.line} | ${m.text.replace(/\|/g, '\\|')} |`);
+	}
+	out.push('');
+
+	return { report: out.join('\n'), identical, changed };
+}
+
+async function main() {
+	const base = git(['merge-base', 'HEAD', 'origin/rc']);
+	const head = git(['rev-parse', 'HEAD']);
+	const worktree = path.join(os.tmpdir(), `lf-audit-before-${base.slice(0, 8)}`);
+
+	console.log(`Base (before): ${base}`);
+	console.log(`Head (after):  ${head}`);
+
+	let before;
+	let beforeMarkers;
+	try {
+		if (fs.existsSync(worktree)) {
+			git(['worktree', 'remove', '--force', worktree]);
+		}
+		git(['worktree', 'add', '--detach', worktree, base]);
+		console.log('Measuring BEFORE...');
+		before = await snapshotSizes(worktree);
+		beforeMarkers = scanLegacyMarkers(worktree);
+	} finally {
+		try {
+			git(['worktree', 'remove', '--force', worktree]);
+		} catch (e) {
+			console.warn(`Could not remove worktree ${worktree}: ${e.message}`);
+		}
+	}
+
+	console.log('Measuring AFTER...');
+	const after = await snapshotSizes(MAIN_ROOT);
+	const afterManifest = readManifest(MAIN_ROOT);
+
+	const { report, identical, changed } = buildReport({ base, head, before, after, beforeMarkers, afterManifest });
+	fs.writeFileSync(REPORT, report);
+	console.log(`\nWrote ${path.relative(MAIN_ROOT, REPORT)}`);
+	console.log(`${identical} identical, ${changed} changed.`);
+
+	if (changed > 0 && !process.argv.includes('--allow-diff')) {
+		console.error('\nSize/hash differences detected. See the report. Pass --allow-diff to allow.');
+		process.exit(1);
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/packages/scss/tools/audit-size.js
+++ b/packages/scss/tools/audit-size.js
@@ -82,8 +82,17 @@ async function snapshotSizes(repoRoot) {
 	modules['bundle (maximal config)'] = measure(maximal.css);
 
 	// Per module — plain compressed (autoprefixer is identical on both sides, so it
-	// adds nothing to a delta and doubles the cost across 125 compiles).
-	modules['commons (main.scss)'] = measure(sass.compile(path.join(src, 'main.scss'), opts).css);
+	// adds nothing to a delta and doubles the cost across 125 compiles). Some modules
+	// may not compile standalone in a given tree (pre-existing broken component); record
+	// those as errored rather than aborting the whole audit.
+	const compileModule = (key, input) => {
+		try {
+			modules[key] = measure(sass.compile(input, opts).css);
+		} catch (e) {
+			modules[key] = { error: e.message.split('\n')[0] };
+		}
+	};
+	compileModule('commons (main.scss)', path.join(src, 'main.scss'));
 	const componentsDir = path.join(src, 'components');
 	for (const dirent of fs.readdirSync(componentsDir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
 		if (!dirent.isDirectory() || dirent.name.startsWith('_')) {
@@ -91,7 +100,7 @@ async function snapshotSizes(repoRoot) {
 		}
 		const index = path.join(componentsDir, dirent.name, 'index.scss');
 		if (fs.existsSync(index)) {
-			modules[`components/${dirent.name}`] = measure(sass.compile(index, opts).css);
+			compileModule(`components/${dirent.name}`, index);
 		}
 	}
 	return modules;
@@ -141,15 +150,20 @@ function buildReport({ base, head, before, after, beforeMarkers, afterManifest }
 	let identical = 0;
 	let changed = 0;
 	const rows = [];
+	let errored = 0;
 	for (const key of keys) {
 		const b = before[key];
 		const a = after[key];
-		if (b && a) {
+		if (b && a && !b.error && !a.error) {
 			const same = b.sha256 === a.sha256;
 			same ? identical++ : changed++;
 			if (!same || process.argv.includes('--full')) {
 				rows.push(`| \`${key}\` | ${fmtBytes(b.raw)} | ${fmtBytes(a.raw)} | ${a.raw - b.raw} | ${fmtBytes(b.gzip)} | ${fmtBytes(a.gzip)} | ${same ? '✅' : '⚠️ changed'} |`);
 			}
+		} else if ((b && b.error) || (a && a.error)) {
+			errored++;
+			const note = (a && a.error) || (b && b.error);
+			rows.push(`| \`${key}\` | ${b && !b.error ? fmtBytes(b.raw) : 'n/a'} | ${a && !a.error ? fmtBytes(a.raw) : 'n/a'} | n/a | — | — | ⓘ does not compile standalone (${note.replace(/\|/g, '\\|')}) |`);
 		} else {
 			changed++;
 			rows.push(`| \`${key}\` | ${b ? fmtBytes(b.raw) : '—'} | ${a ? fmtBytes(a.raw) : '—'} | ${b && a ? a.raw - b.raw : 'n/a'} | ${b ? fmtBytes(b.gzip) : '—'} | ${a ? fmtBytes(a.gzip) : '—'} | ${b ? '➖ removed' : '➕ added'} |`);
@@ -162,7 +176,7 @@ function buildReport({ base, head, before, after, beforeMarkers, afterManifest }
 	out.push(`- **Head** (after): \`${head}\``);
 	out.push('');
 	out.push('## Compiled + compressed size', '');
-	out.push(`**${identical}/${identical + changed} outputs are byte-identical** (sha256).`, '');
+	out.push(`**${identical}/${identical + changed} comparable outputs are byte-identical** (sha256)${errored ? `; ${errored} module(s) do not compile standalone in one of the trees and are excluded` : ''}.`, '');
 	out.push('| Module | Before (B) | After (B) | Δ raw | gzip before | gzip after | Status |');
 	out.push('| --- | ---: | ---: | ---: | ---: | ---: | :---: |');
 	out.push(...(rows.length ? rows : ['| _(all modules byte-identical; run with `--full` to list)_ | | | | | | |']));
@@ -203,7 +217,10 @@ function buildReport({ base, head, before, after, beforeMarkers, afterManifest }
 }
 
 async function main() {
-	const base = git(['merge-base', 'HEAD', 'origin/rc']);
+	// `--base <ref>` isolates a specific change (e.g. the commit before a refactor);
+	// otherwise compare against the merge-base with rc.
+	const baseArgIndex = process.argv.indexOf('--base');
+	const base = baseArgIndex !== -1 ? git(['rev-parse', process.argv[baseArgIndex + 1]]) : git(['merge-base', 'HEAD', 'origin/rc']);
 	const head = git(['rev-parse', 'HEAD']);
 	const worktree = path.join(os.tmpdir(), `lf-audit-before-${base.slice(0, 8)}`);
 

--- a/scss-size-audit.md
+++ b/scss-size-audit.md
@@ -1,0 +1,1055 @@
+# SCSS deprecation refactor — size & inventory audit
+
+- **Base** (before): `aa6d5185301a8bd7167a34537a440ad49cf63e9b`
+- **Head** (after): `e8c04524eebd2b483aee10c07df55ca1c6279208`
+
+## Compiled + compressed size
+
+**125/125 comparable outputs are byte-identical** (sha256); 1 module(s) do not compile standalone in one of the trees and are excluded.
+
+| Module | Before (B) | After (B) | Δ raw | gzip before | gzip after | Status |
+| --- | ---: | ---: | ---: | ---: | ---: | :---: |
+| `bundle (lucca-front.min.css)` | 1,242,368 | 1,242,368 | 0 | 120,200 | 120,200 | ✅ |
+| `bundle (maximal config)` | 1,248,519 | 1,248,519 | 0 | 121,334 | 121,334 | ✅ |
+| `commons (main.scss)` | 122,149 | 122,149 | 0 | 16,679 | 16,679 | ✅ |
+| `components/activityFeed` | 6,887 | 6,887 | 0 | 1,376 | 1,376 | ✅ |
+| `components/appLayout` | 1,645 | 1,645 | 0 | 497 | 497 | ✅ |
+| `components/avatar` | 8,109 | 8,109 | 0 | 1,381 | 1,381 | ✅ |
+| `components/box` | 2,239 | 2,239 | 0 | 653 | 653 | ✅ |
+| `components/breadcrumbs` | 4,239 | 4,239 | 0 | 927 | 927 | ✅ |
+| `components/bubbleIcon` | 4,698 | 4,698 | 0 | 781 | 781 | ✅ |
+| `components/bubbleIllustration` | 2,528 | 2,528 | 0 | 438 | 438 | ✅ |
+| `components/button` | 21,360 | 21,360 | 0 | 2,846 | 2,846 | ✅ |
+| `components/buttonGroup` | 2,122 | 2,122 | 0 | 546 | 546 | ✅ |
+| `components/calendar` | 24,737 | 24,737 | 0 | 2,610 | 2,610 | ✅ |
+| `components/callout` | 8,703 | 8,703 | 0 | 1,582 | 1,582 | ✅ |
+| `components/calloutAccordion` | 2,986 | 2,986 | 0 | 706 | 706 | ✅ |
+| `components/calloutDisclosure` | 4,340 | 4,340 | 0 | 924 | 924 | ✅ |
+| `components/calloutFeedbackList` | 3,372 | 3,372 | 0 | 610 | 610 | ✅ |
+| `components/calloutPopover` | 3,636 | 3,636 | 0 | 809 | 809 | ✅ |
+| `components/card` | 3,687 | 3,687 | 0 | 942 | 942 | ✅ |
+| `components/checkbox` | 5,239 | 5,239 | 0 | 1,184 | 1,184 | ✅ |
+| `components/checkboxField` | 10,442 | 10,442 | 0 | 1,388 | 1,388 | ✅ |
+| `components/chip` | 3,943 | 3,943 | 0 | 1,151 | 1,151 | ✅ |
+| `components/clear` | 3,106 | 3,106 | 0 | 961 | 961 | ✅ |
+| `components/code` | 396 | 396 | 0 | 249 | 249 | ✅ |
+| `components/collapse` | 937 | 937 | 0 | 461 | 461 | ✅ |
+| `components/color` | 3,849 | 3,849 | 0 | 1,132 | 1,132 | ✅ |
+| `components/comment` | 4,715 | 4,715 | 0 | 1,015 | 1,015 | ✅ |
+| `components/container` | 1,094 | 1,094 | 0 | 282 | 282 | ✅ |
+| `components/contentSection` | 149 | 149 | 0 | 104 | 104 | ✅ |
+| `components/dataTable` | 27,689 | 27,689 | 0 | 2,582 | 2,582 | ✅ |
+| `components/dataTableSticked` | 9,221 | 9,221 | 0 | 1,108 | 1,108 | ✅ |
+| `components/dateField` | 1,849 | 1,849 | 0 | 381 | 381 | ✅ |
+| `components/dateRangeField` | 5,142 | 5,142 | 0 | 918 | 918 | ✅ |
+| `components/dialog` | 18,422 | 18,422 | 0 | 2,712 | 2,712 | ✅ |
+| `components/divider` | 4,079 | 4,079 | 0 | 915 | 915 | ✅ |
+| `components/dropdown` | 5,453 | 5,453 | 0 | 1,047 | 1,047 | ✅ |
+| `components/emptyState` | 5,626 | 5,626 | 0 | 1,161 | 1,161 | ✅ |
+| `components/errorPage` | 1,760 | 1,760 | 0 | 542 | 542 | ✅ |
+| `components/fancyBox` | 3,298 | 3,298 | 0 | 755 | 755 | ✅ |
+| `components/field` | 134,868 | 134,868 | 0 | 8,351 | 8,351 | ✅ |
+| `components/fieldset` | 4,961 | 4,961 | 0 | 1,170 | 1,170 | ✅ |
+| `components/file` | 5,956 | 5,956 | 0 | 1,240 | 1,240 | ✅ |
+| `components/fileEntry` | 7,567 | 7,567 | 0 | 1,564 | 1,564 | ✅ |
+| `components/fileToolbar` | 2,669 | 2,669 | 0 | 659 | 659 | ✅ |
+| `components/fileUpload` | 8,230 | 8,230 | 0 | 1,566 | 1,566 | ✅ |
+| `components/filterBar` | 3,645 | 3,645 | 0 | 903 | 903 | ✅ |
+| `components/filterBarDeprecated` | 2,277 | 2,277 | 0 | 661 | 661 | ✅ |
+| `components/filterPill` | 12,905 | 12,905 | 0 | 2,070 | 2,070 | ✅ |
+| `components/filters` | 1,467 | 1,467 | 0 | 525 | 525 | ✅ |
+| `components/footer` | 4,181 | 4,181 | 0 | 782 | 782 | ✅ |
+| `components/form` | 48,180 | 48,180 | 0 | 4,603 | 4,603 | ✅ |
+| `components/formLabel` | 3,736 | 3,736 | 0 | 762 | 762 | ✅ |
+| `components/gauge` | 3,943 | 3,943 | 0 | 895 | 895 | ✅ |
+| `components/grid` | 20,395 | 20,395 | 0 | 1,572 | 1,572 | ✅ |
+| `components/header` | 3,304 | 3,304 | 0 | 1,101 | 1,101 | ✅ |
+| `components/highlightData` | 4,754 | 4,754 | 0 | 995 | 995 | ✅ |
+| `components/highlightText` | 2,356 | 2,356 | 0 | 417 | 417 | ✅ |
+| `components/horizontalNavigation` | 19,319 | 19,319 | 0 | 2,470 | 2,470 | ✅ |
+| `components/impersonation` | 3,339 | 3,339 | 0 | 797 | 797 | ✅ |
+| `components/indexTable` | 43,411 | 43,411 | 0 | 4,754 | 4,754 | ✅ |
+| `components/inlineMessage` | 1,967 | 1,967 | 0 | 482 | 482 | ✅ |
+| `components/inputFramed` | 6,511 | 6,511 | 0 | 1,089 | 1,089 | ✅ |
+| `components/label` | 1,751 | 1,751 | 0 | 439 | 439 | ✅ |
+| `components/layout` | 5,018 | 5,018 | 0 | 973 | 973 | ✅ |
+| `components/link` | 1,946 | 1,946 | 0 | 642 | 642 | ✅ |
+| `components/list` | 2,286 | 2,286 | 0 | 820 | 820 | ✅ |
+| `components/listboxOption` | 24,042 | 24,042 | 0 | 2,064 | 2,064 | ✅ |
+| `components/listing` | 6,176 | 6,176 | 0 | 1,274 | 1,274 | ✅ |
+| `components/loading` | 3,575 | 3,575 | 0 | 850 | 850 | ✅ |
+| `components/main` | 813 | 813 | 0 | 307 | 307 | ✅ |
+| `components/mainLayout` | 4,498 | 4,498 | 0 | 847 | 847 | ✅ |
+| `components/mobileHeader` | 970 | 970 | 0 | 397 | 397 | ✅ |
+| `components/mobileNavigation` | 1,287 | 1,287 | 0 | 521 | 521 | ✅ |
+| `components/mobilePush` | 1,770 | 1,770 | 0 | 585 | 585 | ✅ |
+| `components/multiSelect` | 7,283 | 7,283 | 0 | 1,432 | 1,432 | ✅ |
+| `components/navside` | 15,008 | 15,008 | 0 | 2,590 | 2,590 | ✅ |
+| `components/newBadge` | 600 | 600 | 0 | 252 | 252 | ✅ |
+| `components/notchBox` | 14,021 | 14,021 | 0 | 1,443 | 1,443 | ✅ |
+| `components/numericBadge` | 2,628 | 2,628 | 0 | 775 | 775 | ✅ |
+| `components/pageHeader` | 5,407 | 5,407 | 0 | 1,116 | 1,116 | ✅ |
+| `components/pagination` | 846 | 846 | 0 | 344 | 344 | ✅ |
+| `components/phoneNumber` | 412 | 412 | 0 | 240 | 240 | ✅ |
+| `components/plgPush` | 1,176 | 1,176 | 0 | 450 | 450 | ✅ |
+| `components/popover` | 3,485 | 3,485 | 0 | 893 | 893 | ✅ |
+| `components/presentation` | 1,228 | 1,228 | 0 | 456 | 456 | ✅ |
+| `components/progress` | 2,234 | 2,234 | 0 | 672 | 672 | ✅ |
+| `components/progressStepper` | 15,974 | 15,974 | 0 | 1,677 | 1,677 | ✅ |
+| `components/radio` | 3,862 | 3,862 | 0 | 861 | 861 | ✅ |
+| `components/radioButtons` | 3,264 | 3,264 | 0 | 786 | 786 | ✅ |
+| `components/radioField` | 3,553 | 3,553 | 0 | 787 | 787 | ✅ |
+| `components/readMore` | 2,999 | 2,999 | 0 | 845 | 845 | ✅ |
+| `components/resourceCard` | 17,815 | 17,815 | 0 | 2,251 | 2,251 | ✅ |
+| `components/richText` | 6,650 | 6,650 | 0 | 1,213 | 1,213 | ✅ |
+| `components/scrollBox` | 4,664 | 4,664 | 0 | 910 | 910 | ✅ |
+| `components/section` | 431 | 431 | 0 | 221 | 221 | ✅ |
+| `components/segmentedControl` | 7,400 | 7,400 | 0 | 1,363 | 1,363 | ✅ |
+| `components/simpleSelect` | 6,296 | 6,296 | 0 | 1,177 | 1,177 | ✅ |
+| `components/skeleton` | 5,977 | 5,977 | 0 | 907 | 907 | ✅ |
+| `components/skipLinks` | 1,188 | 1,188 | 0 | 535 | 535 | ✅ |
+| `components/softwareIcon` | 6,124 | 6,124 | 0 | 1,086 | 1,086 | ✅ |
+| `components/sortableList` | 5,728 | 5,728 | 0 | 1,132 | 1,132 | ✅ |
+| `components/statusBadge` | 1,693 | 1,693 | 0 | 557 | 557 | ✅ |
+| `components/suggestion` | 798 | 798 | 0 | 282 | 282 | ✅ |
+| `components/switch` | 5,111 | 5,111 | 0 | 1,126 | 1,126 | ✅ |
+| `components/switchField` | 4,711 | 4,711 | 0 | 980 | 980 | ✅ |
+| `components/table` | 16,467 | 16,467 | 0 | 2,143 | 2,143 | ✅ |
+| `components/tableFixed` | 4,664 | 4,664 | 0 | 390 | 390 | ✅ |
+| `components/tableFixedDeprecated` | 45,055 | 45,055 | 0 | 2,403 | 2,403 | ✅ |
+| `components/tableOfContent` | 4,420 | 4,420 | 0 | 712 | 712 | ✅ |
+| `components/tableSortable` | 3,950 | 3,950 | 0 | 819 | 819 | ✅ |
+| `components/tableSticked` | 8,315 | 8,315 | 0 | 1,003 | 1,003 | ✅ |
+| `components/tableStickedDeprecated` | 146,155 | 146,155 | 0 | 5,703 | 5,703 | ✅ |
+| `components/tag` | 3,751 | 3,751 | 0 | 930 | 930 | ✅ |
+| `components/textField` | 12,177 | 12,177 | 0 | 1,907 | 1,907 | ✅ |
+| `components/textfields` | 40,211 | 40,211 | 0 | 4,315 | 4,315 | ✅ |
+| `components/textFlow` | 618 | 618 | 0 | 191 | 191 | ✅ |
+| `components/timeline` | 11,802 | 11,802 | 0 | 1,820 | 1,820 | ✅ |
+| `components/timepicker` | 7,558 | 7,558 | 0 | 1,462 | 1,462 | ✅ |
+| `components/timepickerDeprecated` | n/a | n/a | n/a | — | — | ⓘ does not compile standalone (Can't find stylesheet to import.) |
+| `components/title` | 1,335 | 1,335 | 0 | 387 | 387 | ✅ |
+| `components/titleSection` | 1,283 | 1,283 | 0 | 350 | 350 | ✅ |
+| `components/toast` | 3,906 | 3,906 | 0 | 977 | 977 | ✅ |
+| `components/tooltip` | 1,670 | 1,670 | 0 | 548 | 548 | ✅ |
+| `components/userPopover` | 2,110 | 2,110 | 0 | 629 | 629 | ✅ |
+| `components/userTile` | 2,656 | 2,656 | 0 | 551 | 551 | ✅ |
+| `components/verticalNavigation` | 3,562 | 3,562 | 0 | 781 | 781 | ✅ |
+
+## Deprecated elements — before vs after
+
+- **Before**: 210 legacy comment markers found by heuristic scan (no single machine-readable source).
+- **After**: 684 exact registry entries in `deprecations.json`.
+
+### After — registry entries by kind
+
+| Kind | Count |
+| --- | ---: |
+| class | 477 |
+| css-variable | 140 |
+| sass-api | 18 |
+| selector | 49 |
+
+### After — full deprecated inventory
+
+| Kind | Name | Replacement | Scope |
+| --- | --- | --- | --- |
+| sass-api | `config palette: grey` | — | commons/config |
+| sass-api | `config palette: lucca` | — | commons/config |
+| sass-api | `config palette: primary` | — | commons/config |
+| sass-api | `config palette: secondary` | — | commons/config |
+| sass-api | `config.$borderRadius` | `config.$borderRadiusVars` | commons/config |
+| sass-api | `config.$colors` | — | commons/config |
+| sass-api | `config.$colorsRgb` | — | commons/config |
+| sass-api | `config.$deprecatedCardBoxMargin` | — | commons/config |
+| sass-api | `config.$deprecatedSpacings` | — | commons/config |
+| sass-api | `config.$deprecatedUtilityPrefix` | — | commons/config |
+| sass-api | `core.borderRadius` | `core.borderRadiusTokens` | commons/core |
+| sass-api | `core.sizes` | — | commons/core |
+| class | `pr-u-borderBottom0` | `pr-u-borderBlockEnd0` | commons/utils |
+| class | `pr-u-borderBottomLeftRadiusFull` | — | commons/utils |
+| class | `pr-u-borderBottomLeftRadiusL` | — | commons/utils |
+| class | `pr-u-borderBottomLeftRadiusM` | — | commons/utils |
+| class | `pr-u-borderBottomLeftRadiusXL` | — | commons/utils |
+| class | `pr-u-borderBottomRightRadiusFull` | — | commons/utils |
+| class | `pr-u-borderBottomRightRadiusL` | — | commons/utils |
+| class | `pr-u-borderBottomRightRadiusM` | — | commons/utils |
+| class | `pr-u-borderBottomRightRadiusXL` | — | commons/utils |
+| class | `pr-u-borderEndEndRadiusFull` | — | commons/utils |
+| class | `pr-u-borderEndEndRadiusL` | — | commons/utils |
+| class | `pr-u-borderEndEndRadiusM` | — | commons/utils |
+| class | `pr-u-borderEndEndRadiusXL` | — | commons/utils |
+| class | `pr-u-borderEndStartRadiusFull` | — | commons/utils |
+| class | `pr-u-borderEndStartRadiusL` | — | commons/utils |
+| class | `pr-u-borderEndStartRadiusM` | — | commons/utils |
+| class | `pr-u-borderEndStartRadiusXL` | — | commons/utils |
+| class | `pr-u-borderLeft0` | `pr-u-borderInlineStart0` | commons/utils |
+| class | `pr-u-borderRadiusL` | — | commons/utils |
+| class | `pr-u-borderRadiusM` | — | commons/utils |
+| class | `pr-u-borderRadiusXL` | — | commons/utils |
+| class | `pr-u-borderRight0` | `pr-u-borderInlineEnd0` | commons/utils |
+| class | `pr-u-borderStartEndRadiusFull` | — | commons/utils |
+| class | `pr-u-borderStartEndRadiusL` | — | commons/utils |
+| class | `pr-u-borderStartEndRadiusM` | — | commons/utils |
+| class | `pr-u-borderStartEndRadiusXL` | — | commons/utils |
+| class | `pr-u-borderStartStartRadiusFull` | — | commons/utils |
+| class | `pr-u-borderStartStartRadiusL` | — | commons/utils |
+| class | `pr-u-borderStartStartRadiusM` | — | commons/utils |
+| class | `pr-u-borderStartStartRadiusXL` | — | commons/utils |
+| class | `pr-u-borderTop0` | `pr-u-borderBlockStart0` | commons/utils |
+| class | `pr-u-borderTopLeftRadiusFull` | — | commons/utils |
+| class | `pr-u-borderTopLeftRadiusL` | — | commons/utils |
+| class | `pr-u-borderTopLeftRadiusM` | — | commons/utils |
+| class | `pr-u-borderTopLeftRadiusXL` | — | commons/utils |
+| class | `pr-u-borderTopRightRadiusFull` | — | commons/utils |
+| class | `pr-u-borderTopRightRadiusL` | — | commons/utils |
+| class | `pr-u-borderTopRightRadiusM` | — | commons/utils |
+| class | `pr-u-borderTopRightRadiusXL` | — | commons/utils |
+| class | `pr-u-bottom0` | `pr-u-insetBlockEnd0` | commons/utils |
+| class | `pr-u-bottomReset` | `pr-u-insetBlockEnd0` | commons/utils |
+| class | `pr-u-clear` | `pr-u-clearBoth` | commons/utils |
+| class | `pr-u-clearLeft` | `pr-u-clearInlineStart` | commons/utils |
+| class | `pr-u-clearRight` | `pr-u-clearInlineEnd` | commons/utils |
+| class | `pr-u-floatLeft` | `pr-u-floatInlineStart` | commons/utils |
+| class | `pr-u-floatRight` | `pr-u-floatInlineEnd` | commons/utils |
+| class | `pr-u-h5` | — | commons/utils |
+| class | `pr-u-h6` | — | commons/utils |
+| class | `pr-u-insetReset` | `pr-u-inset0` | commons/utils |
+| class | `pr-u-left0` | `pr-u-insetInlineStart0` | commons/utils |
+| class | `pr-u-leftReset` | `pr-u-insetInlineStart0` | commons/utils |
+| class | `pr-u-marginBottom0` | `pr-u-marginBlockEnd0` | commons/utils |
+| class | `pr-u-marginBottom100` | `pr-u-marginBlockEnd100` | commons/utils |
+| class | `pr-u-marginBottom150` | `pr-u-marginBlockEnd150` | commons/utils |
+| class | `pr-u-marginBottom200` | `pr-u-marginBlockEnd200` | commons/utils |
+| class | `pr-u-marginBottom25` | `pr-u-marginBlockEnd25` | commons/utils |
+| class | `pr-u-marginBottom250` | `pr-u-marginBlockEnd250` | commons/utils |
+| class | `pr-u-marginBottom300` | `pr-u-marginBlockEnd300` | commons/utils |
+| class | `pr-u-marginBottom400` | `pr-u-marginBlockEnd400` | commons/utils |
+| class | `pr-u-marginBottom50` | `pr-u-marginBlockEnd50` | commons/utils |
+| class | `pr-u-marginBottom500` | `pr-u-marginBlockEnd500` | commons/utils |
+| class | `pr-u-marginBottom600` | `pr-u-marginBlockEnd600` | commons/utils |
+| class | `pr-u-marginBottom700` | `pr-u-marginBlockEnd700` | commons/utils |
+| class | `pr-u-marginBottom75` | `pr-u-marginBlockEnd75` | commons/utils |
+| class | `pr-u-marginBottom800` | `pr-u-marginBlockEnd800` | commons/utils |
+| class | `pr-u-marginBottomAuto` | `pr-u-marginBlockEndAuto` | commons/utils |
+| class | `pr-u-marginLeft0` | `pr-u-marginInlineStart0` | commons/utils |
+| class | `pr-u-marginLeft100` | `pr-u-marginInlineStart100` | commons/utils |
+| class | `pr-u-marginLeft150` | `pr-u-marginInlineStart150` | commons/utils |
+| class | `pr-u-marginLeft200` | `pr-u-marginInlineStart200` | commons/utils |
+| class | `pr-u-marginLeft25` | `pr-u-marginInlineStart25` | commons/utils |
+| class | `pr-u-marginLeft250` | `pr-u-marginInlineStart250` | commons/utils |
+| class | `pr-u-marginLeft300` | `pr-u-marginInlineStart300` | commons/utils |
+| class | `pr-u-marginLeft400` | `pr-u-marginInlineStart400` | commons/utils |
+| class | `pr-u-marginLeft50` | `pr-u-marginInlineStart50` | commons/utils |
+| class | `pr-u-marginLeft500` | `pr-u-marginInlineStart500` | commons/utils |
+| class | `pr-u-marginLeft600` | `pr-u-marginInlineStart600` | commons/utils |
+| class | `pr-u-marginLeft700` | `pr-u-marginInlineStart700` | commons/utils |
+| class | `pr-u-marginLeft75` | `pr-u-marginInlineStart75` | commons/utils |
+| class | `pr-u-marginLeft800` | `pr-u-marginInlineStart800` | commons/utils |
+| class | `pr-u-marginLeftAuto` | `pr-u-marginInlineStartAuto` | commons/utils |
+| class | `pr-u-marginRight0` | `pr-u-marginInlineEnd0` | commons/utils |
+| class | `pr-u-marginRight100` | `pr-u-marginInlineEnd100` | commons/utils |
+| class | `pr-u-marginRight150` | `pr-u-marginInlineEnd150` | commons/utils |
+| class | `pr-u-marginRight200` | `pr-u-marginInlineEnd200` | commons/utils |
+| class | `pr-u-marginRight25` | `pr-u-marginInlineEnd25` | commons/utils |
+| class | `pr-u-marginRight250` | `pr-u-marginInlineEnd250` | commons/utils |
+| class | `pr-u-marginRight300` | `pr-u-marginInlineEnd300` | commons/utils |
+| class | `pr-u-marginRight400` | `pr-u-marginInlineEnd400` | commons/utils |
+| class | `pr-u-marginRight50` | `pr-u-marginInlineEnd50` | commons/utils |
+| class | `pr-u-marginRight500` | `pr-u-marginInlineEnd500` | commons/utils |
+| class | `pr-u-marginRight600` | `pr-u-marginInlineEnd600` | commons/utils |
+| class | `pr-u-marginRight700` | `pr-u-marginInlineEnd700` | commons/utils |
+| class | `pr-u-marginRight75` | `pr-u-marginInlineEnd75` | commons/utils |
+| class | `pr-u-marginRight800` | `pr-u-marginInlineEnd800` | commons/utils |
+| class | `pr-u-marginRightAuto` | `pr-u-marginInlineEndAuto` | commons/utils |
+| class | `pr-u-marginTop0` | `pr-u-marginBlockStart0` | commons/utils |
+| class | `pr-u-marginTop100` | `pr-u-marginBlockStart100` | commons/utils |
+| class | `pr-u-marginTop150` | `pr-u-marginBlockStart150` | commons/utils |
+| class | `pr-u-marginTop200` | `pr-u-marginBlockStart200` | commons/utils |
+| class | `pr-u-marginTop25` | `pr-u-marginBlockStart25` | commons/utils |
+| class | `pr-u-marginTop250` | `pr-u-marginBlockStart250` | commons/utils |
+| class | `pr-u-marginTop300` | `pr-u-marginBlockStart300` | commons/utils |
+| class | `pr-u-marginTop400` | `pr-u-marginBlockStart400` | commons/utils |
+| class | `pr-u-marginTop50` | `pr-u-marginBlockStart50` | commons/utils |
+| class | `pr-u-marginTop500` | `pr-u-marginBlockStart500` | commons/utils |
+| class | `pr-u-marginTop600` | `pr-u-marginBlockStart600` | commons/utils |
+| class | `pr-u-marginTop700` | `pr-u-marginBlockStart700` | commons/utils |
+| class | `pr-u-marginTop75` | `pr-u-marginBlockStart75` | commons/utils |
+| class | `pr-u-marginTop800` | `pr-u-marginBlockStart800` | commons/utils |
+| class | `pr-u-marginTopAuto` | `pr-u-marginBlockStartAuto` | commons/utils |
+| class | `pr-u-paddingBottom0` | `pr-u-paddingBlockEnd0` | commons/utils |
+| class | `pr-u-paddingBottom100` | `pr-u-paddingBlockEnd100` | commons/utils |
+| class | `pr-u-paddingBottom150` | `pr-u-paddingBlockEnd150` | commons/utils |
+| class | `pr-u-paddingBottom200` | `pr-u-paddingBlockEnd200` | commons/utils |
+| class | `pr-u-paddingBottom25` | `pr-u-paddingBlockEnd25` | commons/utils |
+| class | `pr-u-paddingBottom250` | `pr-u-paddingBlockEnd250` | commons/utils |
+| class | `pr-u-paddingBottom300` | `pr-u-paddingBlockEnd300` | commons/utils |
+| class | `pr-u-paddingBottom400` | `pr-u-paddingBlockEnd400` | commons/utils |
+| class | `pr-u-paddingBottom50` | `pr-u-paddingBlockEnd50` | commons/utils |
+| class | `pr-u-paddingBottom500` | `pr-u-paddingBlockEnd500` | commons/utils |
+| class | `pr-u-paddingBottom600` | `pr-u-paddingBlockEnd600` | commons/utils |
+| class | `pr-u-paddingBottom700` | `pr-u-paddingBlockEnd700` | commons/utils |
+| class | `pr-u-paddingBottom75` | `pr-u-paddingBlockEnd75` | commons/utils |
+| class | `pr-u-paddingBottom800` | `pr-u-paddingBlockEnd800` | commons/utils |
+| class | `pr-u-paddingLeft0` | `pr-u-paddingInlineStart0` | commons/utils |
+| class | `pr-u-paddingLeft100` | `pr-u-paddingInlineStart100` | commons/utils |
+| class | `pr-u-paddingLeft150` | `pr-u-paddingInlineStart150` | commons/utils |
+| class | `pr-u-paddingLeft200` | `pr-u-paddingInlineStart200` | commons/utils |
+| class | `pr-u-paddingLeft25` | `pr-u-paddingInlineStart25` | commons/utils |
+| class | `pr-u-paddingLeft250` | `pr-u-paddingInlineStart250` | commons/utils |
+| class | `pr-u-paddingLeft300` | `pr-u-paddingInlineStart300` | commons/utils |
+| class | `pr-u-paddingLeft400` | `pr-u-paddingInlineStart400` | commons/utils |
+| class | `pr-u-paddingLeft50` | `pr-u-paddingInlineStart50` | commons/utils |
+| class | `pr-u-paddingLeft500` | `pr-u-paddingInlineStart500` | commons/utils |
+| class | `pr-u-paddingLeft600` | `pr-u-paddingInlineStart600` | commons/utils |
+| class | `pr-u-paddingLeft700` | `pr-u-paddingInlineStart700` | commons/utils |
+| class | `pr-u-paddingLeft75` | `pr-u-paddingInlineStart75` | commons/utils |
+| class | `pr-u-paddingLeft800` | `pr-u-paddingInlineStart800` | commons/utils |
+| class | `pr-u-paddingRight0` | `pr-u-paddingInlineEnd0` | commons/utils |
+| class | `pr-u-paddingRight100` | `pr-u-paddingInlineEnd100` | commons/utils |
+| class | `pr-u-paddingRight150` | `pr-u-paddingInlineEnd150` | commons/utils |
+| class | `pr-u-paddingRight200` | `pr-u-paddingInlineEnd200` | commons/utils |
+| class | `pr-u-paddingRight25` | `pr-u-paddingInlineEnd25` | commons/utils |
+| class | `pr-u-paddingRight250` | `pr-u-paddingInlineEnd250` | commons/utils |
+| class | `pr-u-paddingRight300` | `pr-u-paddingInlineEnd300` | commons/utils |
+| class | `pr-u-paddingRight400` | `pr-u-paddingInlineEnd400` | commons/utils |
+| class | `pr-u-paddingRight50` | `pr-u-paddingInlineEnd50` | commons/utils |
+| class | `pr-u-paddingRight500` | `pr-u-paddingInlineEnd500` | commons/utils |
+| class | `pr-u-paddingRight600` | `pr-u-paddingInlineEnd600` | commons/utils |
+| class | `pr-u-paddingRight700` | `pr-u-paddingInlineEnd700` | commons/utils |
+| class | `pr-u-paddingRight75` | `pr-u-paddingInlineEnd75` | commons/utils |
+| class | `pr-u-paddingRight800` | `pr-u-paddingInlineEnd800` | commons/utils |
+| class | `pr-u-paddingTop0` | `pr-u-paddingBlockStart0` | commons/utils |
+| class | `pr-u-paddingTop100` | `pr-u-paddingBlockStart100` | commons/utils |
+| class | `pr-u-paddingTop150` | `pr-u-paddingBlockStart150` | commons/utils |
+| class | `pr-u-paddingTop200` | `pr-u-paddingBlockStart200` | commons/utils |
+| class | `pr-u-paddingTop25` | `pr-u-paddingBlockStart25` | commons/utils |
+| class | `pr-u-paddingTop250` | `pr-u-paddingBlockStart250` | commons/utils |
+| class | `pr-u-paddingTop300` | `pr-u-paddingBlockStart300` | commons/utils |
+| class | `pr-u-paddingTop400` | `pr-u-paddingBlockStart400` | commons/utils |
+| class | `pr-u-paddingTop50` | `pr-u-paddingBlockStart50` | commons/utils |
+| class | `pr-u-paddingTop500` | `pr-u-paddingBlockStart500` | commons/utils |
+| class | `pr-u-paddingTop600` | `pr-u-paddingBlockStart600` | commons/utils |
+| class | `pr-u-paddingTop700` | `pr-u-paddingBlockStart700` | commons/utils |
+| class | `pr-u-paddingTop75` | `pr-u-paddingBlockStart75` | commons/utils |
+| class | `pr-u-paddingTop800` | `pr-u-paddingBlockStart800` | commons/utils |
+| class | `pr-u-right0` | `pr-u-insetInlineEnd0` | commons/utils |
+| class | `pr-u-rightReset` | `pr-u-insetInlineEnd0` | commons/utils |
+| class | `pr-u-textAlignLeft` | `pr-u-textAlignStart` | commons/utils |
+| class | `pr-u-textAlignRight` | `pr-u-textAlignEnd` | commons/utils |
+| class | `pr-u-textBlueberry` | `pr-u-colorTextBlueberry` | commons/utils |
+| class | `pr-u-textBrand` | `pr-u-colorTextBrand` | commons/utils |
+| class | `pr-u-textBrandContrasted` | `pr-u-colorTextBrandContrasted` | commons/utils |
+| class | `pr-u-textCc` | `pr-u-colorTextCc` | commons/utils |
+| class | `pr-u-textCenter` | `pr-u-textAlignCenter` | commons/utils |
+| class | `pr-u-textCleemy` | `pr-u-colorTextCleemy` | commons/utils |
+| class | `pr-u-textCoreHR` | `pr-u-colorTextCoreHR` | commons/utils |
+| class | `pr-u-textCritical` | `pr-u-colorTextCritical` | commons/utils |
+| class | `pr-u-textCucumber` | `pr-u-colorTextCucumber` | commons/utils |
+| class | `pr-u-textDefault` | — | commons/utils |
+| class | `pr-u-textError` | `pr-u-colorTextError` | commons/utils |
+| class | `pr-u-textGlacier` | `pr-u-colorTextGlacier` | commons/utils |
+| class | `pr-u-textGrape` | `pr-u-colorTextGrape` | commons/utils |
+| class | `pr-u-textGrey` | `pr-u-colorTextGrey` | commons/utils |
+| class | `pr-u-textKiwi` | `pr-u-colorTextKiwi` | commons/utils |
+| class | `pr-u-textL` | — | commons/utils |
+| class | `pr-u-textLagoon` | `pr-u-colorTextLagoon` | commons/utils |
+| class | `pr-u-textLavender` | `pr-u-colorTextLavender` | commons/utils |
+| class | `pr-u-textLeft` | `pr-u-textAlignStart` | commons/utils |
+| class | `pr-u-textLight` | — | commons/utils |
+| class | `pr-u-textLime` | `pr-u-colorTextLime` | commons/utils |
+| class | `pr-u-textLucca` | `pr-u-colorTextLucca` | commons/utils |
+| class | `pr-u-textM` | — | commons/utils |
+| class | `pr-u-textMint` | `pr-u-colorTextMint` | commons/utils |
+| class | `pr-u-textNavigation` | `pr-u-colorTextNavigation` | commons/utils |
+| class | `pr-u-textNeutral` | `pr-u-colorTextNeutral` | commons/utils |
+| class | `pr-u-textOrchid` | `pr-u-colorTextOrchid` | commons/utils |
+| class | `pr-u-textPagga` | `pr-u-colorTextPagga` | commons/utils |
+| class | `pr-u-textPineapple` | `pr-u-colorTextPineapple` | commons/utils |
+| class | `pr-u-textPineappleContrasted` | `pr-u-colorTextPineappleContrasted` | commons/utils |
+| class | `pr-u-textPlaceholder` | `pr-u-colorInputTextPlaceholder` | commons/utils |
+| class | `pr-u-textPoplee` | `pr-u-colorTextPoplee` | commons/utils |
+| class | `pr-u-textPrimary` | `pr-u-colorTextPrimary` | commons/utils |
+| class | `pr-u-textProduct` | `pr-u-colorTextProduct` | commons/utils |
+| class | `pr-u-textPumpkin` | `pr-u-colorTextPumpkin` | commons/utils |
+| class | `pr-u-textRight` | `pr-u-textAlignEnd` | commons/utils |
+| class | `pr-u-textS` | — | commons/utils |
+| class | `pr-u-textSecondary` | `pr-u-colorTextSecondary` | commons/utils |
+| class | `pr-u-textSuccess` | `pr-u-colorTextSuccess` | commons/utils |
+| class | `pr-u-textSuccessContrasted` | `pr-u-colorTextSuccessContrasted` | commons/utils |
+| class | `pr-u-textTimmi` | `pr-u-colorTextTimmi` | commons/utils |
+| class | `pr-u-textWarning` | `pr-u-colorTextWarning` | commons/utils |
+| class | `pr-u-textWarningContrasted` | `pr-u-colorTextWarningContrasted` | commons/utils |
+| class | `pr-u-textWatermelon` | `pr-u-colorTextWatermelon` | commons/utils |
+| class | `pr-u-textXL` | — | commons/utils |
+| class | `pr-u-textXS` | — | commons/utils |
+| class | `pr-u-textXXL` | — | commons/utils |
+| class | `pr-u-textXXXL` | — | commons/utils |
+| class | `pr-u-top0` | `pr-u-insetBlockStart0` | commons/utils |
+| class | `pr-u-topReset` | `pr-u-insetBlockStart0` | commons/utils |
+| class | `u-alignItemsBaseline` | `pr-u-alignItemsBaseline` | commons/utils |
+| class | `u-alignItemsCenter` | `pr-u-alignItemsCenter` | commons/utils |
+| class | `u-alignItemsFlexEnd` | `pr-u-alignItemsFlexEnd` | commons/utils |
+| class | `u-alignItemsFlexStart` | `pr-u-alignItemsFlexStart` | commons/utils |
+| class | `u-alignItemsStretch` | `pr-u-alignItemsStretch` | commons/utils |
+| class | `u-alignSelfBaseline` | `pr-u-alignSelfBaseline` | commons/utils |
+| class | `u-alignSelfCenter` | `pr-u-alignSelfCenter` | commons/utils |
+| class | `u-alignSelfFlexEnd` | `pr-u-alignSelfFlexEnd` | commons/utils |
+| class | `u-alignSelfFlexStart` | `pr-u-alignSelfFlexStart` | commons/utils |
+| class | `u-alignSelfStretch` | `pr-u-alignSelfStretch` | commons/utils |
+| class | `u-animated` | `pr-u-animated` | commons/utils |
+| class | `u-blockSize100\%` | `pr-u-blockSize100\%` | commons/utils |
+| class | `u-blockSizeFitContent` | `pr-u-blockSizeFitContent` | commons/utils |
+| class | `u-bodyM` | `pr-u-bodyM` | commons/utils |
+| class | `u-bodyS` | `pr-u-bodyS` | commons/utils |
+| class | `u-bodyXS` | `pr-u-bodyXS` | commons/utils |
+| class | `u-borderBottomLeftRadiusFull` | — | commons/utils |
+| class | `u-borderBottomLeftRadiusL` | — | commons/utils |
+| class | `u-borderBottomLeftRadiusM` | — | commons/utils |
+| class | `u-borderBottomLeftRadiusXL` | — | commons/utils |
+| class | `u-borderBottomRightRadiusFull` | — | commons/utils |
+| class | `u-borderBottomRightRadiusL` | — | commons/utils |
+| class | `u-borderBottomRightRadiusM` | — | commons/utils |
+| class | `u-borderBottomRightRadiusXL` | — | commons/utils |
+| class | `u-borderEndEndRadiusFull` | — | commons/utils |
+| class | `u-borderEndEndRadiusL` | — | commons/utils |
+| class | `u-borderEndEndRadiusM` | — | commons/utils |
+| class | `u-borderEndEndRadiusXL` | — | commons/utils |
+| class | `u-borderEndStartRadiusFull` | — | commons/utils |
+| class | `u-borderEndStartRadiusL` | — | commons/utils |
+| class | `u-borderEndStartRadiusM` | — | commons/utils |
+| class | `u-borderEndStartRadiusXL` | — | commons/utils |
+| class | `u-borderRadiusFull` | — | commons/utils |
+| class | `u-borderRadiusL` | — | commons/utils |
+| class | `u-borderRadiusM` | — | commons/utils |
+| class | `u-borderRadiusXL` | — | commons/utils |
+| class | `u-borderStartEndRadiusFull` | — | commons/utils |
+| class | `u-borderStartEndRadiusL` | — | commons/utils |
+| class | `u-borderStartEndRadiusM` | — | commons/utils |
+| class | `u-borderStartEndRadiusXL` | — | commons/utils |
+| class | `u-borderStartStartRadiusFull` | — | commons/utils |
+| class | `u-borderStartStartRadiusL` | — | commons/utils |
+| class | `u-borderStartStartRadiusM` | — | commons/utils |
+| class | `u-borderStartStartRadiusXL` | — | commons/utils |
+| class | `u-borderTopLeftRadiusFull` | — | commons/utils |
+| class | `u-borderTopLeftRadiusL` | — | commons/utils |
+| class | `u-borderTopLeftRadiusM` | — | commons/utils |
+| class | `u-borderTopLeftRadiusXL` | — | commons/utils |
+| class | `u-borderTopRightRadiusFull` | — | commons/utils |
+| class | `u-borderTopRightRadiusL` | — | commons/utils |
+| class | `u-borderTopRightRadiusM` | — | commons/utils |
+| class | `u-borderTopRightRadiusXL` | — | commons/utils |
+| class | `u-bottom0` | `pr-u-insetBlockEnd0` | commons/utils |
+| class | `u-bottomReset` | `pr-u-insetBlockEnd0` | commons/utils |
+| class | `u-buttonReset` | `pr-u-buttonReset` | commons/utils |
+| class | `u-clear` | `pr-u-clearBoth` | commons/utils |
+| class | `u-clearBoth` | `pr-u-clearBoth` | commons/utils |
+| class | `u-clearfix` | `pr-u-clearfix` | commons/utils |
+| class | `u-clearInlineEnd` | `pr-u-clearInlineEnd` | commons/utils |
+| class | `u-clearInlineStart` | `pr-u-clearInlineStart` | commons/utils |
+| class | `u-clearLeft` | `pr-u-clearInlineStart` | commons/utils |
+| class | `u-clearRight` | `pr-u-clearInlineEnd` | commons/utils |
+| class | `u-cursorAuto` | `pr-u-cursorAuto` | commons/utils |
+| class | `u-cursorDefault` | `pr-u-cursorDefault` | commons/utils |
+| class | `u-cursorPointer` | `pr-u-cursorPointer` | commons/utils |
+| class | `u-cursorText` | `pr-u-cursorText` | commons/utils |
+| class | `u-descriptionListReset` | `pr-u-descriptionListReset` | commons/utils |
+| class | `u-displayBlock` | `pr-u-displayBlock` | commons/utils |
+| class | `u-displayContents` | `pr-u-displayContents` | commons/utils |
+| class | `u-displayFlex` | `pr-u-displayFlex` | commons/utils |
+| class | `u-displayGrid` | `pr-u-displayGrid` | commons/utils |
+| class | `u-displayInline` | `pr-u-displayInline` | commons/utils |
+| class | `u-displayInlineBlock` | `pr-u-displayInlineBlock` | commons/utils |
+| class | `u-displayInlineFlex` | `pr-u-displayInlineFlex` | commons/utils |
+| class | `u-displayInlineGrid` | `pr-u-displayInlineGrid` | commons/utils |
+| class | `u-displayNone` | `pr-u-displayNone` | commons/utils |
+| class | `u-ellipsis` | `pr-u-ellipsis` | commons/utils |
+| class | `u-flexBasis0` | `pr-u-flexBasis0` | commons/utils |
+| class | `u-flexBasisAuto` | `pr-u-flexBasisAuto` | commons/utils |
+| class | `u-flexDirectionColumn` | `pr-u-flexDirectionColumn` | commons/utils |
+| class | `u-flexDirectionColumnReverse` | `pr-u-flexDirectionColumnReverse` | commons/utils |
+| class | `u-flexDirectionRow` | `pr-u-flexDirectionRow` | commons/utils |
+| class | `u-flexDirectionRowReverse` | `pr-u-flexDirectionRowReverse` | commons/utils |
+| class | `u-flexGrow0` | `pr-u-flexGrow0` | commons/utils |
+| class | `u-flexGrow1` | `pr-u-flexGrow1` | commons/utils |
+| class | `u-flexShrink0` | `pr-u-flexShrink0` | commons/utils |
+| class | `u-flexShrink1` | `pr-u-flexShrink1` | commons/utils |
+| class | `u-flexWrapNowrap` | `pr-u-flexWrapNowrap` | commons/utils |
+| class | `u-flexWrapWrap` | `pr-u-flexWrapWrap` | commons/utils |
+| class | `u-flexWrapWrapReverse` | `pr-u-flexWrapWrapReverse` | commons/utils |
+| class | `u-floatInlineEnd` | `pr-u-floatInlineEnd` | commons/utils |
+| class | `u-floatInlineStart` | `pr-u-floatInlineStart` | commons/utils |
+| class | `u-floatLeft` | `pr-u-floatInlineStart` | commons/utils |
+| class | `u-floatRight` | `pr-u-floatInlineEnd` | commons/utils |
+| class | `u-fontFamily` | `pr-u-fontFamily` | commons/utils |
+| class | `u-fontFamilyBrand` | `pr-u-fontFamilyBrand` | commons/utils |
+| class | `u-fontFamilyCursive` | `pr-u-fontFamilyCursive` | commons/utils |
+| class | `u-fontStyleItalic` | `pr-u-fontStyleItalic` | commons/utils |
+| class | `u-fontStyleNormal` | `pr-u-fontStyleNormal` | commons/utils |
+| class | `u-fontWeight400` | `pr-u-fontWeight400` | commons/utils |
+| class | `u-fontWeight600` | `pr-u-fontWeight600` | commons/utils |
+| class | `u-fontWeight700` | `pr-u-fontWeight700` | commons/utils |
+| class | `u-fontWeight900` | `pr-u-fontWeight900` | commons/utils |
+| class | `u-fontWeightBold` | `pr-u-fontWeightBold` | commons/utils |
+| class | `u-fontWeightNormal` | `pr-u-fontWeightNormal` | commons/utils |
+| class | `u-fontWeightRegular` | `pr-u-fontWeightRegular` | commons/utils |
+| class | `u-fontWeightSemiBold` | `pr-u-fontWeightSemiBold` | commons/utils |
+| class | `u-h1` | `pr-u-h1` | commons/utils |
+| class | `u-h2` | `pr-u-h2` | commons/utils |
+| class | `u-h3` | `pr-u-h3` | commons/utils |
+| class | `u-h4` | `pr-u-h4` | commons/utils |
+| class | `u-h5` | — | commons/utils |
+| class | `u-h6` | — | commons/utils |
+| class | `u-height100\%` | `pr-u-height100\%` | commons/utils |
+| class | `u-heightFitContent` | `pr-u-heightFitContent` | commons/utils |
+| class | `u-inlineSize100\%` | `pr-u-inlineSize100\%` | commons/utils |
+| class | `u-inlineSizeFitContent` | `pr-u-inlineSizeFitContent` | commons/utils |
+| class | `u-inset0` | `pr-u-inset0` | commons/utils |
+| class | `u-insetBlock-end0` | `pr-u-insetBlock-end0` | commons/utils |
+| class | `u-insetBlock-start0` | `pr-u-insetBlock-start0` | commons/utils |
+| class | `u-insetBlock0` | `pr-u-insetBlock0` | commons/utils |
+| class | `u-insetInline-end0` | `pr-u-insetInline-end0` | commons/utils |
+| class | `u-insetInline-start0` | `pr-u-insetInline-start0` | commons/utils |
+| class | `u-insetInline0` | `pr-u-insetInline0` | commons/utils |
+| class | `u-insetReset` | `pr-u-inset0` | commons/utils |
+| class | `u-justifyContentCenter` | `pr-u-justifyContentCenter` | commons/utils |
+| class | `u-justifyContentFlexEnd` | `pr-u-justifyContentFlexEnd` | commons/utils |
+| class | `u-justifyContentFlexStart` | `pr-u-justifyContentFlexStart` | commons/utils |
+| class | `u-justifyContentSpaceAround` | `pr-u-justifyContentSpaceAround` | commons/utils |
+| class | `u-justifyContentSpaceBetween` | `pr-u-justifyContentSpaceBetween` | commons/utils |
+| class | `u-justifyContentSpaceEvenly` | `pr-u-justifyContentSpaceEvenly` | commons/utils |
+| class | `u-left0` | `pr-u-insetInlineStart0` | commons/utils |
+| class | `u-leftReset` | `pr-u-insetInlineStart0` | commons/utils |
+| class | `u-listReset` | `pr-u-listReset` | commons/utils |
+| class | `u-marginBlock-end0` | `pr-u-marginBlock-end0` | commons/utils |
+| class | `u-marginBlock-start0` | `pr-u-marginBlock-start0` | commons/utils |
+| class | `u-marginBlock0` | `pr-u-marginBlock0` | commons/utils |
+| class | `u-marginInline-end0` | `pr-u-marginInline-end0` | commons/utils |
+| class | `u-marginInline-start0` | `pr-u-marginInline-start0` | commons/utils |
+| class | `u-marginInline0` | `pr-u-marginInline0` | commons/utils |
+| class | `u-mask` | `pr-u-mask` | commons/utils |
+| class | `u-maxInlineSize100\%` | `pr-u-maxInlineSize100\%` | commons/utils |
+| class | `u-maxInlineSizeFitContent` | `pr-u-maxInlineSizeFitContent` | commons/utils |
+| class | `u-minBlockSize0` | `pr-u-minBlockSize0` | commons/utils |
+| class | `u-minHeight0` | `pr-u-minHeight0` | commons/utils |
+| class | `u-minInlineSize0` | `pr-u-minInlineSize0` | commons/utils |
+| class | `u-minWidth0` | `pr-u-minWidth0` | commons/utils |
+| class | `u-noSpinButtons` | `pr-u-noSpinButtons` | commons/utils |
+| class | `u-onlyPrintDisplayBlock` | `pr-u-onlyPrintDisplayBlock` | commons/utils |
+| class | `u-onlyPrintDisplayContents` | `pr-u-onlyPrintDisplayContents` | commons/utils |
+| class | `u-onlyPrintDisplayFlex` | `pr-u-onlyPrintDisplayFlex` | commons/utils |
+| class | `u-onlyPrintDisplayGrid` | `pr-u-onlyPrintDisplayGrid` | commons/utils |
+| class | `u-onlyPrintDisplayInline` | `pr-u-onlyPrintDisplayInline` | commons/utils |
+| class | `u-onlyPrintDisplayInlineBlock` | `pr-u-onlyPrintDisplayInlineBlock` | commons/utils |
+| class | `u-onlyPrintDisplayInlineFlex` | `pr-u-onlyPrintDisplayInlineFlex` | commons/utils |
+| class | `u-onlyPrintDisplayInlineGrid` | `pr-u-onlyPrintDisplayInlineGrid` | commons/utils |
+| class | `u-onlyPrintDisplayNone` | `pr-u-onlyPrintDisplayNone` | commons/utils |
+| class | `u-order1` | `pr-u-order1` | commons/utils |
+| class | `u-orderMinus1` | `pr-u-orderMinus1` | commons/utils |
+| class | `u-overflowAuto` | `pr-u-overflowAuto` | commons/utils |
+| class | `u-overflowHidden` | `pr-u-overflowHidden` | commons/utils |
+| class | `u-overflowScroll` | `pr-u-overflowScroll` | commons/utils |
+| class | `u-overflowVisible` | `pr-u-overflowVisible` | commons/utils |
+| class | `u-paddingBlock-end0` | `pr-u-paddingBlock-end0` | commons/utils |
+| class | `u-paddingBlock-start0` | `pr-u-paddingBlock-start0` | commons/utils |
+| class | `u-paddingBlock0` | `pr-u-paddingBlock0` | commons/utils |
+| class | `u-paddingInline-end0` | `pr-u-paddingInline-end0` | commons/utils |
+| class | `u-paddingInline-start0` | `pr-u-paddingInline-start0` | commons/utils |
+| class | `u-paddingInline0` | `pr-u-paddingInline0` | commons/utils |
+| class | `u-pointerEventsAuto` | `pr-u-pointerEventsAuto` | commons/utils |
+| class | `u-pointerEventsNone` | `pr-u-pointerEventsNone` | commons/utils |
+| class | `u-positionAbsolute` | `pr-u-positionAbsolute` | commons/utils |
+| class | `u-positionFixed` | `pr-u-positionFixed` | commons/utils |
+| class | `u-positionRelative` | `pr-u-positionRelative` | commons/utils |
+| class | `u-positionStatic` | `pr-u-positionStatic` | commons/utils |
+| class | `u-positionSticky` | `pr-u-positionSticky` | commons/utils |
+| class | `u-right0` | `pr-u-insetInlineEnd0` | commons/utils |
+| class | `u-rightReset` | `pr-u-insetInlineEnd0` | commons/utils |
+| class | `u-scrollBehaviorAuto` | `pr-u-scrollBehaviorAuto` | commons/utils |
+| class | `u-scrollBehaviorSmooth` | `pr-u-scrollBehaviorSmooth` | commons/utils |
+| class | `u-summaryReset` | `pr-u-summaryReset` | commons/utils |
+| class | `u-textAlignCenter` | `pr-u-textAlignCenter` | commons/utils |
+| class | `u-textAlignEnd` | `pr-u-textAlignEnd` | commons/utils |
+| class | `u-textAlignLeft` | `pr-u-textAlignStart` | commons/utils |
+| class | `u-textAlignRight` | `pr-u-textAlignEnd` | commons/utils |
+| class | `u-textAlignStart` | `pr-u-textAlignStart` | commons/utils |
+| class | `u-textBlueberry` | `pr-u-colorTextBlueberry` | commons/utils |
+| class | `u-textBrand` | `pr-u-colorTextBrand` | commons/utils |
+| class | `u-textBrandContrasted` | `pr-u-colorTextBrandContrasted` | commons/utils |
+| class | `u-textCc` | `pr-u-colorTextCc` | commons/utils |
+| class | `u-textCenter` | `pr-u-textAlignCenter` | commons/utils |
+| class | `u-textCleemy` | `pr-u-colorTextCleemy` | commons/utils |
+| class | `u-textCoreHR` | `pr-u-colorTextCoreHR` | commons/utils |
+| class | `u-textCritical` | `pr-u-colorTextCritical` | commons/utils |
+| class | `u-textCucumber` | `pr-u-colorTextCucumber` | commons/utils |
+| class | `u-textDecorationLineThrough` | `pr-u-textDecorationLineThrough` | commons/utils |
+| class | `u-textDecorationNone` | `pr-u-textDecorationNone` | commons/utils |
+| class | `u-textDecorationUnderline` | `pr-u-textDecorationUnderline` | commons/utils |
+| class | `u-textDefault` | — | commons/utils |
+| class | `u-textError` | `pr-u-colorTextError` | commons/utils |
+| class | `u-textGlacier` | `pr-u-colorTextGlacier` | commons/utils |
+| class | `u-textGrape` | `pr-u-colorTextGrape` | commons/utils |
+| class | `u-textGrey` | `pr-u-colorTextGrey` | commons/utils |
+| class | `u-textKiwi` | `pr-u-colorTextKiwi` | commons/utils |
+| class | `u-textL` | — | commons/utils |
+| class | `u-textLagoon` | `pr-u-colorTextLagoon` | commons/utils |
+| class | `u-textLavender` | `pr-u-colorTextLavender` | commons/utils |
+| class | `u-textLeft` | `pr-u-textAlignStart` | commons/utils |
+| class | `u-textLight` | — | commons/utils |
+| class | `u-textLime` | `pr-u-colorTextLime` | commons/utils |
+| class | `u-textLucca` | `pr-u-colorTextLucca` | commons/utils |
+| class | `u-textM` | — | commons/utils |
+| class | `u-textMint` | `pr-u-colorTextMint` | commons/utils |
+| class | `u-textNavigation` | `pr-u-colorTextNavigation` | commons/utils |
+| class | `u-textNeutral` | `pr-u-colorTextNeutral` | commons/utils |
+| class | `u-textOrchid` | `pr-u-colorTextOrchid` | commons/utils |
+| class | `u-textPagga` | `pr-u-colorTextPagga` | commons/utils |
+| class | `u-textPineapple` | `pr-u-colorTextPineapple` | commons/utils |
+| class | `u-textPineappleContrasted` | `pr-u-colorTextPineappleContrasted` | commons/utils |
+| class | `u-textPlaceholder` | `pr-u-colorInputTextPlaceholder` | commons/utils |
+| class | `u-textPoplee` | `pr-u-colorTextPoplee` | commons/utils |
+| class | `u-textPrimary` | `pr-u-colorTextPrimary` | commons/utils |
+| class | `u-textProduct` | `pr-u-colorTextProduct` | commons/utils |
+| class | `u-textPumpkin` | `pr-u-colorTextPumpkin` | commons/utils |
+| class | `u-textRight` | `pr-u-textAlignEnd` | commons/utils |
+| class | `u-textS` | — | commons/utils |
+| class | `u-textSecondary` | `pr-u-colorTextSecondary` | commons/utils |
+| class | `u-textSuccess` | `pr-u-colorTextSuccess` | commons/utils |
+| class | `u-textSuccessContrasted` | `pr-u-colorTextSuccessContrasted` | commons/utils |
+| class | `u-textTimmi` | `pr-u-colorTextTimmi` | commons/utils |
+| class | `u-textWarning` | `pr-u-colorTextWarning` | commons/utils |
+| class | `u-textWarningContrasted` | `pr-u-colorTextWarningContrasted` | commons/utils |
+| class | `u-textWatermelon` | `pr-u-colorTextWatermelon` | commons/utils |
+| class | `u-textXL` | — | commons/utils |
+| class | `u-textXS` | — | commons/utils |
+| class | `u-textXXL` | — | commons/utils |
+| class | `u-textXXXL` | — | commons/utils |
+| class | `u-top0` | `pr-u-insetBlockStart0` | commons/utils |
+| class | `u-topReset` | `pr-u-insetBlockStart0` | commons/utils |
+| class | `u-verticalAlignBaseline` | `pr-u-verticalAlignBaseline` | commons/utils |
+| class | `u-verticalAlignBottom` | `pr-u-verticalAlignBottom` | commons/utils |
+| class | `u-verticalAlignMiddle` | `pr-u-verticalAlignMiddle` | commons/utils |
+| class | `u-verticalAlignSub` | `pr-u-verticalAlignSub` | commons/utils |
+| class | `u-verticalAlignSuper` | `pr-u-verticalAlignSuper` | commons/utils |
+| class | `u-verticalAlignTextBottom` | `pr-u-verticalAlignTextBottom` | commons/utils |
+| class | `u-verticalAlignTextTop` | `pr-u-verticalAlignTextTop` | commons/utils |
+| class | `u-verticalAlignTop` | `pr-u-verticalAlignTop` | commons/utils |
+| class | `u-visibilityCollapse` | `pr-u-visibilityCollapse` | commons/utils |
+| class | `u-visibilityHidden` | `pr-u-visibilityHidden` | commons/utils |
+| class | `u-visibilityVisible` | `pr-u-visibilityVisible` | commons/utils |
+| class | `u-whiteSpaceNormal` | `pr-u-whiteSpaceNormal` | commons/utils |
+| class | `u-whiteSpaceNowrap` | `pr-u-whiteSpaceNowrap` | commons/utils |
+| class | `u-whiteSpacePreLine` | `pr-u-whiteSpacePreLine` | commons/utils |
+| class | `u-width100\%` | `pr-u-width100\%` | commons/utils |
+| class | `u-widthFitContent` | `pr-u-widthFitContent` | commons/utils |
+| class | `u-prefersContrastMore` | `pr-u-prefersContrastMore` | commons/vars |
+| css-variable | `--colors-black-color` | — | commons/vars |
+| css-variable | `--colors-grey-400-rgb` | — | commons/vars |
+| css-variable | `--colors-grey-900-rgb` | — | commons/vars |
+| css-variable | `--colors-neutral-400-rgb` | — | commons/vars |
+| css-variable | `--colors-neutral-900-rgb` | — | commons/vars |
+| css-variable | `--colors-white-color` | — | commons/vars |
+| css-variable | `--colors-white-rgb` | — | commons/vars |
+| css-variable | `--commons-background-base` | `--pr-t-elevation-surface-default` | commons/vars |
+| css-variable | `--commons-divider-color` | — | commons/vars |
+| css-variable | `--commons-font-family` | `--pr-t-font-family` | commons/vars |
+| css-variable | `--commons-font-family-brand` | `--pr-t-font-family-brand` | commons/vars |
+| css-variable | `--commons-font-family-cursive` | `--pr-t-font-family-cursive` | commons/vars |
+| css-variable | `--palettes-blueberry-text` | — | commons/vars |
+| css-variable | `--palettes-brand-text` | — | commons/vars |
+| css-variable | `--palettes-brandContrasted-text` | — | commons/vars |
+| css-variable | `--palettes-cc-text` | — | commons/vars |
+| css-variable | `--palettes-cleemy-text` | — | commons/vars |
+| css-variable | `--palettes-coreHR-text` | — | commons/vars |
+| css-variable | `--palettes-critical-text` | — | commons/vars |
+| css-variable | `--palettes-cucumber-text` | — | commons/vars |
+| css-variable | `--palettes-error-text` | — | commons/vars |
+| css-variable | `--palettes-glacier-text` | — | commons/vars |
+| css-variable | `--palettes-grape-text` | — | commons/vars |
+| css-variable | `--palettes-grey-0` | — | commons/vars |
+| css-variable | `--palettes-grey-100` | — | commons/vars |
+| css-variable | `--palettes-grey-200` | — | commons/vars |
+| css-variable | `--palettes-grey-25` | — | commons/vars |
+| css-variable | `--palettes-grey-300` | — | commons/vars |
+| css-variable | `--palettes-grey-400` | — | commons/vars |
+| css-variable | `--palettes-grey-50` | — | commons/vars |
+| css-variable | `--palettes-grey-500` | — | commons/vars |
+| css-variable | `--palettes-grey-600` | — | commons/vars |
+| css-variable | `--palettes-grey-700` | — | commons/vars |
+| css-variable | `--palettes-grey-800` | — | commons/vars |
+| css-variable | `--palettes-grey-900` | — | commons/vars |
+| css-variable | `--palettes-grey-text` | — | commons/vars |
+| css-variable | `--palettes-kiwi-text` | — | commons/vars |
+| css-variable | `--palettes-lagoon-text` | — | commons/vars |
+| css-variable | `--palettes-lavender-text` | — | commons/vars |
+| css-variable | `--palettes-lime-text` | — | commons/vars |
+| css-variable | `--palettes-lucca-0` | — | commons/vars |
+| css-variable | `--palettes-lucca-100` | — | commons/vars |
+| css-variable | `--palettes-lucca-200` | — | commons/vars |
+| css-variable | `--palettes-lucca-300` | — | commons/vars |
+| css-variable | `--palettes-lucca-400` | — | commons/vars |
+| css-variable | `--palettes-lucca-50` | — | commons/vars |
+| css-variable | `--palettes-lucca-500` | — | commons/vars |
+| css-variable | `--palettes-lucca-600` | — | commons/vars |
+| css-variable | `--palettes-lucca-700` | — | commons/vars |
+| css-variable | `--palettes-lucca-800` | — | commons/vars |
+| css-variable | `--palettes-lucca-900` | — | commons/vars |
+| css-variable | `--palettes-lucca-text` | — | commons/vars |
+| css-variable | `--palettes-mint-text` | — | commons/vars |
+| css-variable | `--palettes-navigation-text` | — | commons/vars |
+| css-variable | `--palettes-neutral-text` | — | commons/vars |
+| css-variable | `--palettes-orchid-text` | — | commons/vars |
+| css-variable | `--palettes-pagga-text` | — | commons/vars |
+| css-variable | `--palettes-pineapple-text` | — | commons/vars |
+| css-variable | `--palettes-pineappleContrasted-text` | — | commons/vars |
+| css-variable | `--palettes-poplee-text` | — | commons/vars |
+| css-variable | `--palettes-primary-0` | — | commons/vars |
+| css-variable | `--palettes-primary-100` | — | commons/vars |
+| css-variable | `--palettes-primary-200` | — | commons/vars |
+| css-variable | `--palettes-primary-300` | — | commons/vars |
+| css-variable | `--palettes-primary-400` | — | commons/vars |
+| css-variable | `--palettes-primary-50` | — | commons/vars |
+| css-variable | `--palettes-primary-500` | — | commons/vars |
+| css-variable | `--palettes-primary-600` | — | commons/vars |
+| css-variable | `--palettes-primary-700` | — | commons/vars |
+| css-variable | `--palettes-primary-800` | — | commons/vars |
+| css-variable | `--palettes-primary-900` | — | commons/vars |
+| css-variable | `--palettes-primary-text` | — | commons/vars |
+| css-variable | `--palettes-product-text` | — | commons/vars |
+| css-variable | `--palettes-pumpkin-text` | — | commons/vars |
+| css-variable | `--palettes-secondary-0` | — | commons/vars |
+| css-variable | `--palettes-secondary-100` | — | commons/vars |
+| css-variable | `--palettes-secondary-200` | — | commons/vars |
+| css-variable | `--palettes-secondary-300` | — | commons/vars |
+| css-variable | `--palettes-secondary-400` | — | commons/vars |
+| css-variable | `--palettes-secondary-50` | — | commons/vars |
+| css-variable | `--palettes-secondary-500` | — | commons/vars |
+| css-variable | `--palettes-secondary-600` | — | commons/vars |
+| css-variable | `--palettes-secondary-700` | — | commons/vars |
+| css-variable | `--palettes-secondary-800` | — | commons/vars |
+| css-variable | `--palettes-secondary-900` | — | commons/vars |
+| css-variable | `--palettes-secondary-text` | — | commons/vars |
+| css-variable | `--palettes-success-text` | — | commons/vars |
+| css-variable | `--palettes-successContrasted-text` | — | commons/vars |
+| css-variable | `--palettes-timmi-text` | — | commons/vars |
+| css-variable | `--palettes-warning-text` | — | commons/vars |
+| css-variable | `--palettes-warningContrasted-text` | — | commons/vars |
+| css-variable | `--palettes-watermelon-text` | — | commons/vars |
+| css-variable | `--sizes-L-fontSize` | — | commons/vars |
+| css-variable | `--sizes-L-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-L-verticalPadding` | — | commons/vars |
+| css-variable | `--sizes-M-fontSize` | — | commons/vars |
+| css-variable | `--sizes-M-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-M-verticalPadding` | — | commons/vars |
+| css-variable | `--sizes-S-fontSize` | — | commons/vars |
+| css-variable | `--sizes-S-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-S-verticalPadding` | — | commons/vars |
+| css-variable | `--sizes-XL-fontSize` | — | commons/vars |
+| css-variable | `--sizes-XL-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-XL-verticalPadding` | — | commons/vars |
+| css-variable | `--sizes-XS-fontSize` | — | commons/vars |
+| css-variable | `--sizes-XS-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-XS-verticalPadding` | — | commons/vars |
+| css-variable | `--sizes-XXL-fontSize` | — | commons/vars |
+| css-variable | `--sizes-XXL-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-XXL-verticalPadding` | — | commons/vars |
+| css-variable | `--sizes-XXXL-fontSize` | — | commons/vars |
+| css-variable | `--sizes-XXXL-lineHeight` | — | commons/vars |
+| css-variable | `--sizes-XXXL-verticalPadding` | — | commons/vars |
+| selector | `.lu-user-picture` | `.avatar` | component:avatar |
+| selector | `.box.mod-grey` | `.box.mod-neutral` | component:box |
+| selector | `.box.mod-toggle` | — | component:box |
+| selector | `.active` | `.is-active` | component:breadcrumbs |
+| selector | `.mod-compact` | — | component:breadcrumbs |
+| css-variable | `--components-button-font-size` | `--components-button-font` | component:button |
+| css-variable | `--components-button-line-height` | `--components-button-font` | component:button |
+| selector | `.button.disabled` | `.button.is-disabled` | component:button |
+| selector | `.button.error` | `.button.is-error` | component:button |
+| selector | `.button.loading` | `.button.is-loading` | component:button |
+| selector | `.button.success` | `.button.is-success` | component:button |
+| selector | `.mod-delete` | `.mod-critical` | component:button |
+| selector | `.mod-invert` | `.mod-inverted` | component:button |
+| selector | `.mod-link` | `.mod-ghost` | component:button |
+| selector | `.mod-outline` | `.mod-outlined` | component:button |
+| selector | `.mod-text` | `.mod-ghost` | component:button |
+| css-variable | `--components-callout-fontSize` | `--components-callout-font` | component:callout |
+| css-variable | `--components-callout-lineHeight` | `--components-callout-font` | component:callout |
+| css-variable | `--components-calloutFeedbackList-fontSize` | `--components-calloutFeedbackList-font` | component:calloutFeedbackList |
+| css-variable | `--components-calloutFeedbackList-lineHeight` | `--components-calloutFeedbackList-font` | component:calloutFeedbackList |
+| selector | `.card.mod-grey` | `.card.mod-neutral` | component:card |
+| css-variable | `--components-chip-fontSize` | `--components-chip-font` | component:chip |
+| css-variable | `--components-chip-lineHeight` | `--components-chip-font` | component:chip |
+| css-variable | `--components-comment-text-fontSize` | `--components-comment-text-font` | component:comment |
+| css-variable | `--components-comment-text-lineHeight` | `--components-comment-text-font` | component:comment |
+| css-variable | `--components-container-max-width` | `--commons-container-maxWidth` | component:container |
+| css-variable | `--components-container-padding` | `--commons-container-padding` | component:container |
+| selector | `.dialog-form` | `.dialog-inside-formOptional` | component:dialog |
+| selector | `.dialog-formOptional` | `.dialog-inside-formOptional` | component:dialog |
+| css-variable | `--components-divider-fontSize` | `--components-divider-font` | component:divider |
+| css-variable | `--components-divider-lineHeight` | `--components-divider-font` | component:divider |
+| selector | `.lu-dropdown-content` | `.dropdown` | component:dropdown |
+| selector | `.lu-dropdown-options` | `.dropdown-list` | component:dropdown |
+| selector | `.lu-dropdown-options-item` | `.dropdown-list-option` | component:dropdown |
+| selector | `.lu-dropdown-options-item-action` | `.dropdown-list-option-action` | component:dropdown |
+| selector | `.filterBarDeprecated` | — | component:filterBarDeprecated |
+| sass-api | `form.componentDeprecated` | — | component:form |
+| css-variable | `--components-formLabel-fontSize` | `--components-formLabel-font` | component:formLabel |
+| css-variable | `--components-formLabel-lineHeight` | `--components-formLabel-font` | component:formLabel |
+| css-variable | `--components-gauge-height` | `--components-gauge-blockSize` | component:gauge |
+| sass-api | `gauge.vertical` | — | component:gauge |
+| sass-api | `gauge.verticalThin` | — | component:gauge |
+| selector | `.mod-vertical` | — | component:gauge |
+| selector | `.disabled` | `.is-disabled` | component:horizontalNavigation |
+| selector | `.menu` | `.horizontalNavigation` | component:horizontalNavigation |
+| selector | `.menu-containerOptional` | — | component:horizontalNavigation |
+| selector | `.menu-link` | — | component:horizontalNavigation |
+| selector | `.menu-link-placeholder` | — | component:horizontalNavigation |
+| selector | `.menu-list` | `.horizontalNavigation-list` | component:horizontalNavigation |
+| selector | `.menu-list-item-action` | `.horizontalNavigation-list-item-action` | component:horizontalNavigation |
+| selector | `.indexTable-body-row-cell-action` | — | component:indexTable |
+| selector | `.lucca-icon:first-child` | `.inlineMessage-statusIcon` | component:inlineMessage |
+| selector | `.label` | — | component:label |
+| selector | `.mod-dialog` | `.mod-popin` | component:loading |
+| selector | `.mod-sidePanel` | `.mod-drawer` | component:loading |
+| css-variable | `--components-navSide-fullwidth-palette-alert-color` | — | component:navside |
+| css-variable | `--components-navSide-fullwidth-palette-alert-text` | — | component:navside |
+| selector | `.mod-withMenuCompact` | `.navSide.mod-compact` | component:navside |
+| selector | `.mod-withMenu` | `.mod-withHorizontalNavigation` | component:pageHeader |
+| selector | `.section.mod-grey` | `.section.mod-neutral` | component:section |
+| selector | `.viewTabs` | `.segmentedControl` | component:segmentedControl |
+| selector | `.viewTabs_panel` | `.segmentedControl_panel` | component:segmentedControl |
+| selector | `.viewTabs-item` | `.segmentedControl-item` | component:segmentedControl |
+| selector | `.viewTabs-item-tab` | `.segmentedControl-item-action` | component:segmentedControl |
+| css-variable | `--components-sortableList-description-fontSize` | `--components-sortableList-description-font` | component:sortableList |
+| css-variable | `--components-sortableList-description-lineHeight` | `--components-sortableList-description-font` | component:sortableList |
+| selector | `.mod-actionsHidden` | — | component:table |
+| selector | `.table.mod-layoutFixed` | — | component:tableFixedDeprecated |
+| selector | `.table.mod-stickyColumn` | — | component:tableStickedDeprecated |
+| css-variable | `--components-tag-fontSize` | `--components-tag-font` | component:tag |
+| css-variable | `--components-tag-lineHeight` | `--components-tag-font` | component:tag |
+| selector | `.mod-clickable` | — | component:tag |
+| css-variable | `--component-textField-fontSize` | `--component-textField-font` | component:textField |
+| css-variable | `--component-textField-lineHeight` | `--component-textField-font` | component:textField |
+| css-variable | `--components-toasts-background` | — | component:toast |
+| css-variable | `--components-toasts-padding` | — | component:toast |
+| sass-api | `userTile.XL` | — | component:userTile |
+| sass-api | `userTile.XXL` | — | component:userTile |
+| sass-api | `userTile.XXXL` | — | component:userTile |
+| selector | `.mod-XL` | — | component:userTile |
+| selector | `.mod-XXL` | — | component:userTile |
+| selector | `.mod-XXXL` | — | component:userTile |
+
+### Before — legacy comment markers
+
+| File | Line | Marker |
+| --- | ---: | --- |
+| packages/scss/src/commons/config.scss | 127 | $palettesShades: text, 0, 25, 50, 100, 200, 300, 400, 500, 600, 700, 800, 900; // text is deprecated |
+| packages/scss/src/commons/config.scss | 180 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 196 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 212 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 228 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 244 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 260 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 291 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 307 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 324 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 335 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 351 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 367 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 383 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 399 | // text is deprecated |
+| packages/scss/src/commons/config.scss | 758 | // opacity is deprecated |
+| packages/scss/src/commons/config.scss | 790 | // Deprecated |
+| packages/scss/src/commons/config.scss | 792 | // $colors are deprecated |
+| packages/scss/src/commons/config.scss | 798 | // $colorsRgb are deprecated |
+| packages/scss/src/commons/config.scss | 807 | // $borderRadius are deprecated |
+| packages/scss/src/commons/core.scss | 9 | $boxDirection: '', 'top', 'bottom', 'left', 'right', 'inline', 'block', 'block-start', 'block-end', 'inline-start', 'inline-end'; // top, bottom, left and right are deprecated |
+| packages/scss/src/commons/core.scss | 10 | $corners: '', 'top-left-', 'top-right-', 'bottom-left-', 'bottom-right-', 'start-start-', 'start-end-', 'end-start-', 'end-end-'; // top-left, top-right, bottom-left and bottom-right are deprecated |
+| packages/scss/src/commons/core.scss | 20 | $textAlign: 'left', 'center', 'right', 'start', 'end'; // left and right are deprecated |
+| packages/scss/src/commons/core.scss | 27 | $float: 'left', 'right', 'inline-start', 'inline-end'; // left and right are deprecated |
+| packages/scss/src/commons/core.scss | 107 | // Deprecated .u- utilities |
+| packages/scss/src/commons/core.scss | 118 | // Deprecated .u- utilities |
+| packages/scss/src/commons/core.scss | 129 | // .pr-u-text is deprecated |
+| packages/scss/src/commons/core.scss | 135 | // Deprecated .u- utilities |
+| packages/scss/src/commons/core.scss | 188 | // DEPRECATED |
+| packages/scss/src/commons/core.scss | 197 | // Deprecated .u- utilities |
+| packages/scss/src/commons/core.scss | 214 | // Deprecated .u- utilities |
+| packages/scss/src/commons/utils/color.scss | 6 | // stylelint-disable-next-line scss/no-global-function-names -- This is a redefinition of a deprecated SCSS function. |
+| packages/scss/src/commons/utils/highlight-prisme.scss | 276 | // DEPRECATED COMPONENTS |
+| packages/scss/src/commons/utils/index.scss | 276 | // Deprecated |
+| packages/scss/src/commons/utils/index.scss | 409 | // clear is deprecated |
+| packages/scss/src/commons/utils/index.scss | 415 | // clearLeft is deprecated |
+| packages/scss/src/commons/utils/index.scss | 421 | // clearRight is deprecated |
+| packages/scss/src/commons/utils/index.scss | 464 | // Deprecated |
+| packages/scss/src/commons/utils/index.scss | 469 | // Deprecated |
+| packages/scss/src/commons/utils/index.scss | 485 | // textLeft is deprecated |
+| packages/scss/src/commons/utils/index.scss | 490 | // textRight is deprecated |
+| packages/scss/src/commons/utils/index.scss | 495 | // textCenter is deprecated |
+| packages/scss/src/commons/utils/index.scss | 500 | // textLight is deprecated |
+| packages/scss/src/commons/utils/index.scss | 505 | // textPlaceholder is deprecated |
+| packages/scss/src/commons/utils/index.scss | 511 | // textDefault is deprecated |
+| packages/scss/src/commons/utils/index.scss | 645 | // insetReset is deprecated |
+| packages/scss/src/commons/utils/index.scss | 651 | // Reset is deprecated |
+| packages/scss/src/commons/utils/index.scss | 673 | // Deprecated .u- utilities |
+| packages/scss/src/commons/utils/index.scss | 692 | // clear is deprecated |
+| packages/scss/src/commons/utils/index.scss | 698 | // clearLeft is deprecated |
+| packages/scss/src/commons/utils/index.scss | 704 | // clearRight is deprecated |
+| packages/scss/src/commons/utils/index.scss | 747 | // Deprecated |
+| packages/scss/src/commons/utils/index.scss | 752 | // Deprecated |
+| packages/scss/src/commons/utils/index.scss | 768 | // stylelint-disable-next-line selector-disallowed-list -- textLeft is deprecated |
+| packages/scss/src/commons/utils/index.scss | 773 | // stylelint-disable-next-line selector-disallowed-list -- textRight is deprecated |
+| packages/scss/src/commons/utils/index.scss | 778 | // stylelint-disable-next-line selector-disallowed-list -- textCenter is deprecated |
+| packages/scss/src/commons/utils/index.scss | 783 | // stylelint-disable-next-line selector-disallowed-list -- textLight is deprecated |
+| packages/scss/src/commons/utils/index.scss | 830 | // insetReset is deprecated |
+| packages/scss/src/commons/utils/index.scss | 836 | // Reset is deprecated |
+| packages/scss/src/commons/vars.scss | 107 | // Deprecated |
+| packages/scss/src/commons/vars.scss | 170 | // Deprecated .u- utilities |
+| packages/scss/src/components/avatar/index.scss | 3 | // lu-user-picture is deprecated |
+| packages/scss/src/components/box/index.scss | 10 | // .mod-grey is deprecated |
+| packages/scss/src/components/box/index.scss | 20 | // .mod-toggle is deprecated |
+| packages/scss/src/components/box/mods.scss | 38 | // .mod-grey is deprecated |
+| packages/scss/src/components/breadcrumbs/index.scss | 10 | // .mod-compact is deprecated |
+| packages/scss/src/components/breadcrumbs/index.scss | 21 | // .active is deprecated |
+| packages/scss/src/components/button/component.scss | 17 | font-size: var(--components-button-font-size); // Deprecated |
+| packages/scss/src/components/button/component.scss | 18 | line-height: var(--components-button-line-height); // Deprecated |
+| packages/scss/src/components/button/component.scss | 45 | // deprecated |
+| packages/scss/src/components/button/component.scss | 50 | // .mod-outline is deprecated |
+| packages/scss/src/components/button/index.scss | 44 | // .mod-outline is deprecated |
+| packages/scss/src/components/button/index.scss | 52 | // .mod-link .mod-text deprecated |
+| packages/scss/src/components/button/index.scss | 111 | // .mod-delete is deprecated |
+| packages/scss/src/components/button/index.scss | 116 | // .mod-link is deprecated |
+| packages/scss/src/components/button/index.scss | 122 | // .mod-outline is deprecated |
+| packages/scss/src/components/button/index.scss | 129 | // .mod-invert is deprecated |
+| packages/scss/src/components/button/index.scss | 147 | // .loading is deprecated |
+| packages/scss/src/components/button/index.scss | 169 | // .error is deprecated |
+| packages/scss/src/components/button/index.scss | 175 | // .success is deprecated |
+| packages/scss/src/components/button/index.scss | 190 | // .disabled is deprecated |
+| packages/scss/src/components/button/mods.scss | 19 | // Deprecated |
+| packages/scss/src/components/button/mods.scss | 36 | // Deprecated |
+| packages/scss/src/components/button/mods.scss | 60 | // Deprecated |
+| packages/scss/src/components/button/vars.scss | 24 | // Deprecated |
+| packages/scss/src/components/buttonGroup/index.scss | 11 | // .mod-text deprecated |
+| packages/scss/src/components/buttonGroup/mods.scss | 5 | // .mod-text, .mod-link deprecated |
+| packages/scss/src/components/callout/component.scss | 16 | font-size: var(--components-callout-fontSize); // Deprecated |
+| packages/scss/src/components/callout/component.scss | 17 | line-height: var(--components-callout-lineHeight); // Deprecated |
+| packages/scss/src/components/callout/mods.scss | 22 | // Deprecated |
+| packages/scss/src/components/callout/vars.scss | 14 | // Deprecated |
+| packages/scss/src/components/calloutFeedbackList/component.scss | 12 | font-size: var(--components-calloutFeedbackList-fontSize); // Deprecated |
+| packages/scss/src/components/calloutFeedbackList/component.scss | 13 | line-height: var(--components-calloutFeedbackList-lineHeight); // Deprecated |
+| packages/scss/src/components/calloutFeedbackList/mods.scss | 11 | // Deprecated |
+| packages/scss/src/components/calloutFeedbackList/vars.scss | 5 | // Deprecated |
+| packages/scss/src/components/card/index.scss | 10 | // .mod-grey is deprecated |
+| packages/scss/src/components/card/states.scss | 16 | // Deprecated .u- utilities |
+| packages/scss/src/components/checkboxField/mods.scss | 10 | // stylelint-disable-next-line declaration-property-value-disallowed-list -- --commons-borderRadius-full is deprecated |
+| packages/scss/src/components/chip/vars.scss | 11 | // Deprecated |
+| packages/scss/src/components/comment/vars.scss | 12 | // Deprecated |
+| packages/scss/src/components/container/index.scss | 15 | // deprecated |
+| packages/scss/src/components/container/mods.scss | 5 | // deprecated |
+| packages/scss/src/components/container/vars.scss | 8 | // --components-container-max-width is deprecated |
+| packages/scss/src/components/container/vars.scss | 9 | // --components-container-padding is deprecated |
+| packages/scss/src/components/dataTable/mods.scss | 127 | // .mod-delete is deprecated |
+| packages/scss/src/components/dialog/component.scss | 40 | .dialog-formOptional, // stylelint-disable-line selector-disallowed-list -- .dialog-formOptional is deprecated |
+| packages/scss/src/components/dialog/component.scss | 41 | .dialog-form, // stylelint-disable-line selector-disallowed-list -- .dialog-form is deprecated |
+| packages/scss/src/components/divider/vars.scss | 12 | // Deprecated |
+| packages/scss/src/components/dropdown/component.scss | 16 | // stylelint-disable-next-line selector-disallowed-list -- .lu-dropdown-options is deprecated |
+| packages/scss/src/components/dropdown/component.scss | 32 | // stylelint-disable-next-line selector-disallowed-list -- .lu-dropdown-options-item is deprecated |
+| packages/scss/src/components/dropdown/component.scss | 58 | // stylelint-disable-next-line selector-disallowed-list -- .lu-dropdown-options-item-action is deprecated |
+| packages/scss/src/components/dropdown/index.scss | 3 | // stylelint-disable-next-line selector-disallowed-list -- .lu-dropdown-content is deprecated |
+| packages/scss/src/components/dropdown/index.scss | 12 | // stylelint-disable-next-line selector-disallowed-list -- .lu-dropdown-options-item-action is deprecated |
+| packages/scss/src/components/filterBarDeprecated/component.scss | 5 | // stylelint-disable selector-disallowed-list -- Selectors are all deprecated. |
+| packages/scss/src/components/filterBarDeprecated/index.scss | 3 | // stylelint-disable selector-disallowed-list -- Selectors are all deprecated. |
+| packages/scss/src/components/form/component.scss | 81 | // deprecated |
+| packages/scss/src/components/form/index.scss | 119 | // deprecated |
+| packages/scss/src/components/form/mods.scss | 202 | // deprecated |
+| packages/scss/src/components/form/states.scss | 22 | // deprecated |
+| packages/scss/src/components/formLabel/component.scss | 11 | font-size: var(--components-formLabel-fontSize); // Deprecated |
+| packages/scss/src/components/formLabel/component.scss | 12 | line-height: var(--components-formLabel-lineHeight); // Deprecated |
+| packages/scss/src/components/formLabel/mods.scss | 9 | // Deprecated |
+| packages/scss/src/components/formLabel/mods.scss | 23 | // Deprecated |
+| packages/scss/src/components/formLabel/vars.scss | 11 | // Deprecated |
+| packages/scss/src/components/gauge/index.scss | 18 | // .mod-vertical is deprecated |
+| packages/scss/src/components/gauge/mods.scss | 6 | // @mixin vertical is deprecated |
+| packages/scss/src/components/gauge/mods.scss | 19 | // @mixin verticalThin is deprecated |
+| packages/scss/src/components/gauge/vars.scss | 1 | // --components-gauge-height is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 23 | // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 38 | // stylelint-disable-next-line selector-disallowed-list -- .menu-containerOptional is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 45 | // stylelint-disable-next-line selector-disallowed-list -- .menu-list is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 62 | .menu-link, // stylelint-disable-line selector-disallowed-list -- .menu-list is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 63 | .menu-list-item-action, // stylelint-disable-line selector-disallowed-list -- .menu-link-item-action is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 120 | // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated |
+| packages/scss/src/components/horizontalNavigation/component.scss | 137 | // stylelint-disable-next-line selector-disallowed-list -- .menu-link-placeholder is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 4 | // stylelint-disable-next-line selector-disallowed-list -- .menu is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 32 | // stylelint-disable-next-line selector-disallowed-list -- .menu-list-item-action is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 61 | .menu-link, // stylelint-disable-line selector-disallowed-list -- .menu-link is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 62 | .menu-list-item-action, // stylelint-disable-line selector-disallowed-list -- .menu-list-item-action is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 65 | // .active is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 73 | // .active is deprecated |
+| packages/scss/src/components/horizontalNavigation/index.scss | 80 | &.disabled, // .disabled is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 9 | .menu-list-item-action, // stylelint-disable-line selector-disallowed-list -- .menu-list-item-action is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 10 | .menu-link, // stylelint-disable-line selector-disallowed-list -- .menu-link is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 21 | // stylelint-disable-next-line selector-disallowed-list -- .menu-link is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 26 | // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 48 | // stylelint-disable-next-line selector-disallowed-list -- .menu-list is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 56 | // stylelint-disable-next-line selector-disallowed-list -- .menu-list-item-action is deprecated |
+| packages/scss/src/components/horizontalNavigation/mods.scss | 93 | // stylelint-disable-next-line selector-disallowed-list -- .menu-list-item-action is deprecated |
+| packages/scss/src/components/horizontalNavigation/states.scss | 6 | // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated |
+| packages/scss/src/components/horizontalNavigation/states.scss | 28 | // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated |
+| packages/scss/src/components/indexTable/component.scss | 203 | // .indexTable-body-row-cell-action is deprecated |
+| packages/scss/src/components/indexTable/mods.scss | 295 | // .mod-delete is deprecated |
+| packages/scss/src/components/inlineMessage/component.scss | 31 | // .lucca-icon:first-child is deprecated |
+| packages/scss/src/components/inlineMessage/mods.scss | 6 | // .lucca-icon:first-child is deprecated |
+| packages/scss/src/components/inlineMessage/states.scss | 5 | // .lucca-icon:first-child is deprecated |
+| packages/scss/src/components/inlineMessage/states.scss | 18 | // .lucca-icon:first-child is deprecated |
+| packages/scss/src/components/inlineMessage/states.scss | 32 | // .lucca-icon:first-child is deprecated |
+| packages/scss/src/components/label/index.scss | 3 | // stylelint-disable-next-line selector-disallowed-list -- .label is deprecated |
+| packages/scss/src/components/list/index.scss | 20 | // .mod-actionsHidden is deprecated |
+| packages/scss/src/components/loading/index.scss | 22 | // .mod-dialog is deprecated |
+| packages/scss/src/components/loading/index.scss | 28 | // .mod-sidePanel is deprecated |
+| packages/scss/src/components/navside/index.scss | 37 | // .active is deprecated |
+| packages/scss/src/components/navside/index.scss | 97 | // .active is deprecated |
+| packages/scss/src/components/navside/index.scss | 107 | // .active is deprecated |
+| packages/scss/src/components/navside/mods.scss | 14 | // .mod-withMenuCompact is deprecated |
+| packages/scss/src/components/navside/vars.scss | 21 | // --components-navSide-fullwidth-palette-alert-color is deprecated |
+| packages/scss/src/components/navside/vars.scss | 22 | // --components-navSide-fullwidth-palette-alert-text is deprecated |
+| packages/scss/src/components/pageHeader/index.scss | 11 | // .mod-withMenu is deprecated |
+| packages/scss/src/components/pageHeader/mods.scss | 6 | // stylelint-disable-next-line selector-disallowed-list -- .menu is deprecated |
+| packages/scss/src/components/richText/vars.scss | 9 | // with css vars deprecated before values |
+| packages/scss/src/components/section/index.scss | 11 | // .mod-grey is deprecated |
+| packages/scss/src/components/segmentedControl/component.scss | 29 | // .viewTabs-item is deprecated |
+| packages/scss/src/components/segmentedControl/component.scss | 59 | // .viewTabs-item-tab is deprecated |
+| packages/scss/src/components/segmentedControl/component.scss | 101 | // .viewTabs_panel is deprecated |
+| packages/scss/src/components/segmentedControl/index.scss | 4 | // .viewTabs is deprecated |
+| packages/scss/src/components/segmentedControl/index.scss | 28 | // .viewTabs-item-tab is deprecated |
+| packages/scss/src/components/segmentedControl/index.scss | 42 | // .viewTabs_panel is deprecated |
+| packages/scss/src/components/segmentedControl/index.scss | 45 | // .active is deprecated |
+| packages/scss/src/components/simpleSelect/states.scss | 68 | --components-simpleSelect-placeholder: var(--commons-disabled-placeholder); // Deprecated: no placeholder with disabled state |
+| packages/scss/src/components/skeleton/states.scss | 19 | // Deprecated .u- utilities |
+| packages/scss/src/components/skeleton/states.scss | 67 | // Deprecated .u- utilities |
+| packages/scss/src/components/skeleton/states.scss | 157 | // Deprecated |
+| packages/scss/src/components/skeleton/states.scss | 188 | // Deprecated .u- utilities |
+| packages/scss/src/components/sortableList/component.scss | 43 | font-size: var(--components-sortableList-description-fontSize); // Deprecated |
+| packages/scss/src/components/sortableList/component.scss | 44 | line-height: var(--components-sortableList-description-lineHeight); // Deprecated |
+| packages/scss/src/components/sortableList/mods.scss | 20 | // Deprecated |
+| packages/scss/src/components/sortableList/vars.scss | 7 | // Deprecated |
+| packages/scss/src/components/table/index.scss | 106 | // .mod-actionsHidden is deprecated |
+| packages/scss/src/components/tag/component.scss | 22 | font-size: var(--components-tag-fontSize); // Deprecated |
+| packages/scss/src/components/tag/component.scss | 23 | line-height: var(--components-tag-lineHeight); // Deprecated |
+| packages/scss/src/components/tag/index.scss | 18 | // .mod-clickable is deprecated |
+| packages/scss/src/components/tag/mods.scss | 32 | // Deprecated |
+| packages/scss/src/components/tag/mods.scss | 44 | // Deprecated |
+| packages/scss/src/components/tag/vars.scss | 12 | // Deprecated |
+| packages/scss/src/components/textField/vars.scss | 18 | // Deprecated |
+| packages/scss/src/components/title/mods.scss | 8 | --sizes-verticalPadding: var(--sizes-XXL-verticalPadding); // Deprecated |
+| packages/scss/src/components/title/mods.scss | 13 | --sizes-verticalPadding: var(--sizes-XL-verticalPadding); // Deprecated |
+| packages/scss/src/components/title/mods.scss | 18 | --sizes-verticalPadding: var(--sizes-L-verticalPadding); // Deprecated |
+| packages/scss/src/components/title/mods.scss | 23 | --sizes-verticalPadding: var(--sizes-M-verticalPadding); // Deprecated |
+| packages/scss/src/components/title/mods.scss | 26 | // Deprecated |
+| packages/scss/src/components/titleSection/component.scss | 19 | // Deprecated .u- utilities |
+| packages/scss/src/components/titleSection/index.scss | 41 | // Deprecated .u- utilities |
+| packages/scss/src/components/toast/vars.scss | 12 | // Deprecated |
+| packages/scss/src/components/userTile/index.scss | 22 | // .mod-XL is deprecated |
+| packages/scss/src/components/userTile/index.scss | 27 | // .mod-XXL is deprecated |
+| packages/scss/src/components/userTile/index.scss | 32 | // .mod-XXXL is deprecated |
+| packages/scss/src/components/userTile/mods.scss | 29 | @mixin XL { // Deprecated |
+| packages/scss/src/components/userTile/mods.scss | 35 | @mixin XXL { // Deprecated |
+| packages/scss/src/components/userTile/mods.scss | 41 | @mixin XXXL { // Deprecated |

--- a/stories/documentation/integration/deprecations/deprecations.stories.html
+++ b/stories/documentation/integration/deprecations/deprecations.stories.html
@@ -1,0 +1,73 @@
+<div class="deprecations">
+	<p class="deprecations-intro">
+		Every deprecated utility class, CSS custom property, component selector and Sass API in <code>@lucca-front/scss</code>, with its recommended replacement. This
+		page is generated from <code>packages/scss/css-api/deprecations.json</code>, which is built from the deprecation registry in the SCSS sources — it updates
+		automatically whenever something new is deprecated.
+	</p>
+
+	<lu-filter-bar>
+		<lu-segmented-control
+			class="filterBar-segmentedControl"
+			[ngModel]="kind()"
+			(ngModelChange)="kind.set($event)"
+			[ngModelOptions]="{ standalone: true }"
+		>
+			@for (option of kindOptions; track option.value) {
+				<ng-template #label>{{ option.label }} <lu-numeric-badge [value]="option.count" /></ng-template>
+				<lu-segmented-control-filter [label]="label" [value]="option.value" />
+			}
+		</lu-segmented-control>
+
+		<lu-form-field label="Search a deprecation" hiddenLabel>
+			<lu-text-input
+				[ngModel]="search()"
+				(ngModelChange)="search.set($event ?? '')"
+				[ngModelOptions]="{ standalone: true }"
+				placeholder="Search…"
+				hasSearchIcon
+				hasClearer
+			/>
+		</lu-form-field>
+
+		<span *luFilterPillAddonAfter class="deprecations-results">{{ filtered().length }} result(s)</span>
+	</lu-filter-bar>
+
+	@if (filtered().length === 0) {
+		<div class="deprecations-empty">No deprecation matches your search.</div>
+	} @else {
+		@for (group of grouped(); track group.label) {
+			<section class="deprecations-group">
+				@if (group.label) {
+					<h2 class="deprecations-group-title">{{ group.label }}</h2>
+				}
+				<table class="deprecations-table">
+					<thead>
+						<tr>
+							<th scope="col">Deprecated</th>
+							<th scope="col">Replacement</th>
+							<th scope="col">Note</th>
+						</tr>
+					</thead>
+					<tbody>
+						@for (entry of group.entries; track entry.kind + '|' + entry.name) {
+							<tr>
+								<td class="deprecations-name"><code>{{ entry.name }}</code></td>
+								<td class="deprecations-replacement">
+									@if (entry.replacement) {
+										<code>{{ entry.replacement }}</code>
+									} @else {
+										<span class="deprecations-replacement-none">— no direct replacement</span>
+									}
+								</td>
+								<td class="deprecations-note">{{ entry.note }}</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</section>
+		}
+	}
+</div>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/documentation/integration/deprecations/deprecations.stories.ts
+++ b/stories/documentation/integration/deprecations/deprecations.stories.ts
@@ -1,0 +1,179 @@
+import { ChangeDetectionStrategy, Component, computed, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { FilterBarComponent, FilterPillAddonAfterDirective } from '@lucca-front/ng/filter-pills';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { TextInputComponent } from '@lucca-front/ng/forms';
+import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
+import { SegmentedControlComponent, SegmentedControlFilterComponent } from '@lucca-front/ng/segmented-control';
+import { Meta, StoryObj } from '@storybook/angular';
+import deprecationsJson from '../../../../packages/scss/css-api/deprecations.json';
+
+type DeprecationKind = 'class' | 'css-variable' | 'selector' | 'sass-api';
+
+interface DeprecationEntry {
+	kind: DeprecationKind;
+	name: string;
+	replacement: string | null;
+	note: string | null;
+	since: string | null;
+	scope: string;
+}
+
+const ALL_ENTRIES = (deprecationsJson as { version: number; entries: DeprecationEntry[] }).entries;
+
+const KIND_LABELS: Record<DeprecationKind, string> = {
+	'class': 'Utility classes',
+	'css-variable': 'CSS variables',
+	'selector': 'Component selectors',
+	'sass-api': 'Sass API',
+};
+
+const KIND_ORDER: DeprecationKind[] = ['class', 'css-variable', 'selector', 'sass-api'];
+
+@Component({
+	selector: 'deprecations-stories',
+	templateUrl: './deprecations.stories.html',
+	imports: [FormsModule, FilterBarComponent, FilterPillAddonAfterDirective, FormFieldComponent, TextInputComponent, SegmentedControlComponent, SegmentedControlFilterComponent, NumericBadgeComponent],
+	styles: [
+		`
+			.deprecations {
+				display: flex;
+				flex-direction: column;
+				gap: var(--pr-t-spacings-300);
+			}
+
+			.deprecations-intro {
+				font: var(--pr-t-font-body-M);
+				color: var(--pr-t-color-text-subtle);
+				max-inline-size: 60rem;
+			}
+
+			.deprecations-results {
+				font: var(--pr-t-font-body-S);
+				color: var(--pr-t-color-text-subtle);
+				white-space: nowrap;
+			}
+
+			.deprecations-empty {
+				padding: var(--pr-t-spacings-400);
+				text-align: center;
+				color: var(--pr-t-color-text-subtle);
+				background-color: var(--pr-t-elevation-surface-sunken);
+				border-radius: var(--pr-t-border-radius-structure);
+			}
+
+			.deprecations-group {
+				display: flex;
+				flex-direction: column;
+				gap: var(--pr-t-spacings-100);
+			}
+
+			.deprecations-group-title {
+				font: var(--pr-t-font-heading-4);
+				color: var(--pr-t-color-text-heading);
+				margin: 0;
+				padding-block-end: var(--pr-t-spacings-50);
+				border-block-end: 1px solid var(--palettes-neutral-100);
+			}
+
+			.deprecations-table {
+				inline-size: 100%;
+				border-collapse: collapse;
+				font: var(--pr-t-font-body-S);
+			}
+
+			.deprecations-table th {
+				text-align: start;
+				font-weight: var(--pr-t-font-fontWeight-semibold);
+				color: var(--pr-t-color-text-subtle);
+				padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);
+				border-block-end: 1px solid var(--palettes-neutral-200);
+			}
+
+			.deprecations-table td {
+				padding: var(--pr-t-spacings-100) var(--pr-t-spacings-150);
+				border-block-end: 1px solid var(--palettes-neutral-100);
+				vertical-align: baseline;
+			}
+
+			.deprecations-name code,
+			.deprecations-replacement code {
+				font-family: var(--pr-t-font-family-code, monospace);
+				font-size: var(--pr-t-font-fontSize-150);
+				word-break: break-all;
+			}
+
+			.deprecations-name code {
+				color: var(--pr-t-color-text);
+			}
+
+			.deprecations-replacement code {
+				color: var(--palettes-success-700);
+			}
+
+			.deprecations-replacement-none {
+				color: var(--pr-t-color-text-subtle);
+			}
+
+			.deprecations-note {
+				color: var(--pr-t-color-text-subtle);
+			}
+		`,
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DeprecationsStory {
+	readonly search = signal('');
+	readonly kind = signal<DeprecationKind | 'all'>('all');
+
+	protected readonly kindOptions: Array<{ value: DeprecationKind | 'all'; label: string; count: number }> = [
+		{ value: 'all', label: 'All', count: ALL_ENTRIES.length },
+		...KIND_ORDER.map((k) => ({ value: k, label: KIND_LABELS[k], count: ALL_ENTRIES.filter((e) => e.kind === k).length })),
+	];
+
+	readonly filtered = computed(() => {
+		const search = this.search().trim().toLowerCase();
+		const kind = this.kind();
+		return ALL_ENTRIES.filter((entry) => {
+			if (kind !== 'all' && entry.kind !== kind) {
+				return false;
+			}
+			if (!search) {
+				return true;
+			}
+			return (
+				entry.name.toLowerCase().includes(search) ||
+				(entry.replacement ?? '').toLowerCase().includes(search) ||
+				(entry.note ?? '').toLowerCase().includes(search) ||
+				entry.scope.toLowerCase().includes(search)
+			);
+		});
+	});
+
+	readonly grouped = computed(() => {
+		const entries = this.filtered();
+		if (this.search().trim()) {
+			return entries.length === 0 ? [] : [{ label: '', entries }];
+		}
+		const groups = new Map<string, DeprecationEntry[]>();
+		for (const entry of entries) {
+			const key = `${KIND_LABELS[entry.kind]} · ${entry.scope}`;
+			if (!groups.has(key)) {
+				groups.set(key, []);
+			}
+			groups.get(key)!.push(entry);
+		}
+		return Array.from(groups.entries())
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([label, entries]) => ({ label, entries }));
+	});
+}
+
+export default {
+	title: 'Documentation/Integration/Deprecations',
+	component: DeprecationsStory,
+} as Meta;
+
+export const Deprecations: StoryObj<DeprecationsStory> = {
+	render: () => ({}),
+};


### PR DESCRIPTION
## Description

Deprecation in `@lucca-front/scss` was expressed four incompatible, machine-unreadable ways: silent `//` comments, `// DEPRECATED` section headers, inline value-list annotations, and config flags. None survive Sass compilation, so the VS Code IntelliSense manifest had to reconstruct deprecation from a **frozen regex seed** (`css-api/deprecations.js`) — brittle (false positives/negatives), drift-prone, and a split source of truth. It was untrustworthy enough that the extension shipped deprecation flagging off by default.

## What this PR does

Introduces **one authoritative, colocated, machine-readable deprecation signal** that emits **zero bytes** into the compiled CSS.

### The convention: a registry mixin

`packages/scss/src/commons/deprecated.scss` exposes `deprecated.class()`, `deprecated.cssVariable()`, `deprecated.selector()` and `deprecated.sassApi()`. Each records metadata into a module-level map and emits no CSS. You call it at the declaration site:

```scss
// Before — invisible to tooling, stripped at compile time
// textLeft is deprecated
.pr-u-textLeft { @extend %textLeft; }

// After — authoritative, survives to JSON, still zero CSS
@include deprecated.class('pr-u-textLeft', $replacement: 'pr-u-textAlignStart', $scope: 'commons/utils');
.pr-u-textLeft { @extend %textLeft; }
```

For loop-generated names (spacing/border-radius/palette utilities, the whole `u-` prefix) the registration lives **inside the loop** using the same interpolation that builds the emitted class, so the recorded name is exact by construction — no regex guessing. This is why the approach was chosen over loud `/* @deprecated */` comments: comments can't anchor to `@extend`-merged selectors or loop output, and de-merging `@extend` would *grow* the shipped CSS.

**Rule:** a deprecation isn't a deprecation until it's registered.

### The manifest

A build step (`npm run scss:deprecations`) compiles a maximal-config entry, reads the registry out through a custom Sass function, and writes **`packages/scss/css-api/deprecations.json`** (committed, deterministic, sorted). Schema:

```json
{ "version": 1, "package": "@lucca-front/scss",
  "entries": [ { "kind": "class", "name": "pr-u-textLeft", "replacement": "pr-u-textAlignStart", "note": null, "since": null, "scope": "commons/utils" } ] }
```

**684 entries**: 477 utility classes, 140 CSS variables, 49 component selectors, 18 Sass APIs. The manifest is committed (so Storybook and typecheck work from a clean checkout) and shipped in the published package; CI runs `npm run scss:deprecations -- --check` to fail on drift.

### Storybook page

`Documentation / Integration / Deprecations` — a searchable, kind-filterable table of every deprecated element and its replacement, built programmatically from the committed JSON so it updates automatically. The PR's staging build posts a live preview link.

### Size audit — provably neutral

Registry calls emit no CSS. `npm run scss:audit` compiles the full bundle and every module before/after and compares sha256:

| Output | Before | After | Δ |
| --- | ---: | ---: | ---: |
| bundle `lucca-front.min.css` | 1,242,368 B | 1,242,368 B | **0** |
| bundle (maximal config, `u-` prefix on) | 1,248,519 B | 1,248,519 B | **0** |

**125/125 comparable outputs are byte-identical** (the full bundle + commons + 123 component modules; one pre-existing component that doesn't compile standalone is excluded). Full per-module table and the before/after deprecation inventory: `scss-size-audit.md`.

## Commits

1. `tech(scss): add deprecation registry module and extraction tooling`
2. `tech(scss): register commons deprecations through the registry`
3. `tech(scss): register component deprecations through the registry`
4. `tech(scss): commit generated deprecations manifest with CI drift check`
5. `feat(stories): add deprecations explorer to integration documentation`
6. `tech(scss): satisfy stylelint formatting and harden the audit tool`
7. `docs(scss): document the deprecation registry and audit workflow`

## Notes & known limitations

- Selector deprecations key on `(kind, name)` without scope, so a bare class shared across components (e.g. `.mod-text` in both button and buttonGroup) is recorded once, under one component. Compound selectors (`.box.mod-grey`) are unambiguous. Acceptable given the shared class name; can be refined later if needed.
- A few `--commons-*` custom properties under the legacy block (container/navSide sizing) were left unregistered because they lack a clear replacement and appear semi-active internally — deliberately under-claiming rather than mis-claiming deprecation.
- Usage-site `@warn` (warning consumers who include a deprecated Sass mixin) is intentionally deferred — it adds build-log noise for little value and can be a follow-up.
- No CI size gate: size-neutrality is a property of *this* refactor, not a package invariant (future PRs legitimately change sizes). The audit tool is committed for one-off use.

## Follow-ups (branch `feat.vscode.intellisense`)

- Have `css-api/generate.js` consume `deprecations.json` and **delete the regex seed** `css-api/deprecations.js`.
- Enable the extension's deprecation diagnostics by default now that the data is trustworthy.
- Feed the same JSON into a stylelint rule and `ng update` codemods.


-----
