### PR TITLE
[tooltips] fix safari behaviours

### DIFF
--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -187,7 +187,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 				}
 				const host = this.#host.nativeElement;
 				const hostStyle = getComputedStyle(host);
-				// No need to run a test if the element isn't an ellipse
+				// No need to run a test if the element is not truncated
 				// or if its `display` property is set to `inline`
 				// (especially for Safari, which still calculates a width, unlike other browsers)
 				if (hostStyle.textOverflow !== 'ellipsis' || hostStyle.display === 'inline') {

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -54,7 +54,7 @@ let nextId = 0;
 		'(focus)': 'onFocus()',
 		'(blur)': 'onBlur()',
 		'(keydown.escape)': 'onEscape($event)',
-		'[class]': '"tooltip_trigger"',
+		class: 'tooltip_trigger',
 		'[class.is-whenEllipsis]': 'luTooltipWhenEllipsis()',
 	},
 })

--- a/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/ng/tooltip/trigger/tooltip-trigger.directive.ts
@@ -54,6 +54,8 @@ let nextId = 0;
 		'(focus)': 'onFocus()',
 		'(blur)': 'onBlur()',
 		'(keydown.escape)': 'onEscape($event)',
+		'[class]': '"tooltip_trigger"',
+		'[class.is-whenEllipsis]': 'luTooltipWhenEllipsis()',
 	},
 })
 export class LuTooltipTriggerDirective implements OnDestroy {
@@ -185,7 +187,10 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 				}
 				const host = this.#host.nativeElement;
 				const hostStyle = getComputedStyle(host);
-				if (hostStyle.textOverflow !== 'ellipsis') {
+				// No need to run a test if the element isn't an ellipse
+				// or if its `display` property is set to `inline`
+				// (especially for Safari, which still calculates a width, unlike other browsers)
+				if (hostStyle.textOverflow !== 'ellipsis' || hostStyle.display === 'inline') {
 					return { measure: false } as const;
 				}
 				return { measure: true, host, hostStyle } as const;

--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -26,7 +26,7 @@
 
 	@at-root ($atRoot) {
 		// Prevent Safari to display a native tooltip
-		[luTooltipWhenEllipsis] {
+		.tooltip_trigger.is-whenEllipsis {
 			@supports (background-image: -webkit-named-image(i)) {
 				@media (hover: hover) {
 					&::after {

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -4,9 +4,7 @@ import { IconComponent } from '@lucca-front/ng/icon';
 import { LuTooltipPanelComponent, LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { ButtonComponent } from '@lucca/prisme/button';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { expect, screen, userEvent, within } from 'storybook/test';
-import { createTestStory, generateInputs } from '../../../helpers/stories';
-import { mapInputs, sleep } from '../../../helpers/test';
+import { generateInputs } from '../../../helpers/stories';
 
 export default {
 	title: 'Documentation/Overlays/Tooltip/Basic',


### PR DESCRIPTION
## Description

Two issues resolved: 
- The `[luTooltipWhenEllipsis]` attribute selector was not robust enough, as the attribute was sometimes removed from the DOM. It has now been replaced by a class.
- In Safari, the width calculation was incorrect for `inline` elements, causing behavior that differed from other browsers. 

-----

Fix #5240 

-----
