### PR TITLE
experimental(stories): categorize inputs/outputs in argTypes and document emitted output types

### DIFF
--- a/stories/documentation/structure/box/angular/basic.stories.ts
+++ b/stories/documentation/structure/box/angular/basic.stories.ts
@@ -7,12 +7,19 @@ export default {
 	argTypes: {
 		neutral: {
 			description: 'Applique un fond gris.',
+			table: { category: 'inputs' },
 		},
 		killable: {
 			description: 'Ajoute un bouton de fermeture.',
+			table: { category: 'inputs' },
 		},
 		killed: {
 			description: 'Événement déclenché lorsque la box est fermée.',
+			action: 'killed',
+			// `output()` sans type émet `void` (aucune valeur).
+			// Pour un `output<T>()`, reprendre `T` ici (ex. `'string'`, `'FileList'`…).
+			table: { category: 'outputs', type: { summary: 'void' } },
+			control: false,
 		},
 	},
 	decorators: [
@@ -20,9 +27,13 @@ export default {
 			imports: [BoxComponent],
 		}),
 	],
-	render: ({ ...args }, { argTypes }) => {
+	render: ({ killed, ...args }, { argTypes }) => {
 		return {
-			template: cleanupTemplate(`<lu-box ${generateInputs(args, argTypes)}>Lorem ipsum dolor sit amet</lu-box>`),
+			props: {
+				...args,
+				onKilled: () => killed?.(),
+			},
+			template: cleanupTemplate(`<lu-box ${generateInputs(args, argTypes)} (killed)="onKilled()">Lorem ipsum dolor sit amet</lu-box>`),
 		};
 	},
 } as Meta;


### PR DESCRIPTION
## Description

Introduces a Storybook argTypes convention on the box component: group inputs and outputs into their own table.category sections, expose each output as a logged action (action, control: false), and document the emitted type via table.type.summary (void when the output() has no type, otherwise T). To be rolled out to all components going forward.

-----

<img width="1727" height="843" alt="Capture d’écran 2026-07-27 à 15 03 57" src="https://github.com/user-attachments/assets/0927f993-8be3-4674-a9e4-8c583a3dc5c8" />

-----
