### PR TITLE
fix(simple-select): let the panel grow and flip above once async options land

### DIFF
--- a/packages/ng/simple-select/input/panel-ref.factory.ts
+++ b/packages/ng/simple-select/input/panel-ref.factory.ts
@@ -121,6 +121,10 @@ export class LuSimpleSelectPanelRefFactory {
 		const overlayConfig: OverlayConfig = overlayConfigOverride || {};
 		overlayConfig.positionStrategy = this.positionBuilder
 			.flexibleConnectedTo(this.elementRef)
+			// Options usually arrive after the panel has been opened: without this, every reposition is
+			// capped to the bounding box computed while the panel was still empty, so a panel opened in a
+			// tight space below the field can never grow nor flip above once its options are there.
+			.withGrowAfterOpen(true)
 			.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement, 8))
 			.withPositions([
 				{

--- a/stories/qa/select/select-async-position.stories.html
+++ b/stories/qa/select/select-async-position.stories.html
@@ -1,0 +1,50 @@
+<p class="repro-intro">
+	Options are loaded asynchronously when the panel opens: the panel is still empty when the CDK picks a position, and grows once the options
+	arrive. Use the
+	<code>field</code>, <code>spaceBelow</code>, <code>optionCount</code> and <code>latency</code> args to change the scenario.
+</p>
+
+<div class="repro" [style.inset-block-end.px]="spaceBelow">
+	@switch (field) {
+		@case ("simple-async") {
+			<lu-form-field label="Simple (async)">
+				<lu-simple-select
+					data-testid="target"
+					placeholder="Placeholder"
+					[options]="asyncOptions()"
+					[loading]="loading()"
+					[(ngModel)]="simpleValue"
+					(clueChange)="clue = $event"
+					(panelOpened)="loadOptions()"
+				/>
+			</lu-form-field>
+		}
+		@case ("simple-sync") {
+			<lu-form-field label="Simple (sync)">
+				<lu-simple-select
+					data-testid="target"
+					placeholder="Placeholder"
+					[options]="syncOptions"
+					[(ngModel)]="simpleValue"
+					(clueChange)="clue = $event"
+				/>
+			</lu-form-field>
+		}
+		@case ("multi-async") {
+			<lu-form-field label="Multi (async)">
+				<lu-multi-select
+					data-testid="target"
+					placeholder="Placeholder"
+					[options]="asyncOptions()"
+					[loading]="loading()"
+					[(ngModel)]="multiValue"
+					(clueChange)="clue = $event"
+					(panelOpened)="loadOptions()"
+				/>
+			</lu-form-field>
+		}
+	}
+</div>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/select/select-async-position.stories.ts
+++ b/stories/qa/select/select-async-position.stories.ts
@@ -1,0 +1,91 @@
+import { HiddenArgType } from '@/helpers/common-arg-types';
+import { allLegumes, ILegume } from '@/stories/forms/select/select.utils';
+import { ChangeDetectionStrategy, Component, Input, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
+import { Meta, StoryObj } from '@storybook/angular-vite';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
+import { sleep, waitForAngular } from '../../helpers/test';
+
+@Component({
+	selector: 'select-async-position-stories',
+	templateUrl: './select-async-position.stories.html',
+	imports: [LuSimpleSelectInputComponent, LuMultiSelectInputComponent, FormFieldComponent, FormsModule],
+	styles: [
+		`
+			.repro {
+				position: fixed;
+				inset-inline-start: 2rem;
+				inline-size: 20rem;
+			}
+
+			.repro-intro {
+				max-inline-size: 40rem;
+			}
+		`,
+	],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class SelectAsyncPositionStory {
+	/** Which select to display. */
+	@Input() field: 'simple-async' | 'simple-sync' | 'multi-async' = 'simple-async';
+	/** Distance in px between the bottom of the field and the bottom of the viewport. */
+	@Input() spaceBelow = 150;
+	/** Number of options returned by the fake API. */
+	@Input() optionCount = 20;
+	/** Fake API latency, in ms. */
+	@Input() latency = 300;
+
+	asyncOptions = signal<ILegume[]>([]);
+	loading = signal(false);
+	clue = '';
+	simpleValue: ILegume | null = null;
+	multiValue: ILegume[] = [];
+
+	get syncOptions(): ILegume[] {
+		return allLegumes.slice(0, this.optionCount);
+	}
+
+	loadOptions(): void {
+		this.loading.set(true);
+		this.asyncOptions.set([]);
+		setTimeout(() => {
+			this.asyncOptions.set(this.syncOptions);
+			this.loading.set(false);
+		}, this.latency);
+	}
+}
+
+export default {
+	title: 'QA/Select/AsyncPanelPosition',
+	component: SelectAsyncPositionStory,
+	argTypes: {
+		field: { control: 'inline-radio', options: ['simple-async', 'simple-sync', 'multi-async'] },
+		asyncOptions: HiddenArgType,
+		syncOptions: HiddenArgType,
+		loading: HiddenArgType,
+		clue: HiddenArgType,
+		simpleValue: HiddenArgType,
+		multiValue: HiddenArgType,
+		loadOptions: HiddenArgType,
+	},
+} as Meta<SelectAsyncPositionStory>;
+
+export const Basic: StoryObj<SelectAsyncPositionStory> = {
+	args: { field: 'simple-async', spaceBelow: 150, optionCount: 20, latency: 300 },
+	play: async ({ canvasElement, args }) => {
+		await userEvent.click(within(canvasElement).getByRole('combobox'));
+		await waitForAngular();
+
+		const listbox = await screen.findByRole('listbox');
+		await waitFor(() => expect(within(listbox).getAllByRole('option')).toHaveLength(args.optionCount), { timeout: 3000 });
+		await sleep(100); // repositioning is deferred by a setTimeout once the options are rendered
+
+		// The panel used to be capped to the space left below the field when it was opened — that is, while
+		// it was still empty — so it stayed squashed to `spaceBelow - 8` once the options landed.
+		const panel = listbox.closest('.cdk-overlay-pane');
+		await expect(panel.getBoundingClientRect().height).toBeGreaterThan(args.spaceBelow);
+	},
+};


### PR DESCRIPTION
## Description

A `lu-simple-select` whose options arrive asynchronously no longer gets stuck with a panel sized to the space left below the field. It now grows to its full height and flips above the field when there isn't enough room below.

-----

### Problem

The panel is positioned the moment it opens — while the API call that feeds its options is still in flight, so the panel is only a few dozen pixels tall. The CDK picks the "below" position, sizes its bounding box to the remaining space under the field, and remembers that measurement.

When the options land, `ALuCoreSelectInputComponent` calls `panelRef.updatePosition()` (`core-select/input/select-input.component.ts`), but `FlexibleConnectedPositionStrategy` caps every reposition to the box it computed at opening time:

```js
// _setBoundingBoxStyles
if (!this._isInitialRender && !this._growAfterOpen) {
  boundingBoxRect.height = Math.min(boundingBoxRect.height, this._lastBoundingBoxSize.height);
}
```

The simple-select strategy never opted into `withGrowAfterOpen(true)` — the multi-select one already does. So the panel is locked at `spaceBelow - 8px` forever, whatever arrives in it afterwards.

Concretely, this breaks three things:

- **the panel can't grow**: `.lu-picker-content` allows 320px, but the pane stays at `spaceBelow - 8` — 142px with 150px below the field, 117px with 125px, and so on;
- **its content overflows**: the pane box is too short while the panel paints its full height, so the option list runs over the field and off the bottom of the viewport;
- **flipping above never helps**: even when the CDK does pick a "top" position on the reposition, the clamp keeps the box at the height computed for the space *below*, so the panel still ends up squashed.

It is not systematic, which is what made it confusing: with very little room below, even the initial empty panel doesn't fit, so a top position is chosen right away and everything is fine. The bug lives in the in-between zone — roughly 100px to 250px below the field — where the empty panel fits but the filled one doesn't. A select at the bottom of a `lu-dialog` fed by an API lands there routinely.

Everything hosted on `lu-simple-select` inherits the bug, since `LuSimpleSelectPanelRefFactory` is the single provider for that host: `apiV3`, `apiV4`, `users`, `departments`, `establishments`, `jobQualifications`, `occupationCategories`, `treeSelect`, `noClue`, `noopTreeSelect`, `totalCount`, plus `lu-color-input` and `lu-phone-number-input` which embed a simple-select. The same directives on `lu-multi-select` were never affected.

`maxHeight: '100vh'` on the overlay config was the other suspect: it is not involved. Removing it leaves all 11 measured scenarios strictly identical (the CDK clears it from the pane in flexible-dimensions mode and only puts it on the bounding box, where it constrains nothing), so it stays untouched.

### Fix

One line: `.withGrowAfterOpen(true)` on the simple-select position strategy, aligning it with the multi-select one.

No `minHeight` involved, on purpose. Setting `minHeight` on the `OverlayConfig` does fix the position choice, but `OverlayRef` also applies it as an inline style on the pane, which stretches a one-option panel to the minimum height and visually detaches it from the field. Apps that added that workaround can drop it.

### Proof

New QA story `QA/Select/AsyncPanelPosition` (`stories/qa/select/select-async-position.stories.ts`) reproduces it: 20 options behind a 300ms fake API, field anchored 150px above the bottom of the viewport. Its `play` function asserts the panel is taller than the space below the field, so it runs in CI with `npm run test-storybook`.

Without the fix:

```
 × Basic 1151ms
 FAIL  |storybook (chromium)| stories/qa/select/select-async-position.stories.ts > Basic
AssertionError:
expected 142 to be greater than 150
```

142 is exactly `150 - 8`: the panel is pinned to the space that was available below the field when it opened.

Panel height measured on the CDK pane, panel open, 20 options, 300ms latency:

| Space below the field | Before | After | Sync options (reference) | `lu-multi-select` |
|---|---|---|---|---|
| 125px | 117 | **320** | 320 | 320 |
| 150px | 142 | **320** | 320 | 320 |
| 245px | 237 | **320** | 320 | 320 |
| 64px | 56 | **320** | 320 | 320 |

Short lists are unchanged — no stretching, no gap: 1 option stays at 40px and 3 options at 112px, opening below the field, before and after. The case where neither side has room for 320px (short viewport, CDK push mode) is unchanged too.

### How to test

- Storybook → **QA / Select / AsyncPanelPosition**. The panel opens on its own; play with `spaceBelow`, `optionCount` and `latency`. Around `spaceBelow: 150` with 20 options, the panel opens above the field at its full 320px. Before the fix it was 142px and overflowed the field.
- Or in an app: put a `lu-simple-select` fed by an API at the bottom of a `lu-dialog`, leaving 100–250px under the field, and open it.

Validated beyond Storybook: packed locally and installed in Pagga.Remuneration on the *Launch pay transparency report* dialog (`<lu-simple-select employeeAttributeDefinitions>` at the bottom of the dialog), with that app's `_shame.scss` workaround (`.lu-picker-panel { height: 100%; min-height: 5rem }`) removed — the panel behaves correctly without it.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [ ] `npm run lint` is OK — `npx eslint` on the touched files is clean, full type-aware lint left to CI

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
