### PR TITLE
feat(stories): roll out the argTypes inputs/outputs/models convention on documentation stories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,7 @@ Chaque entrypoint qui affiche du texte a un `translations.ts` indexé par locale
 
 - **Stories QA** (`stories/qa/<composant>/`) : un `@Component` wrapper dans `<composant>.stories.ts` avec `templateUrl` pointant vers `<composant>.stories.html`, qui contient une `<table class="demo-QAtable">` comparant côte à côte la version HTML (classes CSS pures) et la version Angular (composants `<lu-*>`). La colonne Angular doit utiliser de vrais composants `lu-*`, jamais du HTML brut avec des classes.
 - **Stories de documentation** (`stories/documentation/<catégorie>/<composant>/`) : `Meta`/`StoryObj` standards sur la classe du composant, titre reflétant l'arborescence (`Documentation/<Catégorie>/<Composant>/Angular/<Variante>`) ; les variantes Angular et HTML vivent dans des dossiers frères `angular/` et `html&css/`. Utiliser `generateInputs(inputs, argTypes)` et `createTestStory` de `stories/helpers/stories`.
+  - **Convention `argTypes`** : chaque arg est rangé dans une `table.category` — `inputs` (`input()`), `outputs` (`output()`), `models` (`model()`). Un output est en plus exposé comme action loggée (`action: '<nom>'`, `control: false`), documente le type émis via `table.type.summary` (`void` si l'`output()` n'a pas de type, sinon `T`) et est bindé dans le template du `render` (`(nom)="nom($event)"`, avec les args passés en `props`). Voir `stories/documentation/_sample/angular/basic.stories.ts`.
 
 ## Docs & skills
 

--- a/stories/documentation/_sample/angular/basic.stories.ts
+++ b/stories/documentation/_sample/angular/basic.stories.ts
@@ -3,15 +3,26 @@ import { cleanupTemplate } from '@/helpers/stories';
 
 interface SampleBasicStory {
 	content: string;
+	changed?: (value: string) => void;
 }
 
 export default {
 	title: 'Documentation/Sample/Angular/Basic',
+	// Chaque arg est rangé dans une `table.category` : `inputs` pour un `input()`, `outputs` pour un `output()`,
+	// `models` pour un `model()`. Un output est en plus exposé comme action loggée (`action`, `control: false`)
+	// et documente le type émis via `table.type.summary` (`void` si l'`output()` n'a pas de type, sinon `T`).
 	argTypes: {
 		content: {
 			control: {
 				type: 'text',
 			},
+			table: { category: 'inputs' },
+		},
+		changed: {
+			description: 'Événement déclenché lorsque le contenu change.',
+			action: 'changed',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'string' } },
 		},
 	},
 	decorators: [
@@ -21,7 +32,10 @@ export default {
 	],
 	render: (args: SampleBasicStory) => {
 		return {
-			template: cleanupTemplate(`<luSample>
+			props: {
+				...args,
+			},
+			template: cleanupTemplate(`<luSample (changed)="changed($event)">
 	${args.content}
 </luSample>`),
 		};

--- a/stories/documentation/actions/button/angular/button-ai.stories.ts
+++ b/stories/documentation/actions/button/angular/button-ai.stories.ts
@@ -15,6 +15,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	render: ({ label, icon, altIcon, hiddenLabel }) => {

--- a/stories/documentation/actions/button/angular/button-counter.stories.ts
+++ b/stories/documentation/actions/button/angular/button-counter.stories.ts
@@ -29,9 +29,11 @@ export const Basic: StoryObj<ButtonComponent> = {
 				type: 'select',
 			},
 			description: 'Modifie la hierarchie ou le style du bouton.<br>[v20.3] AI',
+			table: { category: 'inputs' },
 		},
 		block: {
 			description: 'Applique <code>display: block</code>.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			if: { arg: 'luButton', neq: 'AI' },
@@ -40,6 +42,7 @@ export const Basic: StoryObj<ButtonComponent> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		state: {
 			description: 'Modifie l’état du bouton.',
@@ -47,15 +50,19 @@ export const Basic: StoryObj<ButtonComponent> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		critical: {
 			description: '[v20.2] Marque une action aux conséquences importantes ou irréversibles au survol et focus. Seulement compatible avec <code>outlined</code> et <code>ghost</code>.',
+			table: { category: 'inputs' },
 		},
 		disclosure: {
 			description: 'Indique la présence d’un menu.',
+			table: { category: 'inputs' },
 		},
 		delete: {
 			description: '[Deprecated] Remplacé par <code>critical</code>.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			description: 'Modifie la taille du composant.',
@@ -63,6 +70,7 @@ export const Basic: StoryObj<ButtonComponent> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	args: {

--- a/stories/documentation/actions/button/angular/button-icon.stories.ts
+++ b/stories/documentation/actions/button/angular/button-icon.stories.ts
@@ -34,6 +34,7 @@ export const Basic: StoryObj<ButtonComponent & { label: string }> = {
 	argTypes: {
 		label: {
 			description: '[Story] Modifie le label du bouton.',
+			table: { category: 'inputs' },
 		},
 		luButton: {
 			options: setStoryOptions(BUTTON_TYPE),
@@ -41,9 +42,11 @@ export const Basic: StoryObj<ButtonComponent & { label: string }> = {
 				type: 'select',
 			},
 			description: 'Modifie la hierarchie ou le style du bouton.<br>[v20.3] AI',
+			table: { category: 'inputs' },
 		},
 		block: {
 			description: 'Applique <code>display: block</code>.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			if: { arg: 'luButton', neq: 'AI' },
@@ -52,6 +55,7 @@ export const Basic: StoryObj<ButtonComponent & { label: string }> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		state: {
 			description: 'Modifie l’état du bouton.',
@@ -59,15 +63,19 @@ export const Basic: StoryObj<ButtonComponent & { label: string }> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		critical: {
 			description: '[v20.2] Marque une action aux conséquences importantes ou irréversibles au survol et focus. Seulement compatible avec <code>outlined</code> et <code>ghost</code>.',
+			table: { category: 'inputs' },
 		},
 		disclosure: {
 			description: 'Indique la présence d’un menu.',
+			table: { category: 'inputs' },
 		},
 		delete: {
 			description: '[Deprecated] Remplacé par <code>critical</code>.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			description: 'Modifie la taille du composant.',
@@ -75,6 +83,7 @@ export const Basic: StoryObj<ButtonComponent & { label: string }> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	args: {

--- a/stories/documentation/actions/links/angular.stories.ts
+++ b/stories/documentation/actions/links/angular.stories.ts
@@ -38,22 +38,27 @@ Lien (nouvelle fenêtre) uniquement au survol/focus/touch : <a href="${href}" l
 		disabled: {
 			description: 'Désactive le lien.',
 			type: 'boolean',
+			table: { category: 'inputs' },
 		},
 		external: HiddenArgType,
 		label: {
 			type: 'string',
 			description: '[Story] Modifie le label du lien.',
+			table: { category: 'inputs' },
 		},
 		href: {
 			type: 'string',
 			description: 'Adresse de la page cible. À n’utiliser qu’en lien externe ou non connu par le routeur.',
+			table: { category: 'inputs' },
 		},
 		routerLink: {
 			type: 'string',
 			description: 'Adresse de la page cible.',
+			table: { category: 'inputs' },
 		},
 		decorationHover: {
 			description: 'Souligne le lien seulement au survol.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout-disclosure/angular/callout-disclosure.stories.ts
+++ b/stories/documentation/feedback/callout-disclosure/angular/callout-disclosure.stories.ts
@@ -19,7 +19,10 @@ export default {
 		const paletteArg = palette !== 'none' && palette !== undefined ? ` palette="${palette}"` : ``;
 
 		return {
-			template: `<lu-callout-disclosure ${paletteArg}${generateInputs(args, argTypes)}>
+			props: {
+				...args,
+			},
+			template: `<lu-callout-disclosure ${paletteArg}${generateInputs(args, argTypes)} (openChange)="openChange($event)">
 		<ul lu-callout-feedback-list palette="neutral">
 			<li lu-callout-feedback-item>
 				<lu-feedback-item-description>
@@ -45,6 +48,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Ajoute une icône au callout.',
+			table: { category: 'inputs' },
 		},
 		state: {
 			options: setStoryOptions(CalloutStates),
@@ -52,6 +56,7 @@ export default {
 				type: 'select',
 			},
 			description: 'État du callout.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(CALLOUT_SIZE),
@@ -59,9 +64,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du callout.',
+			table: { category: 'inputs' },
 		},
 		heading: {
 			description: 'Titre du callout. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions(PALETTE),
@@ -69,12 +76,17 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au callout.',
+			table: { category: 'inputs' },
 		},
 		open: {
 			description: 'Place le callout dans son état déplié.',
+			table: { category: 'inputs' },
 		},
 		openChange: {
 			description: "Événement déclenché lors du changement d'état déplié/replié du callout.",
+			action: 'openChange',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'boolean' } },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
+++ b/stories/documentation/feedback/callout-popover/angular/callout-popover.stories.ts
@@ -52,12 +52,15 @@ export default {
 			},
 			if: { arg: 'customText', truthy: false },
 			description: 'Nombre d’éléments présentés dans la story.',
+			table: { category: 'inputs' },
 		},
 		buttonLabel: {
 			description: 'Label du bouton.',
+			table: { category: 'inputs' },
 		},
 		buttonAlt: {
 			description: 'Information restituée par le bouton.',
+			table: { category: 'inputs' },
 		},
 		popoverPosition: {
 			options: ['', 'below', 'before', 'after'],
@@ -65,6 +68,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Position du popover par rapport au bouton de déclenchement.',
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: ['', 'info', 'success', 'warning', 'error', 'help'],
@@ -72,6 +76,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Ajoute une icône au callout.',
+			table: { category: 'inputs' },
 		},
 		state: {
 			options: setStoryOptions(CalloutStates),
@@ -79,10 +84,12 @@ export default {
 				type: 'select',
 			},
 			description: 'État du callout.',
+			table: { category: 'inputs' },
 		},
 		heading: {
 			description: 'Ajoute un titre au popover. [PortalContent]',
 			if: { arg: 'customText', truthy: false },
+			table: { category: 'inputs' },
 		},
 		headingHiddenIfSingleItem: {
 			control: {
@@ -90,6 +97,7 @@ export default {
 			},
 			if: { arg: 'customText', truthy: false },
 			description: 'Masque le titre si le popover ne contient qu’un élément.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions(PALETTE),
@@ -97,6 +105,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au callout.',
+			table: { category: 'inputs' },
 		},
 		popoverTrigger: {
 			options: ['click', 'click+hover', 'hover+focus'],
@@ -104,12 +113,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Détermine le mode d’ouverture du popover.',
+			table: { category: 'inputs' },
 		},
 		popoverDisabled: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Désactive l’apparition du popover.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(CALLOUT_POPOVER_SIZE),
@@ -117,15 +128,19 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		closeDelay: {
 			description: 'Délai nécessaire à la fermeture du popover.',
+			table: { category: 'inputs' },
 		},
 		openDelay: {
 			description: 'Délai nécessaire à l’ouverture du popover.',
+			table: { category: 'inputs' },
 		},
 		customText: {
 			description: 'Remplace la liste d’éléments par un texte personnalisé.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout/angular/callout-ai-action.stories.ts
+++ b/stories/documentation/feedback/callout/angular/callout-ai-action.stories.ts
@@ -30,6 +30,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout/angular/callout-ai-event.stories.ts
+++ b/stories/documentation/feedback/callout/angular/callout-ai-event.stories.ts
@@ -33,6 +33,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout/angular/callout-ai-suggestion.stories.ts
+++ b/stories/documentation/feedback/callout/angular/callout-ai-suggestion.stories.ts
@@ -52,6 +52,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout/angular/callout-ai.stories.ts
+++ b/stories/documentation/feedback/callout/angular/callout-ai.stories.ts
@@ -26,6 +26,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/callout/angular/callout-basic.stories.ts
+++ b/stories/documentation/feedback/callout/angular/callout-basic.stories.ts
@@ -31,7 +31,10 @@ export default {
 			: ``;
 
 		return {
-			template: `<lu-callout${headingArg}${hxArg}${paletteArg}${generateInputs(inputs, context.argTypes)}>
+			props: {
+				...args,
+			},
+			template: `<lu-callout${headingArg}${hxArg}${paletteArg}${generateInputs(inputs, context.argTypes)} (removedChange)="removedChange($event)">
 	<p>Feedback description</p>${actionsTemplate}
 </lu-callout>`,
 		};
@@ -39,10 +42,12 @@ export default {
 	argTypes: {
 		removable: {
 			description: 'Ajoute un bouton de suppression au callout.',
+			table: { category: 'inputs' },
 		},
 		removed: {
 			if: { arg: 'removable', truthy: true },
 			description: 'Masque le callout.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions(PALETTE),
@@ -51,6 +56,7 @@ export default {
 			},
 			description: 'Applique une palette de couleurs au callout.',
 			if: { arg: 'AI', truthy: false },
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: ['', 'signInfo', 'signSuccess', 'signWarning', 'signError', 'signHelp', 'weatherStars', 'officePenStar'],
@@ -58,10 +64,12 @@ export default {
 				type: 'select',
 			},
 			description: 'Ajoute une icône au callout.',
+			table: { category: 'inputs' },
 		},
 		iconAlt: {
 			description: 'Information de l’icône restituée par le lecteur d’écran.',
 			type: 'string',
+			table: { category: 'inputs' },
 		},
 		state: {
 			options: setStoryOptions(CalloutStates),
@@ -69,6 +77,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(CALLOUT_SIZE),
@@ -76,10 +85,12 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du callout.',
+			table: { category: 'inputs' },
 		},
 		heading: {
 			type: 'string',
 			description: 'Ajoute un titre au callout. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		hx: {
 			options: setStoryOptions(CALLOUT_HX),
@@ -88,22 +99,29 @@ export default {
 			},
 			description: '[v21.4] Applique un niveau sémantique au titre.',
 			if: { arg: 'heading', truthy: true },
+			table: { category: 'inputs' },
 		},
 		removedChange: {
 			description: 'Événement déclenché lors de l’activation du bouton de suppression.',
+			action: 'removedChange',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'boolean' } },
 		},
 		AI: {
 			description: '[v20.3] Applique les couleurs IA.',
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 		actions: {
 			description: '[v20.3] Ajoute une liste d’actions sous la description.',
+			table: { category: 'inputs' },
 		},
 		actionsInline: {
 			if: { arg: 'actions', truthy: true },
 			description: '[v20.3] Déplace les actions sur la droite du callout.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/empty-state/angular/empty-state-page-onboarding.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-page-onboarding.stories.ts
@@ -68,6 +68,7 @@ lu-empty-state-page {
 	argTypes: {
 		heading: {
 			description: 'Titre de l’empty state.',
+			table: { category: 'inputs' },
 		},
 		hx: {
 			control: {
@@ -76,12 +77,15 @@ lu-empty-state-page {
 				max: 6,
 			},
 			description: 'Définit le niveau sémantique du titre.',
+			table: { category: 'inputs' },
 		},
 		src: {
 			description: 'URL de l’illustration.',
+			table: { category: 'inputs' },
 		},
 		alt: {
 			description: 'Texte alternatif de l’illustration restitué par les lecteurs d’écran.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-page.stories.ts
@@ -89,6 +89,7 @@ export default {
 			],
 			control: 'select',
 			description: 'Illustration de fond dans le coin supérieur droit.',
+			table: { category: 'inputs' },
 		},
 		topRightForeground: {
 			options: [
@@ -106,6 +107,7 @@ export default {
 			],
 			control: 'select',
 			description: 'Illustration de premier plan dans le coin supérieur droit.',
+			table: { category: 'inputs' },
 		},
 		bottomLeftBackground: {
 			options: [
@@ -127,6 +129,7 @@ export default {
 			],
 			control: 'select',
 			description: 'Illustration de fond dans le coin inférieur gauche.',
+			table: { category: 'inputs' },
 		},
 		bottomLeftForeground: {
 			options: [
@@ -155,6 +158,7 @@ export default {
 			],
 			control: 'select',
 			description: 'Illustration de premier plan dans le coin inférieur gauche.',
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: ['', 'medal-01', 'post-it-01'],
@@ -162,12 +166,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Affiche une illustration au dessus du titre.',
+			table: { category: 'inputs' },
 		},
 		contentBackgroundColor: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie la couleur de fond du contenu (variable CSS, couleur hexadécimale, etc.).',
+			table: { category: 'inputs' },
 		},
 		hx: {
 			control: {
@@ -176,6 +182,7 @@ export default {
 				max: EMPTY_STATE_HX.at(EMPTY_STATE_HX.length - 1),
 			},
 			description: 'Niveau de titre (sémantique).',
+			table: { category: 'inputs' },
 		},
 		hxStyle: {
 			control: {
@@ -184,15 +191,19 @@ export default {
 				max: EMPTY_STATE_HX_STYLE.at(EMPTY_STATE_HX_STYLE.length - 1),
 			},
 			description: '[v21.2] Niveau du titre (style).',
+			table: { category: 'inputs' },
 		},
 		heading: {
 			description: 'Titre du composant.',
+			table: { category: 'inputs' },
 		},
 		description: {
 			description: 'Description du composant. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		slotTop: {
 			description: '[v19.3] Ajout d’un slot au dessus du titre. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
+++ b/stories/documentation/feedback/empty-state/angular/empty-state-section.stories.ts
@@ -26,12 +26,14 @@ export default {
 		};
 	},
 	argTypes: {
-		palette: { ...PaletteArgType, description: 'Applique une palette de couleurs au composant.' },
+		palette: { ...PaletteArgType, description: 'Applique une palette de couleurs au composant.', table: { category: 'inputs' } },
 		center: {
 			description: 'Centre le contenu horizontalement.',
+			table: { category: 'inputs' },
 		},
 		action: {
 			description: 'Ajoute une icône (+) à l’illustration.',
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			options: setStoryOptions(BUBBLE_ILLUSTRATION),
@@ -39,6 +41,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’illustration.',
+			table: { category: 'inputs' },
 		},
 		hx: {
 			control: {
@@ -47,12 +50,15 @@ export default {
 				max: EMPTY_STATE_HX.at(EMPTY_STATE_HX.length - 1),
 			},
 			description: 'Définit le niveau sémantique du titre.',
+			table: { category: 'inputs' },
 		},
 		heading: {
 			description: 'Titre de l’empty state.',
+			table: { category: 'inputs' },
 		},
 		description: {
 			description: 'Description de l’empty state. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/error-page/angular/error-page-basic.stories.ts
+++ b/stories/documentation/feedback/error-page/angular/error-page-basic.stories.ts
@@ -35,6 +35,7 @@ export default {
 		heading: {
 			type: 'string',
 			description: 'Titre de la page d’erreur.',
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			options: setStoryOptions(ERROR_PAGE_ILLUSTRATION),
@@ -42,6 +43,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’illustration.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/mobile-push/angular/mobile-push-basic.stories.ts
+++ b/stories/documentation/feedback/mobile-push/angular/mobile-push-basic.stories.ts
@@ -16,7 +16,10 @@ export default {
 	render: (args: MobilePushComponent & { description: string }, context) => {
 		const { description, ...inputs } = args;
 		return {
-			template: `<lu-mobile-push ${generateInputs(inputs, context.argTypes)}>
+			props: {
+				...args,
+			},
+			template: `<lu-mobile-push ${generateInputs(inputs, context.argTypes)} (appStoreLinkClicked)="appStoreLinkClicked()" (googlePlayLinkClicked)="googlePlayLinkClicked()">
 	Posez une absence depuis n’importe où avec l’application Lucca.
 </lu-mobile-push>`,
 		};
@@ -27,12 +30,16 @@ export default {
 				type: null,
 			},
 			description: 'Clic sur le bouton App Store.',
+			action: 'appStoreLinkClicked',
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		googlePlayLinkClicked: {
 			control: {
 				type: null,
 			},
 			description: 'Clic sur le bouton Google Play.',
+			action: 'googlePlayLinkClicked',
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 	},
 } as Meta;

--- a/stories/documentation/feedback/plg-push/angular/plg-push-basic.stories.ts
+++ b/stories/documentation/feedback/plg-push/angular/plg-push-basic.stories.ts
@@ -28,12 +28,14 @@ export default {
 		heading: {
 			type: 'string',
 			description: 'Ajoute un titre au composant.',
+			table: { category: 'inputs' },
 		},
 		removable: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Rend le composant supprimable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/data-presentation/angular/basic.stories.ts
+++ b/stories/documentation/forms/data-presentation/angular/basic.stories.ts
@@ -8,11 +8,13 @@ export default {
 		label: {
 			control: { type: 'text' },
 			description: 'Valeur affichée. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: [null, 'S'],
 			control: { type: 'select' },
 			description: 'Taille du composant.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args, { argTypes }) => {

--- a/stories/documentation/forms/date/select/date-select.stories.ts
+++ b/stories/documentation/forms/date/select/date-select.stories.ts
@@ -10,12 +10,12 @@ type StoryComponent = LuDateSelectInputComponent<string> & { selectedDate: strin
 
 const generateStory = getStoryGenerator<StoryComponent>({
 	argTypes: {
-		selectedDate: { control: { type: 'text' }, table: { type: { summary: 'D' } } },
-		secondSelectedDate: { control: { type: 'text' }, table: { type: { summary: 'D' } } },
-		startOn: { control: { type: 'text' } },
-		min: { control: { type: 'text' } },
-		max: { control: { type: 'text' } },
-		multiple: { control: false },
+		selectedDate: { control: { type: 'text' }, table: { type: { summary: 'D' }, category: 'inputs' } },
+		secondSelectedDate: { control: { type: 'text' }, table: { type: { summary: 'D' }, category: 'inputs' } },
+		startOn: { control: { type: 'text' }, table: { category: 'inputs' } },
+		min: { control: { type: 'text' }, table: { category: 'inputs' } },
+		max: { control: { type: 'text' }, table: { category: 'inputs' } },
+		multiple: { control: false, table: { category: 'inputs' } },
 	},
 });
 

--- a/stories/documentation/forms/date2/basic-decade.stories.ts
+++ b/stories/documentation/forms/date2/basic-decade.stories.ts
@@ -16,20 +16,30 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
-			template: `<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="year" (dateClicked)="selected($event)" />`,
+			template: `<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="year" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />`,
 		};
 	},
 } as Meta;

--- a/stories/documentation/forms/date2/basic-year.stories.ts
+++ b/stories/documentation/forms/date2/basic-year.stories.ts
@@ -16,20 +16,30 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
-			template: `<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="month" (dateClicked)="selected($event)" />`,
+			template: `<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="month" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />`,
 		};
 	},
 } as Meta;

--- a/stories/documentation/forms/date2/basic.stories.ts
+++ b/stories/documentation/forms/date2/basic.stories.ts
@@ -16,20 +16,30 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
-			template: `<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />`,
+			template: `<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />`,
 		};
 	},
 } as Meta;

--- a/stories/documentation/forms/date2/date-input.stories.ts
+++ b/stories/documentation/forms/date2/date-input.stories.ts
@@ -10,236 +10,257 @@ import { StoryModelDisplayComponent } from '../../../helpers/story-model-display
 import { waitForAngular } from '../../../helpers/test';
 
 export default {
-  title: 'Documentation/Forms/Date2/DateInput',
-  decorators: [
-    moduleMetadata({
-      imports: [DateInputComponent, FormsModule, IconComponent, StoryModelDisplayComponent, FormFieldComponent],
-    }),
-    applicationConfig({
-      providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
-    }),
-  ],
-  argTypes: {
-    min: {
-      control: 'date',
-      description: 'Définit une date minimum de sélection.',
-    },
-    max: {
-      control: 'date',
-      description: 'Définit une date maximum de sélection.',
-    },
-    selected: {
-      control: 'date',
-      description: 'Définit une date sélectionnée.',
-    },
-    hideToday: {
-      control: 'boolean',
-      description: 'Retire la mise en valeur de la date du jour.',
-    },
-    clearable: {
-      control: 'boolean',
-      description: 'Ajoute un bouton de suppression lorsqu’une date est sélectionnée.',
-    },
-    clearBehavior: {
-      control: 'select',
-      options: setStoryOptions(DATE2_CLEAR_BEHAVIOR),
-      description: '[v20.1] Change le comportement au clic sur la croix de suppression',
-    },
-    format: {
-      control: 'select',
-      options: setStoryOptions(DATE_FORMAT_CONST),
-      description: 'Modifie le format de date.',
-    },
-    mode: {
-      control: 'select',
-      options: setStoryOptions(CALENDAR_MODE),
-      description: "Modifie le mode de sélection au mois ou à l'année.",
-    },
-    focusedDate: {
-      control: 'date',
-      description: 'Définit la date préselectionnée à l’ouverture du calendrier.',
-    },
-    widthAuto: {
-      control: 'boolean',
-      description: 'Applique une pleine largeur au composant.',
-    },
-    disableOverflow: {
-      description: 'Empêche la sélection des jours du mois précédent ou suivant visibles sur le mois en cours.',
-    },
-    hideOverflow: {
-      description: 'Masque les jours du mois précédent ou suivant visibles sur le mois en cours.',
-      if: { arg: 'mode', neq: 'week' },
-    },
-    hideWeekend: {
-      description: 'Retire l’effet grisé visible sur les jours du isWeekend.',
-    },
-    presentation: {
-      description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
-    },
-    panelOpened: {
-      description: "Événement déclenché à l'ouverture du calendrier.",
-    },
-    panelClosed: {
-      description: 'Événement déclenché à la fermeture du calendrier.',
-    },
-  },
-  render: (args, { argTypes }) => {
-    const { min, max, focusedDate, presentation, ...flags } = args;
-    const selected = args['selected'] ? new Date(args['selected']) : null;
-    const defaultDate = args['format'] === 'date' ? selected : selected?.toISOString().substring(0, 10);
-    const minValue = args['format'] === 'date' ? new Date(args['min']) : new Date(args['min'] ?? 0)?.toISOString().substring(0, 10);
-    const maxValue = args['format'] === 'date' ? new Date(args['max']) : new Date(args['max'] ?? 0)?.toISOString().substring(0, 10);
-    const focusedDateValue = args['format'] === 'date' ? new Date(args['focusedDate']) : new Date(args['focusedDate'] ?? 0)?.toISOString().substring(0, 10);
-    return {
-      props: {
-        selected: defaultDate,
-        min: args['min'] ? minValue : null,
-        max: args['max'] ? maxValue : null,
-        focusedDate: args['focusedDate'] ? focusedDateValue : null,
-      },
-      template: `
+	title: 'Documentation/Forms/Date2/DateInput',
+	decorators: [
+		moduleMetadata({
+			imports: [DateInputComponent, FormsModule, IconComponent, StoryModelDisplayComponent, FormFieldComponent],
+		}),
+		applicationConfig({
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
+		}),
+	],
+	argTypes: {
+		min: {
+			control: 'date',
+			description: 'Définit une date minimum de sélection.',
+			table: { category: 'inputs' },
+		},
+		max: {
+			control: 'date',
+			description: 'Définit une date maximum de sélection.',
+			table: { category: 'inputs' },
+		},
+		selected: {
+			control: 'date',
+			description: 'Définit une date sélectionnée.',
+			table: { category: 'inputs' },
+		},
+		hideToday: {
+			control: 'boolean',
+			description: 'Retire la mise en valeur de la date du jour.',
+			table: { category: 'inputs' },
+		},
+		clearable: {
+			control: 'boolean',
+			description: 'Ajoute un bouton de suppression lorsqu’une date est sélectionnée.',
+			table: { category: 'inputs' },
+		},
+		clearBehavior: {
+			control: 'select',
+			options: setStoryOptions(DATE2_CLEAR_BEHAVIOR),
+			description: '[v20.1] Change le comportement au clic sur la croix de suppression',
+			table: { category: 'inputs' },
+		},
+		format: {
+			control: 'select',
+			options: setStoryOptions(DATE_FORMAT_CONST),
+			description: 'Modifie le format de date.',
+			table: { category: 'inputs' },
+		},
+		mode: {
+			control: 'select',
+			options: setStoryOptions(CALENDAR_MODE),
+			description: "Modifie le mode de sélection au mois ou à l'année.",
+			table: { category: 'inputs' },
+		},
+		focusedDate: {
+			control: 'date',
+			description: 'Définit la date préselectionnée à l’ouverture du calendrier.',
+			table: { category: 'inputs' },
+		},
+		widthAuto: {
+			control: 'boolean',
+			description: 'Applique une pleine largeur au composant.',
+			table: { category: 'inputs' },
+		},
+		disableOverflow: {
+			description: 'Empêche la sélection des jours du mois précédent ou suivant visibles sur le mois en cours.',
+			table: { category: 'inputs' },
+		},
+		hideOverflow: {
+			description: 'Masque les jours du mois précédent ou suivant visibles sur le mois en cours.',
+			if: { arg: 'mode', neq: 'week' },
+			table: { category: 'inputs' },
+		},
+		hideWeekend: {
+			description: 'Retire l’effet grisé visible sur les jours du isWeekend.',
+			table: { category: 'inputs' },
+		},
+		presentation: {
+			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
+		},
+		panelOpened: {
+			description: "Événement déclenché à l'ouverture du calendrier.",
+			action: 'panelOpened',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
+		},
+		panelClosed: {
+			description: 'Événement déclenché à la fermeture du calendrier.',
+			action: 'panelClosed',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
+		},
+	},
+	render: (args, { argTypes }) => {
+		const { min, max, focusedDate, presentation, ...flags } = args;
+		const selected = args['selected'] ? new Date(args['selected']) : null;
+		const defaultDate = args['format'] === 'date' ? selected : selected?.toISOString().substring(0, 10);
+		const minValue = args['format'] === 'date' ? new Date(args['min']) : new Date(args['min'] ?? 0)?.toISOString().substring(0, 10);
+		const maxValue = args['format'] === 'date' ? new Date(args['max']) : new Date(args['max'] ?? 0)?.toISOString().substring(0, 10);
+		const focusedDateValue = args['format'] === 'date' ? new Date(args['focusedDate']) : new Date(args['focusedDate'] ?? 0)?.toISOString().substring(0, 10);
+		return {
+			props: {
+				...args,
+				selected: defaultDate,
+				min: args['min'] ? minValue : null,
+				max: args['max'] ? maxValue : null,
+				focusedDate: args['focusedDate'] ? focusedDateValue : null,
+			},
+			template: `
 			<lu-form-field label="Date input example" inlineMessage="Inline message example"${generateInputs({ presentation }, argTypes)}>
-				<lu-date-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" autocomplete="off"${generateInputs(flags, argTypes)} />
+				<lu-date-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" autocomplete="off"${generateInputs(flags, argTypes)} (panelOpened)="panelOpened()" (panelClosed)="panelClosed()" />
 			</lu-form-field>
 
 			<pr-story-model-display>{{ selected }}</pr-story-model-display>
 			`,
-    };
-  },
+		};
+	},
 } as Meta;
 
 export const Basic: StoryObj<DateInputComponent & { selected: Date; presentation: boolean }> = {
-  args: {
-    disableOverflow: false,
-    hideOverflow: false,
-    hideToday: false,
-    hideWeekend: false,
-    clearable: false,
-    clearBehavior: 'clear',
-    widthAuto: false,
-    mode: 'day',
-    format: 'date',
-    presentation: false,
-    // Underlying ngModel
-    selected: new Date(),
-  },
+	args: {
+		disableOverflow: false,
+		hideOverflow: false,
+		hideToday: false,
+		hideWeekend: false,
+		clearable: false,
+		clearBehavior: 'clear',
+		widthAuto: false,
+		mode: 'day',
+		format: 'date',
+		presentation: false,
+		// Underlying ngModel
+		selected: new Date(),
+	},
 };
 
 export const StartFromYear: StoryObj<DateInputComponent & { selected: Date; presentation: boolean }> = {
-  args: {
-    disableOverflow: false,
-    hideOverflow: false,
-    hideToday: false,
-    hideWeekend: false,
-    clearable: false,
-    clearBehavior: 'clear',
-    widthAuto: false,
-    mode: 'day',
-    calendarMode: 'year',
-    format: 'date',
-    presentation: false,
-    // Underlying ngModel
-    selected: null,
-  },
+	args: {
+		disableOverflow: false,
+		hideOverflow: false,
+		hideToday: false,
+		hideWeekend: false,
+		clearable: false,
+		clearBehavior: 'clear',
+		widthAuto: false,
+		mode: 'day',
+		calendarMode: 'year',
+		format: 'date',
+		presentation: false,
+		// Underlying ngModel
+		selected: null,
+	},
 };
 
 export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) => {
-  await waitForAngular();
-  const canvas = within(canvasElement);
-  const input = canvas.getByTestId('lu-date-input');
+	await waitForAngular();
+	const canvas = within(canvasElement);
+	const input = canvas.getByTestId('lu-date-input');
 
-  await step('Vérifie le rendu initial', async () => {
-    await expect(input).toBeVisible();
-  });
+	await step('Vérifie le rendu initial', async () => {
+		await expect(input).toBeVisible();
+	});
 
-  await step('Interaction souris - ouverture du calendrier', async () => {
-    await userEvent.click(input);
-    await waitForAngular();
-    await expect(screen.getByRole('grid')).toBeVisible();
-    await userEvent.keyboard('{Escape}');
-    await waitForAngular();
-  });
+	await step('Interaction souris - ouverture du calendrier', async () => {
+		await userEvent.click(input);
+		await waitForAngular();
+		await expect(screen.getByRole('grid')).toBeVisible();
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+	});
 
-  await step('Interaction clavier - ouverture du calendrier', async () => {
-    input.focus();
-    await expect(input).toHaveFocus();
-    await userEvent.keyboard('{ArrowDown}');
-    await waitForAngular();
-    await expect(screen.getByRole('grid')).toBeVisible();
-    await userEvent.keyboard('{Escape}');
-    await waitForAngular();
-  });
+	await step('Interaction clavier - ouverture du calendrier', async () => {
+		input.focus();
+		await expect(input).toHaveFocus();
+		await userEvent.keyboard('{ArrowDown}');
+		await waitForAngular();
+		await expect(screen.getByRole('grid')).toBeVisible();
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+	});
 });
 
 export const Week: StoryObj<DateInputComponent & { selected: Date; presentation: boolean }> = {
-  name: 'Week',
-  args: {
-    disableOverflow: false,
-    hideOverflow: false,
-    hideToday: false,
-    hideWeekend: false,
-    clearable: false,
-    clearBehavior: 'clear',
-    widthAuto: false,
-    mode: 'week',
-    format: 'date',
-    presentation: false,
-    selected: null,
-    focusedDate: 1784678400000,
-  },
+	name: 'Week',
+	args: {
+		disableOverflow: false,
+		hideOverflow: false,
+		hideToday: false,
+		hideWeekend: false,
+		clearable: false,
+		clearBehavior: 'clear',
+		widthAuto: false,
+		mode: 'week',
+		format: 'date',
+		presentation: false,
+		selected: null,
+		focusedDate: 1784678400000,
+	},
 };
 
 export const WeekTEST = createTestStory(Week, async ({ canvasElement, step }) => {
-  const canvas = within(canvasElement);
-  const input = canvas.getByRole('combobox');
+	const canvas = within(canvasElement);
+	const input = canvas.getByRole('combobox');
 
-  await step('Souris : ouvrir le calendrier et sélectionner une semaine', async () => {
-    await userEvent.click(input);
-    await waitForAngular();
+	await step('Souris : ouvrir le calendrier et sélectionner une semaine', async () => {
+		await userEvent.click(input);
+		await waitForAngular();
 
-    const rowheaders = within(screen.getByRole('grid')).getAllByRole('rowheader');
-    await userEvent.click(within(rowheaders[2]).getByRole('button'));
-    await waitForAngular();
+		const rowheaders = within(screen.getByRole('grid')).getAllByRole('rowheader');
+		await userEvent.click(within(rowheaders[2]).getByRole('button'));
+		await waitForAngular();
 
-    // Le popover se ferme et l'input affiche la semaine sélectionnée
-    await expect(input).not.toHaveValue('');
+		// Le popover se ferme et l'input affiche la semaine sélectionnée
+		await expect(input).not.toHaveValue('');
 
-    // Réouverture : exactement une ligne de semaine doit être sélectionnée
-    await userEvent.click(input);
-    await waitForAngular();
-    const selectedWeeks = within(screen.getByRole('grid'))
-      .getAllByRole('rowheader')
-      .filter((th) => th.getAttribute('aria-selected') === 'true');
-    await expect(selectedWeeks).toHaveLength(1);
+		// Réouverture : exactement une ligne de semaine doit être sélectionnée
+		await userEvent.click(input);
+		await waitForAngular();
+		const selectedWeeks = within(screen.getByRole('grid'))
+			.getAllByRole('rowheader')
+			.filter((th) => th.getAttribute('aria-selected') === 'true');
+		await expect(selectedWeeks).toHaveLength(1);
 
-    await userEvent.keyboard('{Escape}');
-    await waitForAngular();
-  });
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+	});
 
-  await step('Clavier : naviguer dans le calendrier et sélectionner une semaine', async () => {
-    await userEvent.click(input);
-    await waitForAngular();
-    // Le focus est sur le bouton de la semaine tabbable
+	await step('Clavier : naviguer dans le calendrier et sélectionner une semaine', async () => {
+		await userEvent.click(input);
+		await waitForAngular();
+		// Le focus est sur le bouton de la semaine tabbable
 
-    // Descendre d'une semaine
-    await userEvent.keyboard('{ArrowDown}');
-    await waitForAngular();
+		// Descendre d'une semaine
+		await userEvent.keyboard('{ArrowDown}');
+		await waitForAngular();
 
-    // Sélectionner avec Entrée
-    await userEvent.keyboard('{Enter}');
-    await waitForAngular();
+		// Sélectionner avec Entrée
+		await userEvent.keyboard('{Enter}');
+		await waitForAngular();
 
-    await expect(input).not.toHaveValue('');
+		await expect(input).not.toHaveValue('');
 
-    // Réouverture : exactement une ligne de semaine doit être sélectionnée
-    await userEvent.click(input);
-    await waitForAngular();
-    const selectedWeeks = within(screen.getByRole('grid'))
-      .getAllByRole('rowheader')
-      .filter((th) => th.getAttribute('aria-selected') === 'true');
-    await expect(selectedWeeks).toHaveLength(1);
+		// Réouverture : exactement une ligne de semaine doit être sélectionnée
+		await userEvent.click(input);
+		await waitForAngular();
+		const selectedWeeks = within(screen.getByRole('grid'))
+			.getAllByRole('rowheader')
+			.filter((th) => th.getAttribute('aria-selected') === 'true');
+		await expect(selectedWeeks).toHaveLength(1);
 
-    await userEvent.keyboard('{Escape}');
-    await waitForAngular();
-  });
+		await userEvent.keyboard('{Escape}');
+		await waitForAngular();
+	});
 });

--- a/stories/documentation/forms/date2/date-range-input.stories.ts
+++ b/stories/documentation/forms/date2/date-range-input.stories.ts
@@ -23,71 +23,93 @@ export default {
 		min: {
 			control: 'date',
 			description: 'Définit une date minimum de sélection.',
+			table: { category: 'inputs' },
 		},
 		max: {
 			control: 'date',
 			description: 'Définit une date maximum de sélection.',
+			table: { category: 'inputs' },
 		},
 		hideToday: {
 			control: 'boolean',
 			description: 'Retire la mise en valeur de la date du jour.',
+			table: { category: 'inputs' },
 		},
 		clearable: {
 			control: 'boolean',
 			description: 'Ajoute un bouton de suppression lorsqu’une date est sélectionnée.',
+			table: { category: 'inputs' },
 		},
 		clearBehavior: {
 			control: 'select',
 			options: setStoryOptions(DATE2_CLEAR_BEHAVIOR),
 			description: '[v20.1] Change le comportement au clic sur la croix de suppression',
+			table: { category: 'inputs' },
 		},
 		format: {
 			control: 'select',
 			options: setStoryOptions(DATE_FORMAT_CONST),
 			description: 'Modifie le format de date.',
+			table: { category: 'inputs' },
 		},
 		mode: {
 			control: 'select',
 			options: setStoryOptions(CALENDAR_MODE),
 			description: "Modifie le mode de sélection au mois ou à l'année.",
+			table: { category: 'inputs' },
 		},
 		focusedDate: {
 			control: 'date',
 			description: 'Définit la date préselectionnée à l’ouverture du calendrier.',
+			table: { category: 'inputs' },
 		},
 		widthAuto: {
 			control: 'boolean',
 			description: 'Applique une pleine largeur au composant.',
+			table: { category: 'inputs' },
 		},
 		selected: {
 			description: 'Définit une période sélectionnée.',
+			table: { category: 'inputs' },
 		},
 		hideWeekend: {
 			description: 'Retire l’effet grisé visible sur les jours du isWeekend.',
+			table: { category: 'inputs' },
 		},
 		autocomplete: {
 			control: 'select',
 			options: ['', 'on'],
 			description: 'Applique une valeur d’autocomplete au champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			control: 'text',
 			description: 'Modifie le placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		shortcuts: {
 			description: 'Définit une liste de sélection rapide de périodes',
+			table: { category: 'inputs' },
 		},
 		hasTodayButton: {
 			description: 'Ajoute un bouton pour sélectionner la date du jour.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 		panelOpened: {
 			description: "Événement déclenché à l'ouverture du calendrier.",
+			action: 'panelOpened',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		panelClosed: {
 			description: 'Événement déclenché à la fermeture du calendrier.',
+			action: 'panelClosed',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 	},
 	render: (args, { argTypes }) => {
@@ -97,13 +119,14 @@ export default {
 		const focusedDateValue = args['format'] === 'date' ? new Date(args['focusedDate']) : new Date(args['focusedDate'] ?? 0)?.toISOString().substring(0, 10);
 		return {
 			props: {
+				...args,
 				selected,
 				min: args['min'] ? minValue : null,
 				max: args['max'] ? maxValue : null,
 				focusedDate: args['focusedDate'] ? focusedDateValue : null,
 			},
 			template: cleanupTemplate(`<lu-form-field label="Date range input example" inlineMessage="Inline message example" ${generateInputs({ presentation }, argTypes)}>
-				<lu-date-range-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" ${generateInputs(flags, argTypes)} />
+				<lu-date-range-input [(ngModel)]="selected" [min]="min" [max]="max" [focusedDate]="focusedDate" ${generateInputs(flags, argTypes)} (panelOpened)="panelOpened()" (panelClosed)="panelClosed()" />
 			</lu-form-field>
 
 			<pr-story-model-display>{{ selected | json }}</pr-story-model-display>`),
@@ -133,6 +156,7 @@ export const WithShortcuts: StoryObj<DateRangeInputComponent & { selected: DateR
 		const { min, max, selected, presentation, ...flags } = args;
 		return {
 			props: {
+				...args,
 				selected,
 				min: min ? new Date(min) : null,
 				max: max ? new Date(max) : null,
@@ -155,7 +179,7 @@ export const WithShortcuts: StoryObj<DateRangeInputComponent & { selected: DateR
 
 			template: cleanupTemplate(`
 			<lu-form-field label="Date range input example" inlineMessage="Inline message example" ${generateInputs({ presentation }, argTypes)}>
-				<lu-date-range-input [(ngModel)]="selected" [min]="min" [max]="max" [shortcuts]="shortcuts" ${generateInputs(flags, argTypes)} />
+				<lu-date-range-input [(ngModel)]="selected" [min]="min" [max]="max" [shortcuts]="shortcuts" ${generateInputs(flags, argTypes)} (panelOpened)="panelOpened()" (panelClosed)="panelClosed()" />
 			</lu-form-field>
 
 			<pr-story-model-display>{{ selected | json }}</pr-story-model-display>`),

--- a/stories/documentation/forms/date2/option-overflow-disabled.stories.ts
+++ b/stories/documentation/forms/date2/option-overflow-disabled.stories.ts
@@ -16,21 +16,31 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
 			template: `
-				<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="false" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />
+				<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="false" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 			`,
 		};
 	},

--- a/stories/documentation/forms/date2/option-overflow-hidden.stories.ts
+++ b/stories/documentation/forms/date2/option-overflow-hidden.stories.ts
@@ -16,21 +16,31 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
 			template: `
-				<lu-calendar2 [hideToday]="false" [showOverflow]="false" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />
+				<lu-calendar2 [hideToday]="false" [showOverflow]="false" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 			`,
 		};
 	},

--- a/stories/documentation/forms/date2/option-today-hidden.stories.ts
+++ b/stories/documentation/forms/date2/option-today-hidden.stories.ts
@@ -16,21 +16,31 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
 			template: `
-				<lu-calendar2 [hideToday]="true" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />
+				<lu-calendar2 [hideToday]="true" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 			`,
 		};
 	},

--- a/stories/documentation/forms/date2/option-weekend-hidden.stories.ts
+++ b/stories/documentation/forms/date2/option-weekend-hidden.stories.ts
@@ -16,21 +16,31 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 			},
 			template: `
-				<lu-calendar2 [hideWeekend]="true" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />
+				<lu-calendar2 [hideWeekend]="true" [showOverflow]="true" [enableOverflow]="true" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 			`,
 		};
 	},

--- a/stories/documentation/forms/date2/select-day.stories.ts
+++ b/stories/documentation/forms/date2/select-day.stories.ts
@@ -16,17 +16,27 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 				getDayInfo: (date: Date, mode: CalendarMode) => {
 					if (mode === 'day' && date.getDate() === 10 && date.getMonth() === new Date().getMonth()) {
@@ -50,7 +60,7 @@ export default {
 				},
 			},
 			template: `
-				<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [getCellInfo]="getDayInfo" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />
+				<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [getCellInfo]="getDayInfo" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 			`,
 		};
 	},

--- a/stories/documentation/forms/date2/select-in-progress.stories.ts
+++ b/stories/documentation/forms/date2/select-in-progress.stories.ts
@@ -16,17 +16,27 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				date: new Date(),
 				getDayInfo: (date: Date, mode: CalendarMode) => {
 					if (mode === 'day' && date.getDate() < 8) {
@@ -73,7 +83,7 @@ export default {
 			template: `
 				<div class="calendarWrapper">
 					<div class="calendarWrapper-content palette-watermelon">
-						<lu-calendar2 [date]="date" [getCellInfo]="getDayInfo" />
+						<lu-calendar2 [date]="date" [getCellInfo]="getDayInfo" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 					</div>
 				</div>
 			`,

--- a/stories/documentation/forms/date2/select-range.stories.ts
+++ b/stories/documentation/forms/date2/select-range.stories.ts
@@ -17,17 +17,27 @@ export default {
 	argTypes: {
 		nextPage: {
 			description: 'Événement déclenché lors de la navigation vers la page suivante du calendrier.',
+			action: 'nextPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		previousPage: {
 			description: 'Événement déclenché lors de la navigation vers la page précédente du calendrier.',
+			action: 'previousPage',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		dateClicked: {
 			description: 'Événement déclenché lors du clic sur une date, avec la date en paramètre.',
+			action: 'dateClicked',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Date' } },
 		},
 	},
 	render: (args, { argTypes }) => {
 		return {
 			props: {
+				...args,
 				currentMonth: new Date(),
 				ranges: [
 					{
@@ -53,7 +63,7 @@ export default {
 				],
 			},
 			template: `
-				<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [ranges]="ranges" [date]="currentMonth" mode="day" (dateClicked)="selected($event)" />
+				<lu-calendar2 [hideToday]="false" [showOverflow]="true" [enableOverflow]="true" [ranges]="ranges" [date]="currentMonth" mode="day" (dateClicked)="dateClicked($event)" (nextPage)="nextPage()" (previousPage)="previousPage()" />
 			`,
 		};
 	},

--- a/stories/documentation/forms/fields/checkbox/angular/checkbox-field.stories.ts
+++ b/stories/documentation/forms/fields/checkbox/angular/checkbox-field.stories.ts
@@ -23,6 +23,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille de la checkbox.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -30,46 +31,55 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		checklist: {
 			control: {
 				type: 'boolean',
 			},
 			description: '[v20.2] Présente la checkbox sous la forme d’un élément d’une liste de tâches.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		mixed: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Applique un état de sélection mixte (-) à la checkbox.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: 'Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/color-input/angular/color-input-field.stories.ts
+++ b/stories/documentation/forms/fields/color-input/angular/color-input-field.stories.ts
@@ -23,12 +23,15 @@ export default {
 			type: 'string',
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle. ',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le label du champ.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -36,6 +39,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		width: {
 			options: setStoryOptions(FORM_FIELD_WIDTH),
@@ -43,9 +47,11 @@ export default {
 				type: 'select',
 			},
 			description: '[v19.2] Applique une largeur fixe au champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -53,15 +59,19 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		clearable: {
 			description: 'Affiche un bouton pour vider le champ lorsque celui-ci est rempli.',
+			table: { category: 'inputs' },
 		},
 		compact: {
 			description: 'Modifie la taille du color picker pour le rendre plus petit.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/date/date-input-field.stories.ts
+++ b/stories/documentation/forms/fields/date/date-input-field.stories.ts
@@ -21,39 +21,49 @@ export default {
 	argTypes: {
 		min: {
 			control: 'date',
+			table: { category: 'inputs' },
 		},
 		max: {
 			control: 'date',
+			table: { category: 'inputs' },
 		},
 		selected: {
 			control: 'date',
+			table: { category: 'inputs' },
 		},
 		hideToday: {
 			control: 'boolean',
 			description: 'Masque la mise en valeur du jour en cours.',
+			table: { category: 'inputs' },
 		},
 		hasTodayButton: {
 			control: 'boolean',
+			table: { category: 'inputs' },
 		},
 		enableOverflow: {
 			control: 'boolean',
 			description: 'Autorise la sélection des jours du mois précédent ou suivant sur la vue du mois en cours.',
+			table: { category: 'inputs' },
 		},
 		showOverflow: {
 			control: 'boolean',
 			description: 'Affiche la sélection des jours du mois précédent ou suivant sur la vue du mois en cours.',
+			table: { category: 'inputs' },
 		},
 		clearable: {
 			control: 'boolean',
+			table: { category: 'inputs' },
 		},
 		clearBehavior: {
 			control: 'select',
 			options: setStoryOptions(DATE2_CLEAR_BEHAVIOR),
 			description: '[v20.1] Change le comportement au clic sur la croix de suppression',
+			table: { category: 'inputs' },
 		},
 		mode: {
 			control: 'select',
 			options: setStoryOptions(CALENDAR_MODE),
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args, { argTypes }) => {

--- a/stories/documentation/forms/fields/form-field.stories.ts
+++ b/stories/documentation/forms/fields/form-field.stories.ts
@@ -21,21 +21,25 @@ export default {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte indicatif sous le champ de formulaire. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -43,19 +47,23 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		errorInlineMessage: {
 			description: 'Ajoute un texte d’erreur sous le champ de formulaire lorsque celui-ci est en erreur. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		invalid: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Applique l’état invalide au champ.',
+			table: { category: 'inputs' },
 		},
 		counter: {
 			control: {
@@ -63,6 +71,7 @@ export default {
 			},
 			description:
 				'Nombre de caractères maximum autorisés pour un champ de type texte. A seulement un impact sur l’interface et doit être complété à un réglage au niveau de <code>FormControl</code>.',
+			table: { category: 'inputs' },
 		},
 		width: {
 			options: setStoryOptions(FORM_FIELD_WIDTH),
@@ -70,9 +79,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une largeur fixe au champ. À n’utiliser que lorsque la grille de formulaire n’est pas adaptée.',
+			table: { category: 'inputs' },
 		},
 		rolePresentationLabel: {
 			description: "Applique role='presentation' au label du champ dans le cas où celui-ci ne doit pas être lu par le lecteur d’écran.",
+			table: { category: 'models' },
 		},
 	},
 	render: (args, { argTypes }) => {

--- a/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
+++ b/stories/documentation/forms/fields/multi-select/angular/multi-select.stories.ts
@@ -24,15 +24,19 @@ export default {
 			type: 'string',
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle. ',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le label du champ.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Modifie le placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -40,6 +44,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		width: {
 			options: setStoryOptions(FORM_FIELD_WIDTH),
@@ -47,9 +52,11 @@ export default {
 				type: 'select',
 			},
 			description: '[v19.2] Applique une largeur fixe au champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -57,27 +64,39 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		clearable: {
 			description: 'Affiche un bouton pour vider le champ lorsque celui-ci est rempli.',
+			table: { category: 'inputs' },
 		},
 		keepSearchAfterSelection: {
 			description: 'Permet de poursuivre la recherche après une sélection',
+			table: { category: 'inputs' },
 		},
 		loading: {
 			description: 'Applique l’état de chargement.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
-		onOpen: {
+		panelOpened: {
 			description: "Événement déclenché à l'ouverture du panneau de sélection.",
+			action: 'panelOpened',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
-		onClose: {
+		panelClosed: {
 			description: 'Événement déclenché à la fermeture du panneau de sélection.',
+			action: 'panelClosed',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		clueChange: HiddenArgType,
 		nextPage: HiddenArgType,
@@ -94,7 +113,7 @@ export const Basic: StoryObj<InputAlias<LuMultiSelectInputComponent<unknown> & F
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, presentation, ...inputArgs } = args;
 		const model = useStoryModel<ILegume[]>([]);
 		return {
-			props: { legumes: allLegumes, model },
+			props: { ...args, legumes: allLegumes, model },
 			template: `<lu-form-field ${generateInputs(
 				{
 					label,
@@ -108,7 +127,7 @@ export const Basic: StoryObj<InputAlias<LuMultiSelectInputComponent<unknown> & F
 				},
 				argTypes,
 			)}>
-	<lu-multi-select [(ngModel)]="model.example" [options]="legumes | filterLegumes:clue" (clueChange)="clue = $event"${generateInputs(inputArgs, argTypes)} />
+	<lu-multi-select [(ngModel)]="model.example" [options]="legumes | filterLegumes:clue" (clueChange)="clue = $event"${generateInputs(inputArgs, argTypes)} (panelOpened)="panelOpened()" (panelClosed)="panelClosed()" />
 </lu-form-field>
 <pr-story-model-display>{{ model.example | json }}</pr-story-model-display>`,
 			moduleMetadata: {

--- a/stories/documentation/forms/fields/multilanguage/angular/multilanguage-field.stories.ts
+++ b/stories/documentation/forms/fields/multilanguage/angular/multilanguage-field.stories.ts
@@ -25,18 +25,21 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label du champ.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: ['S', 'M'],
@@ -44,15 +47,18 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille de la checkbox.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -60,16 +66,20 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Modifie le placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		openOnFocus: {
 			description: 'Ouvre le panel automatiquement au focus du champ.',
+			table: { category: 'inputs' },
 		},
 		width: {
 			options: setStoryOptions(FORM_FIELD_WIDTH),
@@ -77,24 +87,30 @@ export default {
 				type: 'select',
 			},
 			description: '[v19.2] Applique une largeur fixe au champ. À n’utiliser que lorsque la grille de formulaire n’est pas adaptée.',
+			table: { category: 'inputs' },
 		},
 		autocomplete: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie l’attribut autocomplete des champs input.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 		hasNoInvariant: {
 			description: "[v21.3] Supprime la notion d'invariant du champ, nécessite d'être associé à un Validateur required et l'utilisation de `displayLocale`.",
+			table: { category: 'inputs' },
 		},
 		hasAIButtons: {
 			description: "[v21.3] Ajoute les boutons 'translate with ai', qui émettent la locale à traduire via l'output `translateWithAI`",
+			table: { category: 'inputs' },
 		},
 		displayLocale: {
 			description: '[v21.3] Locale à utiliser comme valeur affichée dans le champ en version collapsed lorsque `hasNoInvariant` est active.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/number-format/angular/number-format-field.stories.ts
+++ b/stories/documentation/forms/fields/number-format/angular/number-format-field.stories.ts
@@ -25,6 +25,7 @@ export default {
 			type: 'string',
 			description: 'Affiche une icône (?) associée à une info-bulle. ',
 			if: { arg: 'hiddenLabel', truthy: false },
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -32,9 +33,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -42,39 +45,50 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		required: {
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		hasClearer: {
 			description: 'Affiche un bouton pour vider le champ lorsque celui-ci est rempli.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Modifie le placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		valueAlignRight: {
 			description: 'Aligne la valeur du champ à droite.',
+			table: { category: 'inputs' },
 		},
 		useAutoPrefixSuffix: {
 			type: 'boolean',
 			description: 'Affiche le préfixe ou suffixe (en fonction de la locale)',
+			table: { category: 'inputs' },
 		},
 		min: {
 			type: 'number',
 			description: 'Définit une valeur minimale.',
+			table: { category: 'inputs' },
 		},
 		max: {
 			type: 'number',
 			description: 'Définit une valeur maximale.',
+			table: { category: 'inputs' },
 		},
 		formatStyle: {
 			options: ['decimal', 'percent', 'currency', 'unit'],
@@ -82,6 +96,7 @@ export default {
 				type: 'select',
 			},
 			description: 'En <code>percent</code>, la valeur est comprise entre 0 et 1',
+			table: { category: 'inputs' },
 		},
 		currency: {
 			options: ['EUR', 'USD', 'CNY', 'JPY'],
@@ -89,6 +104,7 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'formatStyle', eq: 'currency' },
+			table: { category: 'inputs' },
 		},
 		currencyDisplay: {
 			options: ['code', 'symbol', 'narrowSymbol', 'name'],
@@ -96,6 +112,7 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'formatStyle', eq: 'currency' },
+			table: { category: 'inputs' },
 		},
 		unit: {
 			options: ['second', 'kilometer', 'kilogram'],
@@ -103,6 +120,7 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'formatStyle', eq: 'unit' },
+			table: { category: 'inputs' },
 		},
 		unitDisplay: {
 			options: ['short', 'narrow', 'long'],
@@ -110,6 +128,7 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'formatStyle', eq: 'unit' },
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/number/angular/number-field.stories.ts
+++ b/stories/documentation/forms/fields/number/angular/number-field.stories.ts
@@ -21,6 +21,7 @@ export default {
 			type: 'string',
 			description: 'Affiche une icône (?) associée à une info-bulle. ',
 			if: { arg: 'hiddenLabel', truthy: false },
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -28,9 +29,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -38,39 +41,51 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		required: {
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		hasClearer: {
 			description: 'Affiche un bouton pour vider le champ lorsque celui-ci est rempli. Il est alors conseillé de masquer les boutons d’incrémentation (noSpinButtons).',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Modifie le placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		step: {
 			description: 'Modifie le pas d’incrémentation.',
+			table: { category: 'inputs' },
 		},
 		min: {
 			description: 'Définit une valeur minimale.',
+			table: { category: 'inputs' },
 		},
 		max: {
 			description: 'Définit une valeur maximale.',
+			table: { category: 'inputs' },
 		},
 		valueAlignRight: {
 			description: 'Aligne la valeur du champ à droite.',
+			table: { category: 'inputs' },
 		},
 		noSpinButtons: {
 			description: 'Masque les boutons d’incrémentation.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/phone-number-input/angular/phone-number-input.stories.ts
+++ b/stories/documentation/forms/fields/phone-number-input/angular/phone-number-input.stories.ts
@@ -60,18 +60,21 @@ export const Basic: StoryObj<PhoneNumberInputComponent & FormFieldComponent & { 
 				type: 'boolean',
 			},
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label du champ.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -79,15 +82,18 @@ export const Basic: StoryObj<PhoneNumberInputComponent & FormFieldComponent & { 
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -95,9 +101,11 @@ export const Basic: StoryObj<PhoneNumberInputComponent & FormFieldComponent & { 
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		errorInlineMessage: {
 			description: 'Ajoute un texte d’erreur sous le champ lorsque celui-ci est en erreur.',
+			table: { category: 'inputs' },
 		},
 		autocomplete: {
 			options: setStoryOptions(PHONE_NUMBER_INPUT_AUTOCOMPLETE),
@@ -105,16 +113,20 @@ export const Basic: StoryObj<PhoneNumberInputComponent & FormFieldComponent & { 
 				type: 'select',
 			},
 			description: 'Modifie le comportement autocomplete du champ.',
+			table: { category: 'inputs' },
 		},
 		noAutoPlaceholder: {
 			description: '[v19.2] Désactive le placeholder.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 	args: {

--- a/stories/documentation/forms/fields/radio/angular/radio-field.stories.ts
+++ b/stories/documentation/forms/fields/radio/angular/radio-field.stories.ts
@@ -23,6 +23,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du radio.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -30,37 +31,45 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 		inline: {
 			description: 'Affiche les différentes options sur un axe horizontal.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
+++ b/stories/documentation/forms/fields/rich-text/angular/rich-text-input.stories.ts
@@ -28,27 +28,35 @@ export default {
 	argTypes: {
 		value: {
 			description: '[Story] Valeur du champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Applique un placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		disableSpellcheck: {
 			description: 'Désactive le correcteur d’orthographe.',
+			table: { category: 'inputs' },
 		},
 		autoResize: {
 			description: 'Active / désactive l’autoresize du champ.',
+			table: { category: 'inputs' },
 		},
 		hideToolbar: {
 			description: 'Masque les options de mise en forme.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
+++ b/stories/documentation/forms/fields/simple-select/angular/simple-select.stories.ts
@@ -24,12 +24,15 @@ export default {
 			type: 'string',
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle. ',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le label du champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Modifie le placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -37,6 +40,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		width: {
 			options: setStoryOptions(FORM_FIELD_WIDTH),
@@ -44,9 +48,11 @@ export default {
 				type: 'select',
 			},
 			description: '[v19.2] Applique une largeur fixe au champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -54,27 +60,39 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		clearable: {
 			description: 'Affiche un bouton pour vider le champ lorsque celui-ci est rempli.',
+			table: { category: 'inputs' },
 		},
 		loading: {
 			description: 'Applique l’état de chargement.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
-		onOpen: {
+		panelOpened: {
 			description: "Événement déclenché à l'ouverture du panneau de sélection.",
+			action: 'panelOpened',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
-		onClose: {
+		panelClosed: {
 			description: 'Événement déclenché à la fermeture du panneau de sélection.',
+			action: 'panelClosed',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		optionComparer: HiddenArgType,
 		options: HiddenArgType,
@@ -99,7 +117,7 @@ export const Basic: StoryObj<
 		const { label, hiddenLabel, tooltip, inlineMessage, inlineMessageState, size, width, presentation, ...inputArgs } = args;
 		const model = useStoryModel<ILegume>(allLegumes[0]);
 		return {
-			props: { legumes: allLegumes, model },
+			props: { ...args, legumes: allLegumes, model },
 			template: `<lu-form-field ${generateInputs(
 				{
 					label,
@@ -113,7 +131,7 @@ export const Basic: StoryObj<
 				},
 				argTypes,
 			)}>
-	<lu-simple-select ${generateInputs(inputArgs, argTypes)}
+	<lu-simple-select ${generateInputs(inputArgs, argTypes)} (panelOpened)="panelOpened()" (panelClosed)="panelClosed()"
 		[options]="legumes | filterLegumes:clue"
 		(clueChange)="clue = $event"
 		[(ngModel)]="model.example">

--- a/stories/documentation/forms/fields/switch/angular/switch-field.stories.ts
+++ b/stories/documentation/forms/fields/switch/angular/switch-field.stories.ts
@@ -23,12 +23,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du switch.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -36,28 +38,34 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/text/angular/text-field.stories.ts
+++ b/stories/documentation/forms/fields/text/angular/text-field.stories.ts
@@ -28,20 +28,24 @@ export default {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		tag: {
 			type: 'string',
 			description: 'Ajoute un tag après le label du champ.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -49,12 +53,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -62,6 +68,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		type: {
 			options: ['text', 'email', 'password', 'url'],
@@ -69,16 +76,20 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		valueAlignRight: {
 			description: 'Aligne la valeur du champ à droite.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		autocomplete: {
 			type: 'string',
 			description: 'Modifie le comportement autocomplete du champ.',
+			table: { category: 'inputs' },
 		},
 		width: {
 			options: setStoryOptions(FORM_FIELD_WIDTH),
@@ -86,36 +97,47 @@ export default {
 				type: 'select',
 			},
 			description: '[v19.2] Applique une largeur fixe au champ.',
+			table: { category: 'inputs' },
 		},
 		AI: {
 			description: '[v20.3] Indique que la valeur du champ a été générée par IA.',
+			table: { category: 'inputs' },
 		},
 		iconAIalt: {
 			description: 'Information restituée par le lecteur d’écran.',
+			table: { category: 'inputs' },
 		},
 		iconAItooltip: {
 			description: 'Ajoute une info-bulle à l’icône AI.',
+			table: { category: 'inputs' },
 		},
 		hasClearer: {
 			description: 'Affiche un bouton pour vider le champ lorsque celui-ci est rempli.',
+			table: { category: 'inputs' },
 		},
 		hasSearchIcon: {
 			description: 'Affiche une icône de recherche.',
+			table: { category: 'inputs' },
 		},
 		searchIcon: {
 			description: 'Modifie l’icône (loupe par défaut)',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Applique un placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		counter: {
 			description: 'Indique le nombre de caractères maximum du champ. Cette information n’est présente qu’à titre indicatif. La longueur du champ doit également être limitée via formControl.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: 'Affiche une version présentation, en lecture seule, de la valeur',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/fields/textarea/angular/textarea-field.stories.ts
+++ b/stories/documentation/forms/fields/textarea/angular/textarea-field.stories.ts
@@ -21,22 +21,27 @@ export default {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le champ.',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Applique un placeholder au champ.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FORM_FIELD_SIZE),
@@ -44,12 +49,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -57,31 +64,39 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		rows: {
 			control: { type: 'number' },
 			description: 'Nombre de lignes visibles par défaut.',
+			table: { category: 'inputs' },
 		},
 		autoResize: {
 			type: 'boolean',
 			description: 'Active l’autoresize du champ.',
+			table: { category: 'inputs' },
 		},
 		autoResizeScrollIntoView: {
 			type: 'boolean',
 			if: { arg: 'autoResize', truthy: true },
 			description: 'Assure que le curseur de saisie soit toujours visible à l’écran en appliquant un scroll.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+			table: { category: 'inputs' },
 		},
 		counter: {
 			description: 'Indique le nombre de caractères maximum du champ. Cette information n’est présente qu’à titre indicatif. La longueur du champ doit également être limitée via formControl.',
+			table: { category: 'inputs' },
 		},
 		disableSpellcheck: {
 			description: 'Désactive le correcteur d’orthographe.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 		value: {
 			table: { disable: true },

--- a/stories/documentation/forms/fieldset/angular/fieldset-basic.stories.ts
+++ b/stories/documentation/forms/fieldset/angular/fieldset-basic.stories.ts
@@ -18,6 +18,7 @@ export default {
 			},
 			if: { arg: 'expandable', truthy: false },
 			description: 'Place le titre du fieldset à gauche des champs.',
+			table: { category: 'inputs' },
 		},
 		expandable: {
 			control: {
@@ -25,10 +26,12 @@ export default {
 			},
 			if: { arg: 'horizontal', truthy: false },
 			description: 'Permet au fieldset de se replier.',
+			table: { category: 'inputs' },
 		},
 		withAction: {
 			if: { arg: 'expandable', eq: false },
 			description: 'Ajoute un bouton d’action à droite du titre.',
+			table: { category: 'inputs' },
 		},
 		expanded: {
 			control: {
@@ -36,6 +39,7 @@ export default {
 			},
 			if: { arg: 'expandable', truthy: true },
 			description: 'Affiche le fieldset en vue dépliée.',
+			table: { category: 'models' },
 		},
 		hiddenLegend: {
 			control: {
@@ -43,6 +47,7 @@ export default {
 			},
 			if: { arg: 'expandable', truthy: false },
 			description: 'Masque la légende en la conservant dans le DOM pour les lecteurs d’écrans. ',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FIELDSET_SIZE),
@@ -50,27 +55,32 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du fieldset.',
+			table: { category: 'inputs' },
 		},
 		heading: {
 			control: {
 				type: 'text',
 			},
 			description: 'Titre du fieldset. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		helper: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un sous-titre au fieldset. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 		maxWidth: {
 			control: {
 				type: 'boolean',
 			},
 			description: "Applique la largeur maximale d'un formulaire au fieldset (cette largeur maximale est généralement appliquée par le formulaire lui-même).",
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/forms/file-entry/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-entry/angular/basic.stories.ts
@@ -12,6 +12,7 @@ export default {
 				type: 'radio',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		state: {
 			options: setStoryOptions(FILE_ENTRY_STATE),
@@ -19,61 +20,83 @@ export default {
 				type: 'radio',
 			},
 			description: 'Modifie l’état du composant.',
+			table: { category: 'inputs' },
 		},
 		previewUrl: {
 			if: { arg: 'iconOverride', truthy: false },
 			description: 'URL de prévisualisation de l’image uploadée.',
+			table: { category: 'inputs' },
 		},
 		displayFileName: {
 			if: { arg: 'media', truthy: true },
 			description: 'Affiche le nom du fichier sous l’image en vue <code>media</code>.',
+			table: { category: 'inputs' },
 		},
 		media: {
 			description: 'Affiche le fichier avec une mise en forme adaptée aux visuels.',
+			table: { category: 'inputs' },
 		},
 		iconOverride: {
 			description: 'Remplace l’icône de format de fichier.',
+			table: { category: 'inputs' },
 		},
 		downloadURL: {
 			description: 'URL de téléchargement du fichier.',
+			table: { category: 'inputs' },
 		},
 		openInNewTab: {
 			description: 'Ouvre le fichier dans un nouvel onglet au lieu de le télécharger. Peut varier selon les navigateurs ou les réglages utilisateurs.',
 			if: { arg: 'downloadURL', truthy: true },
+			table: { category: 'inputs' },
 		},
 		inlineMessageError: {
 			description: 'Message d’erreur affiché sous le composant.',
+			table: { category: 'inputs' },
 		},
 		deletable: {
 			description: 'Affiche un bouton de suppression.',
+			table: { category: 'inputs' },
 		},
 		withPassword: {
 			description: 'Affiche un champ permettant de définir un mot de passe au fichier.',
+			table: { category: 'inputs' },
 		},
 		fileName: {
 			description: 'Nom du fichier.',
+			table: { category: 'inputs' },
 		},
 		fileSize: {
 			description: 'Poids du fichier (en octets).',
+			table: { category: 'inputs' },
 		},
 		fileType: {
 			description: 'Type MIME du fichier.',
+			table: { category: 'inputs' },
 		},
 		structure: {
 			if: { arg: 'size', truthy: true },
 			description: 'Augmente le border-radius du champ pour l’utiliser en élément de structure.',
+			table: { category: 'inputs' },
 		},
 		withFileType: {
 			control: 'boolean',
+			table: { category: 'inputs' },
 		},
 		withFileSize: {
 			control: 'boolean',
+			table: { category: 'inputs' },
 		},
 		deleteFile: {
 			description: 'Événement déclenché lors du clic sur le bouton de suppression du fichier.',
+			action: 'deleteFile',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		passwordChange: {
 			description: 'Événement déclenché lors de la modification du mot de passe du fichier.',
+			action: 'passwordChange',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'string' } },
 		},
 	},
 	decorators: [
@@ -86,10 +109,13 @@ export default {
 		const { fileName, fileSize, fileType, deletable, withPassword, structure, ...otherArgs } = args;
 
 		const deletableParam = deletable ? ` (deleteFile)="deleteFile()"` : ``;
-		const withPasswordParam = withPassword ? ` (passwordChange)="passwordChange()"` : ``;
+		const withPasswordParam = withPassword ? ` (passwordChange)="passwordChange($event)"` : ``;
 		const structureParam = structure ? ` structure` : ``;
 
 		return {
+			props: {
+				...args,
+			},
 			template: `<lu-file-entry${structureParam}${deletableParam}${withPasswordParam} [entry]="{
 			name: '${fileName}',
 			size: ${fileSize},

--- a/stories/documentation/forms/file-upload/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-upload/angular/basic.stories.ts
@@ -119,12 +119,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		fileMaxSize: {
 			description: 'Limite le poids des fichiers importables (en octets).',
 			control: {
 				type: null,
 			},
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			options: ['invoice', 'picture'],
@@ -132,28 +134,35 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’illustration de l’icône dans la zone de drop.',
+			table: { category: 'inputs' },
 		},
 		media: {
 			description: 'Affiche les fichiers importés avec une mise en forme adaptée aux visuels.',
+			table: { category: 'inputs' },
 		},
 		displayFileName: {
 			description: 'Affiche le nom des fichiers importés sous l’image en vue <code>media</code>.',
+			table: { category: 'inputs' },
 		},
 		structure: {
 			description: 'Augmente le border-radius du champ pour l’utiliser en élément de structure.',
+			table: { category: 'inputs' },
 		},
 		buttonFilled: {
 			description: 'Affiche le bouton comme action principale de la page.',
 			if: { arg: 'size', truthy: true },
+			table: { category: 'inputs' },
 		},
 		accept: {
 			control: {
 				type: 'object',
 			},
 			description: 'Liste des formats de fichiers acceptés.',
+			table: { category: 'inputs' },
 		},
 		AItag: {
 			description: '[Story] Ajoute un tag AI au contenu du composant.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/forms/filter-pills/angular/filter-pills.stories.ts
+++ b/stories/documentation/forms/filter-pills/angular/filter-pills.stories.ts
@@ -48,25 +48,31 @@ export default {
 	argTypes: {
 		clearable: {
 			description: 'Affiche une croix pour réinitialiser le filtre si celui-ci est renseigné.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le label du filtre.',
+			table: { category: 'inputs' },
 		},
 		filterPillLabelPlural: {
 			description: 'Dans le cas d’un multi select, permet de définir le label lorsque plusieurs éléments sont sélectionnés.',
+			table: { category: 'inputs' },
 		},
 		optional: {
 			description:
 				'Rend disponible le filtre via le bouton d’ajout de filtre. Celui-ci est désactivé par défaut. Lorsque qu’un filtre est optionnel, celui-ci doit obligatoirement porter un attribut `name`. (Voir Filter bar)',
+			table: { category: 'inputs' },
 		},
 		name: {
 			description: 'Dans le cas d’un filtre optionnel, permet de faire le lien entre la liste de filtres disponible et l’affichage du filtre.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Désactive le filtre.',
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args, { argTypes }) => {

--- a/stories/documentation/forms/form-label/angular/form-label-basic.stories.ts
+++ b/stories/documentation/forms/form-label/angular/form-label-basic.stories.ts
@@ -33,6 +33,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		counterStatus: {
 			if: { arg: 'counterMax', truthy: true },
@@ -41,12 +42,15 @@ export default {
 				step: 1,
 			},
 			description: 'Nombre de caractères actuellement saisis.',
+			table: { category: 'inputs' },
 		},
 		counterId: {
 			if: { arg: 'counterMax', truthy: true },
+			table: { category: 'inputs' },
 		},
 		labelId: {
 			if: { arg: 'counterMax', truthy: true },
+			table: { category: 'inputs' },
 		},
 		counterMax: {
 			control: {
@@ -54,21 +58,27 @@ export default {
 				step: 1,
 			},
 			description: 'Définit la valeur maximale du compteur de caractères.',
+			table: { category: 'inputs' },
 		},
 		for: {
 			description: 'ID du champ de formulaire associé au label.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		tag: {
 			description: 'Ajoute un tag associé au label.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		error: {
 			description: 'Applique l’état d’erreur au label.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/input-framed/angular/basic.stories.ts
+++ b/stories/documentation/forms/input-framed/angular/basic.stories.ts
@@ -44,28 +44,36 @@ export default {
 	argTypes: {
 		panel: {
 			description: 'Ajoute une section visible lorsque le champ est sélectionné.',
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			description: 'Slot dédié à l’ajout d’illustrations.',
+			table: { category: 'inputs' },
 		},
 		info: {
 			description: 'Ajoute une section informative toujours visible sous le champ.',
+			table: { category: 'inputs' },
 		},
 		tag: {
 			description: 'Ajoute un tag après le label du champ.',
+			table: { category: 'inputs' },
 		},
 		checkbox: {
 			description: 'Passe le composant au format checkbox.',
+			table: { category: 'inputs' },
 		},
 		center: {
 			description: 'Aligne le champ et son illustration verticalement lorsque le label est trop court.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		grid: {
 			if: { arg: 'panel', truthy: false },
 			description: 'Affiche les différentes options dans une grille.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(INPUT_FRAMED_SIZE),
@@ -73,9 +81,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args: InputFramedBasicStory) => {

--- a/stories/documentation/forms/listbox-option/angular/basic.stories.ts
+++ b/stories/documentation/forms/listbox-option/angular/basic.stories.ts
@@ -18,16 +18,19 @@ export default {
 	argTypes: {
 		multiple: {
 			description: 'Ajoute une checkbox à l’option.',
+			table: { category: 'inputs' },
 		},
 		state: {
 			control: 'select',
 			options: setStoryOptions(LISTBOX_STATE),
 			description: "Modifie l'état de l'option.",
+			table: { category: 'inputs' },
 		},
 		withOption: {
 			type: 'boolean',
 			if: { arg: 'state', truthy: true },
 			description: 'Conserve l’affichage des options déjà chargées.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args: OptionBasicStory) => {

--- a/stories/documentation/forms/listbox-option/angular/group.stories.ts
+++ b/stories/documentation/forms/listbox-option/angular/group.stories.ts
@@ -17,6 +17,7 @@ export default {
 	argTypes: {
 		multiple: {
 			description: 'Ajoute une checkbox à l’option.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args: OptionBasicStory) => {

--- a/stories/documentation/forms/listbox-option/angular/tree.stories.ts
+++ b/stories/documentation/forms/listbox-option/angular/tree.stories.ts
@@ -13,6 +13,7 @@ export default {
 	argTypes: {
 		multiple: {
 			description: 'Ajoute une checkbox à l’option.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args) => {

--- a/stories/documentation/forms/select/multi-select.stories.ts
+++ b/stories/documentation/forms/select/multi-select.stories.ts
@@ -358,8 +358,8 @@ export const Basic = generateStory({
 			keepSearchAfterSelection: false,
 		},
 		argTypes: {
-			clearable: { control: { type: 'boolean' } },
-			maxValuesShown: { control: { type: 'number' } },
+			clearable: { control: { type: 'boolean' }, table: { category: 'inputs' } },
+			maxValuesShown: { control: { type: 'number' }, table: { category: 'inputs' } },
 		},
 	},
 });
@@ -1035,8 +1035,8 @@ export const TestDynamicDisabled = generateStory({
 			),
 		} as any,
 		argTypes: {
-			clearable: { control: { type: 'boolean' } },
-			maxValuesShown: { control: { type: 'number' } },
+			clearable: { control: { type: 'boolean' }, table: { category: 'inputs' } },
+			maxValuesShown: { control: { type: 'number' }, table: { category: 'inputs' } },
 		},
 	},
 });
@@ -1063,6 +1063,7 @@ export const AddOption = generateStory({
 			addOptionLabel: {
 				control: { type: 'text' },
 				description: 'Label affiché sur le bouton d’ajout d’option.',
+				table: { category: 'inputs' },
 			},
 			addOptionStrategy: {
 				description: 'Définit les conditions pour afficher le bouton d’ajout d’option.',
@@ -1070,6 +1071,7 @@ export const AddOption = generateStory({
 					type: 'select',
 					options: ['never', 'always', 'if-empty-clue', 'if-not-empty-clue'],
 				},
+				table: { category: 'inputs' },
 			},
 		},
 		args: {

--- a/stories/documentation/forms/select/simple-select.stories.ts
+++ b/stories/documentation/forms/select/simple-select.stories.ts
@@ -103,7 +103,7 @@ export const Basic = generateStory({
 	},
 	storyPartial: {
 		argTypes: {
-			clearable: { control: { type: 'boolean' } },
+			clearable: { control: { type: 'boolean' }, table: { category: 'inputs' } },
 		},
 	},
 });
@@ -773,6 +773,7 @@ export const AddOption = generateStory({
 			addOptionLabel: {
 				control: { type: 'text' },
 				description: 'Label affiché sur le bouton d’ajout d’option.',
+				table: { category: 'inputs' },
 			},
 			addOptionStrategy: {
 				description: 'Définit les conditions pour afficher le bouton d’ajout d’option.',
@@ -780,6 +781,7 @@ export const AddOption = generateStory({
 					type: 'select',
 					options: ['never', 'always', 'if-empty-clue', 'if-not-empty-clue'],
 				},
+				table: { category: 'inputs' },
 			},
 		},
 		args: {

--- a/stories/documentation/forms/time/angular/time-picker-basic.stories.ts
+++ b/stories/documentation/forms/time/angular/time-picker-basic.stories.ts
@@ -21,12 +21,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -34,49 +36,58 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		displayArrows: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Affiche les boutons d’incrémentation.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Désactive le composant.',
+			table: { category: 'models' },
 		},
 		step: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le pas d’incrémentation.',
+			table: { category: 'inputs' },
 		},
 		max: {
 			control: {
 				type: 'text',
 			},
 			description: 'Définit une valeur maximale.',
+			table: { category: 'inputs' },
 		},
 		forceMeridiemDisplay: {
 			options: ['', false, true],
@@ -84,9 +95,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Force l’affichage de l’indicateur AM/PM',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/time/angular/time-picker-duration.stories.ts
+++ b/stories/documentation/forms/time/angular/time-picker-duration.stories.ts
@@ -21,12 +21,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: setStoryOptions(INLINE_MESSAGE_STATE),
@@ -34,58 +36,69 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’état de l’inline message.',
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le label de l’input.',
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		hideZeroValue: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Masque le contenu du champ lorsque sa valeur est nulle.',
+			table: { category: 'inputs' },
 		},
 		displayArrows: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Affiche les boutons d’incrémentation.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Désactive le composant.',
+			table: { category: 'models' },
 		},
 		step: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le pas d’incrémentation.',
+			table: { category: 'inputs' },
 		},
 		max: {
 			control: {
 				type: 'text',
 			},
 			description: '[v21.1] Définit une valeur maximale.',
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/forms/time/angular/time-range-picker.stories.ts
+++ b/stories/documentation/forms/time/angular/time-range-picker.stories.ts
@@ -24,12 +24,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du champ.',
+			table: { category: 'inputs' },
 		},
 		inlineMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte descriptif (aide, erreur, etc.) sous le champ de formulaire.',
+			table: { category: 'inputs' },
 		},
 		inlineMessageState: {
 			options: ['default', 'success', 'warning', 'error'],
@@ -37,49 +39,58 @@ export default {
 				type: 'select',
 			},
 			description: "Modifie l'état de l'inline message.",
+			table: { category: 'inputs' },
 		},
 		tooltip: {
 			if: { arg: 'hiddenLabel', truthy: false },
 			description: 'Affiche une icône (?) associée à une info-bulle.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: "Masque le label en le conservant dans le DOM pour les lecteurs d'écrans.",
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: "Modifie le label de l'input.",
+			table: { category: 'inputs' },
 		},
 		required: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Marque le champ comme obligatoire.',
+			table: { category: 'inputs' },
 		},
 		displayArrows: {
 			control: {
 				type: 'boolean',
 			},
 			description: "Affiche les boutons d'incrémention.",
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Désactive le composant.',
+			table: { category: 'models' },
 		},
 		step: {
 			control: {
 				type: 'text',
 			},
 			description: "Modifie le pas d'incrémentation.",
+			table: { category: 'inputs' },
 		},
 		max: {
 			control: {
 				type: 'text',
 			},
 			description: 'Définit une valeur maximale.',
+			table: { category: 'inputs' },
 		},
 		forceMeridiemDisplay: {
 			options: [null, false, true],
@@ -87,9 +98,11 @@ export default {
 				type: 'select',
 			},
 			description: "Force l'affichage de l'indicateur AM/PM",
+			table: { category: 'inputs' },
 		},
 		presentation: {
 			description: '[v21.1] Transforme le champ de formulaire en donnée textuelle non éditable.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/intl/intl.stories.ts
+++ b/stories/documentation/intl/intl.stories.ts
@@ -34,6 +34,7 @@ export const Basic: StoryObj<IntlStory> = {
 	argTypes: {
 		resultIntl: {
 			control: 'text',
+			table: { category: 'inputs' },
 		},
 	},
 };

--- a/stories/documentation/listings/activity-feed/angular/basic.stories.ts
+++ b/stories/documentation/listings/activity-feed/angular/basic.stories.ts
@@ -26,26 +26,32 @@ export default {
 		statusStep: {
 			control: 'boolean',
 			description: 'Exemple avec des étapes success et critical.',
+			table: { category: 'inputs' },
 		},
 		pendingStep: {
 			control: 'boolean',
 			description: 'Exemple avec une étape en attente.',
+			table: { category: 'inputs' },
 		},
 		updated: {
 			control: 'boolean',
 			description: 'Présente une étape avec des valeurs modifiées grâce aux sous-composant <code>lu-activity-feed-update</code> et <code>lu-activity-feed-update-item</code>.',
+			table: { category: 'inputs' },
 		},
 		attachedContent: {
 			options: ['none', 'file', 'readMore'],
 			control: { type: 'select' },
 			description: 'Présente une étape avec un contenu attaché (fichier ou commentaire).',
+			table: { category: 'inputs' },
 		},
 		addAction: {
 			control: 'boolean',
 			description: 'Exemple avec un bouton d’action supplémentaire à la fin du fil d’activité.',
+			table: { category: 'inputs' },
 		},
 		user: {
 			description: 'Permet de définir l’utilisateur présenté dans l’avatar',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/chip/angular/basic.stories.ts
+++ b/stories/documentation/listings/chip/angular/basic.stories.ts
@@ -22,27 +22,32 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Rend le chip non supprimable.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Désactive le composant.',
+			table: { category: 'inputs' },
 		},
 		product: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Applique la palette product au composant.',
+			table: { category: 'inputs' },
 		},
 		withEllipsis: {
 			description: '[20.1] Ellipse le texte et ajoute une tooltip lorsque le label est trop long.',
+			table: { category: 'inputs' },
 		},
 		small: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		feedback: {
 			description: "[20.1] Donne une information sur l'état du composant.",
@@ -50,6 +55,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: IconsList.map((i) => i.icon),
@@ -57,9 +63,13 @@ export default {
 				type: 'select',
 			},
 			description: 'Ajoute une icône au chip.',
+			table: { category: 'inputs' },
 		},
 		kill: {
 			description: 'Événement déclenché lors du clic sur le bouton de suppression du chip.',
+			action: 'kill',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'Event' } },
 		},
 	},
 	decorators: [
@@ -77,7 +87,7 @@ function getTemplate(args: ChipBasicStory): string {
 	const small = args.small ? ` size="S"` : ``;
 	const feedback = args.feedback === 'warning' ? ` state="warning"` : args.feedback === 'critical' ? ` state="critical"` : ``;
 	const icon = args.icon ? ` icon="${args.icon}"` : ``;
-	return `<lu-chip${disabled}${unkillable}${product}${ellipsis}${small}${feedback}${icon}>Label</lu-chip>`;
+	return `<lu-chip${disabled}${unkillable}${product}${ellipsis}${small}${feedback}${icon} (kill)="kill($event)">Label</lu-chip>`;
 }
 
 const Template = (args: ChipBasicStory) => ({

--- a/stories/documentation/listings/data-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/data-table/angular/basic.stories.ts
@@ -29,6 +29,7 @@ export default {
 	argTypes: {
 		empty: {
 			description: 'Affiche un empty state à la place des lignes de tableau.',
+			table: { category: 'inputs' },
 		},
 		sort: {
 			options: setStoryOptions(DATA_TABLE_SORT),
@@ -36,6 +37,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Définit l’état de tri d’une cellule d’en-tête.',
+			table: { category: 'models' },
 		},
 		align: {
 			options: setStoryOptions(DATA_TABLE_ALIGN),
@@ -43,6 +45,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Aligne le contenu des cellules horizontalement.',
+			table: { category: 'inputs' },
 		},
 		verticalAlign: {
 			options: setStoryOptions(DATA_TABLE_VERTICAL_ALIGN),
@@ -50,22 +53,27 @@ export default {
 				type: 'select',
 			},
 			description: 'Aligne le contenu des cellules verticalement.',
+			table: { category: 'inputs' },
 		},
 		inlineSize: {
 			if: { arg: 'layoutFixed', truthy: true },
 			description: 'Modifie la largeur d’une colonne lorsque <code>layoutFixed</code> est activé.',
+			table: { category: 'inputs' },
 		},
 		selected: {
 			if: { arg: 'selectable', truthy: true },
 			description: 'Applique l’état actif à une ligne sélectionnable.',
+			table: { category: 'models' },
 		},
 		selectedLabel: {
 			if: { arg: 'selectable', truthy: true },
 			description: 'Texte alternatif restitué à la sélection d’une ligne.',
+			table: { category: 'inputs' },
 		},
 		selectedLabelHead: {
 			if: { arg: 'selectable', truthy: true },
 			description: 'Texte alternatif restitué à la sélection de l’ensemble des lignes.',
+			table: { category: 'inputs' },
 		},
 		mixed: {
 			if: { arg: 'selectable', truthy: true },
@@ -73,31 +81,38 @@ export default {
 		},
 		disabled: {
 			if: { arg: 'selectable', truthy: true },
+			table: { category: 'inputs' },
 		},
 		inlineSizeValue: {
 			if: { arg: 'inlineSize', truthy: true },
+			table: { category: 'inputs' },
 		},
 		groupButtonAlt: {
 			if: { arg: 'group', truthy: true },
 			description: 'Texte alternatif restitué au focus de l’action sur le groupe.',
+			table: { category: 'inputs' },
 		},
 		expanded: {
 			if: { arg: 'group', truthy: true },
 			description: 'Affiche le groupe dans son état étendu.',
+			table: { category: 'models' },
 		},
 		cols: {
 			control: { type: 'range', min: 2, max: 6 },
 			description: 'Modifie le nombre de colonnes dans la story.',
+			table: { category: 'inputs' },
 		},
 		lines: {
 			control: { type: 'range', min: 2, max: 6 },
 			description: 'Modifie le nombre de lignes dans la story.',
+			table: { category: 'inputs' },
 		},
 		tfoot: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Affiche un footer.',
+			table: { category: 'inputs' },
 		},
 		stickyHeader: HiddenArgType,
 		hover: {
@@ -105,54 +120,63 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Marque la ligne au survol pour faciliter la lisibilité des tableaux larges (ne sous-entend pas une interaction).',
+			table: { category: 'inputs' },
 		},
 		cellBorder: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Ajoute un séparateur vertical entre les cellules.',
+			table: { category: 'inputs' },
 		},
 		layoutFixed: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Applique une largeur fixe aux colonnes. La largeur d’une colonne peut être redéfinie via <code>fixedWidth</code>.',
+			table: { category: 'inputs' },
 		},
 		selectable: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Rend les lignes du tableau sélectionnables via des checkbox.',
+			table: { category: 'inputs' },
 		},
 		group: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Présente un groupe de lignes dans la story.',
+			table: { category: 'inputs' },
 		},
 		editable: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Ajoute un champ de saisie dans une cellule.',
+			table: { category: 'inputs' },
 		},
 		nested: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Réduit le <code>border-radius</code> du tableau pour l’imbriquer dans un composant structure.',
+			table: { category: 'inputs' },
 		},
 		actions: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Ajoute des actions rapides à droite d’une ligne.',
+			table: { category: 'inputs' },
 		},
 		pagination: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Ajoute une pagination au tableau.',
+			table: { category: 'inputs' },
 		},
 		drag: HiddenArgType,
 	},

--- a/stories/documentation/listings/data-table/angular/draggable.stories.html
+++ b/stories/documentation/listings/data-table/angular/draggable.stories.html
@@ -5,7 +5,7 @@
 			<th luDataTableCell>Cell</th>
 		</tr>
 	</thead>
-	<tbody luDataTableBody cdkDropList (cdkDropListDropped)="drop($event)">
+	<tbody luDataTableBody cdkDropList (cdkDropListDropped)="onDrop($event)">
 		@for (item of listItem; track $index) {
 			<tr luDataTableRow selectedLabel="selectable" draggable cdkDrag>
 				<th luDataTableCell>{{ item.header }}</th>

--- a/stories/documentation/listings/data-table/angular/draggable.stories.ts
+++ b/stories/documentation/listings/data-table/angular/draggable.stories.ts
@@ -37,8 +37,12 @@ class DataTableDraggableStory {
 		{ id: 3, header: 'Header 3', cell: 'cell 3' },
 	];
 
-	drop(event: CdkDragDrop<string[]>) {
+	// Remplacé par l'action Storybook déclarée dans `argTypes`, d'où le typage en fonction optionnelle.
+	drop?: (event: CdkDragDrop<string[]>) => void;
+
+	onDrop(event: CdkDragDrop<string[]>) {
 		moveItemInArray(this.listItem, event.previousIndex, event.currentIndex);
+		this.drop?.(event);
 	}
 }
 
@@ -49,9 +53,13 @@ export default {
 		selectable: {
 			control: 'boolean',
 			description: 'Rend les lignes du tableau sélectionnables via des checkbox.',
+			table: { category: 'inputs' },
 		},
 		drop: {
 			description: 'Evénement déclenché au drop.',
+			action: 'drop',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'CdkDragDrop<string[]>' } },
 		},
 		listItem: HiddenArgType,
 	},

--- a/stories/documentation/listings/data-table/angular/overflow.stories.ts
+++ b/stories/documentation/listings/data-table/angular/overflow.stories.ts
@@ -22,27 +22,34 @@ export default {
 		cols: {
 			description: 'Nombre de colonnes.',
 			control: { type: 'range', min: 2, max: 8 },
+			table: { category: 'inputs' },
 		},
 		lines: {
 			description: 'Nombre de lignes.',
 			control: { type: 'range', min: 2, max: 8 },
+			table: { category: 'inputs' },
 		},
 		stickyColsStart: {
 			description: 'Nombre de colonnes figées depuis la gauche. Non compatible avec l’usage de colspan.',
 			control: { type: 'range', min: 0, max: 4 },
+			table: { category: 'inputs' },
 		},
 		stickyColsEnd: {
 			description: 'Nombre de colonnes figées depuis la droite. Non compatible avec l’usage de colspan.',
 			control: { type: 'range', min: 0, max: 4 },
+			table: { category: 'inputs' },
 		},
 		noOverflow: {
 			description: 'Désactive le défilement horizontal du tableau. Celui-ci prendra alors la place nécessaire pour afficher tout son contenu.',
+			table: { category: 'inputs' },
 		},
 		stickyHeader: {
 			description: 'Fige le header lors du défilement vertical.',
+			table: { category: 'inputs' },
 		},
 		pagination: {
 			description: 'Affiche une pagination sous le tableau.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/data-table/angular/responsive.stories.ts
+++ b/stories/documentation/listings/data-table/angular/responsive.stories.ts
@@ -20,12 +20,15 @@ export default {
 	argTypes: {
 		inlineSize: {
 			description: 'Modifie la largeur d’une colonne lorsque <code>layoutFixed</code> est activé.',
+			table: { category: 'inputs' },
 		},
 		inlineSizeValue: {
 			if: { arg: 'inlineSize', truthy: true },
+			table: { category: 'inputs' },
 		},
 		responsiveConfig: {
 			description: 'Applique une configuration responsive à LayoutFixed.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/index-table/angular/actions.stories.ts
+++ b/stories/documentation/listings/index-table/angular/actions.stories.ts
@@ -31,9 +31,11 @@ export default {
 		bob: HiddenArgType,
 		layoutFixed: {
 			description: 'Applique une largeur fixe aux colonnes.',
+			table: { category: 'inputs' },
 		},
 		dropdown: {
 			description: 'Remplace les boutons d’action par un menu déroulant.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/index-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/index-table/angular/basic.stories.ts
@@ -29,12 +29,15 @@ export default {
 		bob: HiddenArgType,
 		empty: {
 			description: 'Affiche un empty state à la place des lignes de tableau.',
+			table: { category: 'inputs' },
 		},
 		layoutFixed: {
 			description: 'Applique une largeur fixe aux colonnes.',
+			table: { category: 'inputs' },
 		},
 		selectable: {
 			description: 'Rend les lignes du tableau sélectionnables via des checkbox.',
+			table: { category: 'inputs' },
 		},
 		mixed: {
 			if: { arg: 'selectable', truthy: true },
@@ -49,24 +52,30 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie le type d’élément HTML cliquable.',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque les cellules d’en-tête du tableau.',
+			table: { category: 'inputs' },
 		},
 		expanded: {
 			if: { arg: 'group', truthy: true },
 			description: 'Affiche le groupe dans son état déplié.',
+			table: { category: 'models' },
 		},
 		group: {
 			description: 'Regroupe des lignes de tableau en les rendant dépliables.',
+			table: { category: 'inputs' },
 		},
 		groupButtonAlt: {
 			if: { arg: 'group', truthy: true },
 			description: 'Texte restitué par le bouton du groupe.',
+			table: { category: 'inputs' },
 		},
 		stack: {
 			control: { type: 'range', min: 1, max: 3 },
 			description: 'Affiche une ligne sous la forme d’un empilement d’éléments.',
+			table: { category: 'inputs' },
 		},
 		sort: {
 			options: setStoryOptions(INDEX_TABLE_SORT),
@@ -74,6 +83,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Définit l’état de tri d’une cellule d’en-tête.',
+			table: { category: 'models' },
 		},
 		align: {
 			options: setStoryOptions(INDEX_TABLE_ALIGN),
@@ -81,21 +91,27 @@ export default {
 				type: 'select',
 			},
 			description: 'Aligne le contenu des cellules horizontalement.',
+			table: { category: 'inputs' },
 		},
 		allowSelection: {
 			description: 'Permet de sélectionner le texte d’une cellule. Désactive l’action principal au clic sur la cellule.',
+			table: { category: 'inputs' },
 		},
 		allowAction: {
 			description: 'Permet de rendre une cellule cliquable. Désactive l’action principal au clic sur la cellule.',
+			table: { category: 'inputs' },
 		},
 		intermediateFooter: {
 			description: 'Présente une ligne de tableau sous la forme d’un footer intermédiaire. Exemple : Sous-total.',
+			table: { category: 'inputs' },
 		},
 		footer: {
 			description: 'Présente le tableau avec un footer.',
+			table: { category: 'inputs' },
 		},
 		pagination: {
 			description: 'Présente le tableau avec une pagination.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/index-table/angular/scrollbox.stories.ts
+++ b/stories/documentation/listings/index-table/angular/scrollbox.stories.ts
@@ -20,9 +20,11 @@ export default {
 	argTypes: {
 		layoutFixed: {
 			description: 'Applique une largeur fixe aux colonnes et force le tableau à se compresser dans le scrollbox.',
+			table: { category: 'inputs' },
 		},
 		pagination: {
 			description: 'Ajoute une pagination au tableau.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/listing/angular/basic.stories.ts
+++ b/stories/documentation/listings/listing/angular/basic.stories.ts
@@ -63,6 +63,7 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 				type: 'select',
 			},
 			description: 'Modifie le type de liste (ordonnée, checklist, icônes, etc.).<br>[v21.2] <code>orderedFancy</code>',
+			table: { category: 'inputs' },
 		},
 		defaultIcon: {
 			options: IconsList.map((i) => i.icon),
@@ -71,6 +72,7 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 			},
 			description: 'Modifie l’icône par défaut.',
 			if: { arg: 'type', eq: 'icons' },
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: IconsList.map((i) => i.icon),
@@ -79,19 +81,22 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 			},
 			description: 'Modifie l’icône d’un élément de la liste.',
 			if: { arg: 'type', eq: 'icons' },
+			table: { category: 'inputs' },
 		},
 		start: {
 			if: { arg: 'type', eq: 'ordered' },
 			description: 'Modifie la valeur initiale de la liste.',
+			table: { category: 'inputs' },
 		},
 		reversed: {
 			if: { arg: 'type', eq: 'ordered' },
 			description: 'Présente la liste sous forme décroissante.',
+			table: { category: 'inputs' },
 		},
 		checklist: HiddenArgType,
 		icons: HiddenArgType,
 		ordered: HiddenArgType,
-		palette: PaletteAllArgType,
+		palette: { ...PaletteAllArgType, table: { category: 'inputs' } },
 	},
 
 	args: {

--- a/stories/documentation/listings/listing/angular/inline.stories.ts
+++ b/stories/documentation/listings/listing/angular/inline.stories.ts
@@ -53,6 +53,7 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 				type: 'select',
 			},
 			description: 'Modifie le type de liste (checklist, icônes, etc.)',
+			table: { category: 'inputs' },
 		},
 		checklist: HiddenArgType,
 		icons: HiddenArgType,
@@ -63,6 +64,7 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 			},
 			if: { arg: 'type', eq: 'icons' },
 			description: 'Modifie l’icône par défaut.',
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: IconsList.map((i) => i.icon),
@@ -71,6 +73,7 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 			},
 			if: { arg: 'type', eq: 'icons' },
 			description: 'Modifie l’icône d’un élément de la liste.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			PaletteAllArgType,
@@ -79,9 +82,11 @@ export const Template: StoryObj<ListingComponent & ListingItemComponent & { type
 			},
 			if: { arg: 'type', truthy: true },
 			description: 'Modifie la couleur des icônes.',
+			table: { category: 'inputs' },
 		},
 		divider: {
 			description: 'Ajoute un séparateur vertical entre les éléments.',
+			table: { category: 'inputs' },
 		},
 	},
 

--- a/stories/documentation/listings/progress-stepper/angular/basic.stories.ts
+++ b/stories/documentation/listings/progress-stepper/angular/basic.stories.ts
@@ -15,18 +15,22 @@ export default {
 		current: {
 			control: { type: 'range', min: 1, max: 6 },
 			description: 'Étape courante.',
+			table: { category: 'inputs' },
 		},
 		steps: {
 			control: { type: 'range', min: 2, max: 6 },
 			description: 'Nombre d’étapes présentées dans l’exemple.',
+			table: { category: 'inputs' },
 		},
 		critical: {
 			control: { type: 'boolean' },
 			description: 'Affiche une étape en état critical.',
+			table: { category: 'inputs' },
 		},
 		success: {
 			control: { type: 'boolean' },
 			description: 'Affiche une étape en état success.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/listings/progress-stepper/angular/route.stories.ts
+++ b/stories/documentation/listings/progress-stepper/angular/route.stories.ts
@@ -6,7 +6,7 @@ import { cleanupTemplate } from '@/helpers/stories';
 export default {
 	title: 'Documentation/Progress stepper/Angular/Route',
 	argTypes: {
-		routerLinkParam: { control: { type: 'object' } },
+		routerLinkParam: { control: { type: 'object' }, table: { category: 'inputs' } },
 	},
 	decorators: [
 		moduleMetadata({

--- a/stories/documentation/listings/sortable-list/angular/draggable.stories.ts
+++ b/stories/documentation/listings/sortable-list/angular/draggable.stories.ts
@@ -8,6 +8,8 @@ interface SortableListDraggableStory {
 	small: boolean;
 	clickable: boolean;
 	unclearable: boolean;
+	// Action Storybook injectée à la place de l'événement de drop documenté dans `argTypes`.
+	drop?: (event: CdkDragDrop<unknown[]>) => void;
 }
 
 export default {
@@ -23,27 +25,35 @@ export default {
 				type: 'text',
 			},
 			description: 'Modifie le texte principal d’un élément de liste. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		helperMessage: {
 			control: {
 				type: 'text',
 			},
 			description: 'Ajoute un texte secondaire à l’élément de liste.',
+			table: { category: 'inputs' },
 		},
 		small: {
 			control: 'boolean',
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		clickable: {
 			control: 'boolean',
 			description: 'Rend les lignes cliquables.',
+			table: { category: 'inputs' },
 		},
 		unclearable: {
 			control: 'boolean',
 			description: 'Masque la croix de suppression.',
+			table: { category: 'inputs' },
 		},
 		drop: {
 			description: 'Événement déclenché au drop.',
+			action: 'drop',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'CdkDragDrop<unknown[]>' } },
 		},
 	},
 	render: (args: SortableListDraggableStory) => {
@@ -55,7 +65,10 @@ export default {
 		return {
 			props: {
 				listItem,
-				drop: (event: CdkDragDrop<unknown[]>) => moveItemInArray(listItem, event.previousIndex, event.currentIndex),
+				drop: (event: CdkDragDrop<unknown[]>) => {
+					moveItemInArray(listItem, event.previousIndex, event.currentIndex);
+					args.drop?.(event);
+				},
 			},
 			template: `<lu-sortable-list cdkDropList (cdkDropListDropped)="drop($event)">
 	<lu-sortable-list-item label="${args.label}" helperMessage="${args.helperMessage}"${unclearable}${clickable}${small} drag cdkDrag />

--- a/stories/documentation/listings/table/table-empty.stories.ts
+++ b/stories/documentation/listings/table/table-empty.stories.ts
@@ -18,6 +18,7 @@ export default {
 	argTypes: {
 		navSideCompact: {
 			if: { arg: 'navSide', truthy: true },
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/loaders/gauge/angular/gauge-basic.stories.ts
+++ b/stories/documentation/loaders/gauge/angular/gauge-basic.stories.ts
@@ -12,30 +12,38 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs à la jauge.',
+			table: { category: 'inputs' },
 		},
 		thin: {
 			description: 'Diminue l’épaisseur de la jauge.',
+			table: { category: 'inputs' },
 		},
 		animated: {
 			description: 'Ajoute une animation au chargement ou lorsque la valeur est modifiée.',
+			table: { category: 'inputs' },
 		},
 		circular: {
 			description: 'Affiche la jauge sous une forme circulaire.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			control: { type: 'range', min: 32, max: 160, step: 8 },
 			if: { arg: 'circular', truthy: true },
 			description: 'Taille du composant pour sa forme circulaire.',
+			table: { category: 'inputs' },
 		},
 		value: {
 			control: { type: 'range', min: 0, max: 100, step: 1 },
 			description: 'Valeur en pourcentage.',
+			table: { category: 'inputs' },
 		},
 		alt: {
 			description: 'Information restituée par le lecteur d’écran.',
+			table: { category: 'inputs' },
 		},
 		noAlt: {
 			description: 'Empêche la restitution par le lecteur d’écran. À n’utiliser que si l’information est déjà présente.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/loaders/loading/angular/loading-basic.stories.ts
+++ b/stories/documentation/loaders/loading/angular/loading-basic.stories.ts
@@ -17,19 +17,24 @@ export default {
 		label: {
 			description: '[Story] Modifie le texte affiché par le composant.',
 			control: 'text',
+			table: { category: 'inputs' },
 		},
 		hiddenLabel: {
 			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écrans.',
+			table: { category: 'inputs' },
 		},
 		L: {
 			description: 'Applique la taille L au loading. Applique également automatiquement le mode block.',
+			table: { category: 'inputs' },
 		},
 		block: {
 			description: 'Centre le loading dans son conteneur pour une utilisation en pleine page, dialog, section, etc.',
 			if: { arg: 'L', truthy: false },
+			table: { category: 'inputs' },
 		},
 		invert: {
 			description: 'Modifie les couleurs du loading pour un usage sur fond foncé.',
+			table: { category: 'inputs' },
 		},
 		template: {
 			description: 'Applique une mise en forme adaptée à certains contextes (pleine page, dialog, etc.).',
@@ -37,6 +42,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/loaders/progress-bar/angular/progress-bar.stories.ts
+++ b/stories/documentation/loaders/progress-bar/angular/progress-bar.stories.ts
@@ -17,12 +17,14 @@ export default {
 				type: 'select',
 			},
 			description: 'État du composant.',
+			table: { category: 'inputs' },
 		},
 		indeterminate: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Affiche un état de chargement sans information de progression.',
+			table: { category: 'inputs' },
 		},
 		value: {
 			control: {
@@ -32,6 +34,7 @@ export default {
 				step: 1,
 			},
 			description: 'Pourcentage de progression.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/horizontal-navigation/angular/horizontal-navigation-basic.stories.ts
+++ b/stories/documentation/navigation/horizontal-navigation/angular/horizontal-navigation-basic.stories.ts
@@ -15,15 +15,19 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		noBorder: {
 			description: 'Retire la bordure sous le composant.',
+			table: { category: 'inputs' },
 		},
 		container: {
 			description: 'Applique un container autour des liens pour aligner le composant avec le contenu de la page.',
+			table: { category: 'inputs' },
 		},
 		numericBadge: {
 			description: 'Présente un exemple avec Numeric Badge.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/horizontal-navigation/angular/horizontal-navigation-tabs.stories.ts
+++ b/stories/documentation/navigation/horizontal-navigation/angular/horizontal-navigation-tabs.stories.ts
@@ -14,12 +14,15 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		noBorder: {
 			description: 'Retire la bordure sous le composant.',
+			table: { category: 'inputs' },
 		},
 		container: {
 			description: 'Applique un container autour des liens pour aligner le composant avec le contenu de la page.',
+			table: { category: 'inputs' },
 		},
 		currentIndex: {
 			description: "[Story] Définit l'index de l'onglet sélectionné.",
@@ -27,9 +30,11 @@ export default {
 				min: 0,
 				max: 3,
 			},
+			table: { category: 'models' },
 		},
 		disabled: {
 			description: 'Désactive un onglet.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/impersonation/angular/impersonation-basic.stories.ts
+++ b/stories/documentation/navigation/impersonation/angular/impersonation-basic.stories.ts
@@ -21,6 +21,7 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Inclus les collaborateurs partis',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/pagination/angular/pagination.stories.ts
+++ b/stories/documentation/navigation/pagination/angular/pagination.stories.ts
@@ -15,22 +15,27 @@ export default {
 		isFirstPage: {
 			type: 'boolean',
 			description: 'Désactive le bouton précédent.',
+			table: { category: 'inputs' },
 		},
 		isLastPage: {
 			type: 'boolean',
 			description: 'Désactive le bouton suivant.',
+			table: { category: 'inputs' },
 		},
 		from: {
 			type: 'number',
 			description: 'Numéro du dernier élément affiché.',
+			table: { category: 'inputs' },
 		},
 		to: {
 			type: 'number',
 			description: 'Numéro du dernier élément affiché.',
+			table: { category: 'inputs' },
 		},
 		itemsCount: {
 			type: 'number',
 			description: 'Nombre total d’éléments.',
+			table: { category: 'inputs' },
 		},
 		mod: {
 			options: setStoryOptions(PAGINATION_MOD),
@@ -38,6 +43,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Affiche la pagination en vue compacte (seulement avec les boutons précédent et suivant).',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/navigation/segmented-control/angular/segmented-control-tabs.stories.ts
+++ b/stories/documentation/navigation/segmented-control/angular/segmented-control-tabs.stories.ts
@@ -20,12 +20,15 @@ export default {
 	argTypes: {
 		S: {
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		withNumericBadge: {
 			description: 'Présente un exemple avec un Numeric Badge.',
+			table: { category: 'inputs' },
 		},
 		vertical: {
 			description: 'Affiche le composant en vue verticale.',
+			table: { category: 'inputs' },
 		},
 	},
 	title: 'Documentation/Navigation/segmentedControl/Angular/Tabs',

--- a/stories/documentation/navigation/segmented-control/angular/segmented-control.stories.ts
+++ b/stories/documentation/navigation/segmented-control/angular/segmented-control.stories.ts
@@ -22,12 +22,15 @@ export default {
 	argTypes: {
 		small: {
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		withNumericBadge: {
 			description: 'Présente un exemple avec un Numeric Badge.',
+			table: { category: 'inputs' },
 		},
 		vertical: {
 			description: 'Affiche le composant en vue verticale.',
+			table: { category: 'inputs' },
 		},
 	},
 	title: 'Documentation/Navigation/segmentedControl/Angular/Basic',

--- a/stories/documentation/navigation/table-of-content/angular/table-of-content.stories.ts
+++ b/stories/documentation/navigation/table-of-content/angular/table-of-content.stories.ts
@@ -16,6 +16,7 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Désactive le lien d’un des éléments.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-disabled.stories.ts
+++ b/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-disabled.stories.ts
@@ -13,6 +13,7 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Désactive le composant.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-iconless.stories.ts
+++ b/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation-iconless.stories.ts
@@ -13,6 +13,7 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Présente le composant sans icônes.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation.stories.ts
+++ b/stories/documentation/navigation/vertical-navigation/angular/vertical-navigation.stories.ts
@@ -16,6 +16,7 @@ export default {
 				type: 'text',
 			},
 			description: 'Titre de la section. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/overlays/dialog/dialog-canClose.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-canClose.stories.ts
@@ -112,12 +112,14 @@ export default {
 				type: 'boolean',
 			},
 			description: 'Permet de définir si la fenêtre de dialogue peut être fermée via les différentes méthodes de fermeture (bouton cancel, clic sur le backdrop, etc.).',
+			table: { category: 'inputs' },
 		},
 		canCloseWithBackdrop: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Permet de définir si la fenêtre de dialogue peut être fermée via un clic sur le backdrop.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/overlays/dialog/dialog-confirmation.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-confirmation.stories.ts
@@ -113,12 +113,14 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: ['fitContent', 'XS', 'S', '', 'L', 'XL', 'XXL', 'maxContent', 'fullScreen'],
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		autoFocus: HiddenArgType,
 		alert: HiddenArgType,

--- a/stories/documentation/overlays/dialog/dialog-fancy.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-fancy.stories.ts
@@ -72,12 +72,14 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			options: setStoryOptions(DIALOG_FANCY_ILLUSTRATION),
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/overlays/dialog/dialog-multiple.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-multiple.stories.ts
@@ -152,12 +152,14 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: ['fitContent', 'XS', 'S', '', 'L', 'XL', 'XXL', 'maxContent', 'fullScreen'],
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		autoFocus: HiddenArgType,
 		alert: HiddenArgType,

--- a/stories/documentation/overlays/dialog/dialog.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog.stories.ts
@@ -90,6 +90,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Permet d’afficher la fenêtre de dialogue en mode drawer.',
+			table: { category: 'inputs' },
 		},
 		autoFocus: {
 			options: ['first-tabbable', 'first-input'],
@@ -97,6 +98,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: ['fitContent', 'XS', 'S', '', 'L', 'XL', 'XXL', 'maxContent', 'fullScreen'],
@@ -104,13 +106,16 @@ export default {
 				type: 'select',
 			},
 			description: 'Largeur de la fenêtre de dialogue.',
+			table: { category: 'inputs' },
 		},
 		panelClasses: {
 			description: 'Permet d’ajouter des classes CSS au composant.',
+			table: { category: 'inputs' },
 		},
 		alert: {
 			description:
 				'Transforme la fenêtre de dialogue en alerte en obligeant l’utilisateur à faire un choix. L’utilisateur ne peut alors plus la fermer en cliquant sur le backdrop ou en appuyant sur la touche Échap.',
+			table: { category: 'inputs' },
 		},
 		fancyIllustration: {
 			options: setStoryOptions(DIALOG_FANCY_ILLUSTRATION),
@@ -119,10 +124,12 @@ export default {
 			},
 			if: { arg: 'mode', eq: 'fancy' },
 			description: 'Modifie l’illustration affichée dans la Fancy dialog.',
+			table: { category: 'inputs' },
 		},
 		fancyIllustrationUrl: {
 			if: { arg: 'mode', eq: 'fancy' },
 			description: 'Surcharge l’illustration avec une URL personnalisée.',
+			table: { category: 'inputs' },
 		},
 		neutralBackground: {
 			control: {
@@ -276,6 +283,7 @@ export const Fancy: StoryObj = {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au callout.',
+			table: { category: 'inputs' },
 		},
 		fancyIllustration: {
 			options: setStoryOptions(DIALOG_FANCY_ILLUSTRATION),
@@ -284,10 +292,12 @@ export const Fancy: StoryObj = {
 			},
 			if: { arg: 'mode', eq: 'fancy' },
 			description: 'Modifie l’illustration affichée dans la Fancy dialog.',
+			table: { category: 'inputs' },
 		},
 		fancyIllustrationUrl: {
 			if: { arg: 'mode', eq: 'fancy' },
 			description: 'Surcharge l’illustration avec une URL personnalisée.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args) => {

--- a/stories/documentation/overlays/dropdown/angular/dropdown-directive.stories.ts
+++ b/stories/documentation/overlays/dropdown/angular/dropdown-directive.stories.ts
@@ -34,12 +34,19 @@ export default {
 			description: 'Modifie la position du dropdown par rapport à son déclencheur.',
 			control: 'select',
 			options: ['above', 'below', 'before', 'after'],
+			table: { category: 'inputs' },
 		},
 		luDropdownOnOpen: {
 			description: "Événement déclenché à l'ouverture du dropdown.",
+			action: 'luDropdownOnOpen',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 		luDropdownOnClose: {
 			description: 'Événement déclenché à la fermeture du dropdown.',
+			action: 'luDropdownOnClose',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'void' } },
 		},
 	},
 } as Meta;
@@ -47,7 +54,7 @@ export default {
 function getTemplate(args: DropdownBasicStory): string {
 	const direction = args.luPopoverPosition !== 'below' ? ` luDropdownPosition="${args.luPopoverPosition}"` : ``;
 	return `<div class="demo">
-	<button type="button" luButton disclosure [luDropdown]="dropdownSample"${direction}>Dropdown<lu-icon icon="arrowChevronBottom" /></button>
+	<button type="button" luButton disclosure [luDropdown]="dropdownSample"${direction} (luDropdownOnOpen)="luDropdownOnOpen()" (luDropdownOnClose)="luDropdownOnClose()">Dropdown<lu-icon icon="arrowChevronBottom" /></button>
 	<ng-template #dropdownSample>
 		<lu-dropdown-menu>
 			<lu-dropdown-item>

--- a/stories/documentation/overlays/modal/modal.stories.ts
+++ b/stories/documentation/overlays/modal/modal.stories.ts
@@ -18,16 +18,18 @@ const globalArgTypes: any = {
 		control: {
 			type: 'select',
 		},
+		table: { category: 'inputs' },
 	},
-	panelClass: { control: { type: 'text' } },
-	undismissable: { control: { type: 'boolean' } },
+	panelClass: { control: { type: 'text' }, table: { category: 'inputs' } },
+	undismissable: { control: { type: 'boolean' }, table: { category: 'inputs' } },
 	size: {
 		options: ['XS', 'S', 'M', 'L', 'XL'],
 		control: {
 			type: 'select',
 		},
+		table: { category: 'inputs' },
 	},
-	noBackdrop: { control: { type: 'boolean' } },
+	noBackdrop: { control: { type: 'boolean' }, table: { category: 'inputs' } },
 } as const;
 
 const generateStory = getStoryGenerator<StoryComponent>({

--- a/stories/documentation/overlays/popover2/popover2.stories.ts
+++ b/stories/documentation/overlays/popover2/popover2.stories.ts
@@ -27,36 +27,45 @@ export default {
 			control: 'select',
 			options: ['click', 'click+hover', 'hover+focus'],
 			description: 'Méthode d’ouverture du popover.',
+			table: { category: 'models' },
 		},
 		luPopoverPosition: {
 			control: 'select',
 			options: ['above', 'below', 'before', 'after'],
 			description: 'Position du popover par rapport à son déclencheur.',
+			table: { category: 'inputs' },
 		},
 		luPopoverDisabled: {
 			description: 'Désactive le popover.',
+			table: { category: 'inputs' },
 		},
 		luPopoverOpenDelay: {
 			description: 'Délai en millisecondes avant ouverture du popover.',
+			table: { category: 'inputs' },
 		},
 		luPopoverCloseDelay: {
 			description: 'Délai en millisecondes avant fermeture du popover.',
+			table: { category: 'inputs' },
 		},
 		overlayScrollStrategy: {
 			control: 'select',
 			options: ['reposition', 'block', 'close'],
 			description: '[v21.1] Comportement du popover lors du scroll.',
+			table: { category: 'inputs' },
 		},
 		luPopoverNoCloseButton: {
 			description: 'Masque le bouton de fermeture du popover visible à la navigation clavier.',
+			table: { category: 'inputs' },
 		},
 		luPopoverMaxBlockSize: {
 			control: 'text',
 			description: 'Modifie la hauteur max de la popover.',
+			table: { category: 'inputs' },
 		},
 		luPopoverMaxInlineSize: {
 			control: 'text',
 			description: 'Modifie la largeur max de la popover.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -54,6 +54,7 @@ export default {
 		},
 		luTooltipOnlyForDisplay: {
 			description: 'Affiche un tooltip non restituée par les lecteurs d’écran. À utiliser si la réstitution est déjà portée par l’élément déclencheur (ex. une icône avec attribut `alt`)',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/bubble-icon/angular/basic.stories.ts
+++ b/stories/documentation/structure/bubble-icon/angular/basic.stories.ts
@@ -14,6 +14,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Définit une direction de la bulle. Aléatoire par défaut.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(BUBBLE_ICON_SIZE),
@@ -21,6 +22,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions([...PALETTE, ...PRODUCT_PALETTE, ...DECORATIVE_PALETTE]),
@@ -28,6 +30,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au composant.',
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: IconsList.filter((i) => !i.deprecated).map((i) => i.icon),
@@ -35,9 +38,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie le glyphe de l’icône.',
+			table: { category: 'inputs' },
 		},
 		alt: {
 			description: 'Information restituée par le lecteur d’écran.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/bubble-illustration/angular/basic.stories.ts
+++ b/stories/documentation/structure/bubble-illustration/angular/basic.stories.ts
@@ -12,6 +12,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’illustration.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(BUBBLE_ILLUSTRATION_SIZE),
@@ -19,6 +20,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions([...PALETTE, ...DECORATIVE_PALETTE]),
@@ -26,9 +28,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au composant.',
+			table: { category: 'inputs' },
 		},
 		action: {
 			description: 'Ajoute une icône d’action (+) à l’illustration.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/container/angular/basic.stories.ts
+++ b/stories/documentation/structure/container/angular/basic.stories.ts
@@ -8,6 +8,7 @@ export default {
 	argTypes: {
 		center: {
 			description: 'Centre horizontalement le container.',
+			table: { category: 'inputs' },
 		},
 		overflow: HiddenArgType,
 		max: {
@@ -16,6 +17,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/divider/angular/divider-basic.stories.ts
+++ b/stories/documentation/structure/divider/angular/divider-basic.stories.ts
@@ -25,34 +25,40 @@ export default {
 			control: {
 				type: 'text',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(DIVIDER_SIZE),
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		separatorRole: {
 			control: {
 				type: 'boolean',
 			},
 			description: 'Permet de restituer Divider comme un séparateur natif (hr). Son éventuel contenu textuel ne sera alors plus restitué.',
+			table: { category: 'inputs' },
 		},
 		button: {
 			control: {
 				type: 'boolean',
 			},
 			if: { arg: 'icon', truthy: false },
+			table: { category: 'inputs' },
 		},
 		icon: {
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 		vertical: {
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/structure/fancy-box/angular/fancy-box-basic.stories.ts
+++ b/stories/documentation/structure/fancy-box/angular/fancy-box-basic.stories.ts
@@ -22,18 +22,21 @@ export default {
 				type: 'text',
 			},
 			description: 'URL de l’image en arrière plan à gauche (200x160).',
+			table: { category: 'inputs' },
 		},
 		backgroundRight: {
 			control: {
 				type: 'text',
 			},
 			description: 'URL de l’image en arrière plan à droite (200x160).',
+			table: { category: 'inputs' },
 		},
 		foreground: {
 			control: {
 				type: 'text',
 			},
 			description: 'URL de l’image au premier plan (200x160).',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(FANCY_BOX_SIZE),
@@ -41,6 +44,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/structure/footer/angular/footer-basic.stories.ts
+++ b/stories/documentation/structure/footer/angular/footer-basic.stories.ts
@@ -12,9 +12,11 @@ export default {
 				type: 'select',
 			},
 			description: 'Définit le breakpoint pour lequel le mode narrow (responsive) est appliqué.',
+			table: { category: 'inputs' },
 		},
 		container: {
 			description: 'Applique un container autour du contenu du footer.',
+			table: { category: 'inputs' },
 		},
 		containerMax: {
 			options: setStoryOptions(FOOTER_CONTAINER_MAX),
@@ -23,12 +25,15 @@ export default {
 			},
 			if: { arg: 'container', truthy: true },
 			description: 'Définit la largeur maximale du container.',
+			table: { category: 'inputs' },
 		},
 		sticky: {
 			description: 'Fige le footer lors du défilement vertical.',
+			table: { category: 'inputs' },
 		},
 		forceNarrow: {
 			description: 'Force le mode narrow (responsive) du footer.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/grids/angular/grids-basic.stories.ts
+++ b/stories/documentation/structure/grids/angular/grids-basic.stories.ts
@@ -14,6 +14,7 @@ export default {
 				max: 12,
 			},
 			if: { arg: 'mode', truthy: false },
+			table: { category: 'inputs' },
 		},
 		colspan: {
 			control: {
@@ -21,6 +22,7 @@ export default {
 				min: 1,
 				max: 12,
 			},
+			table: { category: 'inputs' },
 		},
 		rowspan: {
 			control: {
@@ -28,6 +30,7 @@ export default {
 				min: 1,
 				max: 12,
 			},
+			table: { category: 'inputs' },
 		},
 		column: {
 			control: {
@@ -35,6 +38,7 @@ export default {
 				min: 0,
 				max: 12,
 			},
+			table: { category: 'inputs' },
 		},
 		row: {
 			control: {
@@ -42,6 +46,7 @@ export default {
 				min: 0,
 				max: 12,
 			},
+			table: { category: 'inputs' },
 		},
 		gap: {
 			control: {
@@ -49,36 +54,42 @@ export default {
 			},
 
 			options: setStoryOptions([...GRID_GAP, ...OTHER_GAP]),
+			table: { category: 'inputs' },
 		},
 		columnGap: {
 			control: {
 				type: 'select',
 			},
 			options: setStoryOptions([...GRID_GAP, ...OTHER_GAP]),
+			table: { category: 'inputs' },
 		},
 		rowGap: {
 			control: {
 				type: 'select',
 			},
 			options: setStoryOptions([...GRID_GAP, ...OTHER_GAP]),
+			table: { category: 'inputs' },
 		},
 		align: {
 			control: {
 				type: 'select',
 			},
 			options: setStoryOptions(GRID_COLUMN_ALIGNMENT),
+			table: { category: 'inputs' },
 		},
 		justify: {
 			control: {
 				type: 'select',
 			},
 			options: setStoryOptions(GRID_COLUMN_ALIGNMENT),
+			table: { category: 'inputs' },
 		},
 		mode: {
 			control: {
 				type: 'select',
 			},
 			options: setStoryOptions(GRID_MODE),
+			table: { category: 'inputs' },
 		},
 
 		repeatCols: {
@@ -87,6 +98,7 @@ export default {
 				min: 0,
 				max: 35,
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/grids/angular/grids-responsive.stories.ts
+++ b/stories/documentation/structure/grids/angular/grids-responsive.stories.ts
@@ -12,12 +12,15 @@ export default {
 				max: 12,
 			},
 			if: { arg: 'mode', truthy: false },
+			table: { category: 'inputs' },
 		},
 		responsiveMediaConfig: {
 			if: { arg: 'container', eq: false },
+			table: { category: 'inputs' },
 		},
 		responsiveContainerConfig: {
 			if: { arg: 'container', eq: true },
+			table: { category: 'inputs' },
 		},
 		modeMedia: {
 			if: { arg: 'container', eq: false },
@@ -36,6 +39,7 @@ export default {
 				'autoAtMediaMinXXL',
 				'autoAtMediaMinXXXL',
 			],
+			table: { category: 'inputs' },
 		},
 		modeContainer: {
 			if: { arg: 'container', eq: true },
@@ -54,6 +58,7 @@ export default {
 				'autoAtContainerMinXXL',
 				'autoAtContainerMinXXXL',
 			],
+			table: { category: 'inputs' },
 		},
 		repeatCols: {
 			control: {
@@ -61,6 +66,7 @@ export default {
 				min: 0,
 				max: 34,
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/highlight-data/angular/basic.stories.ts
+++ b/stories/documentation/structure/highlight-data/angular/basic.stories.ts
@@ -37,20 +37,24 @@ export const Template: StoryObj<HighlightDataComponent & { action: string }> = {
 		heading: {
 			type: 'string',
 			description: 'Titre du composant. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		value: {
 			type: 'string',
 			description: 'Valeur affichée. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		subText: {
 			type: 'string',
 			description: 'Texte secondaire. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		bubble: {
 			options: setStoryOptions(HIGHLIGHT_DATA_BUBBLE),
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			options: setStoryOptions(HIGHLIGHT_DATA_ILLUSTRATION),
@@ -58,21 +62,25 @@ export const Template: StoryObj<HighlightDataComponent & { action: string }> = {
 				type: 'select',
 			},
 			description: 'Il est également possible de renseigner une URL.',
+			table: { category: 'inputs' },
 		},
 		valueFirst: {
 			type: 'boolean',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(HIGHLIGHT_DATA_SIZE),
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		theme: {
 			options: setStoryOptions(HIGHLIGHT_DATA_THEME),
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions(HIGHLIGHT_DATA_PALETTE),
@@ -80,12 +88,14 @@ export const Template: StoryObj<HighlightDataComponent & { action: string }> = {
 				type: 'select',
 			},
 			description: 'La palette influençant également la couleur du SVG des bubbles et donc l’URL associée, il est nécessaire de renseigner la gamme.',
+			table: { category: 'inputs' },
 		},
 		action: {
 			options: ['', 'button', 'link'],
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 

--- a/stories/documentation/structure/main-layout/angular/basic.stories.ts
+++ b/stories/documentation/structure/main-layout/angular/basic.stories.ts
@@ -27,31 +27,39 @@ export default {
 	argTypes: {
 		header: {
 			description: 'Présente un exemple de structure avec header.',
+			table: { category: 'inputs' },
 		},
 		footer: {
 			description: 'Présente un exemple de structure avec footer.',
+			table: { category: 'inputs' },
 		},
 		sidebar: {
 			description: 'Présente un exemple de structure avec un panneau latéral.',
+			table: { category: 'inputs' },
 		},
 		headerSticky: {
 			if: { arg: 'header', truthy: true },
 			description: 'Conserve le header visible en haut du layout.',
+			table: { category: 'inputs' },
 		},
 		footerSticky: {
 			if: { arg: 'footer', truthy: true },
 			description: 'Conserve le footer visible en bas du layout.',
+			table: { category: 'inputs' },
 		},
 		repeatContent: {
 			control: { type: 'range', min: 1, max: 10 },
 			description: '[Story] Modifie le nombre d’éléments <lu-main-layout-block>',
+			table: { category: 'inputs' },
 		},
 		repeatOverflow: {
 			control: { type: 'range', min: 1, max: 10 },
 			if: { arg: 'contentOverflowing', truthy: true },
+			table: { category: 'inputs' },
 		},
 		contentOverflowing: {
 			description: 'Permet de rendre un élément <lu-main-layout-block> scrollable horizontalement tout en conservant le comportement du reste du layout.',
+			table: { category: 'inputs' },
 		},
 		bubblesStartEnd: {
 			options: [null, 1, 2, 3],

--- a/stories/documentation/structure/main-layout/angular/inAppLayout.stories.ts
+++ b/stories/documentation/structure/main-layout/angular/inAppLayout.stories.ts
@@ -26,31 +26,39 @@ export default {
 	argTypes: {
 		header: {
 			description: 'Présente un exemple de structure avec header.',
+			table: { category: 'inputs' },
 		},
 		footer: {
 			description: 'Présente un exemple de structure avec footer.',
+			table: { category: 'inputs' },
 		},
 		sidebar: {
 			description: 'Présente un exemple de structure avec un panneau latéral.',
+			table: { category: 'inputs' },
 		},
 		headerSticky: {
 			if: { arg: 'header', truthy: true },
 			description: 'Fixe le footer en haut du layout.',
+			table: { category: 'inputs' },
 		},
 		footerSticky: {
 			if: { arg: 'footer', truthy: true },
 			description: 'Fixe le footer en bas du layout.',
+			table: { category: 'inputs' },
 		},
 		repeatContent: {
 			control: { type: 'range', min: 1, max: 10 },
 			description: '[Story] Modifie le nombre d’éléments <lu-main-layout-block>',
+			table: { category: 'inputs' },
 		},
 		repeatOverflow: {
 			control: { type: 'range', min: 1, max: 10 },
 			if: { arg: 'contentOverflowing', truthy: true },
+			table: { category: 'inputs' },
 		},
 		contentOverflowing: {
 			description: 'Permet de rendre un élément <lu-main-layout-block> scrollable horizontalement tout en conservant le comportement du reste du layout.',
+			table: { category: 'inputs' },
 		},
 		bubblesStartEnd: {
 			options: [null, 1, 2, 3],

--- a/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
+++ b/stories/documentation/structure/page-header/angular/page-header-basic.stories.ts
@@ -23,40 +23,52 @@ export default {
 	argTypes: {
 		label: {
 			description: 'Titre du composant. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		description: {
 			description: 'Description du composant. [PortalContent]',
+			table: { category: 'inputs' },
 		},
 		container: {
 			description: '[v20.1] Applique un container autour du contenu de Page Header.',
+			table: { category: 'inputs' },
 		},
 		sticky: {
 			description: '[v21.2] Applique un comportement sticky au Page Header quand celui ci n’est pas géré par le Main Layout',
+			table: { category: 'inputs' },
 		},
 		breadcrumbs: {
 			description: 'Exemple avec fil d’Ariane.',
+			table: { category: 'inputs' },
 		},
 		actions: {
 			description: 'Exemple avec des actions générales.',
+			table: { category: 'inputs' },
 		},
 		titleActions: {
 			description: 'Exemple avec des actions spécifiques au titre.',
+			table: { category: 'inputs' },
 		},
 		navigation: {
 			description: 'Exemple avec une navigation horizontale.',
+			table: { category: 'inputs' },
 		},
 		backAction: {
 			description: 'Exemple avec une action de retour en arrière.',
+			table: { category: 'inputs' },
 		},
 		leading: {
 			description: 'Ajout d’un slot avant le titre.',
+			table: { category: 'inputs' },
 		},
 		trailing: {
 			if: { arg: 'trailingWithImpersonation', truthy: false },
 			description: 'Ajout d’un slot après le titre.',
+			table: { category: 'inputs' },
 		},
 		trailingWithImpersonation: {
 			description: 'Utilisation du slot après le titre pour passer l’impersonation',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/resource-card/angular/basis.stories.ts
+++ b/stories/documentation/structure/resource-card/angular/basis.stories.ts
@@ -39,42 +39,54 @@ export default {
 	argTypes: {
 		wrapperDraggable: {
 			if: { arg: 'wrapper', truthy: true },
+			table: { category: 'inputs' },
 		},
 		wrapperGrid: {
 			if: { arg: 'wrapper', truthy: true },
+			table: { category: 'inputs' },
 		},
 		draggable: {
 			if: { arg: 'wrapper', truthy: false },
+			table: { category: 'inputs' },
 		},
 		infosTemplate: {
 			if: { arg: 'infos', truthy: true },
+			table: { category: 'inputs' },
 		},
 		illustrationTemplate: {
 			if: { arg: 'illustration', truthy: true },
+			table: { category: 'inputs' },
 		},
 		contentTemplate: {
 			if: { arg: 'content', truthy: true },
+			table: { category: 'inputs' },
 		},
 		contentTemplateDisabled: {
 			if: { arg: 'disabled', truthy: true },
+			table: { category: 'inputs' },
 		},
 		actionTemplate: {
 			if: { arg: 'action', truthy: true },
+			table: { category: 'inputs' },
 		},
 		actionTemplateDisabled: {
 			if: { arg: 'disabled', truthy: true },
+			table: { category: 'inputs' },
 		},
 		illustrationTemplateDisabled: {
 			if: { arg: 'disabled', truthy: true },
+			table: { category: 'inputs' },
 		},
 		addResource: {
 			if: { arg: 'wrapper', truthy: true },
+			table: { category: 'inputs' },
 		},
 		actionType: {
 			options: ['a', 'button'],
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(RESOURCE_CARD_SIZE),
@@ -82,6 +94,7 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'wrapper', truthy: false },
+			table: { category: 'inputs' },
 		},
 		wrapperSize: {
 			options: setStoryOptions(RESOURCE_CARD_SIZE),
@@ -89,6 +102,7 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'wrapper', truthy: true },
+			table: { category: 'inputs' },
 		},
 		headingLevel: {
 			control: {
@@ -96,6 +110,7 @@ export default {
 				min: 1,
 				max: 6,
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/resource-card/angular/dnd.stories.ts
+++ b/stories/documentation/structure/resource-card/angular/dnd.stories.ts
@@ -29,6 +29,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/software-icon/angular/basic.stories.ts
+++ b/stories/documentation/structure/software-icon/angular/basic.stories.ts
@@ -11,6 +11,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie l’icône produit.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(SOFTWARE_ICON_SIZE),
@@ -18,15 +19,19 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		disabled: {
 			description: 'Marque le produit comme inactif.',
+			table: { category: 'inputs' },
 		},
 		iconAlt: {
 			description: 'Texte alternatif de l’illustration restitué par les lecteurs d’écran.',
+			table: { category: 'inputs' },
 		},
 		withTooltip: {
 			description: 'Ajoute une info-bulle qui reprend l’alternative textuelle de l’icône. (Ce paramètre est automatiquement activé quand l’icône est dans son wrapper.)',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/software-icon/angular/wrapper.stories.ts
+++ b/stories/documentation/structure/software-icon/angular/wrapper.stories.ts
@@ -12,6 +12,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		max: {
 			control: {
@@ -20,6 +21,7 @@ export default {
 				max: 12,
 			},
 			description: 'Nombre maximum d’icônes à afficher. Les icônes supplémentaires sont cachées.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/texts/clear/angular/clear.stories.ts
+++ b/stories/documentation/texts/clear/angular/clear.stories.ts
@@ -17,7 +17,10 @@ export default {
 		const hiddenAttr = hidden ? ` hidden` : ``;
 		const paletteAttr = palette ? ` palette="${palette}"` : ``;
 		return {
-			template: `<lu-clear${hiddenAttr}${sizeAttr}${paletteAttr}${generateInputs(inputArgs, argTypes)}>${alt}</lu-clear>`,
+			props: {
+				...args,
+			},
+			template: `<lu-clear${hiddenAttr}${sizeAttr}${paletteAttr}${generateInputs(inputArgs, argTypes)} (onClear)="onClear($event)">${alt}</lu-clear>`,
 		};
 	},
 } as Meta;
@@ -26,6 +29,7 @@ export const Template: StoryObj = {
 	argTypes: {
 		disabled: {
 			description: 'Désactive le bouton.',
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions(PALETTE),
@@ -33,10 +37,12 @@ export const Template: StoryObj = {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au bouton.',
+			table: { category: 'inputs' },
 		},
 		inverted: {
 			if: { arg: 'disabled', truthy: false },
 			description: 'Modifie les couleurs du bouton pour un usage sur fond foncé.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(CLEAR_SIZE),
@@ -44,15 +50,21 @@ export const Template: StoryObj = {
 				type: 'select',
 			},
 			description: 'Modifie la taille du bouton.',
+			table: { category: 'inputs' },
 		},
 		alt: {
 			description: 'Information restituée par le lecteur d’écran.',
+			table: { category: 'inputs' },
 		},
 		hidden: {
 			description: 'Masque le bouton.',
+			table: { category: 'inputs' },
 		},
 		onClear: {
 			description: 'Événement déclenché lors du clic sur le bouton.',
+			action: 'onClear',
+			control: false,
+			table: { category: 'outputs', type: { summary: 'T' } },
 		},
 	},
 	args: {

--- a/stories/documentation/texts/code/angular/code.stories.ts
+++ b/stories/documentation/texts/code/angular/code.stories.ts
@@ -13,6 +13,7 @@ export default {
 		block: {
 			type: 'boolean',
 			description: 'Permet un affichage sur plusieurs lignes.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/texts/comment/angular/basic.stories.ts
+++ b/stories/documentation/texts/comment/angular/basic.stories.ts
@@ -51,24 +51,31 @@ export default {
 	argTypes: {
 		noAvatar: {
 			description: 'Masque l’avatar.',
+			table: { category: 'inputs' },
 		},
 		compact: {
 			description: 'N’affiche l’auteur que sur le premier commentaire de <code><lu-comment-block></code>',
+			table: { category: 'inputs' },
 		},
 		small: {
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		date: {
 			description: 'Modifie la date du commentaire.',
+			table: { category: 'inputs' },
 		},
 		datePipeFormat: {
 			description: "[v20.3] Modifie le format de date affiché, via <a href='https://angular.dev/api/common/DatePipe' target='_blank'>Angular DatePipe</a>. Exemples : 'mediumDate', 'YYYY', etc.",
+			table: { category: 'inputs' },
 		},
 		firstName: {
 			description: 'Modifie le prénom de l’auteur.',
+			table: { category: 'inputs' },
 		},
 		lastName: {
 			description: 'Modifie le nom de l’auteur.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/texts/comment/angular/chat.stories.ts
+++ b/stories/documentation/texts/comment/angular/chat.stories.ts
@@ -58,24 +58,31 @@ export default {
 	argTypes: {
 		noAvatar: {
 			description: 'Masque l’avatar.',
+			table: { category: 'inputs' },
 		},
 		compact: {
 			description: 'N’affiche l’auteur que sur le premier commentaire de <code><lu-comment-block></code>',
+			table: { category: 'inputs' },
 		},
 		small: {
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		date: {
 			description: 'Modifie la date du commentaire.',
+			table: { category: 'inputs' },
 		},
 		datePipeFormat: {
 			description: "[v20.3] Modifie le format de date affiché, via <a href='https://angular.dev/api/common/DatePipe' target='_blank'>Angular DatePipe</a>. Exemples : 'mediumDate', 'YYYY', etc.",
+			table: { category: 'inputs' },
 		},
 		firstName: {
 			description: 'Modifie le prénom de l’auteur.',
+			table: { category: 'inputs' },
 		},
 		lastName: {
 			description: 'Modifie le nom de l’auteur.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/texts/highlight-text/angular/highlight-text.stories.ts
+++ b/stories/documentation/texts/highlight-text/angular/highlight-text.stories.ts
@@ -11,7 +11,7 @@ interface HighlightBasicStory {}
 export default {
 	title: 'Documentation/Texts/Highlight Text/Angular/Basic',
 	argTypes: {
-		palette: PaletteAllArgType,
+		palette: { ...PaletteAllArgType, table: { category: 'inputs' } },
 	},
 	decorators: [
 		moduleMetadata({

--- a/stories/documentation/texts/numeric-badge/angular/numeric-badge.stories.ts
+++ b/stories/documentation/texts/numeric-badge/angular/numeric-badge.stories.ts
@@ -18,17 +18,21 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au composant.',
+			table: { category: 'inputs' },
 		},
 		value: {
 			description: 'Valeur affichée par le composant. Doit obligatoirement contenir une valeur numérique (ex: 7, "3/5", "999+", etc.)',
+			table: { category: 'inputs' },
 		},
 		maxValue: {
 			type: 'number',
 			description: '[v19.2] Valeur maximale affichée au format "999+".',
+			table: { category: 'inputs' },
 		},
 		disableTooltip: {
 			type: 'boolean',
 			description: 'Empêche le déclenchement d’une tooltip si la valeur est supérieure à <code>maxValue</code>.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(NUMERIC_BADGE_SIZE),
@@ -36,12 +40,14 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.',
+			table: { category: 'inputs' },
 		},
 		loading: {
 			control: {
 				type: 'boolean',
 			},
 			description: '[v19.1] Applique l’état de chargement.',
+			table: { category: 'inputs' },
 		},
 	},
 	render: (args, { argTypes }) => {

--- a/stories/documentation/texts/read-more/angular/read-more.stories.ts
+++ b/stories/documentation/texts/read-more/angular/read-more.stories.ts
@@ -17,6 +17,7 @@ export default {
 				step: 1,
 			},
 			description: 'Modifie le nombre de lignes affichées à l’état replié.',
+			table: { category: 'inputs' },
 		},
 		surface: {
 			options: setStoryOptions([...READ_MORE_SURFACE, ...OTHER_SURFACE_OPTIONS]),
@@ -24,15 +25,19 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la couleur de fond sous le bouton "Lire plus / moins" ',
+			table: { category: 'inputs' },
 		},
 		textFlow: {
 			description: 'Applique les espacements du composant Text flow',
+			table: { category: 'inputs' },
 		},
 		openOnly: {
 			description: 'Empêche la fermeture du composant en masquant le bouton "Lire moins"',
+			table: { category: 'inputs' },
 		},
 		innerContent: {
 			description: 'Permet de passer le contenu via un innerHTML',
+			table: { category: 'inputs' },
 		},
 		content: {
 			table: { disable: true },

--- a/stories/documentation/texts/status-badge/angular/status-badge-angular.stories.ts
+++ b/stories/documentation/texts/status-badge/angular/status-badge-angular.stories.ts
@@ -24,6 +24,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au composant.<br>[v19.2] Ajout de Neutral.',
+			table: { category: 'inputs' },
 		},
 		size: {
 			options: setStoryOptions(STATUS_BADGE_SIZE),
@@ -31,15 +32,18 @@ export default {
 				type: 'select',
 			},
 			description: 'Modifie la taille du composant.<br>[v20.2] Ajout de la taille <code>M</code>',
+			table: { category: 'inputs' },
 		},
 		label: {
 			control: {
 				type: 'text',
 			},
 			description: 'Modifie le texte affiché par le composant.',
+			table: { category: 'inputs' },
 		},
 		withEllipsis: {
 			description: '[v20.3] Ellipse le texte et ajoute une tooltip lorsque le label est trop long.',
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/texts/tags/angular/tag.stories.ts
+++ b/stories/documentation/texts/tags/angular/tag.stories.ts
@@ -22,14 +22,16 @@ export const Template: StoryObj<TagComponent> = {
 				type: 'select',
 			},
 			description: 'Modifie la taille du tag.',
+			table: { category: 'inputs' },
 		},
-		palette: PaletteAllArgType,
+		palette: { ...PaletteAllArgType, table: { category: 'inputs' } },
 		outlined: {
 			control: {
 				type: 'boolean',
 			},
 			if: { arg: 'AI', truthy: false },
 			description: 'Applique un style secondaire au tag.',
+			table: { category: 'inputs' },
 		},
 		icon: {
 			options: IconsList.map((i) => i.icon),
@@ -37,16 +39,20 @@ export const Template: StoryObj<TagComponent> = {
 				type: 'select',
 			},
 			description: 'Ajoute une icône au tag.',
+			table: { category: 'inputs' },
 		},
 		link: HiddenArgType,
 		AI: {
 			description: '[v20.3] Applique les couleurs IA.',
+			table: { category: 'inputs' },
 		},
 		withEllipsis: {
 			description: '[v20.3] Ellipse le texte et ajoute une tooltip lorsque le label est trop long.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Modifie le texte affiché par le composant.',
+			table: { category: 'inputs' },
 		},
 	},
 

--- a/stories/documentation/toolbox/numbers/precision.stories.ts
+++ b/stories/documentation/toolbox/numbers/precision.stories.ts
@@ -17,8 +17,8 @@ export default {
 	title: 'Documentation/Toolbox/Numbers/Precision',
 	component: PrecisionStory,
 	argTypes: {
-		value: { control: { type: 'number' } },
-		precision: { control: { type: 'range', min: 1, max: 15, step: 1 } },
+		value: { control: { type: 'number' }, table: { category: 'inputs' } },
+		precision: { control: { type: 'range', min: 1, max: 15, step: 1 }, table: { category: 'inputs' } },
 	},
 } as Meta;
 

--- a/stories/documentation/users/avatars/angular/basic.stories.ts
+++ b/stories/documentation/users/avatars/angular/basic.stories.ts
@@ -46,6 +46,7 @@ export default {
 				'Avec image erronée': georges,
 				'Sans image': jake,
 			},
+			table: { category: 'inputs' },
 		},
 		sizes: {
 			description: "Taille de l'avatar.",
@@ -53,21 +54,25 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		displayFormat: {
 			description: 'Format d’affichage des initiales. F pour prénom (firstname) L pour nom (lastname).',
+			table: { category: 'inputs' },
 		},
 		placeholder: {
 			description: 'Applique un placeholder d’avatar.',
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 		AI: {
 			description: 'Avatar utilisé pour une réponse faite par IA.',
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/users/avatars/angular/group.stories.ts
+++ b/stories/documentation/users/avatars/angular/group.stories.ts
@@ -252,6 +252,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/users/display/display.stories.ts
+++ b/stories/documentation/users/display/display.stories.ts
@@ -37,10 +37,12 @@ export default {
 					...Object.entries(LuDisplayHybrid).reduce((acc, [value, key]) => ({ ...acc, [key]: `LuDisplayHybrid.${value}` }), {}),
 				},
 			},
+			table: { category: 'inputs' },
 		},
 		separator: {
 			description: 'Séparateur utilisé entre les noms.',
 			control: 'text',
+			table: { category: 'inputs' },
 		},
 		formatter: {
 			description: 'Formate la liste d’utilisateurs selon la langue, via `Intl.ListFormat`.',
@@ -49,6 +51,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 } as Meta;

--- a/stories/documentation/users/tile/angular/user-tile.stories.ts
+++ b/stories/documentation/users/tile/angular/user-tile.stories.ts
@@ -123,6 +123,7 @@ export const Basic: StoryObj<UserTileStoryArgs> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		size: {
 			description: 'Taille du composant.',
@@ -130,12 +131,14 @@ export const Basic: StoryObj<UserTileStoryArgs> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		role: {
 			description: 'Rôle de l’utilisateur affiché sous son nom.',
 			control: {
 				type: 'text',
 			},
+			table: { category: 'inputs' },
 		},
 		firstNameFormat: {
 			description: '[Story] Format d’affichage du prénom.',
@@ -143,6 +146,7 @@ export const Basic: StoryObj<UserTileStoryArgs> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		lastNameFormat: {
 			description: '[Story] Format d’affichage du nom de famille.',
@@ -150,18 +154,21 @@ export const Basic: StoryObj<UserTileStoryArgs> = {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		lastNameFirst: {
 			description: '[Story] Affiche le nom de famille avant le prénom.',
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 		withPopover: {
 			description: '[Story] Affiche UserPopover au survol du composant.',
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 };

--- a/stories/helpers/stories.ts
+++ b/stories/helpers/stories.ts
@@ -104,7 +104,8 @@ export function generateInputs(inputs: Record<string, unknown>, argTypes: ArgTyp
 	return Object.entries(inputs).reduce((acc, [name, value]) => {
 		const argType = argTypes[name];
 
-		if (!argType || (argType['table'] && argType['table'].category !== 'inputs')) {
+		// `models` are two-way bound inputs, so they are rendered as attributes just like `inputs`.
+		if (!argType || (argType['table'] && !['inputs', 'models'].includes(argType['table'].category))) {
 			return acc;
 		}
 


### PR DESCRIPTION
## Description

Every Angular story under `stories/documentation` now groups its args into `inputs`, `outputs` and `models` sections in the Storybook table, following up on #5184. Outputs are exposed as logged actions and document the type they emit, so the docs page reads like the component's public API instead of a flat list of knobs.

-----

Rollout of the convention introduced on the box component in #5184, extended with a `models` category for `model()` signals.

**Convention**
- `table.category` on every argTypes entry: `inputs` for `input()`, `outputs` for `output()`, `models` for `model()`.
- Outputs also get `action: '<name>'` + `control: false`, document the emitted type via `table.type.summary` (`void` when the `output()` has no type, otherwise `T`), and are bound in the story template (`(name)="name($event)"`, with args passed through `props`) so the action actually lands in the Actions panel.

**Scope** — 132 files, 752 `inputs` / 51 `outputs` / 12 `models`. Angular stories only: `html&css/` stories and CSS utility pages are untouched, since their args are class modifiers rather than component members. Args hidden from the table (`HiddenArgType`, `table.disable`) are left alone. Categories were resolved by indexing the `input()` / `output()` / `model()` / `@Input` / `@Output` members of `packages/ng` and `packages/prisme` (inheritance resolved) and matching them against the components used in each story, not by hand.

**Beyond the mechanical pass**
- `generateInputs` only rendered the `inputs` category, so newly categorised `models` (time-picker `disabled`, data-table `sort` / `selected`…) would have disappeared from the templates — it now renders `inputs` and `models`, and still skips `outputs`.
- Several output bindings were already dead and now work: the date2 calendars called a non-existent `selected()` handler, file-entry bound handlers that were missing from `props`.
- simple-select / multi-select documented `onOpen` / `onClose`, which belong to the legacy `lu-select`; core-select exposes `panelOpened` / `panelClosed`, so they were renamed and bound.
- The two `draggable` stories document the CDK drop event rather than an `output()`: it is categorised under `outputs` and logged without breaking `moveItemInArray` (data-table's handler renamed to `onDrop`).
- `_sample/angular/basic.stories.ts` and `CLAUDE.md` document the convention for future stories.

**Known gap** — 67 args across 21 files only exist in `args`, with no `argTypes` entry, so Storybook infers them and they stay in the default group. Adding those entries requires writing descriptions per component and is left for a follow-up pass.

**Checks** — full Storybook test suite green (715 files / 869 tests), `tsc -p .storybook/tsconfig.json` identical to baseline (42 pre-existing errors, none new), prettier clean.

-----

Missing cases :


Fichier | Arg | Type détecté
-- | -- | --
actions/button/angular/button-ai | label | story-only
actions/button/angular/button-ai | hiddenLabel | story-only
actions/button/angular/button-ai | altIcon | story-only
feedback/callout/angular/callout-ai | description | story-only
feedback/callout/angular/callout-ai | iconAlt | input
feedback/callout/angular/callout-ai-action | description | story-only
feedback/callout/angular/callout-ai-action | iconAlt | input
feedback/callout/angular/callout-ai-event | description | story-only
feedback/callout/angular/callout-ai-event | iconAlt | input
feedback/callout/angular/callout-ai-event | actions | story-only
feedback/callout/angular/callout-ai-suggestion | description | story-only
feedback/callout/angular/callout-ai-suggestion | iconAlt | input
forms/date/select/date-select | granularity | input
forms/date2/date-input | calendarMode | model
forms/fields/date/date-input-field | label | input
forms/fields/date/date-input-field | tooltip | input
forms/fields/date/date-input-field | hiddenLabel | input
forms/fields/date/date-input-field | inlineMessage | input
forms/fields/date/date-input-field | inlineMessageState | input
forms/fields/date/date-input-field | disableOverflow | input
forms/fields/date/date-input-field | hideOverflow | input
forms/fields/date/date-input-field | hideWeekend | input
forms/fields/number/angular/number-field | prefix | input
forms/fields/number/angular/number-field | suffix | input
forms/fields/rich-text/angular/rich-text-input | valueFr | story-only
forms/fields/text/angular/text-field | prefix | input
forms/fields/text/angular/text-field | suffix | input
forms/select/colors | colors | input
forms/select/colors | compact | input
forms/select/colors | clearable | input
forms/select/multi-select | legumeSelection | story-only
forms/select/multi-select | keepSearchAfterSelection | input
forms/select/multi-select | selectedAxisSection | story-only
forms/select/multi-select | selectedEstablishment | story-only
forms/select/multi-select | selectedDepartments | story-only
forms/select/multi-select | groupingFn | story-only
forms/select/multi-select | legumeColor | story-only
forms/select/multi-select | colorNameByColor | story-only
forms/select/multi-select | addLegume | story-only
forms/select/multi-select | legumes | story-only
forms/select/multi-select | loading | story-only
forms/select/multi-select | page | story-only
forms/select/simple-select | groupingFn | story-only
forms/select/simple-select | legumeColor | story-only
forms/select/simple-select | colorNameByColor | story-only
forms/select/simple-select | addLegume | story-only
forms/select/simple-select | legumes | story-only
forms/select/simple-select | loading | story-only
forms/select/simple-select | page | story-only
listings/table/table-empty | withOverflow | story-only
listings/table/table-empty | navSide | story-only
overlays/modal/modal | message | story-only
overlays/modal/modal | position | story-only
structure/bubble-icon/angular/basic | bubbleDirection | input
structure/grids/angular/grids-basic | semantic | story-only
structure/grids/angular/grids-responsive | container | input
structure/resource-card/angular/basis | wrapper | story-only
structure/resource-card/angular/basis | disabled | input
structure/resource-card/angular/basis | heading | story-only
structure/resource-card/angular/basis | infos | story-only
structure/resource-card/angular/basis | content | story-only
structure/resource-card/angular/basis | illustration | story-only
structure/resource-card/angular/basis | action | story-only
structure/resource-card/angular/dnd | infos | story-only
structure/resource-card/angular/dnd | content | story-only
structure/resource-card/angular/dnd | illustration | story-only
structure/resource-card/angular/dnd | action | story-only


