### PR TITLE
fix(comment, read-more): preserve line breaks in plain-text content

### DIFF
--- a/packages/ng/comment/comment/comment.component.html
+++ b/packages/ng/comment/comment/comment.component.html
@@ -1,4 +1,4 @@
-<div class="comment" [class.mod-noAvatar]="noInfos() || noAvatar()" [class.mod-S]="size() === 'S'">
+<div class="comment" [class.mod-noAvatar]="noInfos() || noAvatar()" [class.mod-S]="size() === 'S'" [class.mod-plainText]="plainText()">
 	@if (!noInfos()) {
 		<div class="comment-infos">
 			@if (!noAvatar()) {

--- a/packages/ng/comment/comment/comment.component.ts
+++ b/packages/ng/comment/comment/comment.component.ts
@@ -54,6 +54,8 @@ export class CommentComponent {
 
 	readonly noInfos = input(false, { transform: booleanAttribute });
 
+	readonly plainText = input(false, { transform: booleanAttribute });
+
 	readonly dateDisplay = computed(() => {
 		const formatted = this.#intlDateTimeFormat.format(this.date());
 		return `${formatted[0].toUpperCase()}${formatted.slice(1)}`;

--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -18,9 +18,7 @@
 
 <ng-container *luPresentationDisplayDefault>
 	@if (ngControl.value) {
-		<lu-read-more preserveLineBreaks>
-			{{ ngControl.value }}
-		</lu-read-more>
+		<lu-read-more plainText [innerContent]="ngControl.value" />
 	} @else {
 		<span aria-hidden="true" data-content-before="–"></span>
 	}

--- a/packages/ng/forms/textarea-input/textarea-input.component.html
+++ b/packages/ng/forms/textarea-input/textarea-input.component.html
@@ -18,7 +18,7 @@
 
 <ng-container *luPresentationDisplayDefault>
 	@if (ngControl.value) {
-		<lu-read-more>
+		<lu-read-more preserveLineBreaks>
 			{{ ngControl.value }}
 		</lu-read-more>
 	} @else {

--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -15,7 +15,7 @@ import { ReadMoreSurface } from './read-more.type';
 		'[style.--components-readMore-content-lastChild-content]': '`"${labelReadLess()}"`',
 		'[class.is-disabled]': '!expanded() && !isClamped()',
 		'[class.mod-openOnly]': 'openOnly()',
-		'[class.mod-preserveLineBreaks]': 'preserveLineBreaks()',
+		'[class.mod-plainText]': 'plainText()',
 		'[class.mod-sunken]': 'surface() === `sunken`',
 		'[class.mod-default]': 'surface() === `default`',
 		'[style.--components-readMore-link-backgroudColor]': 'backgroundColor()',
@@ -38,7 +38,7 @@ export class ReadMoreComponent {
 	 * Display the `\n` of the content as line breaks instead of collapsing them into spaces (`white-space: pre-line`).
 	 * Meant for plain-text content such as a textarea value.
 	 */
-	readonly preserveLineBreaks = input(false, { transform: booleanAttribute });
+	readonly plainText = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Change the background color under the "Read more / less" button

--- a/packages/ng/read-more/read-more.component.ts
+++ b/packages/ng/read-more/read-more.component.ts
@@ -15,6 +15,7 @@ import { ReadMoreSurface } from './read-more.type';
 		'[style.--components-readMore-content-lastChild-content]': '`"${labelReadLess()}"`',
 		'[class.is-disabled]': '!expanded() && !isClamped()',
 		'[class.mod-openOnly]': 'openOnly()',
+		'[class.mod-preserveLineBreaks]': 'preserveLineBreaks()',
 		'[class.mod-sunken]': 'surface() === `sunken`',
 		'[class.mod-default]': 'surface() === `default`',
 		'[style.--components-readMore-link-backgroudColor]': 'backgroundColor()',
@@ -32,6 +33,12 @@ export class ReadMoreComponent {
 	 * Prevent the component from closing by hiding the "Read less" button
 	 */
 	readonly openOnly = input(false, { transform: booleanAttribute });
+
+	/**
+	 * Display the `\n` of the content as line breaks instead of collapsing them into spaces (`white-space: pre-line`).
+	 * Meant for plain-text content such as a textarea value.
+	 */
+	readonly preserveLineBreaks = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Change the background color under the "Read more / less" button

--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -77,7 +77,7 @@
 			margin-block-end: 0;
 			overflow-wrap: anywhere;
 			font: var(--components-comment-text-font);
-			white-space: pre-line;
+			white-space: var(--components-comment-text-whiteSpace);
 		}
 
 		.comment-content-textContainerOptional {

--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -77,6 +77,7 @@
 			margin-block-end: 0;
 			overflow-wrap: anywhere;
 			font: var(--components-comment-text-font);
+			white-space: pre-line;
 		}
 
 		.comment-content-textContainerOptional {

--- a/packages/scss/src/components/comment/index.scss
+++ b/packages/scss/src/components/comment/index.scss
@@ -17,6 +17,10 @@
 			@include noAvatar;
 		}
 
+		&.mod-plainText {
+			@include plainText;
+		}
+
 		&:has(.comment-infos) {
 			@include container.max(25rem, $name: 'comment') {
 				@include narrow;

--- a/packages/scss/src/components/comment/mods.scss
+++ b/packages/scss/src/components/comment/mods.scss
@@ -57,3 +57,7 @@
 		margin-inline: 0 var(--components-comment-content-margin);
 	}
 }
+
+@mixin plainText {
+	--components-comment-text-whiteSpace: pre-line;
+}

--- a/packages/scss/src/components/comment/vars.scss
+++ b/packages/scss/src/components/comment/vars.scss
@@ -1,5 +1,6 @@
 @mixin vars {
 	--components-comment-max-width: 66ch;
+	--components-comment-text-whiteSpace: normal;
 	--components-comment-text-font: var(--pr-t-font-body-M);
 	--components-comment-margin: 0;
 	--components-comment-content-margin: calc(1.5rem + var(--pr-t-spacings-100)); // 1.5rem for the width of the avatar and 0.5rem for the gap

--- a/packages/scss/src/components/readMore/component.scss
+++ b/packages/scss/src/components/readMore/component.scss
@@ -62,6 +62,8 @@
 			$wrappingElements: 'ol, ul';
 
 			&:not(:has(#{$notPlainText})) {
+				white-space: var(--components-readMore-content-whiteSpace);
+
 				&::after {
 					@extend %after;
 				}

--- a/packages/scss/src/components/readMore/index.scss
+++ b/packages/scss/src/components/readMore/index.scss
@@ -28,5 +28,9 @@
 		&.mod-sunken {
 			@include sunken;
 		}
+
+		&.mod-preserveLineBreaks {
+			@include preserveLineBreaks;
+		}
 	}
 }

--- a/packages/scss/src/components/readMore/index.scss
+++ b/packages/scss/src/components/readMore/index.scss
@@ -29,8 +29,8 @@
 			@include sunken;
 		}
 
-		&.mod-preserveLineBreaks {
-			@include preserveLineBreaks;
+		&.mod-plainText {
+			@include plainText;
 		}
 	}
 }

--- a/packages/scss/src/components/readMore/mods.scss
+++ b/packages/scss/src/components/readMore/mods.scss
@@ -9,3 +9,9 @@
 @mixin linkReset {
 	--components-readMore-link-insetBlockEnd: 0;
 }
+
+@mixin preserveLineBreaks {
+	.readMore-content {
+		white-space: pre-line;
+	}
+}

--- a/packages/scss/src/components/readMore/mods.scss
+++ b/packages/scss/src/components/readMore/mods.scss
@@ -10,8 +10,6 @@
 	--components-readMore-link-insetBlockEnd: 0;
 }
 
-@mixin preserveLineBreaks {
-	.readMore-content {
-		white-space: pre-line;
-	}
+@mixin plainText {
+	--components-readMore-content-whiteSpace: pre-line;
 }

--- a/packages/scss/src/components/readMore/vars.scss
+++ b/packages/scss/src/components/readMore/vars.scss
@@ -3,4 +3,5 @@
 	--components-readMore-link-backgroudColor: var(--pr-t-elevation-surface-raised);
 	--components-readMore-link-paddingInlineStart: var(--pr-t-spacings-500);
 	--components-readMore-link-insetBlockEnd: var(--pr-t-spacings-50);
+	--components-readMore-content-whiteSpace: normal;
 }

--- a/stories/qa/comment/comment.stories.html
+++ b/stories/qa/comment/comment.stories.html
@@ -12,130 +12,20 @@
 		<tr>
 			<td>Default</td>
 			<td>
-				<div class="comment">
-					<div class="comment-infos">
-						<!-- TODO: Change to avatar component -->
-						<div class="avatar"></div>
-
-						<div class="comment-infos-content">
-							<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-							<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-						</div>
-					</div>
-					<blockquote class="comment-content">
-						<p class="comment-content-text">
-							Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
-							nulla iste neque ex?
-						</p>
-					</blockquote>
-				</div>
-
-				<div class="comment mod-noAvatar">
-					<div class="comment-infos">
-						<div class="comment-infos-content">
-							<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-							<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-						</div>
-					</div>
-					<blockquote class="comment-content">
-						<p class="comment-content-text">
-							Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
-							nulla iste neque ex?
-						</p>
-					</blockquote>
-				</div>
-
-				<div class="comment">
-					<div class="comment-infos">
-						<!-- TODO: Change to avatar component -->
-						<div class="avatar"></div>
-
-						<div class="comment-infos-content">
-							<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-						</div>
-					</div>
-					<blockquote class="comment-content">
-						<p class="comment-content-text">
-							Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
-							nulla iste neque ex?
-						</p>
-					</blockquote>
-				</div>
-
-				<div class="comment">
-					<div class="comment-infos">
-						<!-- TODO: Change to avatar component -->
-						<div class="avatar"></div>
-
-						<div class="comment-infos-content"><span class="comment-infos-name">Marie Bragoulet</span>&ngsp;</div>
-					</div>
-					<blockquote class="comment-content">
-						<p class="comment-content-text">
-							Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
-							nulla iste neque ex?
-						</p>
-					</blockquote>
-				</div>
-
-				<div class="comment mod-noAvatar">
-					<blockquote class="comment-content">
-						<p class="comment-content-text">
-							Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
-							nulla iste neque ex?
-						</p>
-					</blockquote>
-				</div>
-
-				<div class="comment mod-S">
-					<div class="comment-infos">
-						<!-- TODO: Change to avatar component -->
-						<div class="avatar"></div>
-
-						<div class="comment-infos-content">
-							<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-							<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-						</div>
-					</div>
-					<blockquote class="comment-content">
-						<p class="comment-content-text">
-							Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident
-							nulla iste neque ex?
-						</p>
-					</blockquote>
-				</div>
-
-				<div class="comment">
-					<div class="comment-infos">
-						<!-- TODO: Change to avatar component -->
-						<div class="avatar"></div>
-
-						<div class="comment-infos-content">
-							<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-							<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-						</div>
-					</div>
-					<blockquote class="comment-content">
-						<div class="comment-content-textContainerOptional">
-							<h3>Lorem, ipsum.</h3>
-							<p>
-								Lorem ipsum, dolor sit amet consectetur adipisicing elit. <strong>Facilis voluptates ex</strong> qui iste libero suscipit
-								cum earum harum animi praesentium, quidem non incidunt vel illum sunt nihil reprehenderit a itaque.
-							</p>
-							<p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Cumque numquam itaque at facilis iusto inventore.</p>
-						</div>
-					</blockquote>
-				</div>
-
 				<ol class="commentWrapper">
-					<li class="commentWrapper-item">
+					<li class="commentWrapper-item" role="listitem">
 						<div class="comment">
 							<div class="comment-infos">
-								<!-- TODO: Change to avatar component -->
-								<div class="avatar"></div>
-
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
 								<div class="comment-infos-content">
-									<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-									<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
 								</div>
 							</div>
 							<blockquote class="comment-content">
@@ -146,71 +36,23 @@
 							</blockquote>
 						</div>
 					</li>
-					<li class="commentWrapper-item">
+					<li class="commentWrapper-item" role="listitem">
 						<div class="comment">
 							<div class="comment-infos">
-								<!-- TODO: Change to avatar component -->
-								<div class="avatar"></div>
-
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
 								<div class="comment-infos-content">
-									<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-									<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
 								</div>
 							</div>
 							<blockquote class="comment-content">
-								<p class="comment-content-text">Lorem ipsum dolor sit amet,</p>
-							</blockquote>
-						</div>
-					</li>
-					<li class="commentWrapper-item">
-						<div class="comment">
-							<div class="comment-infos">
-								<!-- TODO: Change to avatar component -->
-								<div class="avatar"></div>
-
-								<div class="comment-infos-content">
-									<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-									<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-								</div>
-							</div>
-							<blockquote class="comment-content">
-								<p class="comment-content-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
-							</blockquote>
-						</div>
-					</li>
-				</ol>
-
-				<ol class="commentWrapper">
-					<li class="commentWrapper-item">
-						<div class="comment">
-							<div class="comment-infos">
-								<!-- TODO: Change to avatar component -->
-								<div class="avatar"></div>
-
-								<div class="comment-infos-content">
-									<span class="comment-infos-name">Marie Bragoulet</span>&ngsp;
-									<time class="comment-infos-date" datetime="2024-01-04T16:50:00+00:00">Lun. 4 janv. à 16:50</time>
-								</div>
-							</div>
-							<blockquote class="comment-content">
-								<p class="comment-content-text">
-									Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
-									provident nulla iste neque ex?
-								</p>
-							</blockquote>
-						</div>
-					</li>
-					<li class="commentWrapper-item">
-						<div class="comment">
-							<blockquote class="comment-content">
-								<p class="comment-content-text">Lorem ipsum dolor sit amet</p>
-							</blockquote>
-						</div>
-					</li>
-					<li class="commentWrapper-item">
-						<div class="comment">
-							<blockquote class="comment-content">
-								<p class="comment-content-text">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
 							</blockquote>
 						</div>
 					</li>
@@ -221,22 +63,269 @@
 					<ng-template #avatarTpl>
 						<lu-user-picture [user]="{ firstName: 'Marie', lastName: 'Bragoulet' }" />
 					</ng-template>
+
 					<lu-comment
 						[date]="date"
 						content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
 					/>
 					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
 				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>No avatar</td>
+			<td>
+				<ol class="commentWrapper">
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment mod-noAvatar">
+							<div class="comment-infos">
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">
+									Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
+									provident nulla iste neque ex?
+								</p>
+							</blockquote>
+						</div>
+					</li>
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment mod-noAvatar">
+							<div class="comment-infos">
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
+							</blockquote>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
 				<lu-comment-block authorName="Marie Bragoulet">
-					<ng-template #avatarTpl>
-						<lu-user-picture [user]="{ firstName: 'Marie', lastName: 'Bragoulet' }" />
-					</ng-template>
 					<lu-comment
 						[date]="date"
 						content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
 					/>
 					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
 				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>No infos</td>
+			<td>
+				<ol class="commentWrapper">
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment mod-noAvatar">
+							<blockquote class="comment-content">
+								<p class="comment-content-text">
+									Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
+									provident nulla iste neque ex?
+								</p>
+							</blockquote>
+						</div>
+					</li>
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment mod-noAvatar">
+							<blockquote class="comment-content">
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
+							</blockquote>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
+				<lu-comment-block>
+					<lu-comment
+						noInfos
+						content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
+					/>
+					<lu-comment noInfos content="Lorem ipsum dolor sit amet." />
+				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>Rich text</td>
+			<td>
+				<ol class="commentWrapper">
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<h4>Lorem ipsum dolor sit amet</h4>
+								<p>Consectetur adipisicing elit temporibus a veniam necessitatibus aut facilis repellendus.</p>
+								<ul>
+									<li>provident</li>
+									<li>nulla iste</li>
+									<li>neque ex?</li>
+								</ul>
+							</blockquote>
+						</div>
+					</li>
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
+							</blockquote>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
+				<lu-comment-block [avatar]="avatarTpl" authorName="Marie Bragoulet">
+					<ng-template #portalSample>
+						<h4>Lorem ipsum dolor sit amet</h4>
+						<p>Consectetur adipisicing elit temporibus a veniam necessitatibus aut facilis repellendus.</p>
+						<ul>
+							<li>provident</li>
+							<li>nulla iste</li>
+							<li>neque ex?</li>
+						</ul>
+					</ng-template>
+					<lu-comment [date]="date" [content]="portalSample" />
+					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
+				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>Plain text</td>
+			<td>
+				<ol class="commentWrapper">
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment mod-plainText">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">
+									<!-- prettier-ignore -->
+									Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+									<br /><br /><!-- only for the story -->
+									Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?
+								</p>
+							</blockquote>
+						</div>
+					</li>
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
+							</blockquote>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
+				<lu-comment-block [avatar]="avatarTpl" authorName="Marie Bragoulet">
+					<lu-comment plainText [date]="date" [content]="formatedSample" />
+					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
+				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>Compact</td>
+			<td>
+				<ol class="commentWrapper mod-compact">
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">
+									Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
+									provident nulla iste neque ex?
+								</p>
+							</blockquote>
+						</div>
+					</li>
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
+							</blockquote>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
 				<lu-comment-block [avatar]="avatarTpl" compact authorName="Marie Bragoulet">
 					<ng-template #avatarTpl>
 						<lu-user-picture [user]="{ firstName: 'Marie', lastName: 'Bragoulet' }" />
@@ -247,6 +336,58 @@
 					/>
 					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
 				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>Small</td>
+			<td>
+				<ol class="commentWrapper mod-S">
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">
+									Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
+									provident nulla iste neque ex?
+								</p>
+							</blockquote>
+						</div>
+					</li>
+					<li class="commentWrapper-item" role="listitem">
+						<div class="comment">
+							<div class="comment-infos">
+								<div class="pr-u-displayContents" aria-hidden="true">
+									<div class="avatar">
+										<div class="avatar-picture" style="background-color: #d6835c">
+											<span class="avatar-picture-initials" translate="no">BM</span>
+										</div>
+									</div>
+								</div>
+								<div class="comment-infos-content">
+									<span class="comment-infos-name">Marie Bragoulet</span>
+									<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+								</div>
+							</div>
+							<blockquote class="comment-content">
+								<p class="comment-content-text">Lorem ipsum dolor sit amet.</p>
+							</blockquote>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
 				<lu-comment-block [avatar]="avatarTpl" small authorName="Marie Bragoulet">
 					<ng-template #avatarTpl>
 						<lu-user-picture [user]="{ firstName: 'Marie', lastName: 'Bragoulet' }" />
@@ -257,16 +398,65 @@
 					/>
 					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
 				</lu-comment-block>
-				<lu-comment-block [avatar]="avatarTpl" compact small authorName="Marie Bragoulet">
-					<ng-template #avatarTpl>
-						<lu-user-picture [user]="{ firstName: 'Marie', lastName: 'Bragoulet' }" />
-					</ng-template>
-					<lu-comment
-						[date]="date"
-						content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
-					/>
-					<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
-				</lu-comment-block>
+			</td>
+		</tr>
+		<tr>
+			<td>Chat</td>
+			<td>
+				<ol class="commentWrapperChat">
+					<li class="commentWrapper" role="listitem">
+						<div class="commentWrapper-item">
+							<div class="comment">
+								<div class="comment-infos">
+									<div class="pr-u-displayContents" aria-hidden="true">
+										<div class="avatar">
+											<div class="avatar-picture" style="background-color: #d6835c">
+												<span class="avatar-picture-initials" translate="no">BM</span>
+											</div>
+										</div>
+									</div>
+									<div class="comment-infos-content">
+										<span class="comment-infos-name">Marie Bragoulet</span>
+										<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+									</div>
+								</div>
+								<blockquote class="comment-content">
+									<p class="comment-content-text">
+										Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
+										provident nulla iste neque ex?
+									</p>
+								</blockquote>
+							</div>
+						</div>
+					</li>
+					<li class="commentWrapper mod-chatAnswer" role="listitem">
+						<div class="commentWrapper-item">
+							<div class="comment">
+								<div class="comment-infos">
+									<div class="pr-u-displayContents" aria-hidden="true">
+										<div class="avatar">
+											<div class="avatar-picture" style="background-color: #b15cd6">
+												<span class="avatar-picture-initials" translate="no">AC</span>
+											</div>
+										</div>
+									</div>
+									<div class="comment-infos-content">
+										<span class="comment-infos-name">Chloé Alibert</span>
+										<time class="comment-infos-date" datetime="2026-08-14T12:35:00.000Z">Vendredi 14 août 2026, 14:35</time>
+									</div>
+								</div>
+								<blockquote class="comment-content">
+									<p class="comment-content-text">
+										Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus
+										provident nulla iste neque ex?
+									</p>
+								</blockquote>
+							</div>
+						</div>
+					</li>
+				</ol>
+			</td>
+			<td>
 				<lu-comment-chat>
 					<lu-comment-block [avatar]="avatarTpl" authorName="Marie Bragoulet">
 						<ng-template #avatarTpl>
@@ -276,30 +466,8 @@
 							[date]="date"
 							content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
 						/>
-						<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
 					</lu-comment-block>
 					<lu-comment-block [chatAnswer]="true" [avatar]="avatarTpl2" authorName="Chloé Alibert">
-						<ng-template #avatarTpl2>
-							<lu-user-picture [user]="{ firstName: 'Chloé', lastName: 'Alibert' }" />
-						</ng-template>
-						<lu-comment
-							[date]="date"
-							content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
-						/>
-					</lu-comment-block>
-				</lu-comment-chat>
-				<lu-comment-chat>
-					<lu-comment-block compact small authorName="Marie Bragoulet">
-						<ng-template #avatarTpl>
-							<lu-user-picture [user]="{ firstName: 'Marie', lastName: 'Bragoulet' }" />
-						</ng-template>
-						<lu-comment
-							[date]="date"
-							content="Lorem ipsum dolor sit amet, consectetur adipisicing elit. Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex?"
-						/>
-						<lu-comment [date]="date" content="Lorem ipsum dolor sit amet." />
-					</lu-comment-block>
-					<lu-comment-block [chatAnswer]="true" compact small authorName="Chloé Alibert">
 						<ng-template #avatarTpl2>
 							<lu-user-picture [user]="{ firstName: 'Chloé', lastName: 'Alibert' }" />
 						</ng-template>

--- a/stories/qa/comment/comment.stories.ts
+++ b/stories/qa/comment/comment.stories.ts
@@ -1,31 +1,19 @@
 import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
-import { CommentBlockComponent, CommentComponent } from '@lucca-front/ng/comment';
+import { CommentBlockComponent, CommentChatComponent, CommentComponent } from '@lucca-front/ng/comment';
 import { LuUserPictureComponent } from '@lucca-front/ng/user';
 import { applicationConfig, Meta, StoryObj } from '@storybook/angular-vite';
 
 @Component({
 	selector: 'comment-stories',
 	templateUrl: './comment.stories.html',
-	imports: [CommentComponent, CommentBlockComponent, LuUserPictureComponent],
-	styles: [
-		`
-			.comment {
-				margin-block-end: var(--pr-t-spacings-200);
-			}
-			.avatar {
-				inline-size: 1.5rem;
-				block-size: 1.5rem;
-				border-radius: 50%;
-				background: var(--palettes-neutral-100) url('https://cdn.lucca.fr/lucca-front/avatars/finn.png') center;
-				background-size: cover;
-				flex-shrink: 0;
-			}
-		`,
-	],
+	imports: [CommentComponent, CommentBlockComponent, LuUserPictureComponent, CommentChatComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class CommentStory {
 	date = new Date();
+	formatedSample = `Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+
+	Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex? `;
 }
 
 export default {

--- a/stories/qa/forms/presentation.stories.ts
+++ b/stories/qa/forms/presentation.stories.ts
@@ -1,3 +1,4 @@
+import { cleanupTemplate, generateInputs } from '@/helpers/stories';
 import { allLegumes } from '@/stories/forms/select/select.utils';
 import { LOCALE_ID } from '@angular/core';
 import { FormsModule } from '@angular/forms';
@@ -22,7 +23,6 @@ import { provideLuRichTextMarkdownFormatter } from '@lucca-front/ng/forms/rich-t
 import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { cleanupTemplate, generateInputs } from '@/helpers/stories';
 
 export default {
 	title: 'QA/Forms/Presentation',
@@ -91,8 +91,9 @@ export const Basic: StoryObj = {
 				legume: allLegumes[2],
 				richTextContent,
 			},
+			styles: [`:host { display: flex; flex-direction: column; gap: 1rem } :host > *:not(:first-child) { border-top: 1px solid var(--commons-divider-color);  padding-block-start: 1rem }`],
 			template: cleanupTemplate(`
-<lu-form-field presentation label="Checkbox input" ${generateInputs(
+<lu-form-field presentation label="Checkbox input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -101,9 +102,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-checkbox-input [(ngModel)]="boolean" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Switch input" ${generateInputs(
+
+<lu-form-field presentation label="Switch input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -112,9 +112,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-switch-input [(ngModel)]="boolean" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Text input" ${generateInputs(
+
+<lu-form-field presentation label="Text input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -123,9 +122,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-text-input [(ngModel)]="text"/>
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Text Area input" ${generateInputs(
+
+<lu-form-field presentation label="Text Area input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -134,9 +132,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-textarea-input [(ngModel)]="textAreaValue"/>
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Date input" ${generateInputs(
+
+<lu-form-field presentation label="Date input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -145,9 +142,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-date-input [(ngModel)]="dateValue" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Multilanguage input" ${generateInputs(
+
+<lu-form-field presentation label="Multilanguage input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -156,9 +152,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-multilanguage-input [(ngModel)]="multiLanguageValue" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Number input" ${generateInputs(
+
+<lu-form-field presentation label="Number input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -167,9 +162,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-number-input [(ngModel)]="numberValue" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Number format input" ${generateInputs(
+
+<lu-form-field presentation label="Number format input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -178,9 +172,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-number-format-input [(ngModel)]="numberValue" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Phone number input" ${generateInputs(
+
+<lu-form-field presentation label="Phone number input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -189,9 +182,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-phone-number-input [(ngModel)]="phoneNumberValue" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Simple select input" ${generateInputs(
+
+<lu-form-field presentation label="Simple select input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -200,9 +192,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-simple-select [options]="legumes" [(ngModel)]="legume" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Multiple select input" ${generateInputs(
+
+<lu-form-field presentation label="Multiple select input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -211,9 +202,8 @@ export const Basic: StoryObj = {
 			)}>
 	<lu-multi-select [options]="legumes" [(ngModel)]="legumes" />
 </lu-form-field>
-<br>
-<br>
-<lu-form-field presentation label="Radio input" ${generateInputs(
+
+<lu-form-field presentation label="Radio input"${generateInputs(
 				{
 					tooltip,
 					size,
@@ -226,8 +216,7 @@ export const Basic: StoryObj = {
 		<lu-radio [value]="3" [inlineMessage]="template" disabled>Option C</lu-radio>
 	</lu-radio-group-input>
 </lu-form-field>
-<br>
-<br>
+
 <lu-form-field presentation label="Rich Text Editor">
 	<lu-rich-text-input placeholder="Placeholder…" autoResize	[(ngModel)]="richTextContent">
 		<lu-rich-text-input-toolbar />
@@ -245,8 +234,9 @@ export const Basic: StoryObj = {
 		dateValue: new Date(),
 		numberValue: 123456789,
 		phoneNumberValue: '+33700000000',
-		textAreaValue:
-			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?',
+		textAreaValue: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. `,
 	},
 };
 
@@ -282,9 +272,10 @@ export const GlobalToForm: StoryObj = {
 				legumes: allLegumes,
 				legume: allLegumes[2],
 			},
+			styles: [`form { display: flex; flex-direction: column; gap: 1rem } form > *:not(:first-child) { border-top: 1px solid var(--commons-divider-color);  padding-block-start: 1rem }`],
 			template: cleanupTemplate(`
 <form luForm presentation>
-	<lu-form-field label="Checkbox input" ${generateInputs(
+	<lu-form-field label="Checkbox input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -293,9 +284,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-checkbox-input [(ngModel)]="boolean" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Switch input" ${generateInputs(
+
+	<lu-form-field label="Switch input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -304,9 +294,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-switch-input [(ngModel)]="boolean" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Text input" ${generateInputs(
+
+	<lu-form-field label="Text input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -315,9 +304,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-text-input [(ngModel)]="text" [ngModelOptions]="{standalone: true}"/>
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Text Area input" ${generateInputs(
+
+	<lu-form-field label="Text Area input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -326,9 +314,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-textarea-input [(ngModel)]="textAreaValue" [ngModelOptions]="{standalone: true}"/>
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Date input" ${generateInputs(
+
+	<lu-form-field label="Date input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -337,9 +324,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-date-input [(ngModel)]="dateValue" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Multilanguage input" ${generateInputs(
+
+	<lu-form-field label="Multilanguage input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -348,9 +334,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-multilanguage-input [(ngModel)]="multiLanguageValue" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Number input" ${generateInputs(
+
+	<lu-form-field label="Number input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -359,9 +344,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-number-input [(ngModel)]="numberValue" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Number format input" ${generateInputs(
+
+	<lu-form-field label="Number format input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -370,9 +354,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-number-format-input [(ngModel)]="numberValue" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Phone number input" ${generateInputs(
+
+	<lu-form-field label="Phone number input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -381,9 +364,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-phone-number-input [(ngModel)]="phoneNumberValue" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Simple select input" ${generateInputs(
+
+	<lu-form-field label="Simple select input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -392,9 +374,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-simple-select [options]="legumes" [(ngModel)]="legume" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Multiple select input" ${generateInputs(
+
+	<lu-form-field label="Multiple select input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -403,9 +384,8 @@ export const GlobalToForm: StoryObj = {
 	)}>
 		<lu-multi-select [options]="legumes" [(ngModel)]="legumes" [ngModelOptions]="{standalone: true}" />
 	</lu-form-field>
-	<br>
-	<br>
-	<lu-form-field label="Radio input" ${generateInputs(
+
+	<lu-form-field label="Radio input"${generateInputs(
 		{
 			tooltip,
 			size,
@@ -430,8 +410,9 @@ export const GlobalToForm: StoryObj = {
 		dateValue: new Date(),
 		numberValue: 123456789,
 		phoneNumberValue: '+33700000000',
-		textAreaValue:
-			'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\nSed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?',
+		textAreaValue: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+			Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n\n Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. `,
 	},
 };
 

--- a/stories/qa/read-more/read-more.stories.html
+++ b/stories/qa/read-more/read-more.stories.html
@@ -9,96 +9,104 @@
 		<tr>
 			<td>Default</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-read-more [lineClamp]="3" surface="default">
-						<p>
-							Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis
-							natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
-						</p>
-						<p>
-							Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
-							totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
-						</p>
-					</lu-read-more>
-				</div>
+				<lu-read-more [lineClamp]="3" surface="default">
+					<p>
+						Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus
+						nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+					</p>
+					<p>
+						Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
+						totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
+					</p>
+				</lu-read-more>
 			</td>
 		</tr>
 		<tr>
 			<td>Surface</td>
-			<td>
-				<div class="demo-QAtable-list" style="background: var(--pr-t-elevation-surface-sunken)">
-					<lu-read-more [lineClamp]="3" surface="sunken">
-						<p>
-							Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis
-							natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
-						</p>
-						<p>
-							Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
-							totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
-						</p>
-					</lu-read-more>
-				</div>
+			<td style="background: var(--pr-t-elevation-surface-sunken)">
+				<lu-read-more [lineClamp]="3" surface="sunken">
+					<p>
+						Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus
+						nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+					</p>
+					<p>
+						Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
+						totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
+					</p>
+				</lu-read-more>
 			</td>
 		</tr>
 		<tr>
-			<td>openOnly</td>
+			<td>Open only</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-read-more [lineClamp]="3" surface="default" openOnly>
-						<p>
-							Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis
-							natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
-						</p>
-						<p>
-							Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
-							totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
-						</p>
-					</lu-read-more>
-				</div>
+				<lu-read-more [lineClamp]="3" surface="default" openOnly>
+					<p>
+						Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus
+						nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+					</p>
+					<p>
+						Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
+						totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
+					</p>
+				</lu-read-more>
 			</td>
 		</tr>
 		<tr>
-			<td>textFlow</td>
+			<td>Rich text</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-read-more [lineClamp]="3" surface="default" textFlow>
-						<p>
-							Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis
-							natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
-						</p>
-						<p>
-							Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
-							totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
-						</p>
-					</lu-read-more>
-				</div>
+				<lu-read-more [lineClamp]="3" surface="default" textFlow>
+					<p>
+						Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus
+						nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+					</p>
+					<p>
+						Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
+						totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
+					</p>
+				</lu-read-more>
 			</td>
 		</tr>
 		<tr>
-			<td>lineClamp</td>
+			<td>Plain text</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-read-more [lineClamp]="2" surface="default">
-						<p>
-							Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis
-							natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
-						</p>
-						<p>
-							Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
-							totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
-						</p>
-					</lu-read-more>
-					<lu-read-more [lineClamp]="10" surface="default">
-						<p>
-							Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis
-							natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
-						</p>
-						<p>
-							Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
-							totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
-						</p>
-					</lu-read-more>
-				</div>
+				<lu-read-more
+					plainText
+					[lineClamp]="3"
+					surface="default"
+					[innerContent]="`Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+
+								Vitae	veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.`"
+				></lu-read-more>
+			</td>
+		</tr>
+		<tr>
+			<td>Line clamp: 2</td>
+			<td>
+				<lu-read-more [lineClamp]="2" surface="default">
+					<p>
+						Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus
+						nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+					</p>
+					<p>
+						Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
+						totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
+					</p>
+				</lu-read-more>
+			</td>
+		</tr>
+		<tr>
+			<td>Line clamp: 10</td>
+			<td>
+				<lu-read-more [lineClamp]="10" surface="default">
+					<p>
+						Lorem ipsum dolor sit amet consectetur, adipisicing elit. Dignissimos ut maiores ullam facere voluptatum odio eum? Debitis natus
+						nulla fugit deleniti esse ipsum sint voluptatibus! Debitis voluptates impedit blanditiis natus.
+					</p>
+					<p>
+						Vitae veritatis non aliquam obcaecati illum voluptatum, voluptas dignissimos perspiciatis velit odit, magnam aspernatur culpa
+						totam nemo, magni cum? Magni sapiente voluptatibus temporibus. Quas reprehenderit deleniti sit veniam, molestias obcaecati.
+					</p>
+				</lu-read-more>
 			</td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
## Description

Addition: The `readMore` and `comment` components now have a `plainText` option.

Change: The presentation mode of a textarea that uses a `readMore` component is now configured to accept rich or plain text.

-----

Fixes #5238.

-----

<img width="1090" height="555" alt="Capture d’écran 2026-08-14 à 16 21 11" src="https://github.com/user-attachments/assets/e010da95-1671-4db6-b2a2-e9ef1057d6bf" />

<img width="1084" height="200" alt="Capture d’écran 2026-08-14 à 16 22 23" src="https://github.com/user-attachments/assets/cd34f456-28b0-4300-bae2-ee5df82466ad" />

<img width="963" height="193" alt="Capture d’écran 2026-08-14 à 16 21 58" src="https://github.com/user-attachments/assets/656593dd-0380-4ab9-aaf2-f8f7ce16d3ba" />



