### PR TITLE
test(stories): add QA missing story pages 

### DIFF
--- a/stories/qa/error-page/error-page.stories.html
+++ b/stories/qa/error-page/error-page.stories.html
@@ -1,0 +1,111 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Default</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Erreur 404" illustration="404">
+						<p>La page que vous cherchez n’existe pas.</p>
+						<p><a href="#">Revenir à la page précédente</a></p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration 400</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Erreur 400" illustration="400">
+						<p>La requête est invalide.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration 403</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Erreur 403" illustration="403">
+						<p>Vous n’êtes pas autorisé à consulter cette page ou cette ressource.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration 429</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Erreur 429" illustration="429">
+						<p>Trop de requêtes ont été effectuées.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration 500</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Erreur 500" illustration="500">
+						<p>Une erreur interne est survenue.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration keyboard</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Une erreur est survenue" illustration="keyboard">
+						<p>Merci de réessayer plus tard.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration lock</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Accès restreint" illustration="lock">
+						<p>Vous n’avez pas accès à cette ressource.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Illustration map</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page heading="Page introuvable" illustration="map">
+						<p>La page que vous cherchez a peut-être été déplacée.</p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Contenu long</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-error-page
+						heading="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore"
+						illustration="404"
+					>
+						<p>
+							Flatus obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos potest vile diversitate flatus. Flatus
+							obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos potest vile diversitate flatus.
+						</p>
+						<p><a href="#">Revenir à la page précédente</a></p>
+					</lu-error-page>
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/error-page/error-page.stories.ts
+++ b/stories/qa/error-page/error-page.stories.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ErrorPageComponent } from '@lucca-front/ng/error-page';
+import { Meta, StoryObj } from '@storybook/angular';
+
+@Component({
+	selector: 'error-page-stories',
+	templateUrl: './error-page.stories.html',
+	imports: [ErrorPageComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ErrorPageStory {}
+
+export default {
+	title: 'QA/ErrorPage',
+	component: ErrorPageStory,
+} as Meta;
+
+const template = () => ({});
+
+export const Basic: StoryObj<ErrorPageStory> = {
+	args: {},
+	render: template,
+};

--- a/stories/qa/form-header/form-header.stories.html
+++ b/stories/qa/form-header/form-header.stories.html
@@ -1,0 +1,80 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">HTML</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Default (aria-level 1)</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="form-header">
+						<div class="form-header-title" role="heading" aria-level="1">Form title</div>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-form-header>Form title</lu-form-header>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Heading level 2</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="form-header">
+						<div class="form-header-title" role="heading" aria-level="2">Form title</div>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-form-header [headingLevel]="2">Form title</lu-form-header>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Heading level 6</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="form-header">
+						<div class="form-header-title" role="heading" aria-level="6">Form title</div>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-form-header [headingLevel]="6">Form title</lu-form-header>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Titre long</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="form-header">
+						<div class="form-header-title" role="heading" aria-level="1">
+							Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+						</div>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-form-header>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
+					</lu-form-header>
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/form-header/form-header.stories.ts
+++ b/stories/qa/form-header/form-header.stories.ts
@@ -1,0 +1,23 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormHeaderComponent } from '@lucca-front/ng/form-header';
+import { Meta, StoryObj } from '@storybook/angular';
+
+@Component({
+	selector: 'form-header-stories',
+	templateUrl: './form-header.stories.html',
+	imports: [FormHeaderComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class FormHeaderStory {}
+
+export default {
+	title: 'QA/FormHeader',
+	component: FormHeaderStory,
+} as Meta;
+
+const template = () => ({});
+
+export const Basic: StoryObj<FormHeaderStory> = {
+	args: {},
+	render: template,
+};

--- a/stories/qa/segmented-control-tabs/segmented-control-tabs.stories.html
+++ b/stories/qa/segmented-control-tabs/segmented-control-tabs.stories.html
@@ -1,0 +1,104 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Default</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-segmented-control-tabs>
+						<lu-segmented-control-tabs-panel label="Lorem" value="0">Content Lorem</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Ipsum" value="1">Content Ipsum</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Dolor sit amet" value="2">Content Dolor sit amet</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Deuxième onglet actif</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-segmented-control-tabs active="1">
+						<lu-segmented-control-tabs-panel label="Lorem" value="0">Content Lorem</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Ipsum" value="1">Content Ipsum</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Dolor sit amet" value="2">Content Dolor sit amet</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Numeric badge</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<ng-template #labelWithBadge>Lorem <lu-numeric-badge value="8" /></ng-template>
+					<lu-segmented-control-tabs>
+						<lu-segmented-control-tabs-panel [label]="labelWithBadge" value="0">Content Lorem</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Ipsum" value="1">Content Ipsum</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Dolor sit amet" value="2">Content Dolor sit amet</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Size S</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-segmented-control-tabs small>
+						<lu-segmented-control-tabs-panel label="Lorem" value="0">Content Lorem</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Ipsum" value="1">Content Ipsum</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Dolor sit amet" value="2">Content Dolor sit amet</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Vertical</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-segmented-control-tabs vertical>
+						<lu-segmented-control-tabs-panel label="Lorem" value="0">Content Lorem</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Ipsum" value="1">Content Ipsum</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Dolor sit amet" value="2">Content Dolor sit amet</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Vertical + S</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-segmented-control-tabs vertical small>
+						<lu-segmented-control-tabs-panel label="Lorem" value="0">Content Lorem</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Ipsum" value="1">Content Ipsum</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Dolor sit amet" value="2">Content Dolor sit amet</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Libellés longs</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-segmented-control-tabs>
+						<lu-segmented-control-tabs-panel label="Lorem ipsum dolor sit amet consectetur" value="0">
+							Content Lorem
+						</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Consectetur adipisicing elit sed do eiusmod" value="1">
+							Content Ipsum
+						</lu-segmented-control-tabs-panel>
+						<lu-segmented-control-tabs-panel label="Tempor incididunt ut labore et dolore magna" value="2">
+							Content Dolor sit amet
+						</lu-segmented-control-tabs-panel>
+					</lu-segmented-control-tabs>
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/segmented-control-tabs/segmented-control-tabs.stories.ts
+++ b/stories/qa/segmented-control-tabs/segmented-control-tabs.stories.ts
@@ -1,0 +1,24 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
+import { SegmentedControlTabsComponent, SegmentedControlTabsPanelComponent } from '@lucca-front/ng/segmented-control-tabs';
+import { Meta, StoryObj } from '@storybook/angular';
+
+@Component({
+	selector: 'segmented-control-tabs-stories',
+	templateUrl: './segmented-control-tabs.stories.html',
+	imports: [SegmentedControlTabsComponent, SegmentedControlTabsPanelComponent, NumericBadgeComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class SegmentedControlTabsStory {}
+
+export default {
+	title: 'QA/SegmentedControlTabs',
+	component: SegmentedControlTabsStory,
+} as Meta;
+
+const template = () => ({});
+
+export const Basic: StoryObj<SegmentedControlTabsStory> = {
+	args: {},
+	render: template,
+};

--- a/stories/qa/toast/toast.stories.html
+++ b/stories/qa/toast/toast.stories.html
@@ -1,0 +1,21 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Types (Info, Success, Warning, Error), titre, contenu HTML, message long, sans type</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-toasts />
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/toast/toast.stories.ts
+++ b/stories/qa/toast/toast.stories.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { LuToastsComponent, LuToastsService } from '@lucca-front/ng/toast';
+import { Meta, StoryObj } from '@storybook/angular';
+
+@Component({
+	selector: 'toast-stories',
+	templateUrl: './toast.stories.html',
+	imports: [LuToastsComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	styles: [
+		`
+			@layer components {
+				/* Sort le conteneur de toasts du flux fixed pour l'afficher dans la table QA */
+				.toasts {
+					position: static !important;
+					align-items: flex-start !important;
+				}
+			}
+		`,
+	],
+})
+class ToastStory {
+	constructor() {
+		const toastsService = inject(LuToastsService);
+		// duration: null => dismiss manuel uniquement, les toasts restent affichés pour la comparaison visuelle
+		toastsService.addToast({ type: 'Info', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', duration: null });
+		toastsService.addToast({ type: 'Success', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', duration: null });
+		toastsService.addToast({ type: 'Warning', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', duration: null });
+		toastsService.addToast({ type: 'Error', message: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.', duration: null });
+		toastsService.addToast({ type: 'Info', title: 'Titre du toast', message: 'Lorem ipsum dolor sit amet.', duration: null });
+		toastsService.addToast({
+			type: 'Info',
+			message: 'Lorem <a href="#">ipsum</a> <em>dolor</em> <strong>sit amet</strong>.',
+			duration: null,
+		});
+		toastsService.addToast({
+			type: 'Info',
+			title: 'Message long',
+			message:
+				'Flatus obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos potest vile diversitate flatus, obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos.',
+			duration: null,
+		});
+		toastsService.addToast({ message: 'Toast sans type, sans icône.', duration: null });
+	}
+}
+
+export default {
+	title: 'QA/Toast',
+	component: ToastStory,
+} as Meta;
+
+const template = () => ({});
+
+export const Basic: StoryObj<ToastStory> = {
+	args: {},
+	render: template,
+};

--- a/stories/qa/tree-select/tree-select.stories.html
+++ b/stories/qa/tree-select/tree-select.stories.html
@@ -1,0 +1,72 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td>
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Simple tree empty</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-simple-select placeholder="Placeholder" clearable [treeSelect]="groupingFn" [options]="allLegumes" [ngModel]="null" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>Simple tree filled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-simple-select
+						placeholder="Placeholder"
+						clearable
+						[treeSelect]="groupingFn"
+						[options]="allLegumes"
+						[(ngModel)]="simpleExample"
+					/>
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>Multi tree empty</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-multi-select placeholder="Placeholder" clearable [treeSelect]="groupingFn" [options]="allLegumes" [ngModel]="[]" />
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>Multi tree filled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-multi-select
+						placeholder="Placeholder"
+						clearable
+						[treeSelect]="groupingFn"
+						[options]="allLegumes"
+						[(ngModel)]="multiExample"
+					/>
+				</lu-form-field>
+			</td>
+		</tr>
+		<tr>
+			<td>Disabled</td>
+			<td>
+				<lu-form-field label="Label" tooltip="Tooltip message" inlineMessage="Helper text" inlineMessageState="default">
+					<lu-simple-select
+						placeholder="Placeholder"
+						clearable
+						disabled
+						[treeSelect]="groupingFn"
+						[options]="allLegumes"
+						[ngModel]="simpleExample"
+					/>
+				</lu-form-field>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/tree-select/tree-select.stories.ts
+++ b/stories/qa/tree-select/tree-select.stories.ts
@@ -1,0 +1,33 @@
+import { allLegumes, ILegume } from '@/stories/forms/select/select.utils';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { TreeSelectDirective } from '@lucca-front/ng/tree-select';
+import { Meta } from '@storybook/angular';
+
+@Component({
+	selector: 'tree-select-stories',
+	templateUrl: './tree-select.stories.html',
+	imports: [LuSimpleSelectInputComponent, LuMultiSelectInputComponent, TreeSelectDirective, FormFieldComponent, FormsModule],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TreeSelectStory {
+	allLegumes = allLegumes;
+	// Asperge : enfant d'Artichaut (premier légume vert)
+	simpleExample = allLegumes[1];
+	multiExample = allLegumes.filter((legume) => legume.color === 'green').slice(0, 4);
+
+	groupingFn = (legume: ILegume): ILegume | null => {
+		const parent = allLegumes.find((l) => l.color === legume.color);
+		return parent === legume ? null : parent;
+	};
+}
+
+export default {
+	title: 'QA/TreeSelect',
+	component: TreeSelectStory,
+} as Meta;
+
+export const Basic = {};


### PR DESCRIPTION
## Description

Adds QA story pages to support visual/functional QA of several components:

- `error-page`
- `form-header`
- `segmented-control-tabs`
- `toast`
- `tree-select`

Each page provides an isolated setup to exercise the component's states and behaviors during QA. No changes to library source — stories only.

-----
