### PR TITLE
fix(dialog): Place dialog-inside-header-actionOptional in its grid-area

### DIFF
--- a/packages/scss/src/components/dialog/component.scss
+++ b/packages/scss/src/components/dialog/component.scss
@@ -108,6 +108,7 @@
 		}
 
 		.dialog-inside-header-actionOptional {
+			grid-area: action;
 			margin-inline-end: calc(var(--pr-t-spacings-100) * -1);
 
 			&:empty {


### PR DESCRIPTION
## Description

* `dialog-inside-header-actionOptional` currently lands in the only unoccupied area of the grid.
* Tweaking the grid did not bring any result.

-----
