### PR TITLE
[grid] fix align with Chrome

### DIFF
--- a/packages/scss/src/components/grid/component.scss
+++ b/packages/scss/src/components/grid/component.scss
@@ -29,6 +29,7 @@
 			grid-column-end: span var(--grid-colspan, var(--grid-column-end));
 			grid-row-end: span var(--grid-rowspan, var(--grid-row-end));
 			min-inline-size: 0;
+			text-align: var(--grid-textAlign); // required for Chrome, which interprets the deprecated `align` attribute
 
 			@each $breakpoint, $value in config.$breakpoints {
 				@include media.min($breakpoint) {

--- a/packages/scss/src/components/grid/vars.scss
+++ b/packages/scss/src/components/grid/vars.scss
@@ -5,6 +5,8 @@
 	--grid-row-gap: var(--grid-gap);
 	--grid-maxWidth: none;
 
+	--grid-textAlign: start;
+
 	--grid-column-start: auto;
 	--grid-row-start: auto;
 

--- a/stories/qa/grid/grid.stories.html
+++ b/stories/qa/grid/grid.stories.html
@@ -1,71 +1,162 @@
-@let responsiveSample =
-	{
-		colspanAtMediaMinXXS: 3,
-		rowAtMediaMinXXS: 2,
-		rowspanAtMediaMinXS: 2,
-		columnAtMediaMinS: 2,
-	};
 <table class="demo-QAtable">
 	<tbody>
 		<tr>
 			<td></td>
-			<td>
-				<div class="demo-QAtable-list">HTML</div>
-			</td>
+			<td style="inline-size: 50%">HTML</td>
+			<td style="inline-size: 50%">Angular</td>
 		</tr>
 		<tr>
 			<td>Default</td>
 			<td>
 				<div class="grid">
-					<div class="grid-column" style="--grid-colspan: 6">
-						<div class="gridDemo">--grid-colspan: 6</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-					<div class="grid-column" style="--grid-colspan: 6">
-						<div class="gridDemo">--grid-colspan: 6</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-				</div>
-				<div class="grid">
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinXS: 4">
-						<div class="gridDemo">--grid-colspan: 12; --grid-colspanAtMediaMinXS: 4</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinXS: 8">
-						<div class="gridDemo">--grid-colspan: 12; --grid-colspanAtMediaMinXS: 8</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-				</div>
-				<div class="grid">
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 7">
-						<div class="gridDemo">grid-colspanAtMediaMinS: 7</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 5">
-						<div class="gridDemo">grid-colspanAtMediaMinS: 5</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-				</div>
-				<div class="grid">
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3">
-						<div class="gridDemo">--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3">
-						<div class="gridDemo">--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3">
-						<div class="gridDemo">--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
-					<div class="grid-column" style="--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3">
-						<div class="gridDemo">--grid-colspan: 12; --grid-colspanAtMediaMinS: 6; --grid-colspanAtMediaMinM: 3</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
 					</div>
 				</div>
 			</td>
+			<td>
+				<lu-grid>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
+			</td>
 		</tr>
 		<tr>
-			<td>Auto width</td>
+			<td>Columns</td>
+			<td>
+				<div class="grid" style="--grid-columns: 6">
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+					<div class="grid-column">
+						<div class="gridDemo"></div>
+					</div>
+				</div>
+			</td>
+			<td>
+				<lu-grid columns="6">
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
+			</td>
+		</tr>
+		<tr>
+			<td>Mode form</td>
+			<td>
+				<div class="grid mod-form" style="--grid-max-width: 20rem">
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+				</div>
+			</td>
+			<td>
+				<lu-grid mode="form" style="--grid-max-width: 20rem">
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
+			</td>
+		</tr>
+		<tr>
+			<td>Mode auto</td>
 			<td>
 				<div class="grid mod-auto">
-					<div class="grid-column"><div class="gridDemo">grid mod-auto</div></div>
-					<div class="grid-column"><div class="gridDemo">grid mod-auto</div></div>
-					<div class="grid-column"><div class="gridDemo">grid mod-auto</div></div>
-					<div class="grid-column"><div class="gridDemo">grid mod-auto</div></div>
-					<div class="grid-column"><div class="gridDemo">grid mod-auto</div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
 				</div>
+			</td>
+			<td>
+				<lu-grid mode="auto">
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
 			</td>
 		</tr>
 		<tr>
@@ -81,143 +172,178 @@
 					<div class="grid-column" style="--grid-justify: end"><div class="gridDemo"></div></div>
 				</div>
 			</td>
+			<td>
+				<lu-grid columns="1">
+					<lu-grid-column justify="start"><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
+				<lu-grid columns="1">
+					<lu-grid-column justify="center"><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
+				<lu-grid columns="1">
+					<lu-grid-column justify="end"><div class="gridDemo"></div></lu-grid-column>
+				</lu-grid>
+			</td>
 		</tr>
 		<tr>
 			<td>Vertical Alignment</td>
 			<td>
-				<div class="grid mod-topAtMediaMinXXXS">
-					<div class="grid-6atMediaMinXXXS"><div class="gridDemo" style="block-size: 100px"></div></div>
-					<div class="grid-6atMediaMinXXXS"><div class="gridDemo"></div></div>
+				<div class="demo-QAtable-list">
+					<div class="pr-u-flexGrow1">
+						<div class="grid mod-auto">
+							<div class="grid-column"><div class="gridDemo" style="block-size: 100px"></div></div>
+							<div class="grid-column" style="--grid-align: start"><div class="gridDemo">start</div></div>
+						</div>
+					</div>
+					<div class="pr-u-flexGrow1">
+						<div class="grid mod-auto">
+							<div class="grid-column"><div class="gridDemo" style="block-size: 100px"></div></div>
+							<div class="grid-column" style="--grid-align: center"><div class="gridDemo">center</div></div>
+						</div>
+					</div>
+					<div class="pr-u-flexGrow1">
+						<div class="grid mod-auto">
+							<div class="grid-column"><div class="gridDemo" style="block-size: 100px"></div></div>
+							<div class="grid-column" style="--grid-align: end"><div class="gridDemo">end</div></div>
+						</div>
+					</div>
 				</div>
-				<div class="grid mod-middleAtMediaMinXXXS">
-					<div class="grid-6atMediaMinXXXS"><div class="gridDemo" style="block-size: 100px"></div></div>
-					<div class="grid-6atMediaMinXXXS"><div class="gridDemo"></div></div>
-				</div>
-				<div class="grid mod-bottomAtMediaMinXXXS">
-					<div class="grid-6atMediaMinXXXS"><div class="gridDemo" style="block-size: 100px"></div></div>
-					<div class="grid-6atMediaMinXXXS"><div class="gridDemo"></div></div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="pr-u-flexGrow1">
+						<lu-grid mode="auto">
+							<lu-grid-column style="block-size: 100px"><div class="gridDemo" style="block-size: 100%"></div></lu-grid-column>
+							<lu-grid-column align="start"><div class="gridDemo">start</div></lu-grid-column>
+						</lu-grid>
+					</div>
+					<div class="pr-u-flexGrow1">
+						<lu-grid mode="auto">
+							<lu-grid-column style="block-size: 100px"><div class="gridDemo" style="block-size: 100%"></div></lu-grid-column>
+							<lu-grid-column align="center"><div class="gridDemo">center</div></lu-grid-column>
+						</lu-grid>
+					</div>
+					<div class="pr-u-flexGrow1">
+						<lu-grid mode="auto">
+							<lu-grid-column style="block-size: 100px"><div class="gridDemo" style="block-size: 100%"></div></lu-grid-column>
+							<lu-grid-column align="end"><div class="gridDemo">end</div></lu-grid-column>
+						</lu-grid>
+					</div>
 				</div>
 			</td>
 		</tr>
 		<tr>
 			<td>Reorder</td>
 			<td>
-				<div class="grid mod-dense" style="--grid-columns: 4">
-					<div class="grid-column" style="--grid-column: 2"><div class="gridDemo">1 --grid-column: 2</div></div>
-					<div class="grid-column" style="--grid-column: 3"><div class="gridDemo">2 --grid-column: 3</div></div>
-					<div class="grid-column" style="--grid-column: 1"><div class="gridDemo">3 --grid-column: 1</div></div>
-					<div class="grid-column"><div class="gridDemo">4</div></div>
-				</div>
-				<div class="grid mod-dense" style="--grid-columns: 4">
-					<div class="grid-column"><div class="gridDemo">1</div></div>
-					<div class="grid-column" style="--grid-columnAtMediaMinM: 4"><div class="gridDemo">2 --grid-columnAtMediaMinM: 4</div></div>
+				<div class="grid" style="--grid-columns: 4">
+					<div class="grid-column" style="--grid-column: 2"><div class="gridDemo">1</div></div>
+					<div class="grid-column" style="--grid-column: 3"><div class="gridDemo">2</div></div>
 					<div class="grid-column"><div class="gridDemo">3</div></div>
-					<div class="grid-column"><div class="gridDemo">4</div></div>
+					<div class="grid-column" style="--grid-row: 1"><div class="gridDemo">4</div></div>
 				</div>
 			</td>
-		</tr>
-	</tbody>
-	<tbody>
-		<tr>
-			<td></td>
 			<td>
-				<div class="demo-QAtable-list">Angular</div>
-			</td>
-		</tr>
-		<tr>
-			<td>Default</td>
-			<td>
-				<lu-grid columns="6">
-					<lu-grid-column class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
-				<lu-grid columns="1">
-					<lu-grid-column class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
+				<lu-grid columns="4">
+					<lu-grid-column column="2"><div class="gridDemo">1</div></lu-grid-column>
+					<lu-grid-column column="3"><div class="gridDemo">2</div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo">3</div></lu-grid-column>
+					<lu-grid-column row="1"><div class="gridDemo">4</div></lu-grid-column>
 				</lu-grid>
 			</td>
 		</tr>
 		<tr>
 			<td>Gap</td>
 			<td>
-				<lu-grid columns="2" gap="600">
-					<lu-grid-column class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
-				<lu-grid columns="2" gap="200">
-					<lu-grid-column class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
-				<lu-grid columns="2" gap="400">
-					<lu-grid-column class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
+				<div class="demo-QAtable-list">
+					<div class="pr-u-inlineSize100%">
+						<div class="grid" style="--grid-columns: 2; --grid-gap: var(--pr-t-spacings-25)">
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+						</div>
+					</div>
+					<div class="pr-u-inlineSize100%">
+						<div class="grid" style="--grid-columns: 2; --grid-column-gap: var(--pr-t-spacings-25)">
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+						</div>
+					</div>
+					<div class="pr-u-inlineSize100%">
+						<div class="grid" style="--grid-columns: 2; --grid-row-gap: var(--pr-t-spacings-25)">
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+							<div class="grid-column"><div class="gridDemo"></div></div>
+						</div>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="pr-u-inlineSize100%">
+						<lu-grid columns="2" gap="25">
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+						</lu-grid>
+					</div>
+					<div class="pr-u-inlineSize100%">
+						<lu-grid columns="2" columnGap="25">
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+						</lu-grid>
+					</div>
+					<div class="pr-u-inlineSize100%">
+						<lu-grid columns="2" rowGap="25">
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+							<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+						</lu-grid>
+					</div>
+				</div>
 			</td>
 		</tr>
 		<tr>
 			<td>Colspan</td>
 			<td>
-				<lu-grid columns="2" gap="500" columnGap="0" rowGap="300">
-					<lu-grid-column colspan="3" class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
-				<lu-grid columns="5" gap="500" columnGap="0" rowGap="300">
-					<lu-grid-column colspan="6" rowspan="4" class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
+				<div class="grid" style="--grid-columns: 3">
+					<div class="grid-column" style="--grid-colspan: 3"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+				</div>
+			</td>
+			<td>
+				<lu-grid columns="3">
+					<lu-grid-column colspan="3"><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
 				</lu-grid>
 			</td>
 		</tr>
 		<tr>
-			<td>Justify</td>
+			<td>Rowspan</td>
 			<td>
-				<lu-grid columns="1">
-					<lu-grid-column justify="start" class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
-				<lu-grid columns="1">
-					<lu-grid-column justify="center" class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
-				<lu-grid columns="1">
-					<lu-grid-column justify="end" class="gridDemo">story</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-				</lu-grid>
+				<div class="grid" style="--grid-columns: 3">
+					<div class="grid-column" style="--grid-rowspan: 2"><div class="gridDemo" style="block-size: 100%"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+					<div class="grid-column"><div class="gridDemo"></div></div>
+				</div>
 			</td>
-		</tr>
-		<tr>
-			<td>Responsive</td>
 			<td>
-				<lu-grid columns="6">
-					<lu-grid-column [responsive]="responsiveSample" class="gridDemo">rwd</lu-grid-column>
-					<lu-grid-column [responsive]="{ columnAtMediaMinS: 1, rowAtMediaMinS: 1 }" class="gridDemo">rwd</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
-					<lu-grid-column class="gridDemo">col</lu-grid-column>
+				<lu-grid columns="3">
+					<lu-grid-column rowspan="2"><div class="gridDemo" style="block-size: 100%"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
+					<lu-grid-column><div class="gridDemo"></div></lu-grid-column>
 				</lu-grid>
 			</td>
 		</tr>

--- a/stories/qa/grid/grid.stories.ts
+++ b/stories/qa/grid/grid.stories.ts
@@ -10,12 +10,8 @@ import { Meta, StoryObj } from '@storybook/angular-vite';
 			.gridDemo {
 				background-color: var(--pr-t-elevation-surface-sunken);
 				border-radius: var(--pr-t-border-radius-50);
-				min-block-size: 2.7rem;
-				padding-block: 0.6rem;
-				padding-inline: var(--pr-t-spacings-200);
-			}
-			.grid + .grid {
-				margin-block-start: var(--pr-t-spacings-200);
+				min-block-size: 1.5rem;
+				min-inline-size: 1.5rem;
 			}
 		`,
 	],


### PR DESCRIPTION
## Description

Chrome interprets the deprecated `align` attribute and incorrectly changes the horizontal alignment of the text.

-----

+ QA page refresh

-----

<img width="1056" height="132" alt="Capture d’écran 2026-08-20 à 14 56 36" src="https://github.com/user-attachments/assets/d4469a20-65fb-4fca-8e47-784dd321de8a" />
