### PR TITLE
test(filter-pills): add E2E interaction test for the filter pills story

### DIFF
--- a/stories/documentation/forms/filter-pills/angular/filter-pills.stories.ts
+++ b/stories/documentation/forms/filter-pills/angular/filter-pills.stories.ts
@@ -13,6 +13,9 @@ import { LuMultiSelectInputComponent, LuMultiSelectWithSelectAllDirective } from
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { TreeSelectDirective } from '@lucca-front/ng/tree-select';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { createTestStory } from '@/helpers/stories';
+import { pickDay, waitForAngular } from '@/helpers/test';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 import { StoryModelDisplayComponent } from '../../../../helpers/story-model-display.component';
 
 export default {
@@ -130,3 +133,128 @@ export const Basic: StoryObj<FilterPillComponent & { clearable: boolean; filterP
 		filterPillLabelPlural: 'légumes',
 	},
 };
+
+export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) => {
+	// 1. Wait for Angular to stabilize
+	await waitForAngular();
+
+	const canvas = within(canvasElement);
+	// On cible la pill portée par un simple-select (aucun appel HTTP requis).
+	const getPill = () => canvas.getByRole('button', { name: /Legume \(simple\)/ });
+	// Le bouton de réinitialisation est un frère de la pill dans son wrapper : on scope
+	// la recherche pour éviter les collisions quand plusieurs pills sont renseignées.
+	const getClearer = (pill: HTMLElement) => within(pill.closest('.filterPillWrapper') as HTMLElement).getByRole('button', { name: /Vider ce champ/ });
+	const queryClearer = (pill: HTMLElement) => within(pill.closest('.filterPillWrapper') as HTMLElement).queryByRole('button', { name: /Vider ce champ/ });
+
+	await step('État initial : la pill est fermée et sans valeur', async () => {
+		const pill = getPill();
+		await expect(pill).toBeVisible();
+		await expect(pill).toHaveAttribute('aria-expanded', 'false');
+		// Aucune valeur sélectionnée → pas de bouton de réinitialisation.
+		await expect(queryClearer(pill)).not.toBeInTheDocument();
+	});
+
+	await step('Ouverture du popover à la souris', async () => {
+		await userEvent.click(getPill());
+		await waitForAngular();
+		await expect(getPill()).toHaveAttribute('aria-expanded', 'true');
+		// Le contenu du popover (le select) est rendu dans l'overlay global.
+		await expect(screen.getByRole('combobox')).toBeVisible();
+	});
+
+	let selectedOptionText = '';
+	await step('Sélection d’une option', async () => {
+		const combobox = screen.getByRole('combobox');
+		await userEvent.click(combobox);
+		await waitForAngular();
+		const listbox = within(screen.getByRole('listbox'));
+		const options = await listbox.findAllByRole('option');
+		selectedOptionText = options[0].innerText;
+		await userEvent.click(options[0]);
+		await waitForAngular();
+		// La valeur choisie est reflétée dans la pill et le bouton de réinitialisation apparaît.
+		await expect(getPill()).toHaveTextContent(selectedOptionText);
+		await expect(getClearer(getPill())).toBeVisible();
+	});
+
+	await step('Réinitialisation via le bouton clear', async () => {
+		await userEvent.click(getClearer(getPill()));
+		await waitForAngular();
+		// La valeur est retirée et le bouton de réinitialisation disparaît.
+		await expect(getPill()).not.toHaveTextContent(selectedOptionText);
+		await expect(queryClearer(getPill())).not.toBeInTheDocument();
+	});
+
+	await step('Ouverture et fermeture au clavier', async () => {
+		const pill = getPill();
+		pill.focus();
+		await expect(pill).toHaveFocus();
+		// La flèche bas ouvre le popover.
+		await userEvent.keyboard('{ArrowDown}');
+		await waitForAngular();
+		await expect(getPill()).toHaveAttribute('aria-expanded', 'true');
+		await expect(screen.getByRole('combobox')).toBeVisible();
+		// Échap referme le popover.
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => expect(getPill()).toHaveAttribute('aria-expanded', 'false'));
+	});
+
+	await step('Coche la checkbox', async () => {
+		// La pill checkbox n'ouvre pas de popover : c'est un bouton bascule (aria-pressed).
+		const pill = canvas.getByRole('button', { name: /Inclure les collaborateurs partis/ });
+		await expect(pill).toHaveAttribute('aria-pressed', 'false');
+		await userEvent.click(pill);
+		await waitForAngular();
+		await expect(pill).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	await step('Sélectionne plusieurs items dans le multi-select', async () => {
+		const pill = canvas.getByRole('button', { name: /Légume \(multi\)/ });
+		await userEvent.click(pill);
+		await waitForAngular();
+		await userEvent.click(screen.getByRole('combobox'));
+		await waitForAngular();
+		const listbox = within(screen.getByRole('listbox'));
+		// On écarte l'option « tout sélectionner » pour ne cliquer que de vraies options.
+		const options = (await listbox.findAllByRole('option')).filter((option) => !option.id.includes('select-all'));
+		await userEvent.click(options[0]);
+		await userEvent.click(options[1]);
+		await waitForAngular();
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+		await waitFor(() => expect(screen.queryByRole('listbox')).not.toBeInTheDocument());
+		// Une fois renseignée, la pill affiche le label pluriel « légumes » (son nom
+		// accessible change) : on réutilise la référence capturée plus haut.
+		await expect(pill).toHaveTextContent(/légumes/);
+		await expect(getClearer(pill)).toBeVisible();
+	});
+
+	await step('Sélectionne une date', async () => {
+		const pill = canvas.getByRole('button', { name: /Date de début/ });
+		await userEvent.click(pill);
+		await waitForAngular();
+		const dateInput = screen.getByTestId('lu-date-input');
+		await pickDay(dateInput, 15);
+		await waitForAngular();
+		// Une date choisie → la pill est renseignée et propose une réinitialisation.
+		await expect(getClearer(pill)).toBeVisible();
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+	});
+
+	await step('Sélectionne une période dans le date range', async () => {
+		const pill = canvas.getByRole('button', { name: /Période/ });
+		await userEvent.click(pill);
+		await waitForAngular();
+		const startInput = screen.getByLabelText('Start');
+		const endInput = screen.getByLabelText('End');
+		// `multipleGrid` : le date range affiche deux calendriers côte à côte.
+		await pickDay(startInput, 10, true);
+		await pickDay(endInput, 20, true);
+		await waitForAngular();
+		await expect(getClearer(pill)).toBeVisible();
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+	});
+});


### PR DESCRIPTION
## Description

Add an end-to-end interaction test covering the filter pills, exercising every
pill type: simple-select, multi-select, checkbox toggle, date picker and date range.

-----

Adds a `BasicTEST` story built with `createTestStory` on top of the existing `Basic`
filter-pills story. The test drives the component through realistic user flows and asserts
the accessibility contract along the way:

- Initial state: pill is collapsed (`aria-expanded="false"`) and has no clear button.
- Mouse open, option selection, and reset via the clear button.
- Keyboard open/close (`ArrowDown` to open, `Escape` to close).
- Checkbox pill toggling through `aria-pressed`.
- Multi-select with several items (excluding the "select all" option) and plural label check.
- Date and date-range selection (`multipleGrid`, two calendars) with `pickDay`.

Uses `waitForAngular` between interactions to let change detection stabilize, and scopes
clear-button lookups to each `.filterPillWrapper` to avoid collisions when multiple pills
are filled. No HTTP calls are required (targets the simple-select pill).

-----

-----