### PR TITLE
fix(schematics): skip lu-grid migration when leftover classes remain

### DIFF
--- a/packages/ng/schematics/lu-grid/migration.ts
+++ b/packages/ng/schematics/lu-grid/migration.ts
@@ -186,6 +186,28 @@ function gridHasNonNeutralColumnChildren(node: TmplAstElement): boolean {
 	});
 }
 
+// A grid is migratable only when the migration can be fully carried out. If any
+// class other than `grid`/`mod-auto`/`mod-form` would remain on the element, the
+// migration is considered incomplete: we leave the grid — and therefore its
+// `grid-column` children — untouched for manual review.
+// This is the single source of truth for both grid and grid-column finders so a
+// `grid-column` is never migrated without its parent grid being migrated too.
+function isMigratableGrid(node: unknown): node is TmplAstElement {
+	if (!isInterestingNode(node) || !isNeutralElement(node.name)) {
+		return false;
+	}
+	const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
+	if (!classes?.match(/(^|\s)grid(\s|$)/)) {
+		return false;
+	}
+	if (gridHasNonNeutralColumnChildren(node)) {
+		return false;
+	}
+	// Any leftover class means the migration would keep a `class=` attribute → skip.
+	const extraClasses = classes.split(' ').filter((c) => c && c !== 'grid' && c !== 'mod-auto' && c !== 'mod-form');
+	return extraClasses.length === 0;
+}
+
 function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): HtmlGrid[] {
 	const results: HtmlGrid[] = [];
 	const ngTemplates = extractNgTemplatesIncludingHtml(sourceFile, tree, basePath);
@@ -193,16 +215,10 @@ function findHTMLGrids(sourceFile: SourceFile, basePath: string, tree: Tree): Ht
 	ngTemplates.forEach((template) => {
 		const htmlAst = new HtmlAst(template.content);
 		htmlAst.visitNodes((node) => {
-			if (!isInterestingNode(node) || !isNeutralElement(node.name)) {
+			if (!isMigratableGrid(node)) {
 				return;
 			}
-			const classes = node.attributes.find((attr) => attr.name === 'class')?.value;
-			if (!classes?.match(/(^|\s)grid(\s|$)/)) {
-				return;
-			}
-			if (gridHasNonNeutralColumnChildren(node)) {
-				return;
-			}
+			const classes = node.attributes.find((attr) => attr.name === 'class')?.value || '';
 
 			const styleAttr = node.attributes.find((attr) => attr.name === 'style')?.value || '';
 			const cssProps = parseCssCustomProperties(styleAttr);
@@ -245,14 +261,7 @@ function findHTMLGridColumns(sourceFile: SourceFile, basePath: string, tree: Tre
 			}
 
 			// Only migrate grid-column if its parent grid container is also being migrated
-			if (!isInterestingNode(parent) || !isNeutralElement(parent.name)) {
-				return;
-			}
-			const parentClasses = parent.attributes.find((attr) => attr.name === 'class')?.value;
-			if (!parentClasses?.match(/(^|\s)grid(\s|$)/)) {
-				return;
-			}
-			if (gridHasNonNeutralColumnChildren(parent)) {
+			if (!isMigratableGrid(parent)) {
 				return;
 			}
 

--- a/packages/ng/schematics/lu-grid/tests/output/external-template.component.html
+++ b/packages/ng/schematics/lu-grid/tests/output/external-template.component.html
@@ -30,9 +30,9 @@
 		<lu-grid-column colspan="6"><div class="gridDemo">nested</div></lu-grid-column>
 	</lu-grid>
 </div>
-<lu-grid class="mod-custom-mod">
-	<lu-grid-column colspan="6" style="color: red"><div class="gridDemo">extra styles</div></lu-grid-column>
-</lu-grid>
+<div class="grid mod-custom-mod">
+	<div class="grid-column" style="--grid-colspan: 6; color: red"><div class="gridDemo">extra styles</div></div>
+</div>
 <lu-grid mode="form">
 	<lu-grid-column colspan="6"><div class="gridDemo">form mode</div></lu-grid-column>
 </lu-grid>


### PR DESCRIPTION
## Description

Introduces a single `isMigratableGrid` helper as the shared source of truth for
both the grid and grid-column finders in the `lu-grid` migration schematic.

A grid is now considered migratable only when the migration can be fully carried
out — i.e. no class other than `grid` / `mod-auto` / `mod-form` would remain on
the element. If any extra class would be left behind (keeping a `class=`
attribute), the grid and its `grid-column` children are left untouched for manual
review.

## Why

Previously the grid and grid-column finders duplicated their eligibility checks,
which risked migrating a `grid-column` without its parent grid being migrated too.
Centralizing the logic guarantees they stay in sync and prevents partial/incomplete
migrations that would leave dangling classes.

## How

- Add `isMigratableGrid(node)` encapsulating the neutral-element, `grid` class,
  non-neutral children, and leftover-class checks.
- Use it in both `findHTMLGrids` and `findHTMLGridColumns`, removing the
  duplicated inline conditions.
  
-----

-----
