### PR TITLE
refactor(schematics): preserve assertion stack in migration test helper

### DIFF
--- a/packages/ng/schematics/lib/migration-test.ts
+++ b/packages/ng/schematics/lib/migration-test.ts
@@ -46,7 +46,12 @@ export function expectTree(tree: Tree): { toMatchTree(expectedTree: Tree): void 
 				try {
 					expect(stripLastNewLine(actualContent)).toEqual(stripLastNewLine(expectedContent));
 				} catch (error) {
-					throw error instanceof Error ? new Error(`Expected file content to match for ${path}: \n${error.message}`) : error;
+					if (error instanceof Error) {
+						// Mutate the message in place (rather than re-throwing a new Error) so the original
+						// stack trace and Vitest's expected/actual diff properties are preserved.
+						error.message = `Expected file content to match for ${path}: \n${error.message}`;
+					}
+					throw error;
 				}
 			});
 


### PR DESCRIPTION
## Description

When a schematic migration test fails on a file content mismatch, the failure now points to the actual assertion and keeps Vitest's expected/actual diff, on top of naming the offending file.

Previously `expectTree().toMatchTree()` caught the assertion error and re-threw a brand new `Error` just to prefix it with the file path. That discarded the original stack trace (so the report pointed at the `catch` line, not the comparison) and dropped the `expected`/`actual` properties Vitest relies on for its diff.

-----

The helper now mutates the caught error's `message` in place and re-throws the same object, so the stack trace, the diff, and the file-name context are all preserved.

-----
Avant :

<img width="1181" height="340" alt="Capture d’écran 2026-07-27 à 15 39 35" src="https://github.com/user-attachments/assets/52baf637-3fcd-40b2-afca-205a14ffe3fe" />

Après :

<img width="1184" height="571" alt="Capture d’écran 2026-07-27 à 15 38 46" src="https://github.com/user-attachments/assets/8ebde76c-01fb-4bb4-b540-74f5f1565219" />


-----
