### PR TITLE
fix(core-select): start the loader as soon as the panel opens

### DIFF
--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Directive } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
-import { Observable, map, of } from 'rxjs';
+import { Observable, delay, map, of } from 'rxjs';
 import type { MockInstance } from 'vitest';
 import { MAGIC_OPTION_SCROLL_DELAY } from '../option/option.component';
 import { ALuCoreSelectApiDirective, MAGIC_DEBOUNCE_DURATION } from './api.directive';
@@ -89,6 +89,31 @@ describe('ALuCoreSelectApiDirective', () => {
 
 		expect(testApi.getOptions).toHaveBeenCalledTimes(1);
 		expect(testApi.getOptions).toHaveBeenCalledWith({}, 0);
+	}));
+
+	it('should start the loader as soon as the panel opens', fakeAsync(() => {
+		fixture.detectChanges(); // run ngOnInit first: the directive must observe the panel state before the assertion below
+		tick(); // Component initialization uses a setTimeout :see_no_evil:
+		getOptionsSpy.mockReturnValue(of([{ id: 1, name: 'test' }]).pipe(delay(300)));
+
+		// Capture the loading state at the exact moment the panel opens: if the loader is off
+		// at that point, the "no result" empty state flashes until the first fetch starts
+		let loadingWhenPanelOpens: boolean | undefined;
+		select.isPanelOpen$.subscribe((isOpen) => {
+			if (isOpen) {
+				loadingWhenPanelOpens = select.loading$.value;
+			}
+		});
+
+		select.openPanel();
+		fixture.detectChanges();
+		tick(); // openPanel defers its work in a setTimeout
+
+		expect(loadingWhenPanelOpens).toBe(true);
+
+		tick(300);
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+		expect(select.loading$.value).toBe(false);
 	}));
 
 	it('should query options once when searching while the select is closed', fakeAsync(() => {

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -57,16 +57,21 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	protected buildOptions(): Observable<TOption[]> {
 		// Prevent a double call to getOptions when the clue is changed while the panel is closed
 		const clueIsPendingDebounce$ = merge(this.select.clueChange$.pipe(map(() => true)), this.clue$.pipe(map(() => false))).pipe(distinctUntilChanged());
-		const isOpen$ = combineLatest([this.select.isPanelOpen$, clueIsPendingDebounce$]).pipe(
+		const isOpen$ = combineLatest([
+			this.select.isPanelOpen$.pipe(
+				tap((isOpen) => {
+					// Start the loader synchronously on opening to avoid a short display of the "no result"
+					// message: the first fetch only starts on the next tick (debounced open, async params$)
+					if (isOpen) {
+						this.select.loading = true;
+					}
+				}),
+			),
+			clueIsPendingDebounce$,
+		]).pipe(
 			debounceTime(0),
 			startWith([false, false]),
 			pairwise(),
-			tap(([[wasOpen], [isOpen, clueIsPendingDebounce]]) => {
-				// Start the loader as soon as the panel is opened to avoid a short display of the "no result" message
-				if (!wasOpen && isOpen && clueIsPendingDebounce) {
-					this.select.loading = true;
-				}
-			}),
 			map(([[wasOpen], [isOpen, clueIsPendingDebounce]]) => (isOpen && !wasOpen ? !clueIsPendingDebounce : isOpen)),
 			distinctUntilChanged(),
 		);


### PR DESCRIPTION
## Description

Fixes a flash of the "no value available" empty state when opening any API-backed select (`lu-simple-select`/`lu-multi-select` with `users`, `departments`, `establishments`, api v3/v4 directives…).

### Why it happened

The panel shows its empty state whenever `options.length === 0 && !loading`. On opening, the panel is rendered in the same task as the `isPanelOpen$` emission, but the fetch pipeline only reacts one or more tasks later (`debounceTime(0)` on the open stream, async `params$` — e.g. a `toObservable` in the users directive). `loading` was only set to `true` inside `getOptionsPage()`, i.e. in that later task: the panel's first paint happened with `loading === false`, showing the empty state until the fetch started.

The window is made of task scheduling, so its duration scales with CPU load: barely a frame on an idle machine, but clearly visible on a busy dev server (measured ~130ms at 6x CPU throttling, ~1.5s at 60x).

There was already a guard for this ("Start the loader as soon as the panel is opened to avoid a short display of the 'no result' message"), but it only covered opening with a pending clue debounce, and sat *after* the `debounceTime(0)` — one task too late for the first paint.

### The fix

Start the loader synchronously with the `isPanelOpen$` emission (same task as the panel creation), unconditionally: every open leads to a fetch, which always resolves the loader (response or `catchError`). The pending-clue case is a subset of the new behavior, and the anti-double-call logic downstream is untouched (see the existing search specs, still green).

A regression test asserts that `loading` is already `true` at the moment `isPanelOpen$` delivers the open event — the exact condition that decides what the panel's first paint shows. It fails on the previous implementation.

## Videos

Recorded on the `SimpleSelect / User Select` story, **unmodified code**, with devtools CPU throttling **x60** to widen the window (the same flash occurs at every speed, just shorter):

### Before (empty state flashes on open)

[core-select-before.webm](https://github.com/user-attachments/assets/83581c61-127d-48d7-95af-e91015143267)

### After (loader from the very first paint)

[core-select-after.webm](https://github.com/user-attachments/assets/e9fb8ae8-2228-4b40-95fd-8b48592dd318)

-----