### PR TITLE
fix(filter-pills): guard optional enableFilterPillMode call on input component

### DIFF
--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -142,7 +142,7 @@ export class FilterPillComponent {
 			const ref = this.inputComponentRef();
 			if (ref) {
 				untracked(() => {
-					ref.enableFilterPillMode();
+					ref.enableFilterPillMode?.();
 					ref.registerFilterPillClosePopover(this.closePopover);
 					ref.registerFilterPillUpdatePosition?.(this.updatePosition);
 				});

--- a/packages/ng/impersonation/impersonation/impersonation.component.ts
+++ b/packages/ng/impersonation/impersonation/impersonation.component.ts
@@ -65,7 +65,7 @@ export class ImpersonationComponent {
 			// Because ref appears only when opening the panel, we're going to call the impersonation opened hook too
 			if (ref) {
 				untracked(() => {
-					ref.enableFilterPillMode();
+					ref.enableFilterPillMode?.();
 					ref.registerFilterPillClosePopover(this.closePopover);
 					ref.registerFilterPillUpdatePosition?.(this.updatePosition);
 					ref.onFilterPillOpened?.();


### PR DESCRIPTION
## Description

Un composant custom fourni via `FILTER_PILL_INPUT_COMPONENT` sans implémenter `enableFilterPillMode` (déclarée optionnelle dans `FilterPillInputComponent`) provoquait un `TypeError: ref.enableFilterPillMode is not a function` au rendu du filter pill. L'appel est désormais gardé, comme `registerFilterPillUpdatePosition` juste en dessous.

-----

`FilterPillComponent` et `ImpersonationComponent` appelaient `ref.enableFilterPillMode()` sans garde dans leur effect d'initialisation, alors que l'interface la déclare `enableFilterPillMode?(): void`. L'écart type/runtime ne se voit ni à la compilation du consommateur (la méthode est optionnelle, donc l'implémentation n'est pas exigée) ni côté lib (le build prod tourne avec `strictNullChecks: false`, cf. `tsconfig.lib.prod.json`, donc TS2722 n'est pas levée). Rencontré sur Talent.PeopleReview avec un filter pill custom d'intervalle numérique.

-----

