### PR TITLE
fix(stories): use calendar year in date-select displayer format

### DIFF
--- a/stories/documentation/forms/date/select/date-select.stories.ts
+++ b/stories/documentation/forms/date/select/date-select.stories.ts
@@ -124,7 +124,7 @@ export const SelectMonthWithDisplayer = generateStory({
 	template: `
 <label class="textfield">
 	<lu-date-select class="textfield-input" [(ngModel)]="selectedDate" [granularity]="granularity">
-		<ng-container *luDisplayer="let value">start of {{ value | date : 'MM/YYYY' }}</ng-container>
+		<ng-container *luDisplayer="let value">start of {{ value | date : 'MM/yyyy' }}</ng-container>
 	</lu-date-select>
 	<span class="textfield-label">Label</span>
 </label>


### PR DESCRIPTION
`{{ value | date : 'MM/YYYY' }}` threw NG02100/NG02300 at render because `Y` is the week-based year, which Angular's DatePipe rejects here. Use `yyyy` (calendar year) instead.

## Description

Functional description for the changelog.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
