### PR TITLE
fix(filter-pills): stop the select loader from sticking on the second pill opening

### DIFF
--- a/packages/ng/core-select/api/api.directive.spec.ts
+++ b/packages/ng/core-select/api/api.directive.spec.ts
@@ -116,6 +116,26 @@ describe('ALuCoreSelectApiDirective', () => {
 		expect(select.loading$.value).toBe(false);
 	}));
 
+	it('should not restart the loader when the open state is re-emitted without a close', fakeAsync(() => {
+		fixture.detectChanges();
+		tick(); // Component initialization uses a setTimeout :see_no_evil:
+
+		select.openPanel();
+		fixture.detectChanges();
+		tick(); // openPanel defers its work in a setTimeout
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		expect(select.loading$.value).toBe(false);
+
+		// A filter pill whose popover closed without notifying the select re-emits `true` on the
+		// next opening: no fetch runs on an open → open transition, so nothing would reset the loader
+		select.onFilterPillOpened();
+		fixture.detectChanges();
+		tick(MAGIC_OPTION_SCROLL_DELAY);
+
+		expect(select.loading$.value).toBe(false);
+	}));
+
 	it('should query options once when searching while the select is closed', fakeAsync(() => {
 		tick(); // Component initialization uses a setTimeout :see_no_evil:
 		select.clueChanged('test');

--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -59,6 +59,9 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 		const clueIsPendingDebounce$ = merge(this.select.clueChange$.pipe(map(() => true)), this.clue$.pipe(map(() => false))).pipe(distinctUntilChanged());
 		const isOpen$ = combineLatest([
 			this.select.isPanelOpen$.pipe(
+				// A re-emitted `true` (filter pill reopening) must not start the loader: the fetch below
+				// only runs on a closed → open transition, so nothing would ever turn it off again
+				distinctUntilChanged(),
 				tap((isOpen) => {
 					// Start the loader synchronously on opening to avoid a short display of the "no result"
 					// message: the first fetch only starts on the next tick (debounced open, async params$)

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.html
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.html
@@ -14,6 +14,7 @@
 			[luPopoverNoCloseButton]="true"
 			[customPositions]="popoverPositions"
 			(luPopoverOpened)="popoverOpened()"
+			(luPopoverClosed)="popoverClosed()"
 			#filterPillRef
 			#popoverRef="luPopover2"
 		>

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.spec.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.spec.ts
@@ -1,0 +1,100 @@
+import { ChangeDetectionStrategy, Component, forwardRef, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FILTER_PILL_INPUT_COMPONENT, FilterPillInputComponent } from '../core';
+import { FilterPillComponent } from './filter-pill.component';
+
+@Component({
+	selector: 'lu-test-filter-pill-input',
+	template: ``,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	providers: [
+		{
+			provide: FILTER_PILL_INPUT_COMPONENT,
+			useExisting: forwardRef(() => TestFilterPillInputComponent),
+		},
+	],
+})
+class TestFilterPillInputComponent implements FilterPillInputComponent {
+	// The pill projects its content inside the popover overlay, so the stub only instantiates
+	// once the popover opens — expose the instance for the assertions
+	static lastInstance: TestFilterPillInputComponent;
+
+	constructor() {
+		TestFilterPillInputComponent.lastInstance = this;
+	}
+
+	isFilterPillEmpty = signal(true);
+	isFilterPillClearable = signal(false);
+
+	closePopover?: () => void;
+
+	onFilterPillOpened = vi.fn();
+	onFilterPillClosed = vi.fn();
+
+	enableFilterPillMode(): void {}
+
+	clearFilterPillValue(): void {}
+
+	registerFilterPillClosePopover(closeFn: () => void): void {
+		this.closePopover = closeFn;
+	}
+}
+
+@Component({
+	template: `<lu-filter-pill label="Department">
+		<lu-test-filter-pill-input />
+	</lu-filter-pill>`,
+	imports: [FilterPillComponent, TestFilterPillInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {}
+
+describe(FilterPillComponent.name, () => {
+	let fixture: ComponentFixture<HostComponent>;
+	let pill: FilterPillComponent;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [HostComponent],
+		});
+
+		fixture = TestBed.createComponent(HostComponent);
+		fixture.detectChanges();
+
+		pill = fixture.debugElement.query(By.directive(FilterPillComponent)).componentInstance as FilterPillComponent;
+	});
+
+	function openPopover(): TestFilterPillInputComponent {
+		(fixture.debugElement.query(By.css('.filterPill')).nativeElement as HTMLElement).click();
+		fixture.detectChanges();
+
+		return TestFilterPillInputComponent.lastInstance;
+	}
+
+	it('should notify the input when the popover opens', () => {
+		const input = openPopover();
+
+		expect(input.onFilterPillOpened).toHaveBeenCalledTimes(1);
+	});
+
+	it('should notify the input when the popover closes on its own', () => {
+		const input = openPopover();
+
+		// Close from the popover side (what an outside click or Escape does), without going
+		// through the input's registered close function
+		pill.popoverRef()?.close();
+		fixture.detectChanges();
+
+		expect(input.onFilterPillClosed).toHaveBeenCalledTimes(1);
+	});
+
+	it('should notify the input when it closes the popover itself', () => {
+		const input = openPopover();
+
+		input.closePopover?.();
+		fixture.detectChanges();
+
+		expect(input.onFilterPillClosed).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
+++ b/packages/ng/filter-pills/filter-pill/filter-pill.component.ts
@@ -172,9 +172,14 @@ export class FilterPillComponent {
 		this.inputComponentRef()?.onFilterPillOpened?.();
 	}
 
-	closePopover = () => {
-		this.popoverRef()?.close();
+	popoverClosed(): void {
 		this.inputComponentRef()?.onFilterPillClosed?.();
+	}
+
+	closePopover = () => {
+		// `onFilterPillClosed` is notified by the `luPopoverClosed` binding, which also covers
+		// closes the input never asked for (outside click, Escape handled by the popover)
+		this.popoverRef()?.close();
 	};
 
 	updatePosition = () => {


### PR DESCRIPTION
## Description

An API select hosted in a filter pill no longer shows a stuck "Loading..." row at the bottom of its panel from the second opening onwards.

Closes #5236

-----

The pill template only bound `(luPopoverOpened)`: a popover closed from its own side (outside click, Escape) never called `onFilterPillClosed()`, so the select's `isPanelOpen$` stayed `true`. Since #5172, `ALuCoreSelectApiDirective` turns the loader on upon every `isPanelOpen$` emission while the fetch that turns it off only runs on a closed to open transition. On the second opening the pill re-emitted `true`: the loader lit up and nothing ever reset it.

Two complementary changes:

- `FilterPillComponent` now binds `(luPopoverClosed)` to notify the input, which covers every close path. `closePopover` no longer calls `onFilterPillClosed()` itself: the popover event is the single source of truth.
- `ALuCoreSelectApiDirective` ignores re-emitted open states (`distinctUntilChanged()` before the loader tap), so a desynced panel state can no longer strand the loader.

How to test: put `<lu-multi-select departments />` in a `<lu-filter-pill>`, open the pill, close it by clicking outside, open it again and scroll to the bottom of the panel. Before the fix a permanent "Loading..." row shows; after it the panel behaves like the first opening.

-----
