### PR TITLE
tech(ng): replace remaining setTimeout with afterNextRender and zoneless-friendly alternatives

### DIFF
--- a/packages/ng/core-select/api/api-v4.directive.ts
+++ b/packages/ng/core-select/api/api-v4.directive.ts
@@ -3,7 +3,7 @@ import { computed, Directive, forwardRef, inject, input, model } from '@angular/
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ILuApiItem } from '@lucca-front/ng/api';
 import { applySearchDelimiter, CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider } from '@lucca-front/ng/core-select';
-import { debounceTime, map, Observable, switchMap } from 'rxjs';
+import { debounceTime, map, Observable, of, switchMap } from 'rxjs';
 import { ALuCoreSelectApiDirective } from './api.directive';
 
 @Directive({
@@ -26,6 +26,16 @@ export class LuCoreSelectApiV4Directive<T extends ILuApiItem> extends ALuCoreSel
 	protected httpClient = inject(HttpClient);
 
 	protected readonly clue = toSignal(this.clue$);
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			...(this.sort() ? { sort: this.sort() } : {}),
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()) } : {}),
+		});
+	}
 
 	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -4,7 +4,6 @@ import { By } from '@angular/platform-browser';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { NEVER, Observable, map, of } from 'rxjs';
 import type { MockInstance } from 'vitest';
-import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { ALuCoreSelectApiDirective, MAGIC_DEBOUNCE_DURATION } from './api.directive';
 
 interface TestEntity {
@@ -77,7 +76,7 @@ describe('ALuCoreSelectApiDirective', () => {
 	it('should query options when clicking on the select', fakeAsync(() => {
 		selectElement.click();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
@@ -87,7 +86,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		selectElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
 		fixture.detectChanges();
 		tick(10); // Wait for panel to be opened
-		tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
@@ -120,7 +119,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		select.clueChanged('hey');
 		fixture.detectChanges();
 		tick(MAGIC_DEBOUNCE_DURATION);
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({ clue: 'hey' }, 0);
@@ -154,12 +153,12 @@ describe('ALuCoreSelectApiDirective', () => {
 			]),
 		);
 		select.nextPage$.next();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// // Act (Page 3)
 		getOptionsSpy.mockReturnValue(of([{ id: 5, name: 'test 5' }]));
 		select.nextPage$.next();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act (do nothing)
 		select.nextPage$.next();
@@ -207,11 +206,11 @@ describe('ALuCoreSelectApiDirective', () => {
 		// Act (Page 1)
 		select.openPanel();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act (Page 2)
 		select.nextPage$.next();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		let options: readonly TestEntity[] = [];

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -113,7 +113,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		expect(loadingWhenPanelOpens).toBe(true);
 
 		tick(300);
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 		expect(select.loading()).toBe(false);
 	}));
 

--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -4,7 +4,6 @@ import { By } from '@angular/platform-browser';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { NEVER, Observable, delay, map, of } from 'rxjs';
 import type { MockInstance } from 'vitest';
-import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { ALuCoreSelectApiDirective, MAGIC_DEBOUNCE_DURATION } from './api.directive';
 
 interface TestEntity {
@@ -77,7 +76,7 @@ describe('ALuCoreSelectApiDirective', () => {
 	it('should query options when clicking on the select', fakeAsync(() => {
 		selectElement.click();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
@@ -87,7 +86,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		selectElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
 		fixture.detectChanges();
 		tick(10); // Wait for panel to be opened
-		tick(MAGIC_OPTION_SCROLL_DELAY); // Avoid "1 periodic timer(s) still in the queue." because of the setTimeout in the option component
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
@@ -145,7 +144,7 @@ describe('ALuCoreSelectApiDirective', () => {
 		select.clueChanged('hey');
 		fixture.detectChanges();
 		tick(MAGIC_DEBOUNCE_DURATION);
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({ clue: 'hey' }, 0);
@@ -179,12 +178,12 @@ describe('ALuCoreSelectApiDirective', () => {
 			]),
 		);
 		select.nextPage$.next();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// // Act (Page 3)
 		getOptionsSpy.mockReturnValue(of([{ id: 5, name: 'test 5' }]));
 		select.nextPage$.next();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act (do nothing)
 		select.nextPage$.next();
@@ -232,11 +231,11 @@ describe('ALuCoreSelectApiDirective', () => {
 		// Act (Page 1)
 		select.openPanel();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act (Page 2)
 		select.nextPage$.next();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		let options: readonly TestEntity[] = [];

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -57,9 +57,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		// to avoid stale params when selection triggers an immediate clue reset
 		return of({
 			...this.filters(),
-			...(clue
-				? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' }
-				: { sort: 'legalunit.name,name' }),
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' } : { sort: 'legalunit.name,name' }),
 			...(this.operationIds() ? { operations: this.operationIds()!.join(',') } : {}),
 			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
 			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -3,7 +3,7 @@ import { DestroyRef, Directive, OnInit, computed, forwardRef, inject, input } fr
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, debounceTime, filter, map, switchMap } from 'rxjs';
+import { Observable, debounceTime, filter, map, of, switchMap } from 'rxjs';
 import { LuEstablishmentGroupingComponent } from './establishment-grouping.component';
 import { EstablishmentGroupingService } from './establishment-grouping.service';
 import { LuCoreSelectEstablishment } from './models';
@@ -49,6 +49,20 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 				selector: (option) => option.legalUnitId,
 				content: LuEstablishmentGroupingComponent,
 			});
+		});
+	}
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			...(clue
+				? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' }
+				: { sort: 'legalunit.name,name' }),
+			...(this.operationIds() ? { operations: this.operationIds()!.join(',') } : {}),
+			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
+			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),
 		});
 	}
 

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -58,9 +58,7 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		// to avoid stale params when selection triggers an immediate clue reset
 		return of({
 			...this.filters(),
-			...(clue
-				? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' }
-				: { sort: 'legalunit.name,name' }),
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' } : { sort: 'legalunit.name,name' }),
 			...(this.operationIds() ? { operations: this.operationIds()!.join(',') } : {}),
 			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
 			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -4,7 +4,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { luNullableNumberAttribute } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, debounceTime, filter, map, switchMap } from 'rxjs';
+import { Observable, debounceTime, filter, map, of, switchMap } from 'rxjs';
 import { LuEstablishmentGroupingComponent } from './establishment-grouping.component';
 import { EstablishmentGroupingService } from './establishment-grouping.service';
 import { LuCoreSelectEstablishment } from './models';
@@ -50,6 +50,20 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 				selector: (option) => option.legalUnitId,
 				content: LuEstablishmentGroupingComponent,
 			});
+		});
+	}
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			...(clue
+				? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' }
+				: { sort: 'legalunit.name,name' }),
+			...(this.operationIds() ? { operations: this.operationIds()!.join(',') } : {}),
+			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
+			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),
 		});
 	}
 

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -410,26 +410,18 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		this.inputElementRef()?.nativeElement.focus();
 	}
 
+	// Re-entrancy guard: opening the panel (focus, clueChanged, overlay creation) can synchronously
+	// trigger openPanel again, which used to cause a double tap.
+	#isOpeningPanel = false;
+
 	openPanel(clue: string = ''): void {
-		if (this.filterPillMode || this.isPanelOpen || this.disabled$.value) {
+		if (this.filterPillMode || this.isPanelOpen || this.disabled$.value || this.#isOpeningPanel) {
 			return;
 		}
 
-		this.focusInput();
-
-		/**
-		 * I know what you're thinking, but let me explain:
-		 *
-		 * When setting isPanelOpen$'s internal value to true and then calling clueChanged,
-		 * it creates a race condition which calls this method again from inside clueChanged's code before
-		 * the change is applied inside the Subject, meaning this is called twice and we get a double tap.
-		 *
-		 * The only easy solution is this (or store yet another boolean like "isOpeningPanel" which is, imo, equally ugly.
-		 */
-		setTimeout(() => {
-			if (this.isPanelOpen) {
-				return;
-			}
+		this.#isOpeningPanel = true;
+		try {
+			this.focusInput();
 
 			const isSearchable = this.searchable;
 			this.isPanelOpen$.next(true);
@@ -441,7 +433,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 			this._panelRef = this.buildPanelRef();
 			this.bindInputToPanelRefEvents();
-		});
+		} finally {
+			this.#isOpeningPanel = false;
+		}
 	}
 
 	emitAddOption(): void {

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -409,26 +409,18 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 		this.inputElementRef()?.nativeElement.focus();
 	}
 
+	// Re-entrancy guard: opening the panel (focus, clueChanged, overlay creation) can synchronously
+	// trigger openPanel again, which used to cause a double tap.
+	#isOpeningPanel = false;
+
 	openPanel(clue: string = ''): void {
-		if (this.filterPillMode || this.isPanelOpen || this.disabled$.value) {
+		if (this.filterPillMode || this.isPanelOpen || this.disabled$.value || this.#isOpeningPanel) {
 			return;
 		}
 
-		this.focusInput();
-
-		/**
-		 * I know what you're thinking, but let me explain:
-		 *
-		 * When setting isPanelOpen$'s internal value to true and then calling clueChanged,
-		 * it creates a race condition which calls this method again from inside clueChanged's code before
-		 * the change is applied inside the Subject, meaning this is called twice and we get a double tap.
-		 *
-		 * The only easy solution is this (or store yet another boolean like "isOpeningPanel" which is, imo, equally ugly.
-		 */
-		setTimeout(() => {
-			if (this.isPanelOpen) {
-				return;
-			}
+		this.#isOpeningPanel = true;
+		try {
+			this.focusInput();
 
 			const isSearchable = this.searchable;
 			this.isPanelOpen$.next(true);
@@ -440,7 +432,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 			this._panelRef = this.buildPanelRef();
 			this.bindInputToPanelRefEvents();
-		});
+		} finally {
+			this.#isOpeningPanel = false;
+		}
 	}
 
 	emitAddOption(): void {

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -3,7 +3,7 @@ import { Directive, OnInit, computed, forwardRef, inject, input } from '@angular
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { Observable, debounceTime, map, of, switchMap } from 'rxjs';
 import { LuJobQualificationGroupingComponent } from './job-qualification-grouping.component';
 import { LuCoreSelectJobQualification } from './models';
 
@@ -37,6 +37,15 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 		this.select.groupingSignal.set({
 			selector: (option) => option.job.id,
 			content: LuJobQualificationGroupingComponent,
+		});
+	}
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' } : { sort: 'job.name,level.position' }),
 		});
 	}
 

--- a/packages/ng/core-select/legal-units/legal-units.directive.ts
+++ b/packages/ng/core-select/legal-units/legal-units.directive.ts
@@ -4,7 +4,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { Observable, debounceTime, map, of, switchMap } from 'rxjs';
 import { ARCHIVED_LEGAL_UNITS_CONTEXT, LuCoreSelectArchivedLegalUnitsComponent } from './archived-legal-units.component';
 import { LuCoreSelectLegalUnit } from './models';
 
@@ -40,6 +40,18 @@ export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = L
 	constructor() {
 		super();
 		ɵeffectWithDeps([this.enableArchivedLegalUnits], (enableArchivedLegalUnits) => this.select.panelHeaderTpl.set(enableArchivedLegalUnits ? LuCoreSelectArchivedLegalUnitsComponent : undefined));
+	}
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			sort: 'name',
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()) } : {}),
+			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
+			...(this.includeArchivedLegalUnits() ? { isArchived: true } : {}),
+		});
 	}
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {

--- a/packages/ng/core-select/legal-units/legal-units.directive.ts
+++ b/packages/ng/core-select/legal-units/legal-units.directive.ts
@@ -4,7 +4,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { luBooleanAttribute, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { Observable, debounceTime, map, of, switchMap } from 'rxjs';
 import { ARCHIVED_LEGAL_UNITS_CONTEXT, LuCoreSelectArchivedLegalUnitsComponent } from './archived-legal-units.component';
 import { LuCoreSelectLegalUnit } from './models';
 
@@ -40,6 +40,18 @@ export class LuCoreSelectLegalUnitsDirective<T extends LuCoreSelectLegalUnit = L
 	constructor() {
 		super();
 		ɵeffectWithDeps([this.enableArchivedLegalUnits], (enableArchivedLegalUnits) => this.select.panelHeaderTpl.set(enableArchivedLegalUnits ? LuCoreSelectArchivedLegalUnitsComponent : undefined));
+	}
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			sort: 'name',
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()) } : {}),
+			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
+			...(this.includeArchivedLegalUnits() ? { isArchived: true } : {}),
+		});
 	}
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {

--- a/packages/ng/core-select/occupation-category/occupation-category.directive.ts
+++ b/packages/ng/core-select/occupation-category/occupation-category.directive.ts
@@ -3,7 +3,7 @@ import { Directive, OnInit, computed, forwardRef, inject, input } from '@angular
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
-import { Observable, debounceTime, map, switchMap } from 'rxjs';
+import { Observable, debounceTime, map, of, switchMap } from 'rxjs';
 import { LuCoreSelectOccupationCategory } from './models';
 
 @Directive({
@@ -30,6 +30,15 @@ export class LuCoreSelectOccupationCategoriesDirective<T extends LuCoreSelectOcc
 	readonly searchDelimiter = input<string>(' ');
 
 	protected readonly clue = toSignal(this.clue$);
+
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			...this.filters(),
+			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' } : { sort: 'name' }),
+		});
+	}
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
 		return this.httpClient

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,4 +1,20 @@
-import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
+import {
+	afterNextRender,
+	booleanAttribute,
+	ChangeDetectionStrategy,
+	ChangeDetectorRef,
+	Component,
+	ElementRef,
+	inject,
+	Injector,
+	input,
+	OnInit,
+	output,
+	TemplateRef,
+	Type,
+	untracked,
+	viewChild,
+} from '@angular/core';
 import { intlInputOptions, isNil, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { asyncScheduler, observeOn } from 'rxjs';
@@ -10,8 +26,6 @@ import { LuOptionGroupPipe } from './group.pipe';
 import { LuOptionOutletDirective } from './option-outlet.directive';
 import { LU_OPTION_CONTEXT } from './option.token';
 import { LU_OPTION_TRANSLATIONS } from './option.translate';
-
-export const MAGIC_OPTION_SCROLL_DELAY = 15;
 
 @Component({
 	selector: 'lu-select-option',
@@ -51,6 +65,7 @@ export class LuOptionComponent<T> implements OnInit {
 	readonly optionContext = viewChild(LU_OPTION_CONTEXT);
 
 	private cdr = inject(ChangeDetectorRef);
+	readonly #injector = inject(Injector);
 
 	get id(): string {
 		const groupPart = this.groupIndex() === undefined ? `` : `-group-${this.groupIndex()}`;
@@ -64,10 +79,13 @@ export class LuOptionComponent<T> implements OnInit {
 	constructor() {
 		ɵeffectWithDeps([this.selectableItem.isHighlighted], (isHighlighted, onCleanup) => {
 			if (isHighlighted && !untracked(this.#panelRef.pointerNavigation)) {
-				const timeoutId = setTimeout(() => {
-					this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions());
-				}, MAGIC_OPTION_SCROLL_DELAY);
-				onCleanup(() => clearTimeout(timeoutId));
+				const ref = afterNextRender(
+					() => {
+						this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions());
+					},
+					{ injector: this.#injector },
+				);
+				onCleanup(() => ref.destroy());
 			}
 		});
 

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,25 +1,9 @@
-import {
-	afterNextRender,
-	booleanAttribute,
-	ChangeDetectionStrategy,
-	ChangeDetectorRef,
-	Component,
-	ElementRef,
-	inject,
-	Injector,
-	input,
-	OnInit,
-	output,
-	TemplateRef,
-	Type,
-	untracked,
-	viewChild,
-} from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, Injector, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
 import { intlInputOptions, isNil, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { asyncScheduler, observeOn } from 'rxjs';
 import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from '../panel/panel.instance';
-import { GroupTemplateLocation } from '../panel/panel.utils';
+import { GroupTemplateLocation, scrollIntoViewOnceReady } from '../panel/panel.utils';
 import { CoreSelectPanelElement } from '../panel/selectable-item';
 import { LuOptionContext, LuOptionGrouping, SELECT_ID } from '../select.model';
 import { LuOptionGroupPipe } from './group.pipe';
@@ -79,13 +63,9 @@ export class LuOptionComponent<T> implements OnInit {
 	constructor() {
 		ɵeffectWithDeps([this.selectableItem.isHighlighted], (isHighlighted, onCleanup) => {
 			if (isHighlighted && !untracked(this.#panelRef.pointerNavigation)) {
-				const ref = afterNextRender(
-					() => {
-						this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions());
-					},
-					{ injector: this.#injector },
-				);
-				onCleanup(() => ref.destroy());
+				// Wait for the panel layout to settle (opening animation) before scrolling,
+				// otherwise the browser computes a bogus scroll position.
+				onCleanup(scrollIntoViewOnceReady(this.elementRef.nativeElement, this.#injector, () => this.scrollIntoViewOptions()));
 			}
 		});
 

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,9 +1,9 @@
-import { afterNextRender, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, Injector, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, Injector, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
 import { intlInputOptions, isNil, luBooleanAttribute, luOptionalNumberAttribute, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { asyncScheduler, observeOn } from 'rxjs';
 import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from '../panel/panel.instance';
-import { GroupTemplateLocation } from '../panel/panel.utils';
+import { GroupTemplateLocation, scrollIntoViewOnceReady } from '../panel/panel.utils';
 import { CoreSelectPanelElement } from '../panel/selectable-item';
 import { LuOptionContext, LuOptionGrouping, SELECT_ID } from '../select.model';
 import { LuOptionGroupPipe } from './group.pipe';
@@ -63,13 +63,9 @@ export class LuOptionComponent<T> implements OnInit {
 	constructor() {
 		ɵeffectWithDeps([this.selectableItem.isHighlighted], (isHighlighted, onCleanup) => {
 			if (isHighlighted && !untracked(this.#panelRef.pointerNavigation)) {
-				const ref = afterNextRender(
-					() => {
-						this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions());
-					},
-					{ injector: this.#injector },
-				);
-				onCleanup(() => ref.destroy());
+				// Wait for the panel layout to settle (opening animation) before scrolling,
+				// otherwise the browser computes a bogus scroll position.
+				onCleanup(scrollIntoViewOnceReady(this.elementRef.nativeElement, this.#injector, () => this.scrollIntoViewOptions()));
 			}
 		});
 

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, inject, Injector, input, OnInit, output, TemplateRef, Type, untracked, viewChild } from '@angular/core';
 import { intlInputOptions, isNil, luBooleanAttribute, luOptionalNumberAttribute, PortalDirective, ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { asyncScheduler, observeOn } from 'rxjs';
@@ -10,8 +10,6 @@ import { LuOptionGroupPipe } from './group.pipe';
 import { LuOptionOutletDirective } from './option-outlet.directive';
 import { LU_OPTION_CONTEXT } from './option.token';
 import { LU_OPTION_TRANSLATIONS } from './option.translate';
-
-export const MAGIC_OPTION_SCROLL_DELAY = 15;
 
 @Component({
 	selector: 'lu-select-option',
@@ -51,6 +49,7 @@ export class LuOptionComponent<T> implements OnInit {
 	readonly optionContext = viewChild(LU_OPTION_CONTEXT);
 
 	private cdr = inject(ChangeDetectorRef);
+	readonly #injector = inject(Injector);
 
 	get id(): string {
 		const groupPart = this.groupIndex() === undefined ? `` : `-group-${this.groupIndex()}`;
@@ -64,10 +63,13 @@ export class LuOptionComponent<T> implements OnInit {
 	constructor() {
 		ɵeffectWithDeps([this.selectableItem.isHighlighted], (isHighlighted, onCleanup) => {
 			if (isHighlighted && !untracked(this.#panelRef.pointerNavigation)) {
-				const timeoutId = setTimeout(() => {
-					this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions());
-				}, MAGIC_OPTION_SCROLL_DELAY);
-				onCleanup(() => clearTimeout(timeoutId));
+				const ref = afterNextRender(
+					() => {
+						this.elementRef.nativeElement.scrollIntoView(this.scrollIntoViewOptions());
+					},
+					{ injector: this.#injector },
+				);
+				onCleanup(() => ref.destroy());
 			}
 		});
 

--- a/packages/ng/core-select/panel/index.ts
+++ b/packages/ng/core-select/panel/index.ts
@@ -1,6 +1,6 @@
 export * from './key-manager';
 export * from './panel-header-template.directive';
 export * from './panel.models';
-export { getGroupTemplateLocation as ɵgetGroupTemplateLocation } from './panel.utils';
+export { getGroupTemplateLocation as ɵgetGroupTemplateLocation, scrollIntoViewOnceReady as ɵscrollIntoViewOnceReady } from './panel.utils';
 export { CoreSelectPanelElement as ɵCoreSelectPanelElement } from './selectable-item';
 export * from './panel.instance';

--- a/packages/ng/core-select/panel/panel.utils.ts
+++ b/packages/ng/core-select/panel/panel.utils.ts
@@ -1,4 +1,46 @@
-import { computed, Signal } from '@angular/core';
+import { afterNextRender, computed, Injector, Signal } from '@angular/core';
+
+/**
+ * Scrolls an element into view once its layout has settled.
+ *
+ * When a select panel opens, its opening animation (scale transform) makes the element's visual
+ * geometry differ from its layout geometry; calling scrollIntoView at that point makes the browser
+ * compute a bogus scroll position (e.g. the panel opens scrolled partway down). This waits, frame
+ * by frame, until the element's visual height is stable before scrolling.
+ *
+ * Returns a cancel function to abort the pending scroll (e.g. when the highlight moves elsewhere).
+ */
+export function scrollIntoViewOnceReady(element: HTMLElement, injector: Injector, options?: () => ScrollIntoViewOptions | undefined): () => void {
+	let rafId: number | null = null;
+	let lastHeight = -1;
+
+	const renderRef = afterNextRender(
+		() => {
+			const tryScroll = () => {
+				rafId = null;
+				if (!element.isConnected) {
+					return;
+				}
+				const { height } = element.getBoundingClientRect();
+				if (height > 0 && height === lastHeight) {
+					element.scrollIntoView(options?.());
+				} else {
+					lastHeight = height;
+					rafId = requestAnimationFrame(tryScroll);
+				}
+			};
+			tryScroll();
+		},
+		{ injector },
+	);
+
+	return () => {
+		renderRef.destroy();
+		if (rafId !== null) {
+			cancelAnimationFrame(rafId);
+		}
+	};
+}
 
 export type GroupTemplateLocation = 'group-header' | 'option' | 'none';
 

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -6,7 +6,6 @@ import { skip } from 'rxjs';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { MAGIC_DEBOUNCE_DURATION } from '../api/api.directive';
-import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { provideCoreSelectCurrentUserId } from './me.provider';
 import { LuCoreSelectUser } from './user-option.model';
 import { LuCoreSelectUsersDirective } from './users.directive';
@@ -61,7 +60,7 @@ describe('LuCoreSelectUsersDirective', () => {
 	it('should not make any call on init', fakeAsync(() => {
 		// Act
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		httpTestingController.verify();
@@ -71,7 +70,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		// Act
 		simpleSelect.openPanel();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert (Me + Initial list)
 		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
@@ -87,18 +86,18 @@ describe('LuCoreSelectUsersDirective', () => {
 
 		const page1 = [createUser(1), createUser(2), createUser(3)];
 
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act
 		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
 		meReq.flush(null, { status: 500, statusText: 'Server Error' });
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const page1Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,3`);
 		page1Req.flush(usersResponse(page1));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		let options: readonly LuCoreSelectUser[] = [];
@@ -155,18 +154,18 @@ describe('LuCoreSelectUsersDirective', () => {
 		const page1 = [createUser(1), createUser(2), createUser(3)];
 		const page2 = [createUser(4), meUser, createUser(6)];
 
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act (Page 1)
 		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
 		meReq.flush(usersResponse([meUser]));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const page1Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,3`);
 		page1Req.flush(usersResponse(page1));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert (Page 1)
 		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, ...page1]);
@@ -174,12 +173,12 @@ describe('LuCoreSelectUsersDirective', () => {
 		// Act (Page 2)
 		simpleSelect.nextPage$.next();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const page2Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=3,3`);
 		page2Req.flush(usersResponse(page2));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert (Page 2)
 		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, ...page1, ...page2.filter((u) => u.id !== CURRENT_USER_ID)]);
@@ -192,7 +191,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		simpleSelect.openPanel();
 		fixture.detectChanges();
 
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const meUser = createUser(CURRENT_USER_ID);
 		const user1 = createUser(1);

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -194,7 +194,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		// Act
 		simpleSelect.openPanel();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		// The "me" lookup is a lookup by id and must NOT carry the search filters (`foo=bar`)

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -6,7 +6,6 @@ import { skip } from 'rxjs';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { MAGIC_DEBOUNCE_DURATION } from '../api/api.directive';
-import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { provideCoreSelectCurrentUserId } from './me.provider';
 import { LuCoreSelectUser } from './user-option.model';
 import { LuCoreSelectUsersDirective } from './users.directive';
@@ -62,7 +61,7 @@ describe('LuCoreSelectUsersDirective', () => {
 	it('should not make any call on init', fakeAsync(() => {
 		// Act
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		httpTestingController.verify();
@@ -72,7 +71,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		// Act
 		simpleSelect.openPanel();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert (Me + Initial list)
 		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
@@ -88,18 +87,18 @@ describe('LuCoreSelectUsersDirective', () => {
 
 		const page1 = [createUser(1), createUser(2), createUser(3)];
 
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act
 		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
 		meReq.flush(null, { status: 500, statusText: 'Server Error' });
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const page1Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,3`);
 		page1Req.flush(usersResponse(page1));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert
 		let options: readonly LuCoreSelectUser[] = [];
@@ -156,18 +155,18 @@ describe('LuCoreSelectUsersDirective', () => {
 		const page1 = [createUser(1), createUser(2), createUser(3)];
 		const page2 = [createUser(4), meUser, createUser(6)];
 
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Act (Page 1)
 		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
 		meReq.flush(usersResponse([meUser]));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const page1Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,3`);
 		page1Req.flush(usersResponse(page1));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert (Page 1)
 		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, ...page1]);
@@ -175,12 +174,12 @@ describe('LuCoreSelectUsersDirective', () => {
 		// Act (Page 2)
 		simpleSelect.nextPage$.next();
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const page2Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=3,3`);
 		page2Req.flush(usersResponse(page2));
 		fixture.detectChanges();
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		// Assert (Page 2)
 		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, ...page1, ...page2.filter((u) => u.id !== CURRENT_USER_ID)]);
@@ -211,7 +210,7 @@ describe('LuCoreSelectUsersDirective', () => {
 		simpleSelect.openPanel();
 		fixture.detectChanges();
 
-		tick(MAGIC_OPTION_SCROLL_DELAY);
+		tick();
 
 		const meUser = createUser(CURRENT_USER_ID);
 		const user1 = createUser(1);

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -93,6 +93,21 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 
 	protected readonly clue = toSignal(this.clue$);
 
+	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
+		// Use the clue parameter directly instead of reading from the async signal
+		// to avoid stale params when selection triggers an immediate clue reset
+		return of({
+			fields: this.#userFields,
+			...this.filters(),
+			...(this.orderBy() ? { orderBy: this.orderBy() } : {}),
+			...(clue ? { clue: applySearchDelimiter(clue, this.searchDelimiter()) } : {}),
+			...(this.operationIds() ? { operations: this.operationIds()!.join(',') } : {}),
+			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
+			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),
+			...(this.includeFormerEmployees() ? { formerEmployees: this.includeFormerEmployees() } : {}),
+		});
+	}
+
 	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(
 		computed(() => {
 			const orderBy = this.orderBy();

--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
@@ -6,7 +6,7 @@ import { ButtonComponent } from '@lucca-front/ng/button';
 import { getIntl, Palette } from '@lucca-front/ng/core';
 import { DialogComponent, DialogContentComponent, DialogFooterComponent, DialogHeaderComponent, injectDialogData, injectDialogRef } from '@lucca-front/ng/dialog';
 import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
-import { isObservable, Observable, of, ReplaySubject, Subject } from 'rxjs';
+import { isObservable, Observable, of, ReplaySubject, Subject, timer } from 'rxjs';
 import { delay, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { ALuModalRef } from '../../modal-ref.model';
 import { ILuModalContent, LuModalContentResult } from '../../modal.model';
@@ -83,9 +83,9 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 						error: (err) => {
 							this.submitClass.set('is-error');
 							this.error$.next(err);
-							setTimeout(() => {
-								this.submitClass.set('');
-							}, 2000);
+							timer(2000)
+								.pipe(takeUntilDestroyed(this.#destroyRef))
+								.subscribe(() => this.submitClass.set(''));
 						},
 						complete: () => this.submitClass.set(''),
 					});

--- a/packages/ng/multi-select/input/select-all/multi-select-all-header.component.ts
+++ b/packages/ng/multi-select/input/select-all/multi-select-all-header.component.ts
@@ -1,7 +1,7 @@
-import { afterNextRender, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, Injector } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, Injector } from '@angular/core';
 import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
-import { ɵCoreSelectPanelElement } from '@lucca-front/ng/core-select';
+import { ɵCoreSelectPanelElement, ɵscrollIntoViewOnceReady } from '@lucca-front/ng/core-select';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { CheckboxInputComponent } from '@lucca-front/ng/forms';
 import { MULTI_SELECT_WITH_SELECT_ALL_CONTEXT } from './select-all.models';
@@ -39,13 +39,9 @@ export class LuMultiSelectAllHeaderComponent {
 		this.#selectableItem.id.set(`multi-select-select-all`);
 		effect((onCleanup) => {
 			if (this.#selectableItem.isHighlighted()) {
-				const ref = afterNextRender(
-					() => {
-						this.#elementRef.nativeElement.scrollIntoView();
-					},
-					{ injector: this.#injector },
-				);
-				onCleanup(() => ref.destroy());
+				// Wait for the panel layout to settle (opening animation) before scrolling,
+				// otherwise the browser computes a bogus scroll position.
+				onCleanup(ɵscrollIntoViewOnceReady(this.#elementRef.nativeElement, this.#injector));
 			}
 			if (this.isSelected()) {
 				this.#selectableItem.isSelected.set(true);

--- a/packages/ng/multi-select/input/select-all/multi-select-all-header.component.ts
+++ b/packages/ng/multi-select/input/select-all/multi-select-all-header.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject } from '@angular/core';
+import { afterNextRender, ChangeDetectionStrategy, Component, computed, effect, ElementRef, inject, Injector } from '@angular/core';
 import { outputToObservable, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ɵCoreSelectPanelElement } from '@lucca-front/ng/core-select';
@@ -33,14 +33,19 @@ export class LuMultiSelectAllHeaderComponent {
 	readonly isSelected = computed(() => this.selectAllContext.mode() === 'all' || this.mixed());
 	readonly #selectableItem = inject(ɵCoreSelectPanelElement);
 	readonly #elementRef = inject<ElementRef<HTMLElement>>(ElementRef);
+	readonly #injector = inject(Injector);
 
 	constructor() {
 		this.#selectableItem.id.set(`multi-select-select-all`);
-		effect(() => {
+		effect((onCleanup) => {
 			if (this.#selectableItem.isHighlighted()) {
-				setTimeout(() => {
-					this.#elementRef.nativeElement.scrollIntoView();
-				}, 50);
+				const ref = afterNextRender(
+					() => {
+						this.#elementRef.nativeElement.scrollIntoView();
+					},
+					{ injector: this.#injector },
+				);
+				onCleanup(() => ref.destroy());
 			}
 			if (this.isSelected()) {
 				this.#selectableItem.isSelected.set(true);

--- a/packages/ng/option/picker/option-picker.component.ts
+++ b/packages/ng/option/picker/option-picker.component.ts
@@ -3,6 +3,7 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { DOCUMENT } from '@angular/common';
 import {
+	afterNextRender,
 	AfterViewInit,
 	ChangeDetectionStrategy,
 	ChangeDetectorRef,
@@ -14,6 +15,7 @@ import {
 	forwardRef,
 	inject,
 	Inject,
+	Injector,
 	Input,
 	OnDestroy,
 	Output,
@@ -25,7 +27,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ALuPickerPanel } from '@lucca-front/ng/picker';
 import { luTransformPopover } from '@lucca-front/ng/popover';
 import { merge, of } from 'rxjs';
-import { delay, map, share } from 'rxjs/operators';
+import { delay, map, share, take } from 'rxjs/operators';
 import { ALuOptionItem } from '../item/option-item.model';
 import { ALuOptionPicker, ILuOptionPickerPanel, LuOptionComparer } from './option-picker.model';
 
@@ -39,6 +41,7 @@ export abstract class ALuOptionPickerComponent<T, O extends import('../item/opti
 	implements ILuOptionPickerPanel<T>, OnDestroy, AfterViewInit
 {
 	protected destroyRef = inject(DestroyRef);
+	readonly #injector = inject(Injector);
 
 	/**
 	 * This method takes classes set on the host lu-popover element and applies them on the
@@ -172,9 +175,15 @@ export abstract class ALuOptionPickerComponent<T, O extends import('../item/opti
 				}
 			}),
 		);
-		setTimeout(() => {
-			this.highlightIndex = -1;
-		}, 1);
+	}
+
+	protected _resetHighlightAfterInit() {
+		// Reset the highlight once the initial options have been applied (and _applySelected potentially moved it)
+		this._subs.add(
+			this._options$.pipe(take(1)).subscribe(() => {
+				this.highlightIndex = -1;
+			}),
+		);
 	}
 
 	protected _incrHighlight() {
@@ -222,9 +231,12 @@ export abstract class ALuOptionPickerComponent<T, O extends import('../item/opti
 			highlightedOption.highlighted = true;
 			// scroll to let the highlighted option visible
 			if (reScroll) {
-				setTimeout(() => {
-					this._scrollToHighlight(highlightedOption.element.nativeElement);
-				}, 1);
+				afterNextRender(
+					() => {
+						this._scrollToHighlight(highlightedOption.element.nativeElement);
+					},
+					{ injector: this.#injector },
+				);
 			}
 		}
 		this._changeDetectorRef.markForCheck();
@@ -322,6 +334,7 @@ export abstract class ALuOptionPickerComponent<T, O extends import('../item/opti
 		this._options$ = items$;
 		this._initHighlight();
 		this._initSelected();
+		this._resetHighlightAfterInit();
 	}
 
 	ngAfterViewInit() {

--- a/packages/ng/select/input/select-input.component.ts
+++ b/packages/ng/select/input/select-input.component.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
 import { Overlay } from '@angular/cdk/overlay';
 import {
+	afterNextRender,
 	AfterViewInit,
 	booleanAttribute,
 	ChangeDetectionStrategy,
@@ -11,6 +12,8 @@ import {
 	ElementRef,
 	EventEmitter,
 	forwardRef,
+	inject,
+	Injector,
 	input,
 	linkedSignal,
 	OnDestroy,
@@ -44,6 +47,7 @@ import { ALuSelectInput } from './select-input.model';
 })
 export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<T> = ILuPickerPanel<T>> extends ALuSelectInput<T, TPicker> implements ControlValueAccessor, AfterViewInit, OnDestroy {
 	private readonly _vcDisplayContainer = viewChild('display', { read: ViewContainerRef });
+	readonly #injector = inject(Injector);
 
 	tabindex = 0;
 
@@ -168,12 +172,13 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 		this._picker.setValue(this.value);
 
 		// strange bug where the view renderred in the displayer was only injected after a hover
-		// no matter how many cdr.markforchack i added
-		// but with a timeout it works
-		// shrug emoji
-		setTimeout(() => {
-			this._changeDetectorRef.markForCheck();
-		}, 1);
+		// unless we trigger another change detection cycle right after the first render
+		afterNextRender(
+			() => {
+				this._changeDetectorRef.markForCheck();
+			},
+			{ injector: this.#injector },
+		);
 	}
 
 	ngOnDestroy() {

--- a/packages/ng/select/input/select-input.component.ts
+++ b/packages/ng/select/input/select-input.component.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @angular-eslint/no-output-on-prefix */
 import { Overlay } from '@angular/cdk/overlay';
 import {
+	afterNextRender,
 	AfterViewInit,
 	ChangeDetectionStrategy,
 	ChangeDetectorRef,
@@ -10,6 +11,8 @@ import {
 	ElementRef,
 	EventEmitter,
 	forwardRef,
+	inject,
+	Injector,
 	input,
 	linkedSignal,
 	OnDestroy,
@@ -43,6 +46,7 @@ import { ALuSelectInput } from './select-input.model';
 })
 export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<T> = ILuPickerPanel<T>> extends ALuSelectInput<T, TPicker> implements ControlValueAccessor, AfterViewInit, OnDestroy {
 	private readonly _vcDisplayContainer = viewChild('display', { read: ViewContainerRef });
+	readonly #injector = inject(Injector);
 
 	tabindex = 0;
 
@@ -167,12 +171,13 @@ export abstract class ALuSelectInputComponent<T, TPicker extends ILuPickerPanel<
 		this._picker.setValue(this.value);
 
 		// strange bug where the view renderred in the displayer was only injected after a hover
-		// no matter how many cdr.markforchack i added
-		// but with a timeout it works
-		// shrug emoji
-		setTimeout(() => {
-			this._changeDetectorRef.markForCheck();
-		}, 1);
+		// unless we trigger another change detection cycle right after the first render
+		afterNextRender(
+			() => {
+				this._changeDetectorRef.markForCheck();
+			},
+			{ injector: this.#injector },
+		);
 	}
 
 	ngOnDestroy() {

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -578,6 +578,70 @@ export const Establishment = generateStory({
 	},
 });
 
+export const EstablishmentTEST = createTestStory(Establishment, async ({ canvasElement, step }) => {
+	await waitForAngular();
+	const canvas = within(canvasElement);
+	const input = canvas.getByRole('combobox');
+	let initialCount = 0;
+
+	await step('Open panel and load initial options', async () => {
+		await userEvent.click(input);
+		await waitForAngular();
+		const panel = within(screen.getByRole('listbox'));
+		const options = await panel.findAllByRole('option');
+		initialCount = options.length;
+		await expect(initialCount).toBeGreaterThan(1);
+	});
+
+	await step('Search filters the options through the API', async () => {
+		await userEvent.type(input, 'Marseille');
+		// Wait for the debounced API call to filter the options
+		await waitFor(async () => {
+			const options = await within(screen.getByRole('listbox')).findAllByRole('option');
+			expect(options.length).toBeLessThan(initialCount);
+		});
+		const options = await within(screen.getByRole('listbox')).findAllByRole('option');
+		await expect(options[0]).toHaveTextContent('Marseille');
+	});
+
+	await step('Selecting an option clears the search and restores the full list', async () => {
+		const panel = within(screen.getByRole('listbox'));
+		const options = await panel.findAllByRole('option');
+		await userEvent.click(options[0]);
+		await waitForAngular();
+		// The search input must be cleared…
+		await expect(input).toHaveValue('');
+		// …and the panel must show the unfiltered list again
+		// (regression: the panel used to keep showing only the filtered results)
+		await waitFor(async () => {
+			const refreshedOptions = await within(screen.getByRole('listbox')).findAllByRole('option');
+			expect(refreshedOptions.length).toBe(initialCount);
+		});
+	});
+
+	await step('Keyboard: search then Enter also restores the full list', async () => {
+		await expect(input).toHaveFocus();
+		await userEvent.type(input, 'Marseille');
+		await waitFor(async () => {
+			const options = await within(screen.getByRole('listbox')).findAllByRole('option');
+			expect(options.length).toBeLessThan(initialCount);
+		});
+		// Enter toggles the highlighted option (unselects the one picked above)
+		await userEvent.keyboard('{Enter}');
+		await waitForAngular();
+		await expect(input).toHaveValue('');
+		await waitFor(async () => {
+			const refreshedOptions = await within(screen.getByRole('listbox')).findAllByRole('option');
+			expect(refreshedOptions.length).toBe(initialCount);
+		});
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => {
+			expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+		});
+	});
+});
+
 export const Department = generateStory({
 	name: 'Departement Select',
 	description: 'Pour saisir un département, il suffit d’utiliser la directive `departments`',

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -40,7 +40,7 @@ import { createTestStory, getStoryGenerator } from '@/helpers/stories';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 import { InputAlias, SelectCommonAliasInput } from '../../../helpers/stories';
-import { sleep, waitForAngular } from '../../../helpers/test';
+import { ensurePickerPanelStyles, getPanelScrollContainer, isFullyVisibleInPanel, sleep, waitForAngular } from '../../../helpers/test';
 import { allLegumes, colorNameByColor, coreSelectStory, FilterLegumesPipe, ILegume, LuCoreSelectInputStoryComponent, SortLegumesPipe } from './select.utils';
 
 type LuMultiSelectInputStoryComponent = LuCoreSelectInputStoryComponent & {
@@ -262,6 +262,65 @@ export const SelectAllTEST = createTestStory(SelectAll, async (context) => {
 	});
 });
 
+export const SelectAllScrollTEST = {
+	...createTestStory(SelectAll, async ({ canvasElement, step }) => {
+		await waitForAngular();
+		ensurePickerPanelStyles();
+		const canvas = within(canvasElement);
+		const input = canvas.getByRole('combobox');
+
+		await step('Panel opens at the top with "select all" visible (mouse)', async () => {
+			await userEvent.click(input);
+			await waitForAngular();
+			const panel = within(screen.getByRole('listbox'));
+			const options = await panel.findAllByRole('option');
+			const selectAllOption = options.find((el) => el.id.includes('select-all'));
+			await expect(selectAllOption).not.toBeUndefined();
+			// The opening animation must settle without applying a spurious scroll:
+			// the panel stays at the top and the "select all" header is visible
+			await waitFor(() => {
+				expect(getPanelScrollContainer().scrollTop).toBeLessThan(5);
+				expect(isFullyVisibleInPanel(selectAllOption)).toBe(true);
+			});
+		});
+
+		await step('Selected option stays marked and scrolled into view on reopen', async () => {
+			const panel = within(screen.getByRole('listbox'));
+			const options = await panel.findAllByRole('option').then((opts) => opts.filter((el) => !el.id.includes('select-all')));
+			// Pick an option far enough down that it is NOT visible without scrolling
+			const pickedText = options[12].textContent;
+			await userEvent.click(options[12]);
+			await waitForAngular();
+			await userEvent.keyboard('{Escape}');
+			await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+
+			await userEvent.click(input);
+			await waitForAngular();
+			const reopenedPanel = within(screen.getByRole('listbox'));
+			const selectedOptions = await reopenedPanel.findAllByRole('option', { selected: true });
+			// The picked option is still marked as selected...
+			const pickedOption = selectedOptions.find((el) => el.textContent === pickedText);
+			await expect(pickedOption).not.toBeUndefined();
+			// ...and the panel scrolls it into view once the opening animation settles
+			await waitFor(() => expect(isFullyVisibleInPanel(pickedOption)).toBe(true));
+			await userEvent.keyboard('{Escape}');
+			await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+		});
+
+		await step('Keyboard: panel opens at the top too', async () => {
+			input.focus();
+			await expect(input).toHaveFocus();
+			await userEvent.keyboard('{ArrowDown}');
+			await waitForAngular();
+			await expect(screen.getByRole('listbox')).toBeVisible();
+			await waitFor(() => expect(getPanelScrollContainer().scrollTop).toBeLessThan(5));
+			await userEvent.keyboard('{Escape}');
+			await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+		});
+	}),
+	name: 'Select all scroll TEST',
+};
+
 export const Basic = generateStory({
 	name: 'Basic',
 	description: '',
@@ -394,17 +453,11 @@ export const ScrollOnOpen = generateStory({
 
 export const ScrollOnOpenTEST = createTestStory(ScrollOnOpen, async ({ canvasElement, step }) => {
 	await waitForAngular();
+	ensurePickerPanelStyles();
 	const canvas = within(canvasElement);
 	const input = canvas.getByRole('combobox');
 
-	// Walk up from the listbox to the scrollable ancestor (.lu-picker-content)
-	const getPanelScrollTop = () => {
-		let el: HTMLElement | null = screen.getByRole('listbox');
-		while (el && el.scrollHeight <= el.clientHeight + 1) {
-			el = el.parentElement;
-		}
-		return el?.scrollTop ?? 0;
-	};
+	const getPanelScrollTop = () => getPanelScrollContainer().scrollTop;
 
 	await step('Opening with the mouse shows the top of the list', async () => {
 		await userEvent.click(input);

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -373,6 +373,66 @@ export const WithClueTEST = createTestStory(WithClue, async (context) => {
 	});
 });
 
+export const ScrollOnOpen = generateStory({
+	name: 'Scroll on open',
+	description: `À l’ouverture, le panneau doit être positionné en haut de la liste (aucun défilement parasite), même si aucune valeur n’est sélectionnée.`,
+	template: `<lu-multi-select
+	#selectRef
+	[(ngModel)]="selectedLegumes"
+	[options]="legumes | filterLegumes:clue"
+	(clueChange)="clue = $event"
+/>`,
+	neededImports: {
+		'@lucca-front/ng/multi-select': ['LuMultiSelectInputComponent'],
+	},
+	storyPartial: {
+		args: {
+			selectedLegumes: [],
+		},
+	},
+});
+
+export const ScrollOnOpenTEST = createTestStory(ScrollOnOpen, async ({ canvasElement, step }) => {
+	await waitForAngular();
+	const canvas = within(canvasElement);
+	const input = canvas.getByRole('combobox');
+
+	// Walk up from the listbox to the scrollable ancestor (.lu-picker-content)
+	const getPanelScrollTop = () => {
+		let el: HTMLElement | null = screen.getByRole('listbox');
+		while (el && el.scrollHeight <= el.clientHeight + 1) {
+			el = el.parentElement;
+		}
+		return el?.scrollTop ?? 0;
+	};
+
+	await step('Opening with the mouse shows the top of the list', async () => {
+		await userEvent.click(input);
+		await waitForAngular();
+		const panel = within(screen.getByRole('listbox'));
+		const options = await panel.findAllByRole('option');
+		// The list must be scrollable for the assertion to be meaningful
+		await expect(options.length).toBeGreaterThan(10);
+		await expect(options[0]).toBeVisible();
+		// No spurious scroll should be applied on open: the panel stays at the top
+		await waitFor(() => expect(getPanelScrollTop()).toBeLessThan(10));
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+	});
+
+	await step('Opening with the keyboard shows the top of the list', async () => {
+		input.focus();
+		await userEvent.keyboard('{ArrowDown}');
+		await waitForAngular();
+		await expect(screen.getByRole('listbox')).toBeVisible();
+		await waitFor(() => expect(getPanelScrollTop()).toBeLessThan(10));
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+	});
+});
+
 export const WithMultiDisplayer = generateStory({
 	name: 'With MultiDisplayer',
 	description:

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -110,6 +110,64 @@ export const Basic = generateStory({
 
 export const BasicTEST = createTestStory(Basic, basePlay);
 
+export const ScrollOnOpen = generateStory({
+	name: 'Scroll on open',
+	description: `À l’ouverture, le panneau doit être positionné en haut de la liste (aucun défilement parasite), même si aucune valeur n’est sélectionnée.`,
+	template: `<lu-simple-select
+	#selectRef
+	[options]="legumes | filterLegumes:clue"
+	(clueChange)="clue = $event"
+	[(ngModel)]="selectedLegume"
+>
+	<ng-container *luOption="let legume; select: selectRef">{{ legume.name }}</ng-container>
+</lu-simple-select>`,
+	neededImports: {
+		'@lucca-front/ng/core-select': ['LuOptionDirective'],
+		'@lucca-front/ng/simple-select': ['LuSimpleSelectInputComponent'],
+	},
+});
+
+export const ScrollOnOpenTEST = createTestStory(ScrollOnOpen, async ({ canvasElement, step }) => {
+	await waitForAngular();
+	const canvas = within(canvasElement);
+	const input = canvas.getByRole('combobox');
+
+	// Walk up from the listbox to the scrollable ancestor (.lu-picker-content)
+	const getPanelScrollTop = () => {
+		let el: HTMLElement | null = screen.getByRole('listbox');
+		while (el && el.scrollHeight <= el.clientHeight + 1) {
+			el = el.parentElement;
+		}
+		return el?.scrollTop ?? 0;
+	};
+
+	await step('Opening with the mouse shows the top of the list', async () => {
+		await userEvent.click(input);
+		await waitForAngular();
+		const panel = within(screen.getByRole('listbox'));
+		const options = await panel.findAllByRole('option');
+		// The list must be scrollable for the assertion to be meaningful
+		await expect(options.length).toBeGreaterThan(10);
+		await expect(options[0]).toBeVisible();
+		// No spurious scroll should be applied on open: the panel stays at the top
+		await waitFor(() => expect(getPanelScrollTop()).toBeLessThan(10));
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+	});
+
+	await step('Opening with the keyboard shows the top of the list', async () => {
+		input.focus();
+		await userEvent.keyboard('{ArrowDown}');
+		await waitForAngular();
+		await expect(screen.getByRole('listbox')).toBeVisible();
+		await waitFor(() => expect(getPanelScrollTop()).toBeLessThan(10));
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+	});
+});
+
 export const Minimal = generateStory({
 	name: 'Minimal',
 	description: 'Pas besoin systématiquement de `*luOption`, le simple-select affiche par défaut la propriété `name` ou l’option elle-même.',

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -27,7 +27,7 @@ import { LuUserDisplayPipe, LuUserPictureComponent } from '@lucca-front/ng/user'
 import { applicationConfig, Meta, moduleMetadata } from '@storybook/angular-vite';
 import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 import { InputAlias, SelectCommonAliasInput } from '../../../helpers/stories';
-import { waitForAngular } from '../../../helpers/test';
+import { ensurePickerPanelStyles, getPanelScrollContainer, isFullyVisibleInPanel, waitForAngular } from '../../../helpers/test';
 import { LuCoreSelectLegumesDirective } from './custom-api-example.component';
 import { LuCoreSelectCustomEstablishmentsDirective } from './custom-establishment-example.component';
 import { LuCoreSelectCustomUsersDirective } from './custom-user-example.component';
@@ -129,17 +129,11 @@ export const ScrollOnOpen = generateStory({
 
 export const ScrollOnOpenTEST = createTestStory(ScrollOnOpen, async ({ canvasElement, step }) => {
 	await waitForAngular();
+	ensurePickerPanelStyles();
 	const canvas = within(canvasElement);
 	const input = canvas.getByRole('combobox');
 
-	// Walk up from the listbox to the scrollable ancestor (.lu-picker-content)
-	const getPanelScrollTop = () => {
-		let el: HTMLElement | null = screen.getByRole('listbox');
-		while (el && el.scrollHeight <= el.clientHeight + 1) {
-			el = el.parentElement;
-		}
-		return el?.scrollTop ?? 0;
-	};
+	const getPanelScrollTop = () => getPanelScrollContainer().scrollTop;
 
 	await step('Opening with the mouse shows the top of the list', async () => {
 		await userEvent.click(input);
@@ -336,6 +330,43 @@ export const WithClearerTEST = createTestStory(WithClearer, async (context) => {
 	await userEvent.click(input.getByRole('button'));
 	await expect(inputContentElement).toHaveTextContent('');
 });
+
+export const ScrollToSelectedTEST = {
+	...createTestStory(WithClearer, async ({ canvasElement, step }) => {
+		await waitForAngular();
+		ensurePickerPanelStyles();
+		const canvas = within(canvasElement);
+		const input = canvas.getByRole('combobox');
+
+		await step('Opening scrolls the preselected option into view (mouse)', async () => {
+			await userEvent.click(input);
+			await waitForAngular();
+			const panel = within(screen.getByRole('listbox'));
+			const selectedOption = await panel.findByRole('option', { selected: true });
+			await expect(selectedOption).toHaveTextContent('Concombre');
+			// The list must actually overflow for this test to be meaningful
+			const container = getPanelScrollContainer();
+			await expect(container.scrollHeight).toBeGreaterThan(container.clientHeight);
+			// Once the opening animation settles, the panel must be scrolled to the selected option
+			await waitFor(() => expect(isFullyVisibleInPanel(selectedOption)).toBe(true));
+			await userEvent.keyboard('{Escape}');
+			await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+		});
+
+		await step('Opening with the keyboard scrolls to the selected option too', async () => {
+			input.focus();
+			await expect(input).toHaveFocus();
+			await userEvent.keyboard('{ArrowDown}');
+			await waitForAngular();
+			const panel = within(screen.getByRole('listbox'));
+			const selectedOption = await panel.findByRole('option', { selected: true });
+			await waitFor(() => expect(isFullyVisibleInPanel(selectedOption)).toBe(true));
+			await userEvent.keyboard('{Escape}');
+			await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+		});
+	}),
+	name: 'Scroll to selected TEST',
+};
 
 export const WithDisabledOptions = generateStory({
 	name: 'Disabled options',

--- a/stories/documentation/overlays/modal/modal.stories.ts
+++ b/stories/documentation/overlays/modal/modal.stories.ts
@@ -341,3 +341,37 @@ export const ModalTEST = createTestStory(Modal, async ({ canvasElement, step }) 
 		await expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 	});
 });
+
+export const ModalSubmitTEST = createTestStory(Modal, async ({ canvasElement, step }) => {
+	await waitForAngular();
+	const canvas = within(canvasElement);
+
+	const openModal = async () => {
+		await userEvent.click(canvas.getByRole('button', { name: 'Open' }));
+		await waitForAngular();
+		return within(screen.getByRole('dialog'));
+	};
+
+	await step('Le bouton de submit est visible dans la modale', async () => {
+		const dialog = await openModal();
+		await expect(dialog.getByRole('button', { name: 'Ok' })).toBeVisible();
+		await expect(dialog.getByRole('button', { name: 'Annuler' })).toBeVisible();
+	});
+
+	await step('Le clic sur submit ferme la modale', async () => {
+		const dialog = within(screen.getByRole('dialog'));
+		await userEvent.click(dialog.getByRole('button', { name: 'Ok' }));
+		await waitForAngular();
+		await expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+
+	await step('Le submit est déclenchable au clavier (Enter)', async () => {
+		const dialog = await openModal();
+		const submitButton = dialog.getByRole('button', { name: 'Ok' });
+		submitButton.focus();
+		await expect(submitButton).toHaveFocus();
+		await userEvent.keyboard('{Enter}');
+		await waitForAngular();
+		await expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+	});
+});

--- a/stories/helpers/test.ts
+++ b/stories/helpers/test.ts
@@ -22,6 +22,59 @@ export async function expectNgModelDisplay(canvas: HTMLElement, expectedValue: s
 	await expect(modelDisplay).toHaveTextContent(expectedValue);
 }
 
+/**
+ * The vitest browser environment doesn't load the global component styles (packages/ng/styles),
+ * so select panels have no max-height nor opening animation there. This re-creates the production
+ * constraints (copied from packages/ng/styles/components/_picker.scss and
+ * packages/scss/src/commons/utils/keyframe.scss) so scroll-related assertions are meaningful.
+ */
+export function ensurePickerPanelStyles(): void {
+	if (document.getElementById('test-picker-panel-styles')) {
+		return;
+	}
+	const style = document.createElement('style');
+	style.id = 'test-picker-panel-styles';
+	style.textContent = `
+		/* Hold at scale(0) for the first half: production's scaleIn starts at scale(0) for a frame,
+		   widening that window makes the "scroll during opening animation" regression deterministic */
+		@keyframes testScaleIn { 0% { transform: scale(0); } 50% { transform: scale(0); } 100% { transform: scale(1); } }
+		.lu-picker-content {
+			max-block-size: 20rem;
+			overflow-y: auto;
+			display: block;
+			animation: testScaleIn 300ms cubic-bezier(0.25, 0.8, 0.25, 1);
+		}
+		/* Realistic option row height (production ~2.75rem), so long lists actually overflow */
+		.lu-picker-content [role='option'] {
+			display: block;
+			min-block-size: 2.75rem;
+		}
+	`;
+	document.head.appendChild(style);
+}
+
+/**
+ * Returns the scrollable container of the currently open select panel
+ * (walks up from the listbox element to the first scrollable ancestor).
+ */
+export function getPanelScrollContainer(): HTMLElement {
+	let element: HTMLElement | null = screen.getByRole('listbox');
+	while (element && element.scrollHeight <= element.clientHeight + 1) {
+		element = element.parentElement;
+	}
+	return element ?? screen.getByRole('listbox');
+}
+
+/**
+ * Whether the given option is fully visible inside the open select panel's scroll container.
+ */
+export function isFullyVisibleInPanel(option: HTMLElement): boolean {
+	const containerRect = getPanelScrollContainer().getBoundingClientRect();
+	const rect = option.getBoundingClientRect();
+	// While the opening animation runs (scale(0)), rects are degenerate: not visible yet
+	return rect.height > 0 && rect.top >= containerRect.top - 2 && rect.bottom <= containerRect.bottom + 2;
+}
+
 export async function clearInputs(inputs: HTMLElement[]) {
 	for (const input of inputs) {
 		await userEvent.clear(input);

--- a/stories/helpers/test.ts
+++ b/stories/helpers/test.ts
@@ -33,6 +33,59 @@ export async function expectNgModelDisplay(canvas: HTMLElement, expectedValue: s
 	await expect(modelDisplay).toHaveTextContent(expectedValue);
 }
 
+/**
+ * The vitest browser environment doesn't load the global component styles (packages/ng/styles),
+ * so select panels have no max-height nor opening animation there. This re-creates the production
+ * constraints (copied from packages/ng/styles/components/_picker.scss and
+ * packages/scss/src/commons/utils/keyframe.scss) so scroll-related assertions are meaningful.
+ */
+export function ensurePickerPanelStyles(): void {
+	if (document.getElementById('test-picker-panel-styles')) {
+		return;
+	}
+	const style = document.createElement('style');
+	style.id = 'test-picker-panel-styles';
+	style.textContent = `
+		/* Hold at scale(0) for the first half: production's scaleIn starts at scale(0) for a frame,
+		   widening that window makes the "scroll during opening animation" regression deterministic */
+		@keyframes testScaleIn { 0% { transform: scale(0); } 50% { transform: scale(0); } 100% { transform: scale(1); } }
+		.lu-picker-content {
+			max-block-size: 20rem;
+			overflow-y: auto;
+			display: block;
+			animation: testScaleIn 300ms cubic-bezier(0.25, 0.8, 0.25, 1);
+		}
+		/* Realistic option row height (production ~2.75rem), so long lists actually overflow */
+		.lu-picker-content [role='option'] {
+			display: block;
+			min-block-size: 2.75rem;
+		}
+	`;
+	document.head.appendChild(style);
+}
+
+/**
+ * Returns the scrollable container of the currently open select panel
+ * (walks up from the listbox element to the first scrollable ancestor).
+ */
+export function getPanelScrollContainer(): HTMLElement {
+	let element: HTMLElement | null = screen.getByRole('listbox');
+	while (element && element.scrollHeight <= element.clientHeight + 1) {
+		element = element.parentElement;
+	}
+	return element ?? screen.getByRole('listbox');
+}
+
+/**
+ * Whether the given option is fully visible inside the open select panel's scroll container.
+ */
+export function isFullyVisibleInPanel(option: HTMLElement): boolean {
+	const containerRect = getPanelScrollContainer().getBoundingClientRect();
+	const rect = option.getBoundingClientRect();
+	// While the opening animation runs (scale(0)), rects are degenerate: not visible yet
+	return rect.height > 0 && rect.top >= containerRect.top - 2 && rect.bottom <= containerRect.bottom + 2;
+}
+
 export async function clearInputs(inputs: HTMLElement[]) {
 	for (const input of inputs) {
 		await userEvent.clear(input);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -17,7 +17,12 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-Element.prototype.scrollIntoView = () => {};
+// happy-dom doesn't implement scrollIntoView: stub it for unit tests only.
+// In vitest browser mode (storybook tests) the native implementation must be kept,
+// otherwise scroll-related behaviors can't be tested at all.
+if (!('__vitest_browser__' in globalThis)) {
+	Element.prototype.scrollIntoView = () => {};
+}
 
 const originalError = console.error;
 const hideCssParseError = (...args: unknown[]) => {


### PR DESCRIPTION
## Description

Remove the last render/change-detection `setTimeout` calls from components, one of the final prerequisites for switching the project to zoneless.

Problem
When searching in an API-backed select (e.g. the establishment multi-select), typing a query, then selecting an option left the panel stuck on the filtered results. The search input was cleared, but the option list kept showing only the previously filtered items — the other options never came back until the panel was reopened.

Root cause
When an option is selected, the clue is immediately reset to '', which synchronously triggers getOptions({ clue: '' }) → buildParamsFromClue('').

However, the affected directives derive their request params from a signal:

protected readonly clue = toSignal(this.clue$);
protected readonly params$ = toObservable(computed(() => ({ ..., search: this.clue() ... })));
params$ (via toObservable) updates asynchronously. So buildParamsFromClue reading params$.pipe(take(1)) synchronously got the stale params, still containing search=Marseille. The API was therefore re-queried with the old search term, returning only the filtered results.

This is unlike api-v3, which builds params$ from a synchronous combineLatest([..., this.clue$]) and was not affected.

Fix
Override buildParamsFromClue(clue) in each affected directive to build the params directly from the clue argument instead of reading the async signal, guaranteeing fresh params on the immediate clue reset.

Affected directives: api-v4, establishments, users, legal-units, job-qualifications, occupation-category.

Test
Added EstablishmentTEST (Storybook play) covering the regression: open → search → select → assert the input is cleared and the full option list is restored (mouse + keyboard flows). Verified it fails on the pre-fix code and passes with the fix.

-----

Follow-up to #5092, covering the components it didn't touch:

- **`afterNextRender(..., { injector })`** for deferred DOM work: option scroll-into-view in `core-select` (drops the `MAGIC_OPTION_SCROLL_DELAY` constant, which wasn't part of the public API), the select-all header `scrollIntoView`, the deprecated `option-picker` highlight scroll, and the deprecated `lu-select` post-`ngAfterViewInit` `markForCheck`.
- **`core-select` `openPanel()`**: the `setTimeout` guarding against a double-tap is replaced by a synchronous `#isOpeningPanel` re-entrancy flag (the alternative the original author called out in the comment). Panel opening is now synchronous on click.
- **modal `dialog-content-adapter`**: the 2s error-class reset now uses `timer(2000)` + `takeUntilDestroyed`, so it's cancelled cleanly on destroy.
- **deprecated `option-picker`**: the init highlight reset now subscribes to the first `_options$` emission instead of `setTimeout(…, 1)`.

The genuine wall-clock timer in `humanize.utils.ts` (relative-time ticking) is left as-is — it's a real timer, not a rendering hack, and already emits through an Observable.

Specs importing `MAGIC_OPTION_SCROLL_DELAY` were updated to plain `tick()`.

-----
