### PR TITLE
fix(user-popover): uncaugth exception on API errors

### DIFF
--- a/packages/ng/user-popover/service/user-popover.store.ts
+++ b/packages/ng/user-popover/service/user-popover.store.ts
@@ -54,6 +54,9 @@ export function cacheImage<T>(accessor: (value: T) => string | undefined): Opera
 						subscriber.next(value);
 					};
 				},
+				error(err: Error) {
+					subscriber.error(err);
+				},
 			});
 		});
 }


### PR DESCRIPTION
## Description

Fixed uncaugth exception when user-popover API call fails.

-----

User-popover image caching operator did not handle exceptions coming from source observable. It broke the rest of the pipe and ended in console.
* Unwanted logs in datadog
* Infinite skeleton
* Fallback behavior with basic info was never visible

-----
Before:
<img width="678" height="248" alt="firefox_p5rX2GKjr1" src="https://github.com/user-attachments/assets/88adaf46-3501-4141-a6a2-08f2835aa430" />
After: 
<img width="664" height="271" alt="firefox_OBa6v4OQWB" src="https://github.com/user-attachments/assets/556900a5-ccbe-4029-ae9e-2e1b4e45daad" />

