### PR TITLE
[DateRange] fix calendar anchor for ranges with an open start

### DIFF
--- a/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { addMonths } from 'date-fns';
+import { addMonths, startOfDay } from 'date-fns';
 import { DateRange } from '../calendar2/date-range';
 import { DateRangeInputComponent } from './date-range-input.component';
 import localeFr from '@angular/common/locales/fr';
@@ -334,5 +334,27 @@ describe('DateRangeInputComponent', () => {
 			expect(getInput(fixture, 'start').disabled).toBe(false);
 			expect(getInput(fixture, 'end').disabled).toBe(false);
 		});
+	});
+
+	it('should anchor the calendar on the end bound when the written range has no start', () => {
+		const formControl = new FormControl<DateRange | null>(null);
+
+		TestBed.configureTestingModule({
+			imports: [FormControlHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
+		});
+
+		const fixture = TestBed.createComponent(FormControlHostComponent);
+		fixture.componentInstance.formControl = formControl;
+		fixture.detectChanges();
+
+		const end = new Date(2025, 11, 31);
+		// The component itself emits such a range when only the end field is filled
+		formControl.setValue({ start: null, end } as unknown as DateRange);
+		fixture.detectChanges();
+
+		const dateRangeInput = fixture.debugElement.query(By.directive(DateRangeInputComponent)).componentInstance as DateRangeInputComponent;
+
+		expect(dateRangeInput['currentDate']()).toEqual(startOfDay(end));
 	});
 });

--- a/packages/ng/date2/date-range-input/date-range-input.component.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.ts
@@ -475,7 +475,8 @@ export class DateRangeInputComponent extends AbstractDateComponent implements On
 
 		if (isNotNil(dateRange)) {
 			this.selectedRange.set(_dateRange);
-			this.currentDate.set(startOfDay(dateRange.start));
+			const calendarAnchor = _dateRange?.start ?? _dateRange?.end ?? new Date();
+			this.currentDate.set(startOfDay(calendarAnchor));
 		}
 	}
 


### PR DESCRIPTION
Fixes #5262

## What

`writeValue` anchored the calendar on `startOfDay(dateRange.start)` unconditionally. A range with an open start (`{ start: null, end }` — which the component itself emits when only the end field is filled) turned `currentDate` into an Invalid Date, and the calendar threw `RangeError: Invalid time value` when the popover opened.

The calendar is now anchored on the first available bound (`start`, then `end`), falling back to today, using the transformed range so ISO-string inputs are covered too.

## Tests

Added a spec writing `{ start: null, end }` through a `FormControl` and asserting the calendar anchors on the end bound.