### PR TITLE
fix(date2): compare min/max at day granularity in day mode

### DIFF
--- a/docs/date-input.md
+++ b/docs/date-input.md
@@ -8,13 +8,26 @@ Le composant s'utilise via la balise `lu-form-field` et supporte `ngModel` ainsi
 
 Il est possible d'utiliser `lu-date-input` de plusieurs façons différentes, via ses inputs, tout d'abord:
 
-- `min` et `max`, servent à définir des dates minimales et maximales pour la sélection, **ils ne constituent pas un validateur**, ainsi, vous devrez spécficier un `Validator` à la main pour traiter une sélection hors limites comme erreur.
+- `min` et `max`, servent à définir les dates minimales et maximales sélectionnables. Ce sont **des validateurs** : une valeur hors bornes fait remonter l'erreur `{ min: true }` ou `{ max: true }` sur le `FormControl`.
 - `hideToday` permet de désactiver le style spécifique appliqué au jour en cours.
 - `hasTodayButton` permet d'ajouter un bouton "aujourd'hui", automatiquement traduit via `Intl`, qui sélectionne la date d'aujourd'hui.
 - `hideWeekend` permet de désactiver le style spécifiques des jours du weekend.
 - `clearable` permet d'ajouter un bouton "clear" à la fin de l'input.
 
-Le composant utilise uniquement des objets de type `Date`, le premier jour de la semaine ainsi que les jours du weekend sont récupérés via la locale Angular, car à ce jour, l'implémentation proposée dans `Intl` n'est pas présente dans Firefox.
+#### Bornes `min` / `max` : limites actuelles
+
+En mode `day`, les bornes sont **inclusives à la journée** : l'heure portée par la valeur est ignorée des deux côtés. `[min]="new Date()"` laisse donc le jour même sélectionnable, quelle que soit l'heure.
+
+Les deux inputs acceptent une `Date` ou une string `yyyy-MM-dd`, et les interprètent comme un **jour calendaire local**. N'y passez donc qu'une valeur qui ne transporte pas d'instant :
+
+- ✅ `'2026-12-31'`, `new Date()`, `new Date(2026, 11, 31)`, `new Date('2026-12-31T00:00:00')`
+- ❌ `new Date('2026-12-31')` — interprété en UTC par JS, contrairement à la forme avec `T00:00:00`
+- ❌ toute `Date` issue d'un instant horodaté (`…T00:00:00Z`, `…+01:00`)
+- ❌ le résultat d'une fonction `date-fns` appliquée à une string : `subDays('2026-12-31', 1)` convertit la string en UTC avant de calculer
+
+Les formes ❌ sont décalées d'un jour dans les fuseaux à l'ouest de Greenwich — et, pour les instants de soirée, à l'est. Le symptôme est soit une date valide non sélectionnable, soit une date hors bornes acceptée sans erreur.
+
+Par défaut le composant manipule des objets `Date` ; avec `format="date-iso"`, la valeur du `FormControl` est une string `yyyy-MM-dd`. Le premier jour de la semaine ainsi que les jours du weekend sont récupérés via la locale Angular, car à ce jour, l'implémentation proposée dans `Intl` n'est pas présente dans Firefox.
 
 ### Configuration avancée
 

--- a/packages/ng/date2/abstract-date-component.ts
+++ b/packages/ng/date2/abstract-date-component.ts
@@ -86,7 +86,7 @@ export abstract class AbstractDateComponent {
 
 		switch (mode) {
 			case 'day':
-				return this.min().getTime() <= date.getTime();
+				return startOfDay(this.min()).getTime() <= startOfDay(date).getTime();
 			case 'month':
 				return isBefore(startOfMonth(this.min()), startOfMonth(date)) || isSameMonth(this.min(), date);
 			case 'year':
@@ -103,7 +103,7 @@ export abstract class AbstractDateComponent {
 
 		switch (mode) {
 			case 'day':
-				return this.max().getTime() >= date.getTime();
+				return startOfDay(this.max()).getTime() >= startOfDay(date).getTime();
 			case 'month':
 				return isAfter(startOfMonth(this.max()), startOfMonth(date)) || isSameMonth(this.max(), date);
 			case 'year':

--- a/packages/ng/date2/date-input/date-input.component.spec.ts
+++ b/packages/ng/date2/date-input/date-input.component.spec.ts
@@ -4,19 +4,20 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DateInputComponent } from './date-input.component';
 
 @Component({
-	template: `<lu-date-input [formControl]="formControl" [min]="min" />`,
+	template: `<lu-date-input [formControl]="formControl" [min]="min" [max]="max" />`,
 	imports: [FormsModule, ReactiveFormsModule, DateInputComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class HostComponent {
 	formControl = new FormControl<Date | null>(null);
 	min: Date | null = null;
+	max: Date | null = null;
 }
 
 describe('DateInputComponent', () => {
 	let fixture: ComponentFixture<HostComponent>;
 
-	function createHost(formControl: FormControl<Date | null>, min: Date | null = null): HTMLInputElement {
+	function createHost(formControl: FormControl<Date | null>, min: Date | null = null, max: Date | null = null): HTMLInputElement {
 		TestBed.configureTestingModule({
 			imports: [HostComponent],
 			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
@@ -25,6 +26,7 @@ describe('DateInputComponent', () => {
 		fixture = TestBed.createComponent(HostComponent);
 		fixture.componentInstance.formControl = formControl;
 		fixture.componentInstance.min = min;
+		fixture.componentInstance.max = max;
 		fixture.detectChanges();
 
 		return (fixture.nativeElement as HTMLElement).querySelector('[data-testid="lu-date-input"]') as HTMLInputElement;
@@ -113,5 +115,21 @@ describe('DateInputComponent', () => {
 		typeInElement('31/12/2023', input);
 
 		expect(formControl.errors).toEqual({ min: true });
+	});
+
+	it('should accept the max date itself even when the value carries a time of day', () => {
+		const formControl = new FormControl<Date | null>(new Date('2024-01-31T18:00:00'));
+		createHost(formControl, null, new Date('2024-01-31T00:00:00'));
+
+		expect(formControl.errors).toBeNull();
+	});
+
+	it('should reject a date after the max day', () => {
+		const formControl = new FormControl<Date | null>(null);
+		const input = createHost(formControl, null, new Date('2024-01-31T00:00:00'));
+
+		typeInElement('01/02/2024', input);
+
+		expect(formControl.errors).toEqual({ max: true });
 	});
 });

--- a/packages/ng/date2/date-input/date-input.component.spec.ts
+++ b/packages/ng/date2/date-input/date-input.component.spec.ts
@@ -4,18 +4,19 @@ import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { DateInputComponent } from './date-input.component';
 
 @Component({
-	template: `<lu-date-input [formControl]="formControl" />`,
+	template: `<lu-date-input [formControl]="formControl" [min]="min" />`,
 	imports: [FormsModule, ReactiveFormsModule, DateInputComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class HostComponent {
 	formControl = new FormControl<Date | null>(null);
+	min: Date | null = null;
 }
 
 describe('DateInputComponent', () => {
 	let fixture: ComponentFixture<HostComponent>;
 
-	function createHost(formControl: FormControl<Date | null>): HTMLInputElement {
+	function createHost(formControl: FormControl<Date | null>, min: Date | null = null): HTMLInputElement {
 		TestBed.configureTestingModule({
 			imports: [HostComponent],
 			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
@@ -23,6 +24,7 @@ describe('DateInputComponent', () => {
 
 		fixture = TestBed.createComponent(HostComponent);
 		fixture.componentInstance.formControl = formControl;
+		fixture.componentInstance.min = min;
 		fixture.detectChanges();
 
 		return (fixture.nativeElement as HTMLElement).querySelector('[data-testid="lu-date-input"]') as HTMLInputElement;
@@ -94,4 +96,22 @@ describe('DateInputComponent', () => {
 		tick();
 		expect(valueChanges).toHaveBeenCalledTimes(0);
 	}));
+
+	it('should accept the min date itself even when min carries a time of day', () => {
+		const formControl = new FormControl<Date | null>(null);
+		const input = createHost(formControl, new Date('2024-01-01T14:00:00'));
+
+		typeInElement('01/01/2024', input);
+
+		expect(formControl.errors).toBeNull();
+	});
+
+	it('should reject a date before the min day', () => {
+		const formControl = new FormControl<Date | null>(null);
+		const input = createHost(formControl, new Date('2024-01-01T14:00:00'));
+
+		typeInElement('31/12/2023', input);
+
+		expect(formControl.errors).toEqual({ min: true });
+	});
 });


### PR DESCRIPTION
## Description

In `day` mode, `lu-date-input` now compares `[min]` and `[max]` at day granularity. Previously, passing a `Date` carrying a time of day (the natural `[min]="today"` with `today = new Date()`) made the min day itself unselectable: today's cell was disabled in the calendar and typing today's date raised a `{ min: true }` validation error as soon as it was past midnight. The min/max day is now inclusive, regardless of the time of day carried by the bound `Date`.

-----

Root cause: in `AbstractDateComponent.isAfterMin`/`isBeforeMax`, the `month` and `year` branches normalize both dates to the mode's granularity (`startOfMonth`, `getFullYear`) before comparing, but the `day` branch compared raw `getTime()` values. A `min` of "today 14:00" therefore rejected "today 00:00" (the value produced by the calendar or by parsing user input).

Fix: normalize both sides with `startOfDay` in the `day` branch, mirroring what the other modes already do.

Added red/green regression tests on `DateInputComponent` for both bounds: a `[min]` of `2024-01-01T14:00` accepts a typed `01/01/2024` (fails without the fix with `{ min: true }`) and still rejects `31/12/2023`; a value of `2024-01-31T18:00` is accepted with a `[max]` of `2024-01-31T00:00` (fails without the fix with `{ max: true }`) and `01/02/2024` is still rejected.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
