### PR TITLE
fix(text-input): trigger clearer with keyboard

### DIFF
--- a/packages/ng/forms/text-input/text-input.component.html
+++ b/packages/ng/forms/text-input/text-input.component.html
@@ -41,7 +41,7 @@
 		/>
 		<div class="textField-input-affix">
 			@if (hasClearer() && inputElement.value) {
-				<lu-clear (click)="clearValue()" class="textField-input-affix-clear">{{ intl().clear }}</lu-clear>
+				<lu-clear (onClear)="clearValue()" class="textField-input-affix-clear">{{ intl().clear }}</lu-clear>
 			}
 			@if (hasSearchIcon()) {
 				<span aria-hidden="true" class="textField-input-affix-icon lucca-icon icon-{{ searchIcon() }}"></span>


### PR DESCRIPTION
## Description

On the Textfield component, the clear button could only be activated with a mouse click.
Pressing <kbd>Space</kbd> or <kbd>Enter</kbd> while the clearer was focused did nothing,
making the field impossible to clear with the keyboard only (WCAG 2.1.1 Keyboard).

## Cause

The template was listening to the native `(click)` event on `<lu-clear>` instead of its
`(onClear)` output. `ClearComponent` already handles `click`, `keyup.space` and
`keydown.enter` internally and exposes the result through `onClear` only — so keyboard
activation never reached `clearValue()`.

## Fix

Bind `(onClear)` instead of `(click)` in `text-input.component.html`, which aligns
Textfield with every other consumer of `<lu-clear>` (number-input, number-format-input,
date-input, simple-select, multi-select, filter-pill…). `clearValue()` already restores
focus on the input after resetting the control.

## How to test

1. Open the Textfield story with `hasClearer: true` and type some text.
2. Focus the clear button with <kbd>Tab</kbd>.
3. Press <kbd>Enter</kbd>, then repeat with <kbd>Space</kbd>: the value is cleared and
   focus goes back to the input.
4. Mouse click still clears the value as before.

-----
-----
