### PR TITLE
fix(text-input): keep the caret in place when typing inside the value

### DIFF
--- a/packages/ng/forms/text-input/text-input.component.html
+++ b/packages/ng/forms/text-input/text-input.component.html
@@ -28,19 +28,34 @@
 	}
 
 	<div class="textField-input">
-		<input
-			luInput
-			[type]="typeRef()"
-			[attr.autocomplete]="autocomplete() ? autocomplete() : null"
-			class="textField-input-value"
-			[placeholder]="placeholder()"
-			[formControl]="ngControl.control"
-			(blur)="blur.emit($event)"
-			[mask]="mask()"
-			#inputElement
-		/>
+		<!-- The `mask` directive is only applied when a mask is actually set: as a ControlValueAccessor it rewrites the input value
+		asynchronously, which moves the caret to the end of the value on every keystroke. -->
+		@if (mask(); as mask) {
+			<input
+				luInput
+				[type]="typeRef()"
+				[attr.autocomplete]="autocomplete() ? autocomplete() : null"
+				class="textField-input-value"
+				[placeholder]="placeholder()"
+				[formControl]="ngControl.control"
+				(blur)="blur.emit($event)"
+				[mask]="mask"
+				#inputElement
+			/>
+		} @else {
+			<input
+				luInput
+				[type]="typeRef()"
+				[attr.autocomplete]="autocomplete() ? autocomplete() : null"
+				class="textField-input-value"
+				[placeholder]="placeholder()"
+				[formControl]="ngControl.control"
+				(blur)="blur.emit($event)"
+				#inputElement
+			/>
+		}
 		<div class="textField-input-affix">
-			@if (hasClearer() && inputElement.value) {
+			@if (hasClearer() && hasValue()) {
 				<lu-clear (onClear)="clearValue()" class="textField-input-affix-clear">{{ intl().clear }}</lu-clear>
 			}
 			@if (hasSearchIcon()) {

--- a/packages/ng/forms/text-input/text-input.component.ts
+++ b/packages/ng/forms/text-input/text-input.component.ts
@@ -3,7 +3,7 @@ import { booleanAttribute, ChangeDetectionStrategy, Component, computed, Element
 import { ReactiveFormsModule } from '@angular/forms';
 import { LuccaIcon } from '@lucca-front/icons';
 import { ClearComponent } from '@lucca-front/ng/clear';
-import { intlInputOptions, PortalDirective } from '@lucca-front/ng/core';
+import { intlInputOptions, isNotNil, PortalDirective } from '@lucca-front/ng/core';
 import { InputDirective, ɵPresentationDisplayDefaultDirective } from '@lucca-front/ng/form-field';
 import { NgxMaskDirective, provideNgxMask } from 'ngx-mask';
 import { FormFieldIdDirective } from '../form-field-id.directive';
@@ -60,6 +60,11 @@ export class TextInputComponent {
 	protected typeRef = computed(() => (this.showPassword() ? 'text' : this.type()));
 
 	protected hasTogglePasswordVisibilityIcon = computed(() => this.type() === 'password');
+
+	protected hasValue(): boolean {
+		const value: unknown = this.ngControl.value;
+		return isNotNil(value) && value !== '';
+	}
 
 	clearValue(): void {
 		this.ngControl.reset();

--- a/stories/documentation/forms/fields/text/angular/text-field.stories.ts
+++ b/stories/documentation/forms/fields/text/angular/text-field.stories.ts
@@ -430,6 +430,19 @@ export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step, id
 	});
 });
 
+export const BasicCaretPositionTEST = createTestStory(Basic, async ({ canvasElement }) => {
+	await waitForAngular();
+	const canvas = within(canvasElement);
+	const input = canvas.getByRole('textbox') as HTMLInputElement;
+
+	// Typing at the start of the value must keep the caret right after the typed characters, so the user can keep writing there.
+	await userEvent.type(input, 'AB', { initialSelectionStart: 0, initialSelectionEnd: 0 });
+	await waitForAngular();
+
+	await expect(input).toHaveValue('ABExample value');
+	await expect(input.selectionStart).toBe(2);
+});
+
 export const BasicPasswordVisibilityTEST = createTestStory(PasswordVisiblity, async (context) => {
 	const canvas = within(context.canvasElement);
 	await waitForAngular();


### PR DESCRIPTION
## Description

Typing inside an already filled text input no longer sends the caret to the end of the value. Placing the cursor at the start of `Example value` and typing `A` used to produce `AExample value` with the caret jumping to the end, so you had to click back to the start for every single character. The caret now stays right after what you typed, and you can keep writing where you are.

This affects every text input without a mask, whatever the forms API in use (`[formControl]`, `[(ngModel)]` or signal forms).

-----

`NgxMaskDirective` provides `NG_VALUE_ACCESSOR`, so binding `[mask]` unconditionally made it the input's `ControlValueAccessor` even when no mask was set, replacing Angular's `DefaultValueAccessor`. Its `writeValue` rewrites the DOM value in a microtask (`Promise.resolve().then(() => setProperty(el, 'value', value))`), which lands after the keystroke with the previous value. Two `input.value` assignments with different values in a row make the browser move the caret to the end. The `DefaultValueAccessor` writes synchronously with an unchanged value, which leaves the caret alone.

The `mask` directive is now applied only when a mask is actually set, so unmasked inputs go back to the `DefaultValueAccessor`.

<details>
<summary>Side effect and remaining limitation</summary>

The `#inputElement` template reference is no longer visible outside the `@if` block, so the clearer now reads the control value through a `hasValue()` helper instead of `inputElement.value`. The helper tests `null` / `undefined` / `''` explicitly so a `0` value does not hide the clearer. A `computed()` or a `toSignal()` was ruled out: `ngControl.control` is still `undefined` when class fields initialize (both `[formControl]` and `formControlName` populate it in their `ngOnChanges`), and `valueChanges` stays silent on `setValue(..., { emitEvent: false })`, which is exactly how signal forms push values into the control.

Editing in the middle of a **masked** value still moves the caret to the end. That one comes from `ngx-mask` itself, reproduced with both `[(ngModel)]` and `[formControl]`, and is out of scope here.

</details>

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
