### PR TITLE
[TEST] Please ignore — docs(readme): remove the duplicated `results` key from the intl override example

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,10 +182,9 @@ Components use the `intlInputOptions()` function to create an `intl` input that:
   [to]="10" 
   [itemsCount]="100" 
   [intl]="{
-    results: 'Page {{from}}-{{to}} / {{itemsCount}}',
+    results: 'Showing {{from}} to {{to}} of {{itemsCount}} items',
     previous: 'Prev',
-    next: 'Next',
-    results: 'Showing {{from}} to {{to}} of {{itemsCount}} items'
+    next: 'Next'
   }" 
 />
 ```


### PR DESCRIPTION
> [!WARNING]
> **This is a test PR and will be closed shortly. Please ignore — no review needed.**
> It exists only to verify that our tooling can open a correctly labelled PR against Lucca Front.

The change itself is real, though small: in the `[intl]` override example in `README.md`, the `results` key was declared twice, so the first declaration was silently overwritten. Kept the second wording, since that is the one the example actually applies today.

Not a breaking change — documentation example only.

🤖 Produced by AI