### PR TITLE
fix(core-select): expose aria-disabled on disabled options

### DIFF
--- a/packages/ng/core-select/panel/selectable-item.spec.ts
+++ b/packages/ng/core-select/panel/selectable-item.spec.ts
@@ -1,0 +1,57 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { LuDisabledOptionDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { vi } from 'vitest';
+
+type Entity = { id: number; name: string };
+
+const options: Entity[] = [
+	{ id: 1, name: 'test 1' },
+	{ id: 2, name: 'test 2' },
+];
+
+@Component({
+	selector: 'lu-disabled-option-host',
+	imports: [FormsModule, LuSimpleSelectInputComponent, LuOptionDirective, LuDisabledOptionDirective],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<lu-simple-select #select [ngModel]="selected" [options]="options">
+			<span *luOption="let option; select: select" [luDisabledOption]="option.id === 2">{{ option.name }}</span>
+		</lu-simple-select>
+	`,
+})
+class DisabledOptionHostComponent {
+	selected: Entity | null = null;
+
+	options = options;
+}
+
+describe('CoreSelectPanelElement', () => {
+	let fixture: ComponentFixture<DisabledOptionHostComponent>;
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		fixture = TestBed.createComponent(DisabledOptionHostComponent);
+		fixture.detectChanges();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('should expose aria-disabled on the options disabled through luDisabledOption', async () => {
+		// Arrange
+		const select = fixture.nativeElement.querySelector('lu-simple-select') as HTMLElement;
+
+		// Act
+		select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+		await vi.runAllTimersAsync();
+		fixture.detectChanges();
+
+		// Assert
+		const renderedOptions = Array.from(document.querySelectorAll('[role="option"]'));
+		expect(renderedOptions.map((option) => option.getAttribute('aria-disabled'))).toEqual([null, 'true']);
+	});
+});

--- a/packages/ng/core-select/panel/selectable-item.spec.ts
+++ b/packages/ng/core-select/panel/selectable-item.spec.ts
@@ -1,0 +1,56 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { LuDisabledOptionDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { CoreSelectPanelElement } from './selectable-item';
+
+type Entity = { id: number; name: string };
+
+const options: Entity[] = [
+	{ id: 1, name: 'test 1' },
+	{ id: 2, name: 'test 2' },
+];
+
+@Component({
+	selector: 'lu-disabled-option-host',
+	imports: [FormsModule, LuSimpleSelectInputComponent, LuOptionDirective, LuDisabledOptionDirective],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: `
+		<lu-simple-select #select [ngModel]="selected" [options]="options">
+			<span *luOption="let option; select: select" [luDisabledOption]="option.id === 2">{{ option.name }}</span>
+		</lu-simple-select>
+	`,
+})
+class DisabledOptionHostComponent {
+	selected: Entity | null = null;
+
+	options = options;
+}
+
+describe(CoreSelectPanelElement.name, () => {
+	let fixture: ComponentFixture<DisabledOptionHostComponent>;
+	let overlayContainerElement: HTMLElement;
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(DisabledOptionHostComponent);
+		fixture.detectChanges();
+		overlayContainerElement = TestBed.inject(OverlayContainer).getContainerElement();
+	});
+
+	it('should expose aria-disabled on the options disabled through luDisabledOption', fakeAsync(() => {
+		// Arrange
+		const select = fixture.nativeElement.querySelector('lu-simple-select') as HTMLElement;
+
+		// Act
+		select.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+		fixture.detectChanges();
+		tick(20);
+		fixture.detectChanges();
+
+		// Assert
+		const renderedOptions = Array.from(overlayContainerElement.querySelectorAll('[role="option"]'));
+		expect(renderedOptions.map((option) => option.getAttribute('aria-disabled'))).toEqual(['false', 'true']);
+	}));
+});

--- a/packages/ng/core-select/panel/selectable-item.ts
+++ b/packages/ng/core-select/panel/selectable-item.ts
@@ -10,6 +10,7 @@ import { CoreSelectPanelInstance, SELECT_PANEL_INSTANCE } from './panel.instance
 	host: {
 		'[attr.id]': 'idAttribute()',
 		'[attr.aria-selected]': 'isSelected()',
+		'[attr.aria-disabled]': 'disabled || null',
 		'[class.is-highlighted]': 'isHighlighted()',
 		'(mouseenter)': 'onMouseEnter()',
 		role: 'option',

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -294,15 +294,19 @@ export const WithDisabledOptions = generateStory({
 	},
 });
 
-// export const WithDisabledOptionsTEST = createTestStory(WithDisabledOptions, async (context) => {
-// 	await basePlay(context);
-// 	const input = within(context.canvasElement).getByRole('combobox');
-// 	await userEvent.click(input);
-// 	await waitForAngular();
-// 	const panel = within(screen.getByRole('listbox'));
-// 	const options = await panel.findAllByRole('option');
-// 	await expect(options[1].firstChild).toHaveClass('is-disabled');
-// });
+export const WithDisabledOptionsTEST = createTestStory(WithDisabledOptions, async (context) => {
+	await basePlay(context);
+	const input = within(context.canvasElement).getByRole('combobox');
+	await userEvent.click(input);
+	await waitForAngular();
+	const panel = within(screen.getByRole('listbox'));
+	const options = await panel.findAllByRole('option');
+	await expect(options[1].firstChild).toHaveClass('is-disabled');
+	// The disabled state has to reach the option itself, not only its inner value: assistive
+	// technologies read it from the [role="option"] element.
+	await expect(options[1]).toHaveAttribute('aria-disabled', 'true');
+	await expect(options[0]).not.toHaveAttribute('aria-disabled');
+});
 
 export const ApiV3 = generateStory({
 	name: 'Api V3',

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -385,15 +385,23 @@ export const WithDisabledOptions = generateStory({
 	},
 });
 
-// export const WithDisabledOptionsTEST = createTestStory(WithDisabledOptions, async (context) => {
-// 	await basePlay(context);
-// 	const input = within(context.canvasElement).getByRole('combobox');
-// 	await userEvent.click(input);
-// 	await waitForAngular();
-// 	const panel = within(screen.getByRole('listbox'));
-// 	const options = await panel.findAllByRole('option');
-// 	await expect(options[1].firstChild).toHaveClass('is-disabled');
-// });
+export const WithDisabledOptionsTEST = createTestStory(WithDisabledOptions, async (context) => {
+	await basePlay(context);
+	const input = within(context.canvasElement).getByRole('combobox');
+	await userEvent.click(input);
+	await waitForAngular();
+	const panel = within(screen.getByRole('listbox'));
+	const options = await panel.findAllByRole('option');
+	// luDisabledOption reaches the option one macrotask after it renders, so the assertions have to
+	// wait for it rather than trust findAllByRole: a loaded CI runner loses that race.
+	await waitFor(async () => {
+		// The disabled state lives on the option itself, not only on its inner value: assistive
+		// technologies read it from the [role="option"] element.
+		await expect(options[1]).toHaveClass('is-disabled');
+		await expect(options[1]).toHaveAttribute('aria-disabled', 'true');
+		await expect(options[0]).toHaveAttribute('aria-disabled', 'false');
+	});
+});
 
 export const WithCustomOptionTemplate = generateStory({
 	name: 'Custom option template',


### PR DESCRIPTION
## Description

Screen readers announce an option disabled with `luDisabledOption` as selectable, when it isn't.

`luDisabledOption` pushes into the option context, which `LuOptionComponent` applies as `is-disabled` on the inner `.optionItem-value`: the option greys out and swallows its click. The `[role="option"]` host, carried by `CoreSelectPanelElement`, never reflects it — so the visual and functional blocks are there, only the accessible information is missing.

`CoreSelectPanelElement` already receives that state as its `disabled` input, which it uses to ignore `mouseenter`. It now also exposes it as `aria-disabled`.

<details><summary>Notes for the reviewer</summary>

`disabled` is a plain `@Input`, mutated imperatively from the subscription in `LuOptionComponent.ngAfterViewInit`, not a signal. That was the only real risk of the change: the host binding still updates, because the `markForCheck()` that already sits next to the assignment marks the declaring view dirty. Both tests below fail without the one-line fix, which is what makes them worth reading.

`'disabled || null'` keeps `aria-disabled` off the enabled options rather than spraying `aria-disabled="false"` over the whole panel.

Two levels of coverage, since there was none on `luDisabledOption`:

- a unit spec on `CoreSelectPanelElement`, asserting the attribute lands on the right option and stays off the others;
- `WithDisabledOptionsTEST`, restored. It was the only commented-out test story in the repo, against 61 active ones, and it went down in the 488-file chore of #4270 rather than by decision. It asserted the `is-disabled` class on the inner element; it now also asserts `aria-disabled` on the option itself.

Only the simple-select story is covered: the fix sits in `CoreSelectPanelElement`, shared by both, and the multi-select story had no test story to restore.

Keyboard navigation still skips disabled options entirely, which the ARIA APG argues against for listbox options — that one is a behaviour change, out of scope here.

</details>

-----


