### PR TITLE
fix(tooltip): don't reopen a pending tooltip after the trigger is destroyed

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -96,8 +96,9 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	// guards the one-time setup of the persistent resize/mutation observers
 	#measurementObserversArmed = false;
 
-	// the IntersectionObserver callback can fire after the view is destroyed; avoid touching
-	// the destroyed injector (NG0911) when that happens
+	// the IntersectionObserver callback and a debounced 'open' action (see openTooltip) can
+	// fire after the view is destroyed; avoid touching the destroyed injector (NG0911) or
+	// recreating the overlay when that happens
 	#destroyed = false;
 
 	// written only from the `read` phase of the afterRenderEffect below
@@ -321,7 +322,11 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	}
 
 	private openTooltip(): void {
-		if (this.overlayRef?.hasAttached()) {
+		// A pending debounced 'open' is flushed when `toObservable(#realAction)` completes on
+		// destroy (`debounce` re-emits the held value on completion), i.e. AFTER ngOnDestroy has
+		// disposed the overlay. Opening then would recreate an overlay anchored to a detached
+		// host — pinned to the viewport's top-left corner — that nothing would ever dispose.
+		if (this.#destroyed || this.overlayRef?.hasAttached()) {
 			return;
 		}
 		const position = this.legacyPositionBuilder();


### PR DESCRIPTION
## Description

Fixes a "ghost tooltip": when a `luTooltip` trigger is destroyed while a debounced 'open' is pending (element hovered less than `luTooltipEnterDelay` before its host is removed by a re-render — e.g. quickly switching tabs that re-render a list of cards with `luTooltipWhenEllipsis` titles), a tooltip is created anyway, pinned to the top-left corner of the viewport, and never removed.

**Before / after videos:**

[tooltip-bug-cursor.webm](https://github.com/user-attachments/assets/17036ff5-ff69-485f-82d4-82d4feda728f)

[tooltip-fix-cursor.webm](https://github.com/user-attachments/assets/82c99547-e2c4-43d0-b42a-af86f5097968)

-----

Root cause: the action pipeline is `toObservable(#realAction) → debounce(timer) → tap(open/close) → takeUntilDestroyed()`. On destroy, `ngOnDestroy` first detaches and disposes the overlay, then `toObservable`'s effect is torn down, which **completes** the source — and RxJS `debounce` **re-emits the value it is holding when the source completes**. `takeUntilDestroyed()` sits after the `debounce` in the pipe, so the flushed 'open' still reaches the `tap` and `openTooltip()` runs on the destroyed directive: `overlayRef` was already deleted, so a brand-new overlay is created, anchored to the now-detached host element. Its `getBoundingClientRect()` is all zeros, so the CDK positions the panel at (0,0) — and since the directive is destroyed, nothing ever disposes that overlay.

The fix guards `openTooltip()` with the existing `#destroyed` flag. Registration order makes this safe: `#destroyRef.onDestroy(() => (this.#destroyed = true))` is registered in the constructor **before** `toObservable(...)` registers its own teardown, so the flag is already `true` when the debounce flush fires. No guard is needed in `closeTooltip()`: a flushed 'close' after destroy is harmless (the overlay is already disposed).

Diagnosed by instrumenting the directive at runtime: each stuck overlay matches the sequence `mouseenter` → (at +enterDelay, during the re-render) `ngOnDestroy` → `openTooltip()` with `host.isConnected === false` and no `overlayRef`. The equivalent runtime patch was verified in a real app: 0 ghost tooltips over repeated reproductions, normal open/close behavior intact.

Repro (against a list re-rendered by a `@for` with changing keys): hover an ellipsized `luTooltipWhenEllipsis` title, and within 300 ms trigger a re-render that destroys the hovered card. Repeat: one ghost tooltip stacks up at (0,0) per occurrence.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [ ] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
