### PR TITLE
fix: keep value on stories when component config changes

### DIFF
--- a/stories/documentation/forms/fields/checkbox/angular/checkbox-field.stories.ts
+++ b/stories/documentation/forms/fields/checkbox/angular/checkbox-field.stories.ts
@@ -1,4 +1,4 @@
-import { cleanupTemplate, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { cleanupTemplate, useStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { waitForAngular } from '@/helpers/test';
 import { FormsModule } from '@angular/forms';
@@ -77,10 +77,9 @@ export default {
 export const Basic: StoryObj<CheckboxInputComponent & FormFieldComponent & { required: boolean }> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, presentation, ...inputArgs } = args;
+		const model = useStoryModel(false);
 		return {
-			props: {
-				example: false,
-			},
+			props: { model },
 			template: cleanupTemplate(`<lu-form-field${generateInputs(
 				{
 					label,
@@ -93,9 +92,9 @@ export const Basic: StoryObj<CheckboxInputComponent & FormFieldComponent & { req
 				},
 				argTypes,
 			)}>
-	<lu-checkbox-input [(ngModel)]="example"${generateInputs(inputArgs, argTypes)} />
+	<lu-checkbox-input [(ngModel)]="model.example"${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [CheckboxInputComponent, FormsModule, BrowserAnimationsModule],
 			},

--- a/stories/documentation/forms/fields/color-input/angular/color-input-field.stories.ts
+++ b/stories/documentation/forms/fields/color-input/angular/color-input-field.stories.ts
@@ -7,7 +7,7 @@ import { ColorInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
-import { createTestStory, generateInputs, setStoryOptions } from '../../../../../helpers/stories';
+import { useStoryModel, createTestStory, generateInputs, setStoryOptions } from '../../../../../helpers/stories';
 import { waitForAngular } from '../../../../../helpers/test';
 import { expect, screen, userEvent, within } from 'storybook/test';
 
@@ -69,8 +69,9 @@ export default {
 export const Basic: StoryObj<ColorInputComponent & FormFieldComponent & { required: boolean }> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, ...inputArgs } = args;
+		const model = useStoryModel<string | null>(null);
 		return {
-			props: { colors: colorDecoratives500, example: null },
+			props: { colors: colorDecoratives500, model },
 			template: `<lu-form-field ${generateInputs(
 				{
 					label,
@@ -83,9 +84,9 @@ export const Basic: StoryObj<ColorInputComponent & FormFieldComponent & { requir
 				},
 				argTypes,
 			)}>
-	<lu-color-input [(ngModel)]="example" [colors]="colors"${generateInputs(inputArgs, argTypes)} />
+	<lu-color-input [(ngModel)]="model.example" [colors]="colors"${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example | json }}</pr-story-model-display>`,
+<pr-story-model-display>{{ model.example | json }}</pr-story-model-display>`,
 			moduleMetadata: {
 				imports: [ColorInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},

--- a/stories/documentation/forms/fields/form-field.stories.ts
+++ b/stories/documentation/forms/fields/form-field.stories.ts
@@ -3,7 +3,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { FORM_FIELD_WIDTH, FormFieldComponent, InputDirective } from '@lucca-front/ng/form-field';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { createTestStory, generateInputs, setStoryOptions } from '../../../helpers/stories';
+import { useStoryModel, createTestStory, generateInputs, setStoryOptions } from '../../../helpers/stories';
 import { waitForAngular } from '../../../helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 
@@ -77,7 +77,9 @@ export default {
 	},
 	render: (args, { argTypes }) => {
 		const { required, ...fieldArgs } = args;
+		const model = useStoryModel('');
 		return {
+			props: { model },
 			template: `<lu-form-field extraDescribedBy="extra-message" ${generateInputs(fieldArgs, argTypes)}>
 	<div class="textField">
 		<div class="textField-input">
@@ -86,7 +88,7 @@ export default {
 				luInput
 				class="textField-input-value"
 				${required ? 'required' : ''}
-				[(ngModel)]="example"
+				[(ngModel)]="model.example"
 				placeholder="Placeholder">
 			</textarea>
 		</div>

--- a/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
+++ b/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
@@ -1,4 +1,4 @@
-import { allLegumes, FilterLegumesPipe } from '@/stories/forms/select/select.utils';
+import { allLegumes, FilterLegumesPipe, ILegume } from '@/stories/forms/select/select.utils';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LuOptionDirective } from '@lucca-front/ng/core-select';
@@ -8,7 +8,7 @@ import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { HiddenArgType } from '../../../../../helpers/common-arg-types';
-import { createTestStory, generateInputs, setStoryOptions } from '../../../../../helpers/stories';
+import { useStoryModel, createTestStory, generateInputs, setStoryOptions } from '../../../../../helpers/stories';
 import { waitForAngular } from '../../../../../helpers/test';
 import { expect, screen, userEvent, within } from 'storybook/test';
 
@@ -93,8 +93,9 @@ export default {
 export const Basic: StoryObj<LuMultiSelectInputComponent<unknown> & FormFieldComponent & { required: boolean }> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, presentation, ...inputArgs } = args;
+		const model = useStoryModel<ILegume[]>([]);
 		return {
-			props: { legumes: allLegumes, example: [] },
+			props: { legumes: allLegumes, model },
 			template: `<lu-form-field ${generateInputs(
 				{
 					label,
@@ -108,9 +109,9 @@ export const Basic: StoryObj<LuMultiSelectInputComponent<unknown> & FormFieldCom
 				},
 				argTypes,
 			)}>
-	<lu-multi-select [(ngModel)]="example" [options]="legumes | filterLegumes:clue" (clueChange)="clue = $event"${generateInputs(inputArgs, argTypes)} />
+	<lu-multi-select [(ngModel)]="model.example" [options]="legumes | filterLegumes:clue" (clueChange)="clue = $event"${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example | json }}</pr-story-model-display>`,
+<pr-story-model-display>{{ model.example | json }}</pr-story-model-display>`,
 			moduleMetadata: {
 				imports: [LuMultiSelectInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},

--- a/stories/documentation/forms/fields/multilanguage/angular/multilanguage-field.stories.ts
+++ b/stories/documentation/forms/fields/multilanguage/angular/multilanguage-field.stories.ts
@@ -7,6 +7,7 @@ import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 import { cleanupTemplate, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
+import { useState } from 'storybook/preview-api';
 
 export default {
 	title: 'Documentation/Forms/Fields/MultilanguageField/Angular',
@@ -107,26 +108,32 @@ export const Basic: StoryObj<
 > = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, presentation, disabled, ...inputArgs } = args;
-		const formControl = new FormControl<MultilanguageTranslation[]>([
-			{
-				cultureCode: 'invariant',
-				value: 'Invariant value',
-			},
-			{
-				cultureCode: 'fr-FR',
-				value: 'Valeur en français',
-			},
-			{
-				cultureCode: 'en-US',
-				value: 'English value',
-			},
-			{
-				cultureCode: 'de-DE',
-				value: "I don't speak German",
-			},
-		]);
+		// Same lifetime as useStoryModel: kept across control changes, rebuilt when the story is remounted.
+		const [formControl] = useState(
+			() =>
+				new FormControl<MultilanguageTranslation[]>([
+					{
+						cultureCode: 'invariant',
+						value: 'Invariant value',
+					},
+					{
+						cultureCode: 'fr-FR',
+						value: 'Valeur en français',
+					},
+					{
+						cultureCode: 'en-US',
+						value: 'English value',
+					},
+					{
+						cultureCode: 'de-DE',
+						value: "I don't speak German",
+					},
+				]),
+		);
 		if (disabled) {
 			formControl.disable();
+		} else {
+			formControl.enable();
 		}
 		return {
 			props: {

--- a/stories/documentation/forms/fields/number/angular/number-field.stories.ts
+++ b/stories/documentation/forms/fields/number/angular/number-field.stories.ts
@@ -4,7 +4,7 @@ import { FORM_FIELD_SIZE, FormFieldComponent } from '@lucca-front/ng/form-field'
 import { NumberInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { cleanupTemplate, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { cleanupTemplate, useStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { waitForAngular } from '@/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
@@ -78,10 +78,9 @@ export default {
 export const Basic: StoryObj<NumberInputComponent & { disabled: boolean; required: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
+		const model = useStoryModel(1000);
 		return {
-			props: {
-				example: 1000,
-			},
+			props: { model },
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
 					label,
@@ -93,9 +92,9 @@ export const Basic: StoryObj<NumberInputComponent & { disabled: boolean; require
 				},
 				argTypes,
 			)}>
-	<lu-number-input [(ngModel)]="example"${generateInputs(inputArgs, argTypes)} />
+	<lu-number-input [(ngModel)]="model.example"${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [NumberInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
@@ -127,10 +126,12 @@ export const WithPrefixAndSuffix: StoryObj<
 > = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, prefix, suffix, ...inputArgs } = args;
+		const model = useStoryModel(1000);
 		return {
 			props: {
 				prefix: args.prefix,
 				suffix: args.suffix,
+				model,
 			},
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
@@ -143,9 +144,9 @@ export const WithPrefixAndSuffix: StoryObj<
 				},
 				argTypes,
 			)}>
-	<lu-number-input [(ngModel)]="example" [prefix]="prefix" [suffix]="suffix"${generateInputs(inputArgs, argTypes)} />
+	<lu-number-input [(ngModel)]="model.example" [prefix]="prefix" [suffix]="suffix"${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [NumberInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},

--- a/stories/documentation/forms/fields/phone-number-input/angular/phone-number-input.stories.ts
+++ b/stories/documentation/forms/fields/phone-number-input/angular/phone-number-input.stories.ts
@@ -5,7 +5,7 @@ import { FORM_FIELD_SIZE, FormFieldComponent } from '@lucca-front/ng/form-field'
 import { PHONE_NUMBER_INPUT_AUTOCOMPLETE, PhoneNumberInputComponent } from '@lucca-front/ng/forms/phone-number-input';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { cleanupTemplate, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { cleanupTemplate, useStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { waitForAngular } from '@/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
@@ -25,10 +25,11 @@ export default {
 export const Basic: StoryObj<PhoneNumberInputComponent & FormFieldComponent & { required: boolean; presentation: boolean }> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, errorInlineMessage, size, presentation, ...inputArgs } = args;
+		const model = useStoryModel('+12125550199');
 
 		return {
 			props: {
-				example: '+12125550199',
+				model,
 				country: '',
 			},
 			template: cleanupTemplate(`<lu-form-field [rolePresentationLabel]="true" ${generateInputs(
@@ -44,12 +45,12 @@ export const Basic: StoryObj<PhoneNumberInputComponent & FormFieldComponent & { 
 				},
 				argTypes,
 			)}>
-	<lu-phone-number-input label="${label}" [country]="country" [(ngModel)]="example" #result="ngModel" ${generateInputs(inputArgs, argTypes)} />
+	<lu-phone-number-input label="${label}" [country]="country" [(ngModel)]="model.example" #result="ngModel" ${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
 @if(result.invalid && result.errors.validPhoneNumber){
   <div>{{result.errors.validPhoneNumber}}</div>
 }
-<pr-story-model-display>{{ example }}</pr-story-model-display>
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>
 `),
 		};
 	},

--- a/stories/documentation/forms/fields/radio/angular/radio-field.stories.ts
+++ b/stories/documentation/forms/fields/radio/angular/radio-field.stories.ts
@@ -4,7 +4,7 @@ import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { RADIO_GROUP_INPUT_SIZE, RadioComponent, RadioGroupInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { useStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { waitForAngular } from '@/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
@@ -68,10 +68,9 @@ export default {
 export const Basic: StoryObj<RadioGroupInputComponent & FormFieldComponent & { required: boolean; presentation: boolean }> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, inline, presentation, ...inputArgs } = args;
+		const model = useStoryModel(1);
 		return {
-			props: {
-				example: 1,
-			},
+			props: { model },
 			template: `<lu-form-field${generateInputs(
 				{
 					label,
@@ -85,7 +84,7 @@ export const Basic: StoryObj<RadioGroupInputComponent & FormFieldComponent & { r
 				},
 				argTypes,
 			)}>
-	<lu-radio-group-input${generateInputs(inputArgs, argTypes)} [(ngModel)]="example">
+	<lu-radio-group-input${generateInputs(inputArgs, argTypes)} [(ngModel)]="model.example">
 		<lu-radio [value]="1" inlineMessage="Option text">Option A</lu-radio>
 		<lu-radio [value]="2" inlineMessage="Option text">Option B</lu-radio>
 		<ng-template #template><strong>Option</strong> text</ng-template>
@@ -93,7 +92,7 @@ export const Basic: StoryObj<RadioGroupInputComponent & FormFieldComponent & { r
 	</lu-radio-group-input>
 </lu-form-field>
 
-<pr-story-model-display>{{ example }}</pr-story-model-display>`,
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`,
 		};
 	},
 	args: {

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -10,7 +10,7 @@ import { HtmlFormatterDirective } from '@lucca-front/ng/forms/rich-text-input/fo
 import { DEFAULT_MARKDOWN_TRANSFORMERS, MarkdownFormatterDirective, MarkdownFormatterWithTagsDirective, TAGS } from '@lucca-front/ng/forms/rich-text-input/formatters/markdown';
 import { PLAINTEXT_TAGS, PlainTextFormatterWithTagsDirective } from '@lucca-front/ng/forms/rich-text-input/formatters/plain-text';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { cleanupTemplate, createTestStory, generateInputs } from '@/helpers/stories';
+import { cleanupTemplate, useControlledStoryModel, createTestStory, generateInputs } from '@/helpers/stories';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { expectNgModelDisplay, waitForAngular } from '@/helpers/test';
 import { screen, userEvent, within } from 'storybook/test';
@@ -57,15 +57,15 @@ export const Basic: StoryObj<RichTextInputComponent & { value: string; disabled:
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, presentation, ...inputArgs } = args;
 		return {
-			props: { value, disabled, required },
+			props: { model: useControlledStoryModel(value), disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithMarkdownFormatter
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+		[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
 	</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterDirective],
 			},
@@ -87,15 +87,15 @@ export const RequiredWithNoInitialValue: StoryObj<RichTextInputComponent & { val
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, presentation, ...inputArgs } = args;
 		return {
-			props: { value, disabled, required },
+			props: { model: useControlledStoryModel(value), disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithMarkdownFormatter
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+		[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
 	</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterDirective],
 			},
@@ -117,11 +117,11 @@ export const WithTagPluginWithNoInitialValue: StoryObj<RichTextInputComponent & 
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, presentation, ...inputArgs } = args;
 		return {
-			props: { value, disabled, required },
+			props: { model: useControlledStoryModel(value), disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithHtmlFormatter
 	${generateInputs(inputArgs, argTypes)}
-	[(ngModel)]="value" [disabled]="disabled" [required]="required">
+	[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 		<lu-rich-text-input-toolbar />
 		<lu-rich-text-plugin-tag [tags]="[
 																		{
@@ -139,7 +139,7 @@ export const WithTagPluginWithNoInitialValue: StoryObj<RichTextInputComponent & 
 																	]" />
 		</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, HtmlFormatterDirective],
 			},
@@ -161,15 +161,15 @@ export const WithHtmlFormatter: StoryObj<RichTextInputComponent & { value: strin
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, presentation, ...inputArgs } = args;
 		return {
-			props: { value, disabled, required },
+			props: { model: useControlledStoryModel(value), disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithHtmlFormatter
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+		[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
 	</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, HtmlFormatterDirective],
 			},
@@ -191,11 +191,11 @@ export const WithTagPlugin: StoryObj<RichTextInputComponent & { value: string; d
 	render: (args, { argTypes }) => {
 		const { value, disabled, required, presentation, ...inputArgs } = args;
 		return {
-			props: { value, disabled, required },
+			props: { model: useControlledStoryModel(value), disabled, required },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithHtmlFormatter
 	${generateInputs(inputArgs, argTypes)}
-	[(ngModel)]="value" [disabled]="disabled" [required]="required">
+	[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 		<lu-rich-text-input-toolbar />
 		<lu-rich-text-plugin-tag [tags]="[
 																		{
@@ -213,7 +213,7 @@ export const WithTagPlugin: StoryObj<RichTextInputComponent & { value: string; d
 																	]" />
 		</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, HtmlFormatterDirective],
 			},
@@ -236,11 +236,11 @@ export const WithTagPluginMarkdown: StoryObj<RichTextInputComponent & { value: s
 		const { value, disabled, required, presentation, ...inputArgs } = args;
 		const transformers = [...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS];
 		return {
-			props: { value, disabled, required, transformers },
+			props: { model: useControlledStoryModel(value), disabled, required, transformers },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithMarkdownTagsFormatter
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+		[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
 			<lu-rich-text-plugin-tag [tags]="[
 																	{
@@ -258,7 +258,7 @@ export const WithTagPluginMarkdown: StoryObj<RichTextInputComponent & { value: s
 																]" />
 	</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterWithTagsDirective],
 			},
@@ -282,11 +282,11 @@ export const WithTagPluginPlainText: StoryObj<RichTextInputComponent & { value: 
 
 		const transformers = [PLAINTEXT_TAGS];
 		return {
-			props: { value, disabled, required, transformers },
+			props: { model: useControlledStoryModel(value), disabled, required, transformers },
 			template: cleanupTemplate(`<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithPlainTextTagsFormatter
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+		[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 			<lu-rich-text-plugin-tag [tags]="[
 																	{
 																		key: 'tag1',
@@ -303,7 +303,7 @@ export const WithTagPluginPlainText: StoryObj<RichTextInputComponent & { value: 
 																]" />
 	</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ value }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, PlainTextFormatterWithTagsDirective],
 			},
@@ -327,13 +327,13 @@ export const WithTagPluginMarkdownContentChange: StoryObj<RichTextInputComponent
 		const value = valueEn;
 		const transformers = [...DEFAULT_MARKDOWN_TRANSFORMERS, TAGS];
 		return {
-			props: { value, disabled, required, transformers },
-			template: cleanupTemplate(`<button luButton="outlined" size="S" (click)="value='${valueEn}';">EN</button>
-				<button luButton="outlined" size="S" (click)="value='${valueFr}';">FR</button>
+			props: { model: useControlledStoryModel(value), disabled, required, transformers },
+			template: cleanupTemplate(`<button luButton="outlined" size="S" (click)="model.example='${valueEn}';">EN</button>
+				<button luButton="outlined" size="S" (click)="model.example='${valueFr}';">FR</button>
 				<lu-form-field label="Label" ${generateInputs({ presentation }, argTypes)}>
 	<lu-rich-text-input luWithMarkdownTagsFormatter
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="value" [disabled]="disabled" [required]="required">
+		[(ngModel)]="model.example" [disabled]="disabled" [required]="required">
 			<lu-rich-text-input-toolbar />
 			<lu-rich-text-plugin-tag [tags]="[
 																	{
@@ -351,7 +351,7 @@ export const WithTagPluginMarkdownContentChange: StoryObj<RichTextInputComponent
 																]"/>
 	</lu-rich-text-input>
 </lu-form-field>
-<pr-story-model-display>{{value}}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [RichTextInputComponent, RichTextPluginTagComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule, MarkdownFormatterWithTagsDirective],
 			},

--- a/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
+++ b/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
@@ -1,4 +1,4 @@
-import { allLegumes, FilterLegumesPipe } from '@/stories/forms/select/select.utils';
+import { allLegumes, FilterLegumesPipe, ILegume } from '@/stories/forms/select/select.utils';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { LuOptionDirective } from '@lucca-front/ng/core-select';
@@ -8,7 +8,7 @@ import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { HiddenArgType } from '../../../../../helpers/common-arg-types';
-import { createTestStory, generateInputs, setStoryOptions } from '../../../../../helpers/stories';
+import { useStoryModel, createTestStory, generateInputs, setStoryOptions } from '../../../../../helpers/stories';
 import { waitForAngular } from '../../../../../helpers/test';
 import { expect, screen, userEvent, within } from 'storybook/test';
 
@@ -88,15 +88,16 @@ export default {
 } as Meta;
 
 export const Basic: StoryObj<
-	LuSimpleSelectInputComponent<unknown> &
+	LuSimpleSelectInputComponent<ILegume> &
 		FormFieldComponent & {
 			disabled: boolean;
 		}
 > = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, presentation, ...inputArgs } = args;
+		const model = useStoryModel<ILegume>(allLegumes[0]);
 		return {
-			props: { legumes: allLegumes, example: allLegumes[0] },
+			props: { legumes: allLegumes, model },
 			template: `<lu-form-field ${generateInputs(
 				{
 					label,
@@ -113,10 +114,10 @@ export const Basic: StoryObj<
 	<lu-simple-select ${generateInputs(inputArgs, argTypes)}
 		[options]="legumes | filterLegumes:clue"
 		(clueChange)="clue = $event"
-		[(ngModel)]="example">
+		[(ngModel)]="model.example">
 	</lu-simple-select>
 </lu-form-field>
-<pr-story-model-display>{{ example | json }}</pr-story-model-display>`,
+<pr-story-model-display>{{ model.example | json }}</pr-story-model-display>`,
 			moduleMetadata: {
 				imports: [LuSimpleSelectInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},

--- a/stories/documentation/forms/fields/switch/angular/switch-field.stories.ts
+++ b/stories/documentation/forms/fields/switch/angular/switch-field.stories.ts
@@ -4,7 +4,7 @@ import { FORM_FIELD_SIZE, FormFieldComponent } from '@lucca-front/ng/form-field'
 import { CheckboxInputComponent, SwitchInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { useStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { waitForAngular } from '@/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
@@ -65,10 +65,9 @@ export default {
 export const Basic: StoryObj<SwitchInputComponent & FormFieldComponent & { required: boolean }> = {
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, presentation, ...inputArgs } = args;
+		const model = useStoryModel(false);
 		return {
-			props: {
-				example: false,
-			},
+			props: { model },
 			template: `<lu-form-field${generateInputs(
 				{
 					label,
@@ -81,9 +80,9 @@ export const Basic: StoryObj<SwitchInputComponent & FormFieldComponent & { requi
 				},
 				argTypes,
 			)}>
-	<lu-switch-input [(ngModel)]="example"${generateInputs(inputArgs, argTypes)} />
+	<lu-switch-input [(ngModel)]="model.example"${generateInputs(inputArgs, argTypes)} />
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`,
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`,
 			moduleMetadata: {
 				imports: [CheckboxInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},

--- a/stories/documentation/forms/fields/text/angular/text-field.stories.ts
+++ b/stories/documentation/forms/fields/text/angular/text-field.stories.ts
@@ -7,9 +7,9 @@ import { TextInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 import { HiddenArgType } from '@/helpers/common-arg-types';
-import { cleanupTemplate, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { cleanupTemplate, useStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
-import { waitForAngular } from '@/helpers/test';
+import { updateStoryArgs, waitForAngular } from '@/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 
 export default {
@@ -123,10 +123,9 @@ export default {
 export const Basic: StoryObj<TextInputComponent & { disabled: boolean; required: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
 		const { counter, label, hiddenLabel, tooltip, tag, inlineMessage, inlineMessageState, size, width, AI, iconAItooltip, iconAIalt, presentation, ...inputArgs } = args;
+		const model = useStoryModel('Example value');
 		return {
-			props: {
-				example: 'Example value',
-			},
+			props: { model },
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
 					label,
@@ -147,10 +146,10 @@ export const Basic: StoryObj<TextInputComponent & { disabled: boolean; required:
 			)}>
 	<lu-text-input
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="example">
+		[(ngModel)]="model.example">
 	</lu-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
@@ -183,7 +182,9 @@ export const Basic: StoryObj<TextInputComponent & { disabled: boolean; required:
 export const IBANFormat: StoryObj<TextInputComponent & { disabled: boolean; required: boolean } & FormFieldComponent> = {
 	render: (args, { argTypes }) => {
 		const { counter, label, hiddenLabel, tooltip, tag, inlineMessage, inlineMessageState, size, width, ...inputArgs } = args;
+		const model = useStoryModel('');
 		return {
+			props: { model },
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
 					label,
@@ -200,10 +201,10 @@ export const IBANFormat: StoryObj<TextInputComponent & { disabled: boolean; requ
 			)}>
 	<lu-text-input
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="example" mask="SS00 AAAA 0000 0000 0000 9999 9999 9999 99">
+		[(ngModel)]="model.example" mask="SS00 AAAA 0000 0000 0000 9999 9999 9999 99">
 	</lu-text-input>
 </lu-form-field>
-{{example}}`),
+{{ model.example }}`),
 			moduleMetadata: {
 				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
@@ -237,10 +238,9 @@ export const PasswordVisiblity: StoryObj<
 > = {
 	render: (args, { argTypes }) => {
 		const { counter, label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, ...inputArgs } = args;
+		const model = useStoryModel('');
 		return {
-			props: {
-				example: '',
-			},
+			props: { model },
 			template: `<lu-form-field ${generateInputs(
 				{
 					label,
@@ -255,10 +255,10 @@ export const PasswordVisiblity: StoryObj<
 			)}>
 	<lu-text-input ${generateInputs(inputArgs, argTypes)}
 		type="password"
-		[(ngModel)]="example">
+		[(ngModel)]="model.example">
 	</lu-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`,
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`,
 			moduleMetadata: {
 				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
@@ -288,10 +288,12 @@ export const WithPrefixAndSuffix: StoryObj<
 > = {
 	render: (args, { argTypes }) => {
 		const { counter, label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, prefix, suffix, presentation, ...inputArgs } = args;
+		const model = useStoryModel('42');
 		return {
 			props: {
 				prefix: args.prefix,
 				suffix: args.suffix,
+				model,
 			},
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
@@ -310,10 +312,10 @@ export const WithPrefixAndSuffix: StoryObj<
 		${generateInputs(inputArgs, argTypes)}
 		[prefix]="prefix"
 		[suffix]="suffix"
-		[(ngModel)]="example">
+		[(ngModel)]="model.example">
 	</lu-text-input>
 </lu-form-field>
-<pr-story-model-display>{{ example }}</pr-story-model-display>`),
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>`),
 			moduleMetadata: {
 				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
 			},
@@ -360,7 +362,9 @@ export const AI: StoryObj<FormFieldComponent & TextInputComponent> = {
 	},
 	render: (args, { argTypes }) => {
 		const { label, iconAItooltip, iconAIalt, ...inputArgs } = args;
+		const model = useStoryModel('');
 		return {
+			props: { model },
 			template: cleanupTemplate(`<lu-form-field AI${generateInputs(
 				{
 					label,
@@ -370,9 +374,9 @@ export const AI: StoryObj<FormFieldComponent & TextInputComponent> = {
 				},
 				argTypes,
 			)}>
-	<lu-text-input [(ngModel)]="example" />
+	<lu-text-input [(ngModel)]="model.example" />
 </lu-form-field>
-<pr-story-model-display>{{example}}</pr-story-model-display>
+<pr-story-model-display>{{ model.example }}</pr-story-model-display>
 `),
 			moduleMetadata: {
 				imports: [TextInputComponent, FormFieldComponent, FormsModule, BrowserAnimationsModule],
@@ -386,7 +390,7 @@ export const AI: StoryObj<FormFieldComponent & TextInputComponent> = {
 	},
 };
 
-export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) => {
+export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step, id }) => {
 	await waitForAngular();
 	const canvas = within(canvasElement);
 
@@ -411,6 +415,18 @@ export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) 
 		await userEvent.keyboard('Texte clavier');
 		await waitForAngular();
 		await expect(input).toHaveValue('Texte clavier');
+	});
+
+	await step('La valeur saisie survit à un changement de config', async () => {
+		const input = canvas.getByRole('textbox');
+		await userEvent.clear(input);
+		await userEvent.type(input, 'Valeur à conserver');
+		await waitForAngular();
+
+		await updateStoryArgs(id, { size: 'S' });
+		await waitForAngular();
+
+		await expect(canvas.getByRole('textbox')).toHaveValue('Valeur à conserver');
 	});
 });
 

--- a/stories/documentation/forms/fields/textarea/angular/textarea-field.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textarea-field.stories.ts
@@ -4,7 +4,7 @@ import { FORM_FIELD_SIZE, FormFieldComponent } from '@lucca-front/ng/form-field'
 import { TextareaInputComponent } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { cleanupTemplate, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { cleanupTemplate, useControlledStoryModel, createTestStory, generateInputs, setStoryOptions } from '@/helpers/stories';
 import { waitForAngular } from '@/helpers/test';
 import { expect, userEvent, within } from 'storybook/test';
 
@@ -93,7 +93,7 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean; requi
 	render: (args, { argTypes }) => {
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, counter, autoResize, autoResizeScrollIntoView, value, presentation, ...inputArgs } = args;
 		return {
-			props: { example: value },
+			props: { model: useControlledStoryModel(value) },
 			template: cleanupTemplate(`<lu-form-field ${generateInputs(
 				{
 					label,
@@ -109,7 +109,7 @@ export const Basic: StoryObj<TextareaInputComponent & { disabled: boolean; requi
 			)}>
 	<lu-textarea-input autoResizeScrollIntoView="${autoResizeScrollIntoView}" autoResize="${autoResize}"
 	${generateInputs(inputArgs, argTypes)}
-		[(ngModel)]="example" />
+		[(ngModel)]="model.example" />
 </lu-form-field>
 `),
 			moduleMetadata: {

--- a/stories/helpers/stories.ts
+++ b/stories/helpers/stories.ts
@@ -1,5 +1,6 @@
 import { LOCALE_ID } from '@angular/core';
 import { applicationConfig, Args, ArgTypes, StoryObj } from '@storybook/angular-vite';
+import { useState } from 'storybook/preview-api';
 
 export interface StoryGeneratorArgs<TComponent> {
 	name: string;
@@ -114,6 +115,33 @@ export function generateInputs(inputs: Record<string, unknown>, argTypes: ArgTyp
 		}
 		return `${acc} ${name}="${value.toString()}"`;
 	}, '');
+}
+
+export interface StoryModel<T> {
+	example: T;
+}
+
+/**
+ * Holds the value bound to `ngModel` so it survives a control change, which would otherwise reset a value passed
+ * directly in `props`. Lives as long as the mounted story.
+ */
+export function useStoryModel<T>(initialValue: T): StoryModel<T> {
+	const [model] = useState<StoryModel<T>>(() => ({ example: initialValue }));
+	return model;
+}
+
+/**
+ * {@link useStoryModel} for a value also driven by a control. Re-seeds the model when that control changes,
+ * comparing by reference — pass the arg itself, not a value rebuilt in `render`.
+ */
+export function useControlledStoryModel<T>(controlValue: T): StoryModel<T> {
+	const [synced] = useState(() => ({ model: { example: controlValue }, controlValue }));
+
+	if (controlValue !== synced.controlValue) {
+		synced.controlValue = controlValue;
+		synced.model.example = controlValue;
+	}
+	return synced.model;
 }
 
 export function createTestStory<TArgs = Args>(story: StoryObj<TArgs>, test: StoryObj<TArgs>['play']): StoryObj<TArgs> {

--- a/stories/helpers/test.ts
+++ b/stories/helpers/test.ts
@@ -1,7 +1,18 @@
+import { UPDATE_STORY_ARGS } from 'storybook/internal/core-events';
+import { addons } from 'storybook/preview-api';
 import { expect, screen, userEvent, within } from 'storybook/test';
 
 export async function sleep(ms: number) {
 	await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Changes a story arg from a play function, the same way the Controls panel does, and waits for the rerender.
+ * Use it to assert on what a configuration change does to an already interacted-with story.
+ */
+export async function updateStoryArgs(storyId: string, updatedArgs: Record<string, unknown>) {
+	addons.getChannel().emit(UPDATE_STORY_ARGS, { storyId, updatedArgs });
+	await waitForAngular();
 }
 
 /**


### PR DESCRIPTION
## Description

Actuellement lorsqu'on modifie la valeur d'un champ sur la story, dès qu'on modifie la config, ce champ est réinitialisé à sa valeur par défaut.

Cette PR garde la valeur modifiée par l'utilisateur lors d'un changement de config.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
