### PR TITLE
[tag] hiddenLabel or onlyIcon

### DIFF
--- a/packages/prisme/icon/icon.component.scss
+++ b/packages/prisme/icon/icon.component.scss
@@ -1,4 +1,5 @@
-lu-icon, pr-icon {
+lu-icon,
+pr-icon {
 	@layer base {
 		display: inline-flex;
 	}

--- a/packages/prisme/icon/icon.component.scss
+++ b/packages/prisme/icon/icon.component.scss
@@ -1,4 +1,4 @@
-lu-icon {
+lu-icon, pr-icon {
 	@layer base {
 		display: inline-flex;
 	}

--- a/packages/prisme/tag/tag.component.html
+++ b/packages/prisme/tag/tag.component.html
@@ -3,7 +3,7 @@
 		@if (icon(); as icon) {
 			<pr-icon [icon]="icon" />
 		}
-		<span class="tag-content">{{ label() }}</span>
+		<span class="tag-content" [class.pr-u-mask]="hiddenLabel()">{{ label() }}</span>
 	</a>
 } @else {
 	<span class="tag" [class]="tagClasses()" [class.mod-outlined]="!AI() && outlined()" [class.mod-AI]="AI()">
@@ -11,9 +11,9 @@
 			<pr-icon [icon]="icon" />
 		}
 		@if (withEllipsis()) {
-			<span class="tag-content pr-u-ellipsis" prTooltip prTooltipWhenEllipsis>{{ label() }}</span>
+			<span class="tag-content pr-u-ellipsis" [class.pr-u-mask]="hiddenLabel()" prTooltip prTooltipWhenEllipsis>{{ label() }}</span>
 		} @else {
-			<span class="tag-content">{{ label() }}</span>
+			<span class="tag-content" [class.pr-u-mask]="hiddenLabel()">{{ label() }}</span>
 		}
 	</span>
 }

--- a/packages/prisme/tag/tag.component.html
+++ b/packages/prisme/tag/tag.component.html
@@ -1,14 +1,14 @@
 @if (link()) {
 	<a [routerLink]="link()" class="tag" [class]="tagClasses()" [class.mod-outlined]="!AI() && outlined()" [class.mod-AI]="AI()">
 		@if (icon(); as icon) {
-			<pr-icon [icon]="icon" />
+			<lu-icon [icon]="icon" />
 		}
 		<span class="tag-content" [class.pr-u-mask]="hiddenLabel()">{{ label() }}</span>
 	</a>
 } @else {
 	<span class="tag" [class]="tagClasses()" [class.mod-outlined]="!AI() && outlined()" [class.mod-AI]="AI()">
 		@if (icon(); as icon) {
-			<pr-icon [icon]="icon" />
+			<lu-icon [icon]="icon" />
 		}
 		@if (withEllipsis()) {
 			<span class="tag-content pr-u-ellipsis" [class.pr-u-mask]="hiddenLabel()" prTooltip prTooltipWhenEllipsis>{{ label() }}</span>

--- a/packages/prisme/tag/tag.component.ts
+++ b/packages/prisme/tag/tag.component.ts
@@ -17,7 +17,9 @@ export class TagComponent {
 	/**
 	 * Which text should the tag be? Defaults to medium
 	 */
-	readonly label = input.required<string>();
+	readonly label = input<string | null>(null);
+
+	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Which size should the tag be? Defaults to medium

--- a/packages/prisme/tag/tag.component.ts
+++ b/packages/prisme/tag/tag.component.ts
@@ -1,5 +1,6 @@
-import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { DecorativePalette, Palette } from '@lucca/prisme/core';
 import { IconComponent, LuccaIcon } from '@lucca/prisme/icon';
 import { LuTooltipModule } from '@lucca/prisme/tooltip';
@@ -35,7 +36,7 @@ export class TagComponent {
 	/**
 	 * Should display be outlined?
 	 */
-	readonly outlined = input(false, { transform: booleanAttribute });
+	readonly outlined = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * For routerLink usage
@@ -51,12 +52,12 @@ export class TagComponent {
 	/**
 	 * Truncates the text with an ellipsis and adds a tooltip when the label is too long
 	 */
-	readonly withEllipsis = input(false, { transform: booleanAttribute });
+	readonly withEllipsis = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Applies AI colors
 	 */
-	readonly AI = input(false, { transform: booleanAttribute });
+	readonly AI = input(false, { transform: luBooleanAttribute });
 
 	readonly tagClasses = computed(() => {
 		const size = this.size();

--- a/packages/prisme/tag/tag.component.ts
+++ b/packages/prisme/tag/tag.component.ts
@@ -20,8 +20,6 @@ export class TagComponent {
 	 */
 	readonly label = input<string | null>(null);
 
-	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
-
 	/**
 	 * Which size should the tag be? Defaults to medium
 	 */
@@ -48,6 +46,11 @@ export class TagComponent {
 	 * Defaults to no icon.
 	 */
 	readonly icon = input<LuccaIcon | null>(null);
+
+	/**
+	 * Visually hides the label while keeping it in the DOM for screen readers. Requires an icon.
+	 */
+	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
 
 	/**
 	 * Truncates the text with an ellipsis and adds a tooltip when the label is too long

--- a/packages/prisme/tag/tag.component.ts
+++ b/packages/prisme/tag/tag.component.ts
@@ -1,6 +1,5 @@
-import { ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, computed, input, ViewEncapsulation } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { DecorativePalette, Palette } from '@lucca/prisme/core';
 import { IconComponent, LuccaIcon } from '@lucca/prisme/icon';
 import { LuTooltipModule } from '@lucca/prisme/tooltip';
@@ -34,7 +33,7 @@ export class TagComponent {
 	/**
 	 * Should display be outlined?
 	 */
-	readonly outlined = input(false, { transform: luBooleanAttribute });
+	readonly outlined = input(false, { transform: booleanAttribute });
 
 	/**
 	 * For routerLink usage
@@ -50,17 +49,17 @@ export class TagComponent {
 	/**
 	 * Visually hides the label while keeping it in the DOM for screen readers. Requires an icon.
 	 */
-	readonly hiddenLabel = input(false, { transform: luBooleanAttribute });
+	readonly hiddenLabel = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Truncates the text with an ellipsis and adds a tooltip when the label is too long
 	 */
-	readonly withEllipsis = input(false, { transform: luBooleanAttribute });
+	readonly withEllipsis = input(false, { transform: booleanAttribute });
 
 	/**
 	 * Applies AI colors
 	 */
-	readonly AI = input(false, { transform: luBooleanAttribute });
+	readonly AI = input(false, { transform: booleanAttribute });
 
 	readonly tagClasses = computed(() => {
 		const size = this.size();

--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -6,13 +6,11 @@
 	border-radius: var(--pr-t-border-radius-small);
 	padding-block: 0;
 	padding-inline: var(--pr-t-spacings-50);
-
-	/* autoprefixer: off */
 	text-decoration: var(--components-tag-decoration);
 	box-shadow: 0 0 0 1px var(--components-tag-shadow);
 	gap: var(--components-tag-gap);
 	cursor: var(--components-tag-cursor);
-	display: inline-flex;
+	display: var(--components-tag-display);
 	align-items: center;
 	text-align: center;
 	vertical-align: baseline;
@@ -42,9 +40,11 @@
 	@at-root ($atRoot) {
 		.tag-content {
 			outline: none;
-
-			/* autoprefixer: off */
 			text-decoration: var(--components-tag-decoration);
+
+			&:empty {
+				display: none;
+			}
 		}
 	}
 }

--- a/packages/scss/src/components/tag/index.scss
+++ b/packages/scss/src/components/tag/index.scss
@@ -41,5 +41,15 @@
 		&:has(.lucca-icon) {
 			@include withIcon;
 		}
+
+		&:has(.tag-content:empty) {
+			&:not(:has(.lucca-icon)) {
+				@include empty;
+			}
+		}
+
+		&:empty {
+			@include empty;
+		}
 	}
 }

--- a/packages/scss/src/components/tag/states.scss
+++ b/packages/scss/src/components/tag/states.scss
@@ -8,3 +8,7 @@
 @mixin focusVisible {
 	@include a11y.focusVisible;
 }
+
+@mixin empty {
+	--components-tag-display: none;
+}

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -9,6 +9,7 @@
 	--components-tag-boxShadow: 0 0 0 1px var(--components-tag-shadow);
 	--components-tag-position: static;
 	--components-tag-before-content: none;
+	--components-tag-display: inline-flex;
 
 	// Deprecated
 	--components-tag-fontSize: var(--pr-t-font-body-S-fontSize);

--- a/stories/documentation/texts/tags/angular/tag.stories.ts
+++ b/stories/documentation/texts/tags/angular/tag.stories.ts
@@ -1,8 +1,8 @@
+import { HiddenArgType, PaletteAllArgType } from '@/helpers/common-arg-types';
+import { generateInputs, setStoryOptions } from '@/helpers/stories';
 import { IconsList } from '@/stories/icons-list';
 import { TAG_SIZE, TagComponent } from '@lucca-front/ng/tag';
 import { Meta, StoryObj } from '@storybook/angular-vite';
-import { HiddenArgType, PaletteAllArgType } from '@/helpers/common-arg-types';
-import { generateInputs, setStoryOptions } from '@/helpers/stories';
 
 export default {
 	title: 'Documentation/Texts/Tags/Angular/Basic',
@@ -48,10 +48,15 @@ export const Template: StoryObj<TagComponent> = {
 		label: {
 			description: 'Modifie le texte affiché par le composant.',
 		},
+		hiddenLabel: {
+			if: { arg: 'label', neq: '' },
+			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+		},
 	},
 
 	args: {
 		label: 'Text',
+		hiddenLabel: false,
 		outlined: false,
 		icon: null,
 		withEllipsis: false,

--- a/stories/documentation/texts/tags/angular/tag.stories.ts
+++ b/stories/documentation/texts/tags/angular/tag.stories.ts
@@ -38,6 +38,11 @@ export const Template: StoryObj<TagComponent> = {
 			},
 			description: 'Ajoute une icône au tag.',
 		},
+		hiddenLabel: {
+			name: '↳ hiddenLabel',
+			if: { arg: 'icon', truthy: true },
+			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
+		},
 		link: HiddenArgType,
 		AI: {
 			description: '[v20.3] Applique les couleurs IA.',
@@ -48,17 +53,13 @@ export const Template: StoryObj<TagComponent> = {
 		label: {
 			description: 'Modifie le texte affiché par le composant.',
 		},
-		hiddenLabel: {
-			if: { arg: 'label', neq: '' },
-			description: 'Masque le label en le conservant dans le DOM pour les lecteurs d’écran',
-		},
 	},
 
 	args: {
 		label: 'Text',
-		hiddenLabel: false,
 		outlined: false,
 		icon: null,
+		hiddenLabel: false,
 		withEllipsis: false,
 		AI: false,
 	},

--- a/stories/documentation/texts/tags/html&css/hiddenLabel.stories.ts
+++ b/stories/documentation/texts/tags/html&css/hiddenLabel.stories.ts
@@ -1,0 +1,21 @@
+import { Meta, StoryObj } from '@storybook/angular-vite';
+
+export default {
+	title: 'Documentation/Texts/Tags/HTML&CSS/HiddenLabel',
+} as Meta;
+
+function getTemplate(): string {
+	return `<span class="tag">
+	<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+	<span class="tag-content pr-u-mask">Text</span>
+</span>`;
+}
+
+const Template = () => ({
+	template: getTemplate(),
+});
+
+export const hiddenLabel: StoryObj = {
+	args: {},
+	render: Template,
+};

--- a/stories/documentation/texts/tags/html&css/onlyIcon.stories.ts
+++ b/stories/documentation/texts/tags/html&css/onlyIcon.stories.ts
@@ -1,0 +1,20 @@
+import { Meta, StoryObj } from '@storybook/angular-vite';
+
+export default {
+	title: 'Documentation/Texts/Tags/HTML&CSS/OnlyIcon',
+} as Meta;
+
+function getTemplate(): string {
+	return `<span class="tag">
+	<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+</span>`;
+}
+
+const Template = () => ({
+	template: getTemplate(),
+});
+
+export const OnlyIcon: StoryObj = {
+	args: {},
+	render: Template,
+};

--- a/stories/qa/tags/tags.stories.html
+++ b/stories/qa/tags/tags.stories.html
@@ -63,7 +63,6 @@
 						<span class="tag mod-AI">
 							<span class="lucca-icon icon-heart" aria-hidden="true"></span> <span class="tag-content">Text</span>
 						</span>
-
 						<span class="tag mod-L palette-product">
 							<span class="lucca-icon icon-heart" aria-hidden="true"></span> <span class="tag-content">Text</span>
 						</span>
@@ -90,6 +89,38 @@
 					<lu-tag label="Text" palette="neutal" icon="heart" size="L" />
 					<lu-tag label="Text" AI icon="heart" size="L" />
 				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Icon only</td>
+			<td>
+				<span class="tag">
+					<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+				</span>
+			</td>
+			<td>
+				<lu-tag icon="heart" />
+			</td>
+		</tr>
+		<tr>
+			<td>Hidden label</td>
+			<td>
+				<span class="tag">
+					<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+					<span class="tag-content pr-u-mask">Text</span>
+				</span>
+			</td>
+			<td>
+				<lu-tag icon="heart" label="Text" hiddenLabel />
+			</td>
+		</tr>
+		<tr>
+			<td>Empty</td>
+			<td>
+				<span class="tag"></span>
+			</td>
+			<td>
+				<lu-tag />
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Description

New option for tags: use them only with an icon.
Either without associated text (purely decorative), or with associated text that is hidden (informational).

-----

The component will also detect if it contains neither text nor an icon, in which case it will no longer be displayed.

Close #5217 

-----
<img width="1204" height="140" alt="Capture d’écran 2026-08-31 à 16 24 10" src="https://github.com/user-attachments/assets/207e93c4-d7e2-4413-81ea-347355427c0b" />

