### PR TITLE
[multilanguage] fix inline size for no invariant mode

### DIFF
--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -117,9 +117,12 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	protected getPopoverInlineSizeRem(inputElement: HTMLInputElement): number {
 		const inputContainer = inputElement.closest('.textField-input');
-		const referenceWidth = (inputContainer instanceof HTMLElement ? inputContainer : inputElement).getBoundingClientRect().width;
+		const inputContainerInlineSize = (inputContainer instanceof HTMLElement ? inputContainer : inputElement).getBoundingClientRect().width;
 
-		return this.hasNoInvariant() ? referenceWidth / 16 + 3.25 : referenceWidth / 16 + 0.5;
+		// Add to the inline size of the input container (converted from px to rem):
+		// 2.75rem, which corresponds to the width of the prefix before the field when in "no invariant" mode
+		// 0.5rem, which corresponds to the offset needed to make the poppover slightly wider than the input container
+		return this.hasNoInvariant() ? inputContainerInlineSize / 16 + 2.75 + 0.5 : inputContainerInlineSize / 16 + 0.5;
 	}
 
 	writeValue(value: MultilanguageTranslation[]): void {

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -119,7 +119,7 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 		const inputContainer = inputElement.closest('.textField-input');
 		const referenceWidth = (inputContainer instanceof HTMLElement ? inputContainer : inputElement).getBoundingClientRect().width;
 
-		return referenceWidth / 16 + 1;
+		return this.hasNoInvariant() ? referenceWidth / 16 + 3.25 : referenceWidth / 16 + 0.5;
 	}
 
 	writeValue(value: MultilanguageTranslation[]): void {


### PR DESCRIPTION
## Description

The no invariant mode was not taken into account when calculating the panel inline size.

-----



-----

<img width="1038" height="361" alt="Capture d’écran 2026-07-15 à 18 06 05" src="https://github.com/user-attachments/assets/ccd35042-1b4d-4c80-a499-a71a9537b952" />

<img width="1037" height="366" alt="Capture d’écran 2026-07-15 à 18 07 15" src="https://github.com/user-attachments/assets/89ab7f74-b544-44b2-bf31-d5d381b3a011" />

