### PR TITLE
feat(title): accept Signal<string> as appTitle in provideLuTitleStrategy

### DIFF
--- a/packages/ng/title/title.strategy.spec.ts
+++ b/packages/ng/title/title.strategy.spec.ts
@@ -1,5 +1,5 @@
 import { LiveAnnouncer } from '@angular/cdk/a11y';
-import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Inject, OnInit, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, provideRouter, Router, RouterLink, RouterOutlet, Routes, TitleStrategy } from '@angular/router';
@@ -235,6 +235,61 @@ describe('TitleStrategy', () => {
 	it('should not announce title via LiveAnnouncer when not enabled', async () => {
 		await fixture.whenStable();
 		expect(liveAnnouncer.announce).not.toHaveBeenCalled();
+	});
+});
+
+describe('TitleStrategy with signal appTitle', () => {
+	let fixture: ComponentFixture<AppComponent>;
+	let pageTitleService: LuTitleStrategy;
+	const appTitle = signal('BU');
+
+	const routes: Routes = [
+		{
+			path: '',
+			title: 'Stub',
+			component: StubComponent,
+		},
+	];
+
+	beforeEach(async () => {
+		appTitle.set('BU');
+		TestBed.configureTestingModule({
+			imports: [AppComponent],
+			providers: [
+				{ provide: LiveAnnouncer, useValue: { announce: vi.fn() } },
+				provideRouter(routes),
+				{ provide: Title, useValue: { setTitle: vi.fn(), getTitle: vi.fn().mockReturnValue('') } },
+				provideLuTitleStrategy({
+					appTitle: () => appTitle,
+					translateService: () => new TranslateService(),
+				}),
+			],
+		});
+
+		fixture = TestBed.createComponent(AppComponent);
+		pageTitleService = TestBed.inject(TitleStrategy) as unknown as LuTitleStrategy;
+		fixture.detectChanges();
+		await TestBed.inject(Router).navigateByUrl('/');
+		fixture.detectChanges();
+	});
+
+	it('should set title from the signal value', async () => {
+		let resultTitle = '';
+		pageTitleService.title$.subscribe((title) => (resultTitle = title));
+
+		await fixture.whenStable();
+		expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca BU`);
+	});
+
+	it('should update title when the signal changes', async () => {
+		let resultTitle = '';
+		pageTitleService.title$.subscribe((title) => (resultTitle = title));
+
+		await fixture.whenStable();
+		appTitle.set('Poplee');
+		await vi.waitFor(() => {
+			expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca Poplee`);
+		});
 	});
 });
 

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -1,5 +1,6 @@
 import { LiveAnnouncer } from '@angular/cdk/a11y';
-import { inject, Injectable, InjectionToken, Provider } from '@angular/core';
+import { inject, Injectable, InjectionToken, isSignal, Provider, Signal } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRouteSnapshot, RouterStateSnapshot, TitleStrategy } from '@angular/router';
 import { isNotNil } from '@lucca-front/ng/core';
@@ -8,7 +9,7 @@ import { distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
 import { ILuTitleTranslateService, LU_TITLE_TRANSLATE_SERVICE } from './title-translate.service';
 import { PageTitle, TitleSeparator } from './title.model';
 
-export const ɵAPP_TITLE = new InjectionToken<string | Observable<string>>('APP_TITLE');
+export const ɵAPP_TITLE = new InjectionToken<string | Observable<string> | Signal<string>>('APP_TITLE');
 export type LuTitleNamingStrategy = 'product' | 'other';
 export const ɵNAMING_STRATEGY = new InjectionToken<LuTitleNamingStrategy>('NAMING_STRATEGY', { factory: () => 'product' });
 export const ɵREAD_TITLE_BY_LIVE_ANNOUNCER = new InjectionToken<boolean>('READ_TITLE_BY_LIVE_ANNOUNCEMENT', { factory: () => false });
@@ -29,7 +30,7 @@ export class LuTitleStrategy extends TitleStrategy {
 	private readTitleByLiveAnnouncer = inject(ɵREAD_TITLE_BY_LIVE_ANNOUNCER);
 	private liveAnnouncer = inject(LiveAnnouncer);
 
-	private luccaTitle$ = isObservable(this.appTitle) ? this.appTitle.pipe(map((title) => this.#luccaTitle(title))) : of(this.#luccaTitle(this.appTitle));
+	private readonly luccaTitle$ = this.#toLuccaTitle$(this.appTitle);
 
 	private titlePartsSubject = new BehaviorSubject<Array<string | ObservableInput<string>>>([Lucca]);
 	titleParts$ = this.titlePartsSubject.asObservable();
@@ -79,6 +80,16 @@ export class LuTitleStrategy extends TitleStrategy {
 		return snapshot.firstChild ? [pageTitle, ...this.#getPageTitleParts(snapshot.firstChild)] : [pageTitle];
 	}
 
+	#toLuccaTitle$(appTitle: string | Observable<string> | Signal<string>): Observable<string> {
+		if (isSignal(appTitle)) {
+			return toObservable(appTitle).pipe(map((title) => this.#luccaTitle(title)));
+		}
+		if (isObservable(appTitle)) {
+			return appTitle.pipe(map((title) => this.#luccaTitle(title)));
+		}
+		return of(this.#luccaTitle(appTitle));
+	}
+
 	#luccaTitle(appTitle: string) {
 		if (appTitle.includes(Lucca)) {
 			return appTitle;
@@ -95,7 +106,7 @@ function uniqTitle(titleParts: Array<PageTitle>): Array<PageTitle> {
 }
 
 export interface LuTitleStrategyOptions {
-	appTitle?: () => string | Observable<string>;
+	appTitle?: () => string | Observable<string> | Signal<string>;
 	translateService?: () => ILuTitleTranslateService;
 	namingStrategy?: LuTitleNamingStrategy;
 	readTitleByLiveAnnouncer?: boolean;


### PR DESCRIPTION
## Description

`provideLuTitleStrategy` now also accepts a `Signal<string>` as `appTitle`, in addition to `string` and `Observable<string>`. The document title updates automatically whenever the signal value changes.

-----

The `ɵAPP_TITLE` token and `LuTitleStrategyOptions.appTitle` types are widened to include `Signal<string>`. A private `#toLuccaTitle$` method normalizes the three accepted forms into an `Observable<string>`, converting signals with `toObservable` (valid since field initializers run in an injection context). Fully backward compatible — no change for existing consumers.

Covered by two new specs: initial title from a signal, and title update after `signal.set(...)`.

-----

### Contribution

- [ ] Designs are respected and all relevant options are handled
- [ ] Responsive behavior addressed when needed
- [ ] Feature is accessible (keyboard navigation, screen reader support, ARIA tags, etc.)
- [ ] Stories are updated and Storybook controls have descriptions
- [x] Feature is covered by E2E tests or UI diff
- [ ] `npm run build` OK
- [x] `npm run lint` OK

### Functional review

- [ ] UI diff OK
- [ ] Feature and all options are manually tested and comply with design and guidelines.

-----
