### PR TITLE
chroe(test): expand unit test coverage for string date adapter, intlParams pipe and select model

### DIFF
--- a/packages/ng/core-select/select.model.spec.ts
+++ b/packages/ng/core-select/select.model.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { ɵIsSelectedStrategy } from './select.model';
+import { LuOptionComparer, ɵIsSelectedStrategy } from './select.model';
 
 interface ILegume {
 	id: number;
@@ -12,6 +12,8 @@ const options: ILegume[] = [
 	{ id: 3, name: 'Carotte' },
 ];
 
+const compareById: LuOptionComparer<ILegume> = (a, b) => a?.id === b?.id;
+
 describe('DefaultIsSelectedStrategy', () => {
 	let strategy: ɵIsSelectedStrategy<ILegume>;
 
@@ -19,27 +21,103 @@ describe('DefaultIsSelectedStrategy', () => {
 		strategy = TestBed.inject<ɵIsSelectedStrategy<ILegume>>(ɵIsSelectedStrategy);
 	});
 
-	it('should return true when all options are selected', () => {
-		// Act
-		const isSelected = strategy.isGroupSelected(options, []);
-
+	it('should be provided as the default strategy', () => {
 		// Assert
-		expect(isSelected).toBe(true);
+		expect(strategy).toBeInstanceOf(ɵIsSelectedStrategy);
 	});
 
-	it('should return false when all options are unselected', () => {
-		// Act
-		const isSelected = strategy.isGroupSelected(options, options);
+	describe('isSelected', () => {
+		it('should return true when the option is part of the selection', () => {
+			// Act
+			const isSelected = strategy.isSelected(options[1], [options[1]], compareById);
 
-		// Assert
-		expect(isSelected).toBe(false);
+			// Assert
+			expect(isSelected).toBe(true);
+		});
+
+		it('should return true when a distinct object matches through the comparer', () => {
+			// Act
+			const isSelected = strategy.isSelected(options[1], [{ id: 2, name: 'Chou (copie)' }], compareById);
+
+			// Assert
+			expect(isSelected).toBe(true);
+		});
+
+		it('should return true when the option is one of several selected options', () => {
+			// Act
+			const isSelected = strategy.isSelected(options[2], [options[0], options[2]], compareById);
+
+			// Assert
+			expect(isSelected).toBe(true);
+		});
+
+		it('should return false when the option is not part of the selection', () => {
+			// Act
+			const isSelected = strategy.isSelected(options[1], [options[0], options[2]], compareById);
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
+
+		it('should return false when nothing is selected', () => {
+			// Act
+			const isSelected = strategy.isSelected(options[0], [], compareById);
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
+
+		it('should return false when the comparer rejects an identical option', () => {
+			// Arrange
+			const neverEqual: LuOptionComparer<ILegume> = () => false;
+
+			// Act
+			const isSelected = strategy.isSelected(options[0], [options[0]], neverEqual);
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
 	});
 
-	it('should return false when one option is selected', () => {
-		// Act
-		const isSelected = strategy.isGroupSelected(options, options.slice(1));
+	describe('isGroupSelected', () => {
+		it('should return true when all options are selected', () => {
+			// Act
+			const isSelected = strategy.isGroupSelected(options, []);
 
-		// Assert
-		expect(isSelected).toBe(false);
+			// Assert
+			expect(isSelected).toBe(true);
+		});
+
+		it('should return false when all options are unselected', () => {
+			// Act
+			const isSelected = strategy.isGroupSelected(options, options);
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
+
+		it('should return false when one option is selected', () => {
+			// Act
+			const isSelected = strategy.isGroupSelected(options, options.slice(1));
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
+
+		it('should return false when all but one option are selected', () => {
+			// Act
+			const isSelected = strategy.isGroupSelected(options, options.slice(2));
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
+
+		it('should return false for an empty group', () => {
+			// Act
+			const isSelected = strategy.isGroupSelected([], []);
+
+			// Assert
+			expect(isSelected).toBe(false);
+		});
 	});
 });

--- a/packages/ng/core/date/string/string-date.adapter.spec.ts
+++ b/packages/ng/core/date/string/string-date.adapter.spec.ts
@@ -5,18 +5,236 @@ describe('LuStringDateAdapter', () => {
 	let adapter: LuStringDateAdapter;
 
 	beforeEach(() => {
+		// 'en' short date format is M/d/yy, so parsable inputs are month-first
 		adapter = new LuStringDateAdapter('en');
 	});
 
-	test.each`
-		date             | expectedResult
-		${'01/01/2022'}  | ${'2022-01-01'}
-		${'01/01/20222'} | ${'Invalid Date'}
-	`('should return $expectedResult when parsing $date', ({ date, expectedResult }: { date: string; expectedResult: string }) => {
-		// Act
-		const result = adapter.parse(date, ELuDateGranularity.day);
+	describe('forge', () => {
+		it('should build an ISO 8601 date string', () => {
+			// Act
+			const result = adapter.forge(2022, 3, 15);
 
-		// Assert
-		expect(result).toEqual(expectedResult);
+			// Assert
+			expect(result).toEqual('2022-03-15');
+		});
+
+		it('should pad month and date with a leading zero', () => {
+			// Act
+			const result = adapter.forge(2022, 1, 2);
+
+			// Assert
+			expect(result).toEqual('2022-01-02');
+		});
+
+		it('should overflow to the next month when the date exceeds the month length', () => {
+			// Act
+			const result = adapter.forge(2022, 1, 32);
+
+			// Assert
+			expect(result).toEqual('2022-02-01');
+		});
+	});
+
+	describe('forgeToday', () => {
+		it('should return today as an ISO 8601 date string', () => {
+			// Arrange
+			const today = new Date().toISOString().substring(0, 10);
+
+			// Act
+			const result = adapter.forgeToday();
+
+			// Assert
+			expect(result).toEqual(today);
+		});
+	});
+
+	describe('forgeInvalid', () => {
+		it('should return the invalid date marker', () => {
+			// Act
+			const result = adapter.forgeInvalid();
+
+			// Assert
+			expect(result).toEqual('Invalid Date');
+		});
+	});
+
+	describe('isValid', () => {
+		// only checks that the string builds a valid Date: an out-of-range date such as
+		// 2022-02-29 is rolled over by the JS engine and therefore reported as valid
+		test.each`
+			date              | expectedResult
+			${'2022-03-15'}   | ${true}
+			${'2022-02-29'}   | ${true}
+			${'Invalid Date'} | ${false}
+			${'not a date'}   | ${false}
+			${''}             | ${false}
+		`('should return $expectedResult for "$date"', ({ date, expectedResult }: { date: string; expectedResult: boolean }) => {
+			// Act
+			const result = adapter.isValid(date);
+
+			// Assert
+			expect(result).toBe(expectedResult);
+		});
+	});
+
+	describe('isParsable', () => {
+		test.each`
+			text             | expectedResult
+			${'01/01/2022'}  | ${true}
+			${'12/25/2022'}  | ${true}
+			${'13/25/2022'}  | ${false}
+			${'02/30/2022'}  | ${false}
+			${'01/01/20222'} | ${false}
+			${'01/2022'}     | ${false}
+			${'nope'}        | ${false}
+			${''}            | ${false}
+		`('should return $expectedResult for "$text"', ({ text, expectedResult }: { text: string; expectedResult: boolean }) => {
+			// Act
+			const result = adapter.isParsable(text);
+
+			// Assert
+			expect(result).toBe(expectedResult);
+		});
+	});
+
+	describe('parse', () => {
+		test.each`
+			date             | granularity                 | expectedResult
+			${'01/01/2022'}  | ${ELuDateGranularity.day}   | ${'2022-01-01'}
+			${'12/25/2022'}  | ${ELuDateGranularity.day}   | ${'2022-12-25'}
+			${'01/01/20222'} | ${ELuDateGranularity.day}   | ${'Invalid Date'}
+			${'02/30/2022'}  | ${ELuDateGranularity.day}   | ${'Invalid Date'}
+			${'03/2022'}     | ${ELuDateGranularity.month} | ${'2022-03-01'}
+			${'2022'}        | ${ELuDateGranularity.year}  | ${'2022-01-01'}
+		`(
+			'should return $expectedResult when parsing $date with $granularity granularity',
+			({ date, granularity, expectedResult }: { date: string; granularity: ELuDateGranularity; expectedResult: string }) => {
+				// Act
+				const result = adapter.parse(date, granularity);
+
+				// Assert
+				expect(result).toEqual(expectedResult);
+			},
+		);
+
+		it('should return undefined when the text is empty', () => {
+			// Act
+			const result = adapter.parse('', ELuDateGranularity.day);
+
+			// Assert
+			expect(result).toBeUndefined();
+		});
+	});
+
+	describe('format', () => {
+		test.each`
+			format            | expectedResult
+			${'yyyy-MM-dd'}   | ${'2022-03-15'}
+			${'dd/MM/yyyy'}   | ${'15/03/2022'}
+			${'MMMM d, yyyy'} | ${'March 15, 2022'}
+		`('should format 2022-03-15 as $expectedResult with "$format"', ({ format, expectedResult }: { format: string; expectedResult: string }) => {
+			// Act
+			const result = adapter.format('2022-03-15', format);
+
+			// Assert
+			expect(result).toEqual(expectedResult);
+		});
+	});
+
+	describe('clone', () => {
+		it('should return an equal date string', () => {
+			// Act
+			const result = adapter.clone('2022-03-15');
+
+			// Assert
+			expect(result).toEqual('2022-03-15');
+		});
+	});
+
+	describe('getters', () => {
+		it('should return the year', () => {
+			expect(adapter.getYear('2022-03-15')).toBe(2022);
+		});
+
+		it('should return the 1-based month', () => {
+			expect(adapter.getMonth('2022-03-15')).toBe(3);
+		});
+
+		it('should return the date of the month', () => {
+			expect(adapter.getDate('2022-03-15')).toBe(15);
+		});
+
+		it('should return the day of the week', () => {
+			// 2022-03-15 is a Tuesday
+			expect(adapter.getDay('2022-03-15')).toBe(2);
+		});
+
+		it('should return 0 for a sunday', () => {
+			// 2022-03-20 is a Sunday
+			expect(adapter.getDay('2022-03-20')).toBe(0);
+		});
+	});
+
+	describe('add', () => {
+		test.each`
+			count | granularity                  | expectedResult
+			${1}  | ${ELuDateGranularity.day}    | ${'2022-01-02'}
+			${-1} | ${ELuDateGranularity.day}    | ${'2021-12-31'}
+			${1}  | ${ELuDateGranularity.month}  | ${'2022-02-01'}
+			${-2} | ${ELuDateGranularity.month}  | ${'2021-11-01'}
+			${1}  | ${ELuDateGranularity.year}   | ${'2023-01-01'}
+			${1}  | ${ELuDateGranularity.decade} | ${'2032-01-01'}
+			${0}  | ${ELuDateGranularity.day}    | ${'2022-01-01'}
+		`(
+			'should return $expectedResult when adding $count $granularity to 2022-01-01',
+			({ count, granularity, expectedResult }: { count: number; granularity: ELuDateGranularity; expectedResult: string }) => {
+				// Act
+				const result = adapter.add('2022-01-01', count, granularity);
+
+				// Assert
+				expect(result).toEqual(expectedResult);
+			},
+		);
+
+		it('should cross the month boundary when adding days', () => {
+			// Act
+			const result = adapter.add('2022-01-31', 1, ELuDateGranularity.day);
+
+			// Assert
+			expect(result).toEqual('2022-02-01');
+		});
+	});
+
+	describe('compare', () => {
+		test.each`
+			a               | b               | granularity                  | expectedResult
+			${'2022-03-15'} | ${'2022-03-16'} | ${ELuDateGranularity.day}    | ${-1}
+			${'2022-03-16'} | ${'2022-03-15'} | ${ELuDateGranularity.day}    | ${1}
+			${'2022-03-15'} | ${'2022-03-15'} | ${ELuDateGranularity.day}    | ${0}
+			${'2022-03-15'} | ${'2022-03-16'} | ${ELuDateGranularity.month}  | ${0}
+			${'2022-03-15'} | ${'2022-04-01'} | ${ELuDateGranularity.month}  | ${-1}
+			${'2022-03-15'} | ${'2022-12-31'} | ${ELuDateGranularity.year}   | ${0}
+			${'2022-03-15'} | ${'2029-03-15'} | ${ELuDateGranularity.decade} | ${0}
+			${'2019-03-15'} | ${'2022-03-15'} | ${ELuDateGranularity.decade} | ${-1}
+		`(
+			'should return $expectedResult when comparing $a and $b with $granularity granularity',
+			({ a, b, granularity, expectedResult }: { a: string; b: string; granularity: ELuDateGranularity; expectedResult: number }) => {
+				// Act
+				const result = adapter.compare(a, b, granularity);
+
+				// Assert
+				expect(result).toBe(expectedResult);
+			},
+		);
+
+		it('should throw when one of the dates is invalid', () => {
+			// Act & Assert
+			expect(() => adapter.compare('2022-03-15', 'Invalid Date', ELuDateGranularity.day)).toThrowError('you must provide valid and not null dates to be compared');
+		});
+
+		it('should throw when one of the dates is null', () => {
+			// Act & Assert
+			expect(() => adapter.compare('2022-03-15', null as unknown as string, ELuDateGranularity.day)).toThrowError('you must provide valid and not null dates to be compared');
+		});
 	});
 });

--- a/packages/ng/core/translate/intl-params.pipe.spec.ts
+++ b/packages/ng/core/translate/intl-params.pipe.spec.ts
@@ -1,13 +1,113 @@
 import { IntlParamsPipe } from './intl-params.pipe';
 
 describe('IntlParamsPipe', () => {
+	let pipe: IntlParamsPipe;
+
+	beforeEach(() => {
+		pipe = new IntlParamsPipe();
+	});
+
 	it('create an instance', () => {
-		const pipe = new IntlParamsPipe();
 		expect(pipe).toBeTruthy();
 	});
 
 	it('applies params properly', () => {
-		const pipe = new IntlParamsPipe();
 		expect(pipe.transform('Hello {{param}}', { param: 'World' })).toEqual('Hello World');
+	});
+
+	it('should replace several distinct placeholders', () => {
+		// Act
+		const result = pipe.transform('{{greeting}}, {{name}}!', { greeting: 'Hello', name: 'World' });
+
+		// Assert
+		expect(result).toEqual('Hello, World!');
+	});
+
+	it('should replace every occurrence of the same placeholder', () => {
+		// Act
+		const result = pipe.transform('{{name}} & {{name}}', { name: 'Lucca' });
+
+		// Assert
+		expect(result).toEqual('Lucca & Lucca');
+	});
+
+	it('should stringify numeric params', () => {
+		// Act
+		const result = pipe.transform('{{count}} items', { count: 42 });
+
+		// Assert
+		expect(result).toEqual('42 items');
+	});
+
+	it('should replace a zero param instead of treating it as missing', () => {
+		// Act
+		const result = pipe.transform('{{count}} item(s)', { count: 0 });
+
+		// Assert
+		expect(result).toEqual('0 item(s)');
+	});
+
+	it('should replace an empty string param', () => {
+		// Act
+		const result = pipe.transform('Hello {{param}}!', { param: '' });
+
+		// Assert
+		expect(result).toEqual('Hello !');
+	});
+
+	it('should accept spaces around the placeholder key', () => {
+		// Act
+		const result = pipe.transform('Hello {{ param }}', { param: 'World' });
+
+		// Assert
+		expect(result).toEqual('Hello World');
+	});
+
+	it('should leave the placeholder untouched when the param has no value', () => {
+		// Act
+		const result = pipe.transform('Hello {{param}}', { other: 'World' });
+
+		// Assert
+		expect(result).toEqual('Hello {{param}}');
+	});
+
+	it('should leave the placeholder untouched when the param value is nullish', () => {
+		// Act
+		const result = pipe.transform('Hello {{param}}', { param: null as unknown as string });
+
+		// Assert
+		expect(result).toEqual('Hello {{param}}');
+	});
+
+	it('should leave every placeholder untouched when params are empty', () => {
+		// Act
+		const result = pipe.transform('{{greeting}}, {{name}}!', {});
+
+		// Assert
+		expect(result).toEqual('{{greeting}}, {{name}}!');
+	});
+
+	it('should replace known placeholders and keep unknown ones', () => {
+		// Act
+		const result = pipe.transform('{{greeting}}, {{name}}!', { greeting: 'Hello' });
+
+		// Assert
+		expect(result).toEqual('Hello, {{name}}!');
+	});
+
+	it('should return the value unchanged when it has no placeholder', () => {
+		// Act
+		const result = pipe.transform('Hello World', { param: 'unused' });
+
+		// Assert
+		expect(result).toEqual('Hello World');
+	});
+
+	it('should return an empty string unchanged', () => {
+		// Act
+		const result = pipe.transform('', { param: 'World' });
+
+		// Assert
+		expect(result).toEqual('');
 	});
 });


### PR DESCRIPTION
## Description

No user-facing change: this PR only adds unit tests.

-----

Fills in the three most under-covered spec files of the repo. No production code was touched.

**`core/date/string/string-date.adapter.spec.ts`** (2 → 52 tests)
Only `parse()` was covered. Added one block per public method: `forge` (zero-padding, month overflow), `forgeToday`, `forgeInvalid`, `isValid`, `isParsable`, `parse` (day/month/year granularities, empty text → `undefined`), `format`, `clone`, the four getters, `add` (day/month/year/decade, negative counts, month boundary) and `compare` (every granularity plus both throwing cases). The adapter is built with the `en` locale, so parsable inputs are month-first (`M/d/yy`) — noted in a comment.

**`core/translate/intl-params.pipe.spec.ts`** (2 → 14 tests)
Several placeholders, repeated occurrences, numeric param, `0` (not treated as missing), empty string, spaces around the key (`{{ param }}`), placeholder left untouched when the value is missing or nullish, empty params object, mixed known/unknown keys, value without any placeholder.

**`core-select/select.model.spec.ts`** (3 → 12 tests)
`isSelected` was entirely untested: added presence, match through the comparer on a distinct object, multiple selection, absence, empty selection, and a comparer rejecting everything. Also extended `isGroupSelected` (all but one selected, empty group) and asserted the strategy provided by default through the injector.

### Notes for reviewers

Two existing behaviors surfaced while writing the tests. Assertions follow the current behavior rather than the expected one; nothing was changed to make tests pass.

- `LuStringDateAdapter.isValid('2022-02-29')` returns `true`: `stringToDate` relies on native `Date` parsing, which rolls the date over to March 1st instead of invalidating it. Unlike `isParsable`, there is no year/month/day consistency check. Documented with a comment in the spec.
- `IntlParamsPipe.transform(value, undefined)` throws a `TypeError` (`args[key]` on `undefined`). Not pinned by a test, since that would enshrine a crash rather than a contract; `args?.[key]` in the pipe would make the case safe if we want to support it.

-----

### Contribution

- [ ] `npm run build` is OK
- [x] `npm run lint` is OK
- [x] `npm test` is OK (78 tests passing on the three files)

-----
