### PR TITLE
fix(rich-text): display links as external in presentation mode

### DIFF
--- a/packages/ng/forms/rich-text-input/plugins/link/link.component.html
+++ b/packages/ng/forms/rich-text-input/plugins/link/link.component.html
@@ -14,16 +14,17 @@
 	<lu-icon icon="formatLink" [alt]="intl().linksLabel" />
 </button>
 
-<ng-template #linkNodeTemplate let-href="href" let-title="title" let-target="target" let-isAutoLink="isAutoLink">
+<ng-template #linkNodeTemplate let-href="href" let-title="title" let-isAutoLink="isAutoLink">
 	<a
+		luLink
+		[external]="!isEditable()"
 		[href]="href"
 		[attr.title]="title"
-		[attr.target]="target"
 		[luPopover2]="popover"
 		[luPopoverDisabled]="!isEditable()"
-		rel="noopener noreferrer"
 		#trigger="luPopover2"
-	></a>
+	>
+	</a>
 	<ng-template #popover>
 		<div class="popover-contentOptional linkPopover">
 			<a [href]="href" luLink external class="pr-u-ellipsis">{{ href }}</a>

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
@@ -59,7 +59,7 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 	}
 
 	override getDOMSlot(element: HTMLElement): ElementDOMSlot {
-		return super.getDOMSlot(element.getElementsByClassName('link-text')[0] as HTMLElement);
+		return super.getDOMSlot((element.getElementsByClassName('link-text')[0] as HTMLElement) ?? element);
 	}
 
 	override updateDOM(prevNode: this): boolean {
@@ -79,7 +79,7 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 		};
 	}
 
-	static override importDOM(): null {
+	static override importDOM() {
 		return AutoLinkNode.importDOM();
 	}
 

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-autolink-node.ts
@@ -1,6 +1,6 @@
 import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
 import { AutoLinkNode, LinkAttributes, LinkNode, SerializedAutoLinkNode } from '@lexical/link';
-import { DOMExportOutput, EditorConfig, LexicalEditor, type NodeKey } from 'lexical';
+import { DOMExportOutput, EditorConfig, ElementDOMSlot, LexicalEditor, type NodeKey } from 'lexical';
 import { LinkTemplateContext } from './link-template-context';
 
 export class PopoverAutoLinkNode extends AutoLinkNode {
@@ -50,11 +50,16 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 			}
 			// Create the view
 			this.#view = this.#viewContainerRef.createEmbeddedView(this.#templateRef, context);
+			this.#view.detectChanges();
 
 			// Return the template DOM element
 			return this.#view.rootNodes[0] as HTMLElement;
 		}
 		return super.createDOM(config);
+	}
+
+	override getDOMSlot(element: HTMLElement): ElementDOMSlot {
+		return super.getDOMSlot(element.getElementsByClassName('link-text')[0] as HTMLElement);
 	}
 
 	override updateDOM(prevNode: this): boolean {
@@ -72,6 +77,10 @@ export class PopoverAutoLinkNode extends AutoLinkNode {
 		return {
 			element: super.createDOM(editor._config),
 		};
+	}
+
+	static override importDOM(): null {
+		return AutoLinkNode.importDOM();
 	}
 
 	override remove(preserveEmptyParent?: boolean) {

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
@@ -1,6 +1,6 @@
 import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
 import { LinkAttributes, LinkNode, SerializedLinkNode } from '@lexical/link';
-import { DOMExportOutput, EditorConfig, LexicalEditor, type NodeKey } from 'lexical';
+import { DOMConversionMap, DOMExportOutput, EditorConfig, ElementDOMSlot, LexicalEditor, type NodeKey } from 'lexical';
 import { LinkTemplateContext } from './link-template-context';
 
 export class PopoverLinkNode extends LinkNode {
@@ -50,11 +50,15 @@ export class PopoverLinkNode extends LinkNode {
 			}
 			// Create the view
 			this.#view = this.#viewContainerRef.createEmbeddedView(this.#templateRef, context);
-
+			this.#view.detectChanges();
 			// Return the template DOM element
 			return this.#view.rootNodes[0] as HTMLElement;
 		}
 		return super.createDOM(config);
+	}
+
+	override getDOMSlot(element: HTMLElement): ElementDOMSlot {
+		return super.getDOMSlot(element.getElementsByClassName('link-text')[0] as HTMLElement);
 	}
 
 	override updateDOM(prevNode: this): boolean {
@@ -72,6 +76,10 @@ export class PopoverLinkNode extends LinkNode {
 		return {
 			element: super.createDOM(editor._config),
 		};
+	}
+
+	static override importDOM(): DOMConversionMap | null {
+		return LinkNode.importDOM();
 	}
 
 	override remove(preserveEmptyParent?: boolean) {

--- a/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/link/popover-link-node.ts
@@ -1,6 +1,6 @@
 import { EmbeddedViewRef, TemplateRef, ViewContainerRef } from '@angular/core';
 import { LinkAttributes, LinkNode, SerializedLinkNode } from '@lexical/link';
-import { DOMConversionMap, DOMExportOutput, EditorConfig, ElementDOMSlot, LexicalEditor, type NodeKey } from 'lexical';
+import { DOMExportOutput, EditorConfig, ElementDOMSlot, LexicalEditor, type NodeKey } from 'lexical';
 import { LinkTemplateContext } from './link-template-context';
 
 export class PopoverLinkNode extends LinkNode {
@@ -58,7 +58,7 @@ export class PopoverLinkNode extends LinkNode {
 	}
 
 	override getDOMSlot(element: HTMLElement): ElementDOMSlot {
-		return super.getDOMSlot(element.getElementsByClassName('link-text')[0] as HTMLElement);
+		return super.getDOMSlot((element.getElementsByClassName('link-text')[0] as HTMLElement) ?? element);
 	}
 
 	override updateDOM(prevNode: this): boolean {
@@ -78,7 +78,7 @@ export class PopoverLinkNode extends LinkNode {
 		};
 	}
 
-	static override importDOM(): DOMConversionMap | null {
+	static override importDOM() {
 		return LinkNode.importDOM();
 	}
 

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -176,7 +176,7 @@ export const WithHtmlFormatter: StoryObj<RichTextInputComponent & { value: strin
 		};
 	},
 	args: {
-		value: 'Lorem <b>ipsum</b> dolor',
+		value: '<a href="https://example.com">Lorem</a> <b>ipsum</b> dolor https://example.com',
 		placeholder: 'Placeholder…',
 		disabled: false,
 		required: false,


### PR DESCRIPTION
## Description

In presentation mode, rich text input should display links as external. Behavior in edition mode remains unchanged.

-----

* Added `importDom` functions to link nodes to avoid console warnings.
* Used `luLink` to display links in the editor. Links are external only in presentation mode, otherwise the external icon would block caret when using backspace. Since Lexical is inserting text content automatically, we must target correct element inside luLink with `getDOMSlot` method. This unfortunately creates adherence between our Link Nodes and `luLink` internal structure.

-----

<img width="961" height="179" alt="firefox_FLgpGBugzc" src="https://github.com/user-attachments/assets/68f460fe-fb92-49c3-a854-7ab0c400447c" />


