### PR TITLE
fix(core-select): keep the user select loader on until the "me" lookup resolves

### DIFF
--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -159,6 +159,64 @@ describe('LuCoreSelectUsersDirective', () => {
 		httpTestingController.verify();
 	}));
 
+	it('should keep the loader on until the "me" lookup answers', fakeAsync(() => {
+		// Arrange
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		const meUser = createUser(CURRENT_USER_ID);
+		const users = [createUser(1), createUser(2)];
+
+		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		const usersReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,20`);
+
+		// Act (the users search answers first, the "me" lookup is still pending)
+		usersReq.flush(usersResponse(users));
+		fixture.detectChanges();
+
+		// Assert: still loading — turning the loader off before the options arrive
+		// would show the "no result" empty state of the panel in the meantime
+		expect(simpleSelect.loading$.value).toBe(true);
+
+		// Act (the "me" lookup answers)
+		meReq.flush(usersResponse([meUser]));
+		fixture.detectChanges();
+
+		// Assert
+		let options: readonly LuCoreSelectUser[];
+		simpleSelect.options$.subscribe((o) => (options = o));
+
+		expect(options).toEqual([meUser, ...users]);
+		expect(simpleSelect.loading$.value).toBe(false);
+		httpTestingController.verify();
+	}));
+
+	it('should display the options without "me" when the "me" lookup fails', fakeAsync(() => {
+		// Arrange
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		const users = [createUser(1), createUser(2)];
+
+		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		const usersReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,20`);
+
+		// Act
+		usersReq.flush(usersResponse(users));
+		meReq.flush('boom', { status: 500, statusText: 'Internal Server Error' });
+		fixture.detectChanges();
+
+		// Assert
+		let options: readonly LuCoreSelectUser[];
+		simpleSelect.options$.subscribe((o) => (options = o));
+
+		expect(options).toEqual(users);
+		expect(simpleSelect.loading$.value).toBe(false);
+		httpTestingController.verify();
+	}));
+
 	it('should not forward `filters` to the "me" lookup request', fakeAsync(() => {
 		// Arrange
 		fixture.componentInstance.filters = { foo: 'bar' };

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -6,7 +6,7 @@ import { ɵeffectWithDeps } from '@lucca-front/ng/core';
 import { CORE_SELECT_API_TOTAL_COUNT_PROVIDER, CoreSelectApiTotalCountProvider, LuOptionContext, applySearchDelimiter } from '@lucca-front/ng/core-select';
 import { ALuCoreSelectApiDirective } from '@lucca-front/ng/core-select/api';
 import { LuDisplayFormat, LuDisplayFullname } from '@lucca-front/ng/user';
-import { EMPTY, Observable, catchError, combineLatest, debounceTime, map, of, shareReplay, switchMap, take, tap } from 'rxjs';
+import { Observable, catchError, combineLatest, debounceTime, map, of, shareReplay, switchMap, take, tap } from 'rxjs';
 import { FORMER_EMPLOYEES_CONTEXT, LuCoreSelectFormerEmployeesComponent } from './former-employees.component';
 import { LU_CORE_SELECT_CURRENT_USER_ID } from './me.provider';
 import { LuUserDisplayerComponent } from './user-displayer.component';
@@ -137,9 +137,13 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 						item: T;
 					}>
 				>(this.urlOrDefault(), { params })
-				.pipe(catchError(() => EMPTY)),
+				.pipe(
+					map((res) => res.data.items.map(({ item }) => item)[0] ?? null),
+					// A failed "me" lookup must not block the options: getOptionsPage combines this
+					// stream with the users search, an EMPTY here would leave the select loading forever
+					catchError(() => of(null)),
+				),
 		),
-		map((res) => res.data.items.map(({ item }) => item)[0] ?? null),
 		takeUntilDestroyed(),
 		shareReplay(1),
 	);
@@ -187,10 +191,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 
 		const me$ = prependMe ? this.getMe() : of(null);
 
-		const users$ = this.getOptions(params, page).pipe(
-			map((users) => ({ items: users, isLastPage: users.length < this.pageSize })),
-			tap(() => (this.select.loading = false)),
-		);
+		const users$ = this.getOptions(params, page).pipe(map((users) => ({ items: users, isLastPage: users.length < this.pageSize })));
 
 		const page$ = combineLatest([me$, users$]).pipe(
 			map(([me, { items, isLastPage }]) => {
@@ -209,6 +210,7 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 					})),
 				),
 			),
+			tap(() => (this.select.loading = false)),
 		);
 	}
 


### PR DESCRIPTION
## Description

Fixes two failure modes of the user selects (`lu-simple-select`/`lu-multi-select` with the `users` directive) around the "me" lookup request:

- the "no value available" empty state flashed on opening, for the duration between the users search response and the "me" lookup response;
- a failed "me" lookup left the select stuck forever (no options, previously a permanent empty state), since the options stream never emitted.

-----

### Why it happened

`getOptionsPage()` runs two parallel requests on an empty clue: the users search and the "me" lookup (the option prepended on the first page). The loader was turned off by a `tap` on the **users search response**, but the options only come out of the `combineLatest([me$, users$])` — so between the two responses the panel had `options=[] && !loading`, which is exactly its empty-state condition. Locally the window is one frame; it scales with the latency gap between the two requests (measured 2.5s of empty state with a 2.5s-delayed "me" lookup, see videos).

This is the remaining window after #5172: that fix guarantees the loader is on when the panel opens (the entry of the cycle), this one keeps it on until the options actually arrive (the exit).

On top of that, `me$` swallowed errors with `catchError(() => EMPTY)`: an EMPTY completes without emitting, so a failed "me" lookup froze the `combineLatest` forever. It now emits `null` — the select degrades gracefully by displaying the options without the "me" entry. This is a deliberate behavior change: the "me" option is best-effort, its failure should not discard a successful users search (nor display the misleading "no value available, contact your administrator" message).

Each regression test fails on the previous implementation for its own fix only (verified by applying each fix in isolation).

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [ ] `npm run build` is OK
- [ ] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
