### PR TITLE
fix(calendar2): Type the week-day cell tooltip under strictNullChecks

### DIFF
--- a/packages/ng/date2/calendar2/calendar2.component.html
+++ b/packages/ng/date2/calendar2/calendar2.component.html
@@ -160,7 +160,7 @@
 											(keydown.space)="day.disabled ? null : onCellClicked(day.date)"
 											(focus)="day.isOverflow ? null : dateHovered.set(day.date)"
 											(blur)="day.isOverflow ? null : dateHovered.set(null)"
-											[luTooltip]="day.label"
+											[luTooltip]="day.label ?? ''"
 											tabindex="-1"
 										>
 											{{ day.day }}


### PR DESCRIPTION
## Description

Restore the `release/22.0` build: the calendar week view's day tooltip no longer breaks compilation under `strictNullChecks`.

-----

### Context

- #5122 typed the month-view day tooltip with a `?? ''` fallback.
- #4884 added the week-number row with a second, untyped `[luTooltip]="day.label"`.
- The two PRs merged in close succession; their combination does not compile:
	- `day.label` is `string | undefined`.
	- `luTooltip` expects `string | SafeHtml`.
- Every `release/22.0` build fails since, and PR checks inherit the breakage (e.g. #5095).

### Fix

Apply the same `?? ''` fallback to the week-row binding.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
