### PR TITLE
fix(core-select): stop forwarding search filters to the "me" lookup request

### DIFF
--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -27,10 +27,11 @@ class TestUsersDirective extends LuCoreSelectUsersDirective {
 @Component({
 	selector: 'lu-users-directive-host',
 	imports: [LuSimpleSelectInputComponent, TestUsersDirective],
-	template: `<lu-simple-select luTestUsers />`,
+	template: `<lu-simple-select luTestUsers [filters]="filters" />`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class LuUsersDirectiveHostComponent {
+	filters: Record<string, string | number | boolean> = {};
 	simpleSelect = viewChild.required<LuSimpleSelectInputComponent<LuCoreSelectUser>>(LuSimpleSelectInputComponent);
 	usersDirective = viewChild.required<TestUsersDirective>(TestUsersDirective);
 }
@@ -155,6 +156,24 @@ describe('LuCoreSelectUsersDirective', () => {
 
 		// Assert (Page 2)
 		expect(options).toEqual([meUser, ...page1, ...page2.filter((u) => u.id !== CURRENT_USER_ID)]);
+		httpTestingController.verify();
+	}));
+
+	it('should not forward `filters` to the "me" lookup request', fakeAsync(() => {
+		// Arrange
+		fixture.componentInstance.filters = { foo: 'bar' };
+		fixture.detectChanges();
+
+		// Act
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		// Assert
+		// The "me" lookup is a lookup by id and must NOT carry the search filters (`foo=bar`)
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		// The search list, on the other hand, does carry the filters
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&foo=bar&paging=0,20`);
 		httpTestingController.verify();
 	}));
 

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -119,7 +119,9 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 	protected meParams$ = toObservable(
 		computed(() => ({
 			fields: this.#userFields,
-			...this.filters(),
+			// The "me" request is a lookup by id and must not carry the search `filters`:
+			// they target the search API and aren't necessarily supported by the endpoint
+			// resolving the current user (e.g. API v3), which would fail the request.
 			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()?.join(',') } : {}),
 			...(this.operationIds() ? { operations: this.operationIds()?.join(',') } : {}),
 			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),


### PR DESCRIPTION
## What

The users select (`lu-simple-select[users]` / `lu-multi-select[users]`) issues a
separate "me" request to fetch and pin the current user at the top of the list
(`displayMeOption`). Until now, this lookup reused the `filters` input alongside
`id` and `fields`.

The "me" request is fundamentally a lookup by id — it has no reason to carry the
search `filters`, which target the search API. When those filters aren't supported
by the endpoint resolving the current user (e.g. a custom API vs. API v3, or v3 vs.
a custom API), the request fails with a **400**, breaking the display of results.

## Change

`meParams$` no longer spreads `filters()`. The "me" lookup now only sends
`fields` + `id`, keeping the scoping params (`operations`, `uniqueOperations`,
`appInstanceId`) that determine which endpoint is targeted.

The search list and total-count requests are unchanged and still carry `filters`.

## Tests

Added a test asserting that `filters` is applied to the search list request but
**not** to the "me" lookup request.

## Notes

- No public API change, non-breaking.
- Trade-off: the "me" lookup no longer re-checks that the current user belongs to
  the filtered population. In practice the current user is pinned as a convenience
  shortcut, and a lookup by id shouldn't depend on unrelated search filters. A
  follow-up `feat` could add an optional `currentUser` input to skip the lookup
  entirely when the principal is already available.
