### PR TITLE
fix(file-upload): Fix single accepted format label

### DIFF
--- a/packages/ng/file-upload/multi/multi-file-upload.component.html
+++ b/packages/ng/file-upload/multi/multi-file-upload.component.html
@@ -25,7 +25,7 @@
 				@if (acceptNames().length > 1 || acceptAll()) {
 					{{ intl().acceptedFormat.other }}
 				} @else {
-					intl().acceptedFormat.one
+					{{ intl().acceptedFormat.one }}
 				}
 				{{ acceptNames().join(", ") }}.
 			</span>


### PR DESCRIPTION
## Description

Fix the label that appears when the multi file upload component accepts a single file format.

-----

**Before**
<img width="1281" height="421" alt="Capture d’écran 2026-08-07 à 10 56 39" src="https://github.com/user-attachments/assets/1a09dd3a-b952-4ae4-94fa-96de27ee5078" />

**After**
<img width="1281" height="421" alt="Capture d’écran 2026-08-07 à 10 58 09" src="https://github.com/user-attachments/assets/90f9ae8c-c932-4f29-a50e-f3fbdf5ebcfe" />

-----
