### PR TITLE
[ressourceCard] fix wrapper min inline size

### DIFF
--- a/packages/scss/src/components/resourceCard/component.scss
+++ b/packages/scss/src/components/resourceCard/component.scss
@@ -22,7 +22,17 @@
 
 	@at-root ($atRoot) {
 		.resourceCardWrapper {
-			grid-template-columns: repeat(auto-fill, minmax(var(--components-resourceCardWrapper-gridTemplateColumnsMin), 1fr));
+			grid-template-columns:
+				repeat(
+					auto-fill,
+					minmax(
+						min(
+							var(--components-resourceCardWrapper-gridTemplateColumnsMin),
+							100%
+						),
+						1fr
+					)
+				);
 			display: var(--components-resourceCardWrapper-display);
 			flex-direction: column;
 			gap: var(--pr-t-spacings-100);

--- a/stories/qa/resource-card/resource-card.stories.html
+++ b/stories/qa/resource-card/resource-card.stories.html
@@ -22,100 +22,92 @@
 		<tr>
 			<td>Avec slots</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-resource-card>
-						<a href="#" luResourceCardAction>Titre de la ressource</a>
-						<ng-container resourceCardIllustration>
-							<lu-bubble-icon icon="home" bubbleDirection="left" />
-						</ng-container>
-						<ng-container resourceCardInfos>
-							<span class="chip">Info</span>
-						</ng-container>
-						<ng-container resourceCardContent> Description complémentaire de la ressource avec quelques détails. </ng-container>
-						<ng-container resourceCardAction>
-							<button type="button" class="button mod-onlyIcon mod-ghost">
-								<lu-icon icon="settings" alt="Paramètres" />
-							</button>
-						</ng-container>
-					</lu-resource-card>
-				</div>
+				<lu-resource-card>
+					<a href="#" luResourceCardAction>Titre de la ressource</a>
+					<ng-container resourceCardIllustration>
+						<lu-bubble-icon icon="home" bubbleDirection="left" />
+					</ng-container>
+					<ng-container resourceCardInfos>
+						<span class="chip">Info</span>
+					</ng-container>
+					<ng-container resourceCardContent> Description complémentaire de la ressource avec quelques détails. </ng-container>
+					<ng-container resourceCardAction>
+						<button type="button" class="button mod-onlyIcon mod-ghost">
+							<lu-icon icon="settings" alt="Paramètres" />
+						</button>
+					</ng-container>
+				</lu-resource-card>
 			</td>
 		</tr>
 		<tr>
 			<td>Taille S</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-resource-card size="S">
-						<a href="#" luResourceCardAction>Titre de la ressource</a>
-						<ng-container resourceCardIllustration>
-							<lu-bubble-icon icon="home" bubbleDirection="left" size="S" />
-						</ng-container>
-						<ng-container resourceCardInfos>
-							<span class="chip">Info</span>
-						</ng-container>
-						<ng-container resourceCardContent> Description complémentaire de la ressource. </ng-container>
-					</lu-resource-card>
-				</div>
+				<lu-resource-card size="S">
+					<a href="#" luResourceCardAction>Titre de la ressource</a>
+					<ng-container resourceCardIllustration>
+						<lu-bubble-icon icon="home" bubbleDirection="left" size="S" />
+					</ng-container>
+					<ng-container resourceCardInfos>
+						<span class="chip">Info</span>
+					</ng-container>
+					<ng-container resourceCardContent> Description complémentaire de la ressource. </ng-container>
+				</lu-resource-card>
 			</td>
 		</tr>
 		<tr>
 			<td>Wrapper liste</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-resource-card-wrapper>
-						<lu-resource-card>
-							<a href="#" luResourceCardAction>Ressource 1</a>
-							<ng-container resourceCardIllustration>
-								<lu-bubble-icon icon="home" bubbleDirection="left" />
-							</ng-container>
-							<ng-container resourceCardContent>Description de la ressource 1.</ng-container>
-						</lu-resource-card>
-						<lu-resource-card>
-							<a href="#" luResourceCardAction>Ressource 2</a>
-							<ng-container resourceCardIllustration>
-								<lu-bubble-icon icon="heart" bubbleDirection="right" palette="kiwi" />
-							</ng-container>
-							<ng-container resourceCardContent>Description de la ressource 2.</ng-container>
-						</lu-resource-card>
-						<lu-resource-card>
-							<a href="#" luResourceCardAction>Ressource 3</a>
-							<ng-container resourceCardIllustration>
-								<lu-bubble-icon icon="star" bubbleDirection="top" palette="pumpkin" />
-							</ng-container>
-							<ng-container resourceCardContent>Description de la ressource 3.</ng-container>
-						</lu-resource-card>
-					</lu-resource-card-wrapper>
-				</div>
+				<lu-resource-card-wrapper>
+					<lu-resource-card>
+						<a href="#" luResourceCardAction>Ressource 1</a>
+						<ng-container resourceCardIllustration>
+							<lu-bubble-icon icon="home" bubbleDirection="left" />
+						</ng-container>
+						<ng-container resourceCardContent>Description de la ressource 1.</ng-container>
+					</lu-resource-card>
+					<lu-resource-card>
+						<a href="#" luResourceCardAction>Ressource 2</a>
+						<ng-container resourceCardIllustration>
+							<lu-bubble-icon icon="heart" bubbleDirection="right" palette="kiwi" />
+						</ng-container>
+						<ng-container resourceCardContent>Description de la ressource 2.</ng-container>
+					</lu-resource-card>
+					<lu-resource-card>
+						<a href="#" luResourceCardAction>Ressource 3</a>
+						<ng-container resourceCardIllustration>
+							<lu-bubble-icon icon="star" bubbleDirection="top" palette="pumpkin" />
+						</ng-container>
+						<ng-container resourceCardContent>Description de la ressource 3.</ng-container>
+					</lu-resource-card>
+				</lu-resource-card-wrapper>
 			</td>
 		</tr>
 		<tr>
 			<td>Wrapper grille</td>
 			<td>
-				<div class="demo-QAtable-list">
-					<lu-resource-card-wrapper grid>
-						<lu-resource-card>
-							<a href="#" luResourceCardAction>Ressource 1</a>
-							<ng-container resourceCardIllustration>
-								<lu-bubble-icon icon="home" bubbleDirection="left" />
-							</ng-container>
-							<ng-container resourceCardContent>Description de la ressource 1.</ng-container>
-						</lu-resource-card>
-						<lu-resource-card>
-							<a href="#" luResourceCardAction>Ressource 2</a>
-							<ng-container resourceCardIllustration>
-								<lu-bubble-icon icon="heart" bubbleDirection="right" palette="kiwi" />
-							</ng-container>
-							<ng-container resourceCardContent>Description de la ressource 2.</ng-container>
-						</lu-resource-card>
-						<lu-resource-card>
-							<a href="#" luResourceCardAction>Ressource 3</a>
-							<ng-container resourceCardIllustration>
-								<lu-bubble-icon icon="star" bubbleDirection="top" palette="pumpkin" />
-							</ng-container>
-							<ng-container resourceCardContent>Description de la ressource 3.</ng-container>
-						</lu-resource-card>
-					</lu-resource-card-wrapper>
-				</div>
+				<lu-resource-card-wrapper grid>
+					<lu-resource-card>
+						<a href="#" luResourceCardAction>Ressource 1</a>
+						<ng-container resourceCardIllustration>
+							<lu-bubble-icon icon="home" bubbleDirection="left" />
+						</ng-container>
+						<ng-container resourceCardContent>Description de la ressource 1.</ng-container>
+					</lu-resource-card>
+					<lu-resource-card>
+						<a href="#" luResourceCardAction>Ressource 2</a>
+						<ng-container resourceCardIllustration>
+							<lu-bubble-icon icon="heart" bubbleDirection="right" palette="kiwi" />
+						</ng-container>
+						<ng-container resourceCardContent>Description de la ressource 2.</ng-container>
+					</lu-resource-card>
+					<lu-resource-card>
+						<a href="#" luResourceCardAction>Ressource 3</a>
+						<ng-container resourceCardIllustration>
+							<lu-bubble-icon icon="star" bubbleDirection="top" palette="pumpkin" />
+						</ng-container>
+						<ng-container resourceCardContent>Description de la ressource 3.</ng-container>
+					</lu-resource-card>
+				</lu-resource-card-wrapper>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Description

The minimum width of the wrapper in grid mode used to depend solely on the minimum size of the cards. Now it also depends on the width of the parent container, and the smaller of the two takes precedence.

-----

#5248 

Thanks to @martincadoux  for the fix.

-----
