### PR TITLE
FIX optional filters btn alt text

### DIFF
--- a/packages/ng/filter-pills/filter-bar/filter-bar.component.html
+++ b/packages/ng/filter-pills/filter-bar/filter-bar.component.html
@@ -15,7 +15,7 @@
 				luPopoverNoCloseButton
 				[customPositions]="popoverPositions"
 			>
-				<lu-icon class="filterPill-icon" icon="filtersDescending" [attr.alt]="intl().additionalFilters" />
+				<lu-icon class="filterPill-icon" icon="filtersDescending" [alt]="intl().additionalFilters" />
 			</button>
 		}
 


### PR DESCRIPTION
## Description

The alternative text for the optional filters icon button was passed as an attribute instead of an input

-----
