### PR TITLE
fix(bubble-illustration, bubble-icon, software-icon): Use phrasing content for buttons

### DIFF
--- a/packages/ng/bubble-illustration/bubble-illustration.component.html
+++ b/packages/ng/bubble-illustration/bubble-illustration.component.html
@@ -1,4 +1,4 @@
-<div
+<span
 	class="bubbleIllustration"
 	[class]="paletteClass()"
 	[class.mod-S]="size() === 'S'"
@@ -6,4 +6,4 @@
 	[class.mod-action]="action()"
 	aria-hidden="true"
 	[innerHtml]="illustrationUrl() | luSafeExternalSvg"
-></div>
+></span>

--- a/packages/ng/software-icon/software-icon.component.html
+++ b/packages/ng/software-icon/software-icon.component.html
@@ -1,4 +1,4 @@
-<div
+<span
 	class="softwareIcon"
 	[class.is-disabled]="disabled()"
 	[class.mod-XXS]="size() === 'XXS'"
@@ -10,5 +10,5 @@
 	[luTooltip]="iconAlt()"
 	luTooltipOnlyForDisplay
 	[luTooltipDisabled]="!this.withTooltip() && !this.wrapper"
-></div>
+></span>
 <span class="pr-u-mask" translate="no">{{ iconAlt() }}</span>

--- a/stories/documentation/feedback/empty-state/html&css/empty-state-section-center.stories.ts
+++ b/stories/documentation/feedback/empty-state/html&css/empty-state-section-center.stories.ts
@@ -18,11 +18,11 @@ function getTemplate(args: EmptyStateSectionCenterStory): string {
 	return `<section class="emptyState mod-center">
 	<div class="emptyState-container">
 		<div class="emptyState-content">
-			<div
+			<span
 				class="emptyState-content-icon bubbleIllustration mod-action mod-L"
 				aria-hidden="true"
 				[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/calendar.svg' | luSafeExternalSvg"
-			></div>
+			></span>
 			<div class="emptyState-content-text">
 				<h3 class="emptyState-content-heading">Empty State</h3>
 				<p class="emptyState-content-description">Flatus obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos potest vile diversitate flatus.</p>

--- a/stories/documentation/feedback/empty-state/html&css/empty-state-section-palette.stories.ts
+++ b/stories/documentation/feedback/empty-state/html&css/empty-state-section-palette.stories.ts
@@ -18,11 +18,11 @@ function getTemplate(args: EmptyStateSectionPaletteStory): string {
 	return `<section class="emptyState">
 	<div class="emptyState-container">
 		<div class="emptyState-content">
-			<div
+			<span
 				class="emptyState-content-icon bubbleIllustration mod-action mod-L palette-success"
 				aria-hidden="true"
 				[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/calendar.svg' | luSafeExternalSvg"
-			></div>
+			></span>
 			<div class="emptyState-content-text">
 				<h3 class="emptyState-content-heading">Empty State</h3>
 				<p class="emptyState-content-description">Flatus obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos potest vile diversitate flatus.</p>

--- a/stories/documentation/feedback/empty-state/html&css/empty-state-section.stories.ts
+++ b/stories/documentation/feedback/empty-state/html&css/empty-state-section.stories.ts
@@ -18,11 +18,11 @@ function getTemplate(args: EmptyStateSectionBasicStory): string {
 	return `<section class="emptyState">
 	<div class="emptyState-container">
 		<div class="emptyState-content">
-			<div
+			<span
 				class="emptyState-content-icon bubbleIllustration mod-action mod-L"
 				aria-hidden="true"
 				[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/calendar.svg' | luSafeExternalSvg"
-			></div>
+			></span>
 			<div class="emptyState-content-text">
 				<h3 class="emptyState-content-heading">Empty State</h3>
 				<p class="emptyState-content-description">Flatus obsequiorum potest inanes pomerium obsequiorum credi homines vero caelibes orbos potest vile diversitate flatus.</p>

--- a/stories/documentation/listings/data-table/html&css/empty-state.stories.ts
+++ b/stories/documentation/listings/data-table/html&css/empty-state.stories.ts
@@ -31,7 +31,7 @@ function getTemplate(args: EmptyState): string {
 						<div class="emptyState-container">
 							<div class="emptyState-content">
 								<div class="emptyState-content-icon" aria-hidden="true">
-									<div class="bubbleIllustration mod-L" aria-hidden="true" [innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/magnifyingGlass.svg' | luSafeExternalSvg"></div>
+									<span class="bubbleIllustration mod-L" aria-hidden="true" [innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/magnifyingGlass.svg' | luSafeExternalSvg"></span>
 								</div>
 								<div class="emptyState-content-text">
 									<h3 class="emptyState-content-heading">Empty State</h3>

--- a/stories/documentation/listings/index-table/html&css/index-table-empty-state.stories.ts
+++ b/stories/documentation/listings/index-table/html&css/index-table-empty-state.stories.ts
@@ -30,7 +30,7 @@ function getTemplate(args: IndexTableEmptyStateStory): string {
 					<div class="emptyState-container">
 						<div class="emptyState-content">
 							<div class="emptyState-content-icon" aria-hidden="true">
-								<div class="bubbleIllustration mod-L" aria-hidden="true" [innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/magnifyingGlass.svg' | luSafeExternalSvg"></div>
+								<span class="bubbleIllustration mod-L" aria-hidden="true" [innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/magnifyingGlass.svg' | luSafeExternalSvg"></span>
 							</div>
 							<div class="emptyState-content-text">
 								<h3 class="emptyState-content-heading">Empty State</h3>

--- a/stories/documentation/structure/bubble-icon/html&css/basic.stories.ts
+++ b/stories/documentation/structure/bubble-icon/html&css/basic.stories.ts
@@ -56,7 +56,7 @@ function getTemplate(args: BubbleIconBasicStory): string {
 		: ``;
 	const paletteClass = args.palette !== 'product' ? ` palette-${args.palette}` : ``;
 	const sizeClasse = args.size !== '' ? ` mod-${args.size}` : ``;
-	return `<div class="bubbleIcon${sizeClasse}${paletteClass} mod-${args.direction}">
+	return `<span class="bubbleIcon${sizeClasse}${paletteClass} mod-${args.direction}">
 	<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" fill="none" width="40" height="40" viewBox="0 0 40 40">
 		<path
 			class="bubbleIcon-bubble-pathInline"
@@ -70,7 +70,7 @@ function getTemplate(args: BubbleIconBasicStory): string {
 	<span class="bubbleIcon-icon">
 		<span aria-hidden="true" class="lucca-icon icon-${args.icon}"></span>${altTpl}
 	</span>
-</div>`;
+</span>`;
 }
 
 const Template = (args: BubbleIconBasicStory) => ({

--- a/stories/documentation/structure/bubble-illustration/html&css/basic.stories.ts
+++ b/stories/documentation/structure/bubble-illustration/html&css/basic.stories.ts
@@ -54,7 +54,7 @@ function getTemplate(args: BubbleIllustrationBasicStory): string {
 	const domain = 'https://cdn.lucca.fr';
 	const path = '/transverse/prisme/visuals/bubble-illustration/';
 	const extension = '.svg';
-	return `<div class="bubbleIllustration${palette}${size}${action}" aria-hidden="true" [innerHtml]="'${domain}${path}${args.illustration}${extension}' | luSafeExternalSvg"></div>`;
+	return `<span class="bubbleIllustration${palette}${size}${action}" aria-hidden="true" [innerHtml]="'${domain}${path}${args.illustration}${extension}' | luSafeExternalSvg"></span>`;
 }
 
 const Template = (args: BubbleIllustrationBasicStory) => ({

--- a/stories/documentation/structure/software-icon/html&css/basic.stories.ts
+++ b/stories/documentation/structure/software-icon/html&css/basic.stories.ts
@@ -52,7 +52,7 @@ function getTemplate(args: SoftwareIconBasicStory): string {
 		? `
 	<span class="pr-u-mask">${args.iconAlt}</span>`
 		: ``;
-	return `<div class="softwareIcon${disabled}${size}" aria-hidden="true" [innerHtml]="'${domain}${path}${args.icon}${extension}' | luSafeExternalSvg"></div>${iconAlt}`;
+	return `<span class="softwareIcon${disabled}${size}" aria-hidden="true" [innerHtml]="'${domain}${path}${args.icon}${extension}' | luSafeExternalSvg"></span>${iconAlt}`;
 }
 
 const Template = (args: SoftwareIconBasicStory) => ({

--- a/stories/qa/bubble-icon/bubble-icon.stories.html
+++ b/stories/qa/bubble-icon/bubble-icon.stories.html
@@ -13,7 +13,7 @@
 			<td>Default</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="bubbleIcon mod-left">
+					<span class="bubbleIcon mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -27,7 +27,7 @@
 						<span class="bubbleIcon-icon">
 							<span aria-hidden="true" class="lucca-icon icon-app"></span>
 						</span>
-					</div>
+					</span>
 				</div>
 			</td>
 			<td>
@@ -40,7 +40,7 @@
 			<td>Direction</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="bubbleIcon mod-left">
+					<span class="bubbleIcon mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -52,8 +52,8 @@
 							/>
 						</svg>
 						<span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon mod-right">
+					</span>
+					<span class="bubbleIcon mod-right">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -65,8 +65,8 @@
 							/>
 						</svg>
 						<span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon mod-top">
+					</span>
+					<span class="bubbleIcon mod-top">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -78,8 +78,8 @@
 							/>
 						</svg>
 						<span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon mod-bottom">
+					</span>
+					<span class="bubbleIcon mod-bottom">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -91,7 +91,7 @@
 							/>
 						</svg>
 						<span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
+					</span>
 				</div>
 			</td>
 			<td>
@@ -107,7 +107,7 @@
 			<td>Palette logiciel</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="bubbleIcon mod-left">
+					<span class="bubbleIcon mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -118,8 +118,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-pagga mod-left">
+					</span>
+					<span class="bubbleIcon palette-pagga mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -130,8 +130,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-poplee mod-left">
+					</span>
+					<span class="bubbleIcon palette-poplee mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -142,8 +142,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-coreHR mod-left">
+					</span>
+					<span class="bubbleIcon palette-coreHR mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -154,8 +154,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-timmi mod-left">
+					</span>
+					<span class="bubbleIcon palette-timmi mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -166,8 +166,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-cleemy mod-left">
+					</span>
+					<span class="bubbleIcon palette-cleemy mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -178,8 +178,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-cc mod-left">
+					</span>
+					<span class="bubbleIcon palette-cc mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -190,8 +190,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-brand mod-left">
+					</span>
+					<span class="bubbleIcon palette-brand mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -202,7 +202,7 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
+					</span>
 				</div>
 			</td>
 			<td>
@@ -217,7 +217,7 @@
 			<td>Palette décorative</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="bubbleIcon palette-kiwi mod-left">
+					<span class="bubbleIcon palette-kiwi mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -228,8 +228,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-lime mod-left">
+					</span>
+					<span class="bubbleIcon palette-lime mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -240,8 +240,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-cucumber mod-left">
+					</span>
+					<span class="bubbleIcon palette-cucumber mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -252,8 +252,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-mint mod-left">
+					</span>
+					<span class="bubbleIcon palette-mint mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -264,8 +264,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-glacier mod-left">
+					</span>
+					<span class="bubbleIcon palette-glacier mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -276,8 +276,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-lagoon mod-left">
+					</span>
+					<span class="bubbleIcon palette-lagoon mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -288,8 +288,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-blueberry mod-left">
+					</span>
+					<span class="bubbleIcon palette-blueberry mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -300,8 +300,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-lavender mod-left">
+					</span>
+					<span class="bubbleIcon palette-lavender mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -312,8 +312,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-grape mod-left">
+					</span>
+					<span class="bubbleIcon palette-grape mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -324,8 +324,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-watermelon mod-left">
+					</span>
+					<span class="bubbleIcon palette-watermelon mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -336,8 +336,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-pumpkin mod-left">
+					</span>
+					<span class="bubbleIcon palette-pumpkin mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -348,8 +348,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-pineapple mod-left">
+					</span>
+					<span class="bubbleIcon palette-pineapple mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -360,7 +360,7 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
+					</span>
 				</div>
 			</td>
 			<td>
@@ -375,7 +375,7 @@
 			<td>Palette feedback</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="bubbleIcon palette-neutral mod-left">
+					<span class="bubbleIcon palette-neutral mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -386,8 +386,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-success mod-left">
+					</span>
+					<span class="bubbleIcon palette-success mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -398,8 +398,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-warning mod-left">
+					</span>
+					<span class="bubbleIcon palette-warning mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -410,8 +410,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon palette-critical mod-left">
+					</span>
+					<span class="bubbleIcon palette-critical mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -422,7 +422,7 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
+					</span>
 				</div>
 			</td>
 			<td>
@@ -437,7 +437,7 @@
 			<td>Taille</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="bubbleIcon mod-XS mod-left">
+					<span class="bubbleIcon mod-XS mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -448,8 +448,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon mod-S mod-left">
+					</span>
+					<span class="bubbleIcon mod-S mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -460,8 +460,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon mod-left">
+					</span>
+					<span class="bubbleIcon mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -472,8 +472,8 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
-					<div class="bubbleIcon mod-L mod-left">
+					</span>
+					<span class="bubbleIcon mod-L mod-left">
 						<svg class="bubbleIcon-bubble" xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 40 40">
 							<path
 								class="bubbleIcon-bubble-pathInline"
@@ -484,7 +484,7 @@
 								d="M2.25264 16.3895C8.11117 6.4042 21.9332-9.59108 32.4637 7.57789c5.8129 9.48391 15.5505 29.55471-4.5465 32.07901C6.70786 42.3228-5.2602 28.9757 2.25264 16.3895"
 							/></svg
 						><span class="bubbleIcon-icon"><span aria-hidden="true" class="lucca-icon icon-app"></span></span>
-					</div>
+					</span>
 				</div>
 			</td>
 			<td>

--- a/stories/qa/data-table/data-table.stories.html
+++ b/stories/qa/data-table/data-table.stories.html
@@ -2156,7 +2156,7 @@
 										<div class="emptyState-container">
 											<div class="emptyState-content">
 												<div class="emptyState-content-icon">
-													<div aria-hidden="true" class="bubbleIllustration mod-L">
+													<span aria-hidden="true" class="bubbleIllustration mod-L">
 														<svg fill="none" height="48" viewBox="0 0 48 48" width="48" xmlns="http://www.w3.org/2000/svg">
 															<path
 																d="m7.58697 8.51901c13.85013-18.62671 30.99923-2.27581 36.38083 7.16399 5.3831 9.4385 10.9889 34.5952-24.4368 32.1506-20.245731-1.3949-25.78518-20.696-11.94403-39.31459z"
@@ -2189,7 +2189,7 @@
 																fill="#FFF"
 															></path>
 														</svg>
-													</div>
+													</span>
 												</div>
 												<div class="emptyState-content-text">
 													<h3 class="emptyState-content-heading">Empty State</h3>

--- a/stories/qa/empty-state/empty-state-section.stories.html
+++ b/stories/qa/empty-state/empty-state-section.stories.html
@@ -16,11 +16,11 @@
 					<section class="emptyState">
 						<div class="emptyState-container">
 							<div class="emptyState-content">
-								<div
+								<span
 									class="emptyState-content-icon bubbleIllustration mod-action mod-L"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/calendar.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<div class="emptyState-content-text">
 									<h3 class="emptyState-content-heading">Empty State</h3>
 									<p class="emptyState-content-description">
@@ -57,11 +57,11 @@
 					<section class="emptyState mod-center">
 						<div class="emptyState-container">
 							<div class="emptyState-content">
-								<div
+								<span
 									class="emptyState-content-icon bubbleIllustration mod-L"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/banknote.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<div class="emptyState-content-text">
 									<h3 class="emptyState-content-heading">Empty State</h3>
 									<p class="emptyState-content-description">
@@ -97,11 +97,11 @@
 				<section class="emptyState">
 					<div class="emptyState-container">
 						<div class="emptyState-content">
-							<div
+							<span
 								class="emptyState-content-icon bubbleIllustration mod-L"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/chat.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<div class="emptyState-content-text">
 								<h3 class="emptyState-content-heading">Empty State</h3>
 								<p class="emptyState-content-description">
@@ -118,11 +118,11 @@
 				<section class="emptyState">
 					<div class="emptyState-container">
 						<div class="emptyState-content">
-							<div
+							<span
 								class="emptyState-content-icon bubbleIllustration mod-L palette-neutral"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/chat.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<div class="emptyState-content-text">
 								<h3 class="emptyState-content-heading">Empty State</h3>
 								<p class="emptyState-content-description">
@@ -139,11 +139,11 @@
 				<section class="emptyState">
 					<div class="emptyState-container">
 						<div class="emptyState-content">
-							<div
+							<span
 								class="emptyState-content-icon bubbleIllustration mod-L palette-success"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/thumbUp.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<div class="emptyState-content-text">
 								<h3 class="emptyState-content-heading">Empty State</h3>
 								<p class="emptyState-content-description">
@@ -160,11 +160,11 @@
 				<section class="emptyState">
 					<div class="emptyState-container">
 						<div class="emptyState-content">
-							<div
+							<span
 								class="emptyState-content-icon bubbleIllustration mod-L palette-warning"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/warning.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<div class="emptyState-content-text">
 								<h3 class="emptyState-content-heading">Empty State</h3>
 								<p class="emptyState-content-description">
@@ -181,11 +181,11 @@
 				<section class="emptyState">
 					<div class="emptyState-container">
 						<div class="emptyState-content">
-							<div
+							<span
 								class="emptyState-content-icon bubbleIllustration mod-L palette-critical"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/chat.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<div class="emptyState-content-text">
 								<h3 class="emptyState-content-heading">Empty State</h3>
 								<p class="emptyState-content-description">

--- a/stories/qa/file-upload/file-upload.stories.html
+++ b/stories/qa/file-upload/file-upload.stories.html
@@ -24,11 +24,11 @@
 							aria-labelledby="input-1-label"
 						/>
 						<div class="fileUpload-status">
-							<div
+							<span
 								class="bubbleIllustration palette-product mod-L mod-action"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/invoice.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 						</div>
 						<div class="fileUpload-instruction" id="fileUpload-instruction-1">
 							<span aria-hidden="true" class="fileUpload-instruction-action">
@@ -63,11 +63,11 @@
 							aria-labelledby="input-1-label"
 						/>
 						<div class="fileUpload-status">
-							<div
+							<span
 								class="bubbleIllustration palette-product mod-L mod-action"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/invoice.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 						</div>
 						<div class="fileUpload-instruction" id="fileUpload-instruction-1">
 							<span aria-hidden="true" class="fileUpload-instruction-action">
@@ -102,11 +102,11 @@
 							aria-labelledby="input-1-label"
 						/>
 						<div class="fileUpload-status">
-							<div
+							<span
 								class="bubbleIllustration palette-product mod-L mod-action"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/invoice.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 						</div>
 						<div class="fileUpload-instruction" id="fileUpload-instruction-1">
 							<span aria-hidden="true" class="fileUpload-instruction-action">
@@ -142,11 +142,11 @@
 							multiple="multiple"
 						/>
 						<div class="fileUpload-status">
-							<div
+							<span
 								class="bubbleIllustration palette-product mod-L mod-action"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/bubble-illustration/invoice.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 						</div>
 						<div class="fileUpload-instruction" id="fileUpload-instruction-1">
 							<span aria-hidden="true" class="fileUpload-instruction-action">

--- a/stories/qa/software-icon/software-icon.stories.html
+++ b/stories/qa/software-icon/software-icon.stories.html
@@ -14,11 +14,11 @@
 			<td>
 				<div class="demo-QAtable-list">
 					@for (softwareIcon of softwareIconList; track softwareIcon) {
-						<div
+						<span
 							class="softwareIcon"
 							aria-hidden="true"
 							[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/' + softwareIcon + '.svg' | luSafeExternalSvg"
-						></div>
+						></span>
 					}
 				</div>
 			</td>
@@ -35,11 +35,11 @@
 			<td>
 				<div class="demo-QAtable-list">
 					@for (softwareIcon of softwareIconList; track softwareIcon) {
-						<div
+						<span
 							class="softwareIcon is-disabled"
 							aria-hidden="true"
 							[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/' + softwareIcon + '.svg' | luSafeExternalSvg"
-						></div>
+						></span>
 					}
 				</div>
 			</td>
@@ -55,31 +55,31 @@
 			<td>Size</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div
+					<span
 						class="softwareIcon mod-XXS"
 						aria-hidden="true"
 						[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-					></div>
-					<div
+					></span>
+					<span
 						class="softwareIcon mod-XS"
 						aria-hidden="true"
 						[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/absences.svg' | luSafeExternalSvg"
-					></div>
-					<div
+					></span>
+					<span
 						class="softwareIcon mod-XS"
 						aria-hidden="true"
 						[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/payslip.svg' | luSafeExternalSvg"
-					></div>
-					<div
+					></span>
+					<span
 						class="softwareIcon"
 						aria-hidden="true"
 						[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/benefits.svg' | luSafeExternalSvg"
-					></div>
-					<div
+					></span>
+					<span
 						class="softwareIcon mod-L"
 						aria-hidden="true"
 						[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/office.svg' | luSafeExternalSvg"
-					></div>
+					></span>
 				</div>
 			</td>
 			<td>
@@ -98,27 +98,27 @@
 				<div class="softwareIconWrapper">
 					<ul class="softwareIconWrapper-list">
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Invoices</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/absences.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Absences</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/payslip.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Payslip</span>
 						</li>
 					</ul>
@@ -136,19 +136,19 @@
 					<ng-template #softwareIconWrapperPopoverS>
 						<ul class="popover-contentOptional softwareIconWrapper_popover mod-S">
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/benefits.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Benefits</span>
 							</li>
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/office.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Office</span>
 							</li>
 						</ul>
@@ -174,27 +174,27 @@
 				<div class="softwareIconWrapper mod-S">
 					<ul class="softwareIconWrapper-list">
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Invoices</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/absences.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Absences</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/payslip.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Payslip</span>
 						</li>
 					</ul>
@@ -212,19 +212,19 @@
 					<ng-template #softwareIconWrapperPopoverS>
 						<ul class="popover-contentOptional softwareIconWrapper_popover mod-S">
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/benefits.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Benefits</span>
 							</li>
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/office.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Office</span>
 							</li>
 						</ul>
@@ -234,27 +234,27 @@
 				<div class="softwareIconWrapper mod-XS">
 					<ul class="softwareIconWrapper-list">
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Invoices</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/absences.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Absences</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/payslip.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Payslip</span>
 						</li>
 					</ul>
@@ -272,19 +272,19 @@
 					<ng-template #softwareIconWrapperPopoverXS>
 						<ul class="popover-contentOptional softwareIconWrapper_popover mod-XS">
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/benefits.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Benefits</span>
 							</li>
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/office.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Office</span>
 							</li>
 						</ul>
@@ -317,75 +317,75 @@
 				<div class="softwareIconWrapper" style="inline-size: 8.875rem">
 					<ul class="softwareIconWrapper-list">
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Invoices</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/absences.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Absences</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/payslip.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Payslip</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/benefits.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Benefits</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/office.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Office</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Invoices</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/absences.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Absences</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/payslip.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Payslip</span>
 						</li>
 						<li class="softwareIconWrapper-list-item">
-							<div
+							<span
 								class="softwareIcon"
 								aria-hidden="true"
 								[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/benefits.svg' | luSafeExternalSvg"
-							></div>
+							></span>
 							<span class="pr-u-mask" translate="no">Benefits</span>
 						</li>
 					</ul>
@@ -403,19 +403,19 @@
 					<ng-template #softwareIconWrapperPopoverLB>
 						<ul class="popover-contentOptional softwareIconWrapper_popover">
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/office.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Office</span>
 							</li>
 							<li class="softwareIconWrapper_popover-item">
-								<div
+								<span
 									class="softwareIcon"
 									aria-hidden="true"
 									[innerHtml]="'https://cdn.lucca.fr/transverse/prisme/visuals/software-icon/invoices.svg' | luSafeExternalSvg"
-								></div>
+								></span>
 								<span class="pr-u-mask" translate="no">Invoices</span>
 							</li>
 						</ul>


### PR DESCRIPTION
## Description

Illustration components can now semantically be used inside buttons.

Their markup is [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/button#technical_summary) (`<span>` instead of `<div>`).

[UI Diff available](https://claude.ai/code/artifact/812b94ed-29a4-4335-953e-d1a0a6bf7d03), made locally.

-----

* `lu-bubble-illustration` and `lu-software-icon` inner elements swapped to `<span>`.
* Documentation snippets and QA pages aligned (`bubbleIcon` included).
* No visual change: display comes from the component classes.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [x] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
