### PR TITLE
chore(stories): freeze loading animation in file-entry QA story

### DIFF
--- a/stories/qa/file-entry/file-entry.stories.ts
+++ b/stories/qa/file-entry/file-entry.stories.ts
@@ -9,6 +9,10 @@ import { Meta, StoryObj, moduleMetadata } from '@storybook/angular-vite';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	styles: [
 		`
+			.loading::after,
+			:host ::ng-deep .loading::after {
+				animation-play-state: paused;
+			}
 			:host ::ng-deep .fileEntryDisplayWrapper {
 				inline-size: 100%;
 			}


### PR DESCRIPTION
## Description

The file-entry QA story showed the loading state with its skeleton animation running, so the page never looked the same twice. Screenshots and side-by-side visual comparisons between the HTML and Angular columns were unreliable because both sides were captured at different points of the animation.

The animation is now paused in the story, which freezes the loading state on a stable frame.

-----

Adds `animation-play-state: paused` on `.loading::after` in the story wrapper's `styles`, both for the host scope and through `::ng-deep` so it reaches the `lu-*` components' shadow-free but encapsulation-crossing markup.

Story-only change, no impact on the published packages.

-----
