### PR TITLE
feat(lu-multi-select): use `Intl.ListFormat` for `lu-multi-select` presentation mode

### DIFF
--- a/packages/ng/multi-select/input/select-input.component.html
+++ b/packages/ng/multi-select/input/select-input.component.html
@@ -33,19 +33,15 @@
 @if (!ignorePresentation()) {
 	<ng-container *luPresentationDisplayDefault>
 		@for (v of value; track $index) {
-			@if ($last) {
-				<ng-container *ngTemplateOutlet="noComma; context: { $implicit: v }" />
-			} @else {
-				<ng-container *ngTemplateOutlet="comma; context: { $implicit: v }" />
+			<ng-container *luOptionOutlet="displayerTpl(); value: v" />
+
+			@let separator = presentationSeparators()[$index];
+
+			@if (separator) {
+				<ng-container>{{ separator }}</ng-container>
 			}
 		} @empty {
 			<span aria-hidden="true" data-content-before="–"></span>
 		}
 	</ng-container>
 }
-
-<ng-template #comma let-value><ng-container *luOptionOutlet="displayerTpl(); value: value" />, </ng-template>
-
-<ng-template #noComma let-value>
-	<ng-container *luOptionOutlet="displayerTpl(); value: value" />
-</ng-template>

--- a/packages/ng/multi-select/input/select-input.component.spec.ts
+++ b/packages/ng/multi-select/input/select-input.component.spec.ts
@@ -1,8 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, LOCALE_ID, Type } from '@angular/core';
 import { ComponentFixture, MetadataOverride, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, NgControl, ReactiveFormsModule } from '@angular/forms';
 import { isNotNil } from '@lucca-front/ng/core';
-import { LuCoreSelectTotalCountDirective } from '@lucca-front/ng/core-select';
+import { LuCoreSelectTotalCountDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { vi } from 'vitest';
 import { TestEntity, runALuSelectInputComponentTestSuite } from '../../core-select/input/select-input.component.spec';
 import { LuMultiSelection } from '../select.model';
@@ -47,6 +48,62 @@ class MultiSelectFormControlHostComponent {
 	options: TestEntity[] = options;
 }
 
+interface PresentationHost {
+	selectedOptions: TestEntity[];
+}
+
+@Component({
+	selector: 'lu-multi-select-presentation-host',
+	imports: [FormsModule, LuMultiSelectInputComponent, FormFieldComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<lu-form-field label="Options" presentation>
+			<lu-multi-select [ngModel]="selectedOptions" [options]="options" />
+		</lu-form-field>
+	`,
+})
+class MultiSelectPresentationHostComponent implements PresentationHost {
+	selectedOptions: TestEntity[] = [];
+
+	options: TestEntity[] = options;
+}
+
+@Component({
+	selector: 'lu-multi-select-custom-tpl-presentation-host',
+	imports: [FormsModule, LuMultiSelectInputComponent, FormFieldComponent, LuOptionDirective],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<lu-form-field label="Options" presentation>
+			<lu-multi-select #selectRef [ngModel]="selectedOptions" [options]="options">
+				<ng-container *luOption="let option; select: selectRef"
+					><strong>[{{ option.name }}]</strong></ng-container
+				>
+			</lu-multi-select>
+		</lu-form-field>
+	`,
+})
+class MultiSelectCustomTplPresentationHostComponent implements PresentationHost {
+	selectedOptions: TestEntity[] = [];
+
+	options: TestEntity[] = options;
+}
+
+@Component({
+	selector: 'lu-multi-select-select-all-presentation-host',
+	imports: [FormsModule, LuMultiSelectInputComponent, FormFieldComponent, LuMultiSelectWithSelectAllDirective, LuCoreSelectTotalCountDirective],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<lu-form-field label="Options" presentation>
+			<lu-multi-select [ngModel]="selection" [options]="options" withSelectAll withSelectAllLabel="options" withSelectAllDisplayerLabel="options" [totalCount]="options.length" />
+		</lu-form-field>
+	`,
+})
+class MultiSelectSelectAllPresentationHostComponent {
+	selection: LuMultiSelection<TestEntity> = { mode: 'none' };
+
+	options: TestEntity[] = options;
+}
+
 describe('LuMultiSelectInputComponent', () => {
 	let fixture: ComponentFixture<LuMultiSelectInputComponent<Entity>>;
 	let searchControl: FormControl;
@@ -55,7 +112,7 @@ describe('LuMultiSelectInputComponent', () => {
 		searchControl = new FormControl();
 
 		TestBed.configureTestingModule({
-			imports: [LuMultiSelectInputComponent, MultiSelectFormControlHostComponent, MultiSelectNgModelHostComponent],
+			imports: [LuMultiSelectInputComponent, MultiSelectFormControlHostComponent, MultiSelectNgModelHostComponent, MultiSelectPresentationHostComponent],
 			providers: [
 				// The input inside the displayer needs a NgControl
 				{
@@ -317,6 +374,60 @@ describe('LuMultiSelectInputComponent', () => {
 				// Assert
 				expect(componentInstance.value).toEqual([options[0]]);
 			});
+		});
+	});
+
+	describe('presentation mode', () => {
+		async function renderPresentation<THost>(host: Type<THost>, locale: string, writeValue: (hostComponent: THost) => void): Promise<string> {
+			// A fresh TestBed per call: LOCALE_ID has to be provided before the first component is instantiated
+			TestBed.resetTestingModule();
+			TestBed.configureTestingModule({
+				imports: [host],
+				providers: [
+					{ provide: NgControl, useValue: new FormControl() },
+					{ provide: LOCALE_ID, useValue: locale },
+				],
+				teardown: { destroyAfterEach: false },
+			});
+
+			const hostFixture = TestBed.createComponent(host);
+			writeValue(hostFixture.componentInstance);
+			hostFixture.detectChanges();
+			// ngModel writes its value asynchronously
+			await hostFixture.whenStable();
+			hostFixture.detectChanges();
+
+			const presentation = (hostFixture.nativeElement as HTMLElement).querySelector('.presentation-definition');
+			return presentation?.textContent?.trim() ?? '';
+		}
+
+		function getPresentationText(host: Type<PresentationHost>, selectedOptions: TestEntity[], locale: string): Promise<string> {
+			return renderPresentation(host, locale, (hostComponent) => (hostComponent.selectedOptions = selectedOptions));
+		}
+
+		it.each([
+			['fr-FR', 3, 'test 1, test 2 et test 3'],
+			['en-GB', 3, 'test 1, test 2 and test 3'],
+			['fr-FR', 2, 'test 1 et test 2'],
+			['en-GB', 2, 'test 1 and test 2'],
+			['fr-FR', 1, 'test 1'],
+			['en-GB', 1, 'test 1'],
+		])('should join %s values with locale-aware separators (%i values)', async (locale, count, expected) => {
+			expect(await getPresentationText(MultiSelectPresentationHostComponent, options.slice(0, count), locale)).toBe(expected);
+		});
+
+		it('should interleave separators with a custom option template', async () => {
+			const fixtureText = await getPresentationText(MultiSelectCustomTplPresentationHostComponent, options.slice(0, 3), 'fr-FR');
+
+			expect(fixtureText).toBe('[test 1], [test 2] et [test 3]');
+		});
+
+		it('should base separators on the rendered values, not on withSelectAll displayer count', async () => {
+			// withSelectAll overwrites valueLength() with the selected count: 4 here, while a single excluded value
+			// is rendered. Counting those would leave a trailing separator.
+			const fixtureText = await renderPresentation(MultiSelectSelectAllPresentationHostComponent, 'fr-FR', (hostComponent) => (hostComponent.selection = { mode: 'exclude', values: [options[0]] }));
+
+			expect(fixtureText).toBe('test 1');
 		});
 	});
 });

--- a/packages/ng/multi-select/input/select-input.component.ts
+++ b/packages/ng/multi-select/input/select-input.component.ts
@@ -1,4 +1,4 @@
-import { AsyncPipe, CommonModule } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import {
 	booleanAttribute,
 	ChangeDetectionStrategy,
@@ -10,6 +10,7 @@ import {
 	inject,
 	input,
 	Input,
+	LOCALE_ID,
 	model,
 	numberAttribute,
 	OnDestroy,
@@ -33,6 +34,7 @@ import { IconComponent } from '@lucca/prisme/icon';
 import { Subject } from 'rxjs';
 import { LuMultiSelectDefaultDisplayerComponent } from '../displayer';
 import { LU_MULTI_SELECT_TRANSLATIONS } from '../select.translate';
+import { listSeparators } from '../select.utils';
 import { LuMultiSelectPanelRefFactory } from './panel-ref.factory';
 import { LuMultiSelectPanelRef } from './panel.model';
 
@@ -49,7 +51,6 @@ import { LuMultiSelectPanelRef } from './panel.model';
 		FilterPillLabelDirective,
 		ClearComponent,
 		PresentationDisplayDirective,
-		CommonModule,
 		ɵPresentationDisplayDefaultDirective,
 		IconComponent,
 	],
@@ -111,6 +112,10 @@ export class LuMultiSelectInputComponent<T> extends ALuSelectInputComponent<T, T
 	public valueLength = computed(() => this.valueSignal()?.length ?? 0);
 	public useSingleOptionDisplayer: Signal<boolean> = signal(true);
 	override _value: T[] = [];
+
+	#listFormat = new Intl.ListFormat(inject(LOCALE_ID));
+
+	protected readonly presentationSeparators = computed(() => listSeparators(this.#listFormat, this.valueSignal()?.length ?? 0));
 
 	public override get panelRef(): LuMultiSelectPanelRef<T> | undefined {
 		return this._panelRef;

--- a/packages/ng/multi-select/select.utils.spec.ts
+++ b/packages/ng/multi-select/select.utils.spec.ts
@@ -1,7 +1,20 @@
 import { LuMultiSelection, LuMultiSelectionMode } from './select.model';
-import { selectionToQueryParams } from './select.utils';
+import { listSeparators, selectionToQueryParams } from './select.utils';
 
 describe('multi-select utils', () => {
+	describe('listSeparators', () => {
+		it.each([
+			['fr-FR', 3, [', ', ' et ']],
+			['en-GB', 3, [', ', ' and ']],
+			['fr-FR', 2, [' et ']],
+			['en-GB', 2, [' and ']],
+			['fr-FR', 1, []],
+			['fr-FR', 0, []],
+		])('should return the separators for %s and %i items', (locale, itemCount, expected) => {
+			expect(listSeparators(new Intl.ListFormat(locale), itemCount)).toEqual(expected);
+		});
+	});
+
 	describe('selectionToQueryParams', () => {
 		const selections: Record<LuMultiSelectionMode, LuMultiSelection<{ id: number }>> = {
 			include: {

--- a/packages/ng/multi-select/select.utils.ts
+++ b/packages/ng/multi-select/select.utils.ts
@@ -1,5 +1,21 @@
 import { LuMultiSelection } from './select.model';
 
+/**
+ * Returns the `itemCount - 1` separators `Intl.ListFormat` puts between `itemCount` items, so they can be
+ * interleaved with values rendered by a template rather than by `format()`.
+ *
+ * @example
+ * ```ts
+ * listSeparators(new Intl.ListFormat('fr-FR'), 3); // [', ', ' et ']
+ * ```
+ */
+export function listSeparators(listFormat: Intl.ListFormat, itemCount: number): string[] {
+	return listFormat
+		.formatToParts(Array.from({ length: itemCount }, (_, index) => `${index}`))
+		.filter(({ type }) => type === 'literal')
+		.map(({ value }) => value);
+}
+
 export function selectionToQueryParams<T, Key extends string>(key: Key, value: LuMultiSelection<T>, selector: (value: T) => unknown): Partial<Record<Key | `-${Key}`, string>> {
 	if (value.mode === 'all' || value.mode === 'none') {
 		return {};


### PR DESCRIPTION
## Description

Utilisation de [Intl.ListFormat](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat) pour le mode présentation du `lu-multi-select`.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
