### PR TITLE
fix(core-select): stop triggering change detection on every mouse move

### DIFF
--- a/packages/ng/core-select/panel/index.ts
+++ b/packages/ng/core-select/panel/index.ts
@@ -4,3 +4,4 @@ export * from './panel.models';
 export { getGroupTemplateLocation as ɵgetGroupTemplateLocation } from './panel.utils';
 export { CoreSelectPanelElement as ɵCoreSelectPanelElement } from './selectable-item';
 export * from './panel.instance';
+export { injectPointerNavigation as ɵinjectPointerNavigation } from './pointer-navigation';

--- a/packages/ng/core-select/panel/pointer-navigation.spec.ts
+++ b/packages/ng/core-select/panel/pointer-navigation.spec.ts
@@ -1,0 +1,111 @@
+import { ChangeDetectionStrategy, Component, NgZone, Signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { vi } from 'vitest';
+import { injectPointerNavigation } from './pointer-navigation';
+
+@Component({
+	selector: 'lu-pointer-navigation-test',
+	template: '',
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {
+	pointerNavigation: Signal<boolean> = injectPointerNavigation();
+}
+
+describe('injectPointerNavigation', () => {
+	let fixture: ComponentFixture<HostComponent>;
+	let host: HostComponent;
+
+	function createHost(): void {
+		fixture = TestBed.createComponent(HostComponent);
+		host = fixture.componentInstance;
+	}
+
+	function moveMouse(): void {
+		document.dispatchEvent(new MouseEvent('mousemove'));
+	}
+
+	function pressKey(): void {
+		document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown' }));
+	}
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({ imports: [HostComponent] });
+	});
+
+	it('should assume keyboard navigation until proven otherwise', () => {
+		// Act
+		createHost();
+		// Assert
+		expect(host.pointerNavigation()).toBe(false);
+	});
+
+	it('should switch to pointer navigation on mousemove', () => {
+		// Arrange
+		createHost();
+		// Act
+		moveMouse();
+		// Assert
+		expect(host.pointerNavigation()).toBe(true);
+	});
+
+	it('should switch back to keyboard navigation on keydown', () => {
+		// Arrange
+		createHost();
+		moveMouse();
+		// Act
+		pressKey();
+		// Assert
+		expect(host.pointerNavigation()).toBe(false);
+	});
+
+	it('should stay on keyboard navigation when only keys are pressed', () => {
+		// Arrange
+		createHost();
+		// Act
+		pressKey();
+		// Assert
+		expect(host.pointerNavigation()).toBe(false);
+	});
+
+	it('should register its listeners outside of the Angular zone', () => {
+		// Arrange — TestBed provides a NoopNgZone, so leaving the zone has no observable effect here:
+		// assert that the registration happens within `runOutsideAngular` instead, since that is what
+		// keeps `mousemove` from scheduling a change detection run on every frame in a real app.
+		let insideRunOutsideAngular = false;
+		vi.spyOn(TestBed.inject(NgZone), 'runOutsideAngular').mockImplementation(((fn: () => unknown) => {
+			insideRunOutsideAngular = true;
+			try {
+				return fn();
+			} finally {
+				insideRunOutsideAngular = false;
+			}
+		}) as NgZone['runOutsideAngular']);
+
+		const registeredOutsideAngular: Record<string, boolean> = {};
+		const addEventListener = document.addEventListener.bind(document);
+		vi.spyOn(document, 'addEventListener').mockImplementation(((type: string, listener: EventListener, options?: AddEventListenerOptions) => {
+			registeredOutsideAngular[type] = insideRunOutsideAngular;
+			addEventListener(type, listener, options);
+		}) as typeof document.addEventListener);
+
+		// Act
+		createHost();
+
+		// Assert
+		expect(registeredOutsideAngular['mousemove']).toBe(true);
+		expect(registeredOutsideAngular['keydown']).toBe(true);
+	});
+
+	it('should stop listening once the injection context is destroyed', () => {
+		// Arrange
+		createHost();
+
+		// Act
+		fixture.destroy();
+		moveMouse();
+
+		// Assert
+		expect(host.pointerNavigation()).toBe(false);
+	});
+});

--- a/packages/ng/core-select/panel/pointer-navigation.ts
+++ b/packages/ng/core-select/panel/pointer-navigation.ts
@@ -1,0 +1,46 @@
+import { DestroyRef, DOCUMENT, inject, NgZone, Signal, signal, untracked } from '@angular/core';
+
+/**
+ * Tracks whether the user is currently navigating with the pointer or with the keyboard.
+ *
+ * Both listeners are registered natively and outside of the Angular zone, and the signal is only
+ * written when the value actually changes: `mousemove` fires on every frame the mouse moves, and
+ * going through Angular's event system there schedules a change detection run each time — for a
+ * value that almost never changes.
+ *
+ * Must be called from an injection context.
+ */
+export function injectPointerNavigation(): Signal<boolean> {
+	const document = inject(DOCUMENT);
+	const ngZone = inject(NgZone);
+	const pointerNavigation = signal(false);
+
+	const abortController = new AbortController();
+	inject(DestroyRef).onDestroy(() => abortController.abort());
+
+	ngZone.runOutsideAngular(() => {
+		const options: AddEventListenerOptions = { passive: true, signal: abortController.signal };
+
+		document.addEventListener(
+			'mousemove',
+			() => {
+				if (!untracked(pointerNavigation)) {
+					pointerNavigation.set(true);
+				}
+			},
+			options,
+		);
+
+		document.addEventListener(
+			'keydown',
+			() => {
+				if (untracked(pointerNavigation)) {
+					pointerNavigation.set(false);
+				}
+			},
+			options,
+		);
+	});
+
+	return pointerNavigation.asReadonly();
+}

--- a/packages/ng/forms/color-input/color-input.component.ts
+++ b/packages/ng/forms/color-input/color-input.component.ts
@@ -1,8 +1,8 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, HostListener, input, Signal, signal, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, Signal, signal, ViewEncapsulation } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ColorComponent } from '@lucca-front/ng/color';
 import { intlInputOptions } from '@lucca-front/ng/core';
-import { LuCoreSelectNoClueDirective, LuDisplayerDirective, LuOptionDirective } from '@lucca-front/ng/core-select';
+import { LuCoreSelectNoClueDirective, LuDisplayerDirective, LuOptionDirective, ɵinjectPointerNavigation } from '@lucca-front/ng/core-select';
 import { LuSimpleSelectInputComponent } from '@lucca-front/ng/simple-select';
 import { injectNgControl } from '../inject-ng-control';
 import { NoopValueAccessorDirective } from '../noop-value-accessor.directive';
@@ -24,7 +24,7 @@ import { of, startWith } from 'rxjs';
 export class ColorInputComponent {
 	intl = input(...intlInputOptions(LU_COLOR_TRANSLATIONS));
 
-	pointerNavigation = signal(false);
+	pointerNavigation = ɵinjectPointerNavigation();
 	mouseHighlighted = signal<string>('');
 	keyboardHighlighted = signal<string>('');
 	highlighted = computed(() => {
@@ -60,14 +60,4 @@ export class ColorInputComponent {
 		}
 		return this.colors();
 	});
-
-	@HostListener('document:keydown')
-	onKeydown(): void {
-		this.pointerNavigation.set(false);
-	}
-
-	@HostListener('document:mousemove')
-	onMousemove(): void {
-		this.pointerNavigation.set(true);
-	}
 }

--- a/packages/ng/multi-select/panel/panel.component.ts
+++ b/packages/ng/multi-select/panel/panel.component.ts
@@ -1,6 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, HostListener, inject, signal, TrackByFunction } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
@@ -15,6 +15,7 @@ import {
 	TreeNode,
 	ɵCoreSelectPanelElement,
 	ɵgetGroupTemplateLocation,
+	ɵinjectPointerNavigation,
 	ɵLuOptionComponent,
 	ɵLuOptionGroupPipe,
 } from '@lucca-front/ng/core-select';
@@ -78,17 +79,7 @@ export class LuMultiSelectPanelComponent<T> implements AfterViewInit, CoreSelect
 	optionTpl = this.selectInput.optionTpl;
 
 	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
-	pointerNavigation = signal(false);
-
-	@HostListener('document:keydown')
-	onKeydown(): void {
-		this.pointerNavigation.set(false);
-	}
-
-	@HostListener('document:mousemove')
-	onMousemove(): void {
-		this.pointerNavigation.set(true);
-	}
+	pointerNavigation = ɵinjectPointerNavigation();
 	keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 
 	someGroupOptionEnabled = computed(() => {

--- a/packages/ng/simple-select/panel/panel.component.ts
+++ b/packages/ng/simple-select/panel/panel.component.ts
@@ -1,6 +1,6 @@
 import { A11yModule } from '@angular/cdk/a11y';
 import { AsyncPipe, NgTemplateOutlet } from '@angular/common';
-import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, HostListener, inject, signal, TrackByFunction } from '@angular/core';
+import { AfterViewInit, ChangeDetectionStrategy, Component, computed, forwardRef, inject, signal, TrackByFunction } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { PortalDirective } from '@lucca-front/ng/core';
@@ -15,6 +15,7 @@ import {
 	TreeNode,
 	ɵCoreSelectPanelElement,
 	ɵgetGroupTemplateLocation,
+	ɵinjectPointerNavigation,
 	ɵLuOptionComponent,
 	ɵLuOptionGroupPipe,
 } from '@lucca-front/ng/core-select';
@@ -80,17 +81,7 @@ export class LuSelectPanelComponent<T> implements AfterViewInit, CoreSelectPanel
 	optionTpl = this.selectInput.optionTpl;
 
 	options = signal<ɵCoreSelectPanelElement<T>[]>([]);
-	pointerNavigation = signal(false);
-
-	@HostListener('document:keydown')
-	onKeydown(): void {
-		this.pointerNavigation.set(false);
-	}
-
-	@HostListener('document:mousemove')
-	onMousemove(): void {
-		this.pointerNavigation.set(true);
-	}
+	pointerNavigation = ɵinjectPointerNavigation();
 
 	public keyManager = inject<CoreSelectKeyManager<T>>(CoreSelectKeyManager);
 


### PR DESCRIPTION
## Description

Select panels no longer run change detection on every frame the mouse moves. Simple select, multi
select and color input each listened to `document:mousemove` through Angular's event system, so a
single pointer movement over an open panel triggered one application-wide change detection run per
frame — on large pages, enough to make the whole UI feel sluggish while a select was open. Keyboard
and pointer highlighting behave exactly as before.

-----

**Root cause.** `@HostListener('document:mousemove')` registers the listener through Angular, so
zone.js runs `ApplicationRef.tick()` on every event. The handler only wrote `pointerNavigation`, a
value that changes at most a handful of times per session.

Note that switching to zoneless would *not* have fixed this on its own: Angular's listener wrapper
calls `markAncestorsForTraversal()` and notifies the change detection scheduler on every event,
whatever the handler does. It would only have replaced a global tick with a scheduled targeted one.

**Fix.** New `ɵinjectPointerNavigation()` in `core-select/panel`:

- native `addEventListener` inside `ngZone.runOutsideAngular()`, so no event ever reaches Angular;
- `{ passive: true }`, bubble phase — deliberately iso-behaviour with the host listeners it replaces;
- a single `AbortController` shared by both listeners, aborted on `DestroyRef.onDestroy` — no
  listener leaked on `document` per opened panel;
- returns a readonly `Signal<boolean>`, which is exactly the existing
  `CoreSelectPanelInstance.pointerNavigation` contract.

It also deduplicates the block that was copy-pasted in the three components. Exported with the `ɵ`
prefix: internal cross-entrypoint API, not public.

**Why this is safe.** `pointerNavigation` is only read through `untracked()` in `selectable-item`
and `option`, so the two selects need no change detection at all when it flips. `color-input` reads
it reactively through the `highlighted()` computed, and Angular still notifies the scheduler when a
template-consumed signal is written outside the zone, so its footer keeps updating.

**Tests.** `pointer-navigation.spec.ts` covers the initial state, both transitions, the absence of
false positives on `keydown`, registration outside the zone, and listener cleanup on destroy. I
checked the suite actually bites by mutating the helper: dropping the `abort()` fails the cleanup
test, and swapping `runOutsideAngular` for `run` fails the zone test.

One caveat worth knowing: the TestBed provides a `NoopNgZone`, so leaving the zone has no observable
effect in tests. The zone test asserts that registration happens inside `runOutsideAngular` rather
than asserting `isInAngularZone()`, which would have been trivially green.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required — n/a, no visual change; covered by unit tests
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
