### PR TITLE
[highlightData] fix button palette

### DIFF
--- a/packages/scss/src/components/highlightData/component.scss
+++ b/packages/scss/src/components/highlightData/component.scss
@@ -1,6 +1,5 @@
 @use '@lucca-front/scss/src/commons/utils/namespace';
 @use '@lucca-front/scss/src/commons/utils/reset';
-@use '@lucca-front/scss/src/commons/utils/color';
 
 @mixin component($atRoot: namespace.$defaultAtRoot) {
 	display: block;
@@ -53,10 +52,6 @@
 			.link {
 				--commons-text-link-color: var(--palettes-700, var(--palettes-product-700));
 				--commons-text-link-hover: var(--palettes-800, var(--palettes-product-800));
-			}
-
-			.button {
-				@include color.palette('neutral');
 			}
 		}
 

--- a/stories/documentation/structure/highlight-data/angular/basic.stories.ts
+++ b/stories/documentation/structure/highlight-data/angular/basic.stories.ts
@@ -21,7 +21,7 @@ export default {
 
 		let actionContent = '';
 		if (action === 'button') {
-			actionContent = '<button luButton="outlined" type="button">Action</button>';
+			actionContent = '<button luButton="outlined" palette="neutral" type="button">Action</button>';
 		} else if (action === 'link') {
 			actionContent = '<a luLink>Link</a>';
 		}

--- a/stories/documentation/structure/highlight-data/html&css/action-illustration.stories.ts
+++ b/stories/documentation/structure/highlight-data/html&css/action-illustration.stories.ts
@@ -12,7 +12,7 @@ function getTemplate(args: ActionIllustrationStory): string {
 	<dl class="highlightData-content">
 		<dt class="highlightData-content-title">Title</dt>
 		<dd class="highlightData-content-value">Content</dd>
-		<dd class="highlightData-content-action"><button type="button" class="button mod-outlined">Action</button></dd>
+		<dd class="highlightData-content-action"><button type="button" class="button mod-outlined palette-neutral">Action</button></dd>
 	</dl>
 	<div class="highlightData-illustrations">
 		<img

--- a/stories/documentation/structure/highlight-data/html&css/action.stories.ts
+++ b/stories/documentation/structure/highlight-data/html&css/action.stories.ts
@@ -12,7 +12,7 @@ function getTemplate(args: ActionStory): string {
 	<dl class="highlightData-content">
 		<dt class="highlightData-content-title">Title</dt>
 		<dd class="highlightData-content-value">Content</dd>
-		<dd class="highlightData-content-action"><button type="button" class="button mod-outlined">Action</button></dd>
+		<dd class="highlightData-content-action"><button type="button" class="button mod-outlined palette-neutral">Action</button></dd>
 	</dl>
 </div>`;
 }

--- a/stories/qa/highlight-data/highlight-data.stories.html
+++ b/stories/qa/highlight-data/highlight-data.stories.html
@@ -73,7 +73,7 @@
 					<dl class="highlightData-content">
 						<dt class="highlightData-content-title">Title</dt>
 						<dd class="highlightData-content-value">Content</dd>
-						<dd class="highlightData-content-action"><button type="button" class="button mod-outlined">Action</button></dd>
+						<dd class="highlightData-content-action"><button type="button" class="button mod-outlined palette-neutral">Action</button></dd>
 					</dl>
 					<div class="highlightData-illustrations">
 						<img
@@ -90,9 +90,26 @@
 				</div>
 			</td>
 			<td>
-				<lu-highlight-data heading="Title" value="Content" bubble="1" illustration="polaroid-male"
-					><button luButton="outlined" type="button">Action</button></lu-highlight-data
-				>
+				<lu-highlight-data heading="Title" value="Content" bubble="1" illustration="polaroid-male">
+					<button luButton="outlined" palette="neutral" type="button">Action</button>
+				</lu-highlight-data>
+			</td>
+		</tr>
+		<tr>
+			<td>Actions & palette</td>
+			<td>
+				<div class="highlightData mod-dark palette-critical">
+					<dl class="highlightData-content">
+						<dt class="highlightData-content-title">Title</dt>
+						<dd class="highlightData-content-value">Content</dd>
+						<dd class="highlightData-content-action"><button type="button" class="button mod-outlined palette-neutral">Action</button></dd>
+					</dl>
+				</div>
+			</td>
+			<td>
+				<lu-highlight-data heading="Title" value="Content" theme="dark" palette="critical">
+					<button luButton="outlined" palette="neutral" type="button">Action</button>
+				</lu-highlight-data>
 			</td>
 		</tr>
 		<tr>
@@ -102,12 +119,14 @@
 					<dl class="highlightData-content">
 						<dt class="highlightData-content-title">Title</dt>
 						<dd class="highlightData-content-value">Content</dd>
-						<dd class="highlightData-content-action"><button type="button" class="button mod-outlined">Action</button></dd>
+						<dd class="highlightData-content-action"><button type="button" class="button mod-outlined palette-neutral">Action</button></dd>
 					</dl>
 				</div>
 			</td>
 			<td>
-				<lu-highlight-data heading="Title" value="Content"><button luButton="outlined" type="button">Action</button></lu-highlight-data>
+				<lu-highlight-data heading="Title" value="Content">
+					<button luButton="outlined" palette="neutral" type="button">Action</button>
+				</lu-highlight-data>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Description

The neutral color scheme is no longer enforced via CSS, but rather through an explicit class or input. This makes it possible to override it when desired.

-----



-----

<img width="963" height="115" alt="Capture d’écran 2026-07-10 à 15 28 13" src="https://github.com/user-attachments/assets/31ea4f74-1aa9-443a-9093-8aa953ab00ce" />
