### PR TITLE
[dateInput/dateRangeInput] fix popover a11y

### DIFF
--- a/packages/ng/date2/date-input/date-input.component.html
+++ b/packages/ng/date2/date-input/date-input.component.html
@@ -12,7 +12,9 @@
 			(input)="userTextInput.set(date.value)"
 			(blur)="inputBlurred()"
 			(focus)="inputFocused.set(true)"
-			aria-haspopup="true"
+			aria-haspopup="dialog"
+			[attr.aria-expanded]="popoverRef.opened()"
+			[attr.aria-controls]="popoverRef.ariaControls"
 			role="combobox"
 			(click)="popoverRef.openPopover(true, true)"
 			(keydown.arrowDown)="arrowDown(popoverRef)"
@@ -44,6 +46,7 @@
 				tabindex="-1"
 				type="button"
 				class="button mod-onlyIcon mod-ghost textField-input-affix-toggle"
+				aria-hidden="true"
 			>
 				<lu-icon [icon]="'calendarDate'" [alt]="intl().pickDate" />
 			</button>
@@ -58,7 +61,7 @@
 <div *luFilterPillDisplayer>{{ displayValue() }}</div>
 
 <ng-template #calendar>
-	<div class="calendarWrapper">
+	<div class="calendarWrapper" role="dialog" aria-modal="true" [attr.aria-label]="intl().pickDate">
 		<div class="calendarWrapper-navigation pr-u-left0">
 			<button class="calendarWrapper-navigation-button button" type="button" (click)="prev(calendarMode() ?? mode())" #previousButtonRef>
 				<span aria-hidden="true" class="lucca-icon icon-arrowChevronLeft"></span><span class="pr-u-mask">{{ intl().previous }}</span>

--- a/packages/ng/date2/date-range-input/date-range-input.component.html
+++ b/packages/ng/date2/date-range-input/date-range-input.component.html
@@ -22,7 +22,9 @@
 					(input)="textInputChange(start.value, 'start')"
 					(blur)="inputBlur()"
 					(focus)="inputFocused.set(true); editedField.set(0); highlightedField.set(0)"
-					aria-haspopup="true"
+					aria-haspopup="dialog"
+					[attr.aria-expanded]="popoverRef.opened()"
+					[attr.aria-controls]="popoverRef.ariaControls"
 					role="combobox"
 					(click)="editedField.set(0); openPopover(popoverRef, 'start')"
 					(keydown.arrowDown)="arrowDown(popoverRef, 'start')"
@@ -46,7 +48,9 @@
 					(input)="textInputChange(end.value, 'end')"
 					(blur)="inputBlur()"
 					(focus)="inputFocused.set(true); editedField.set(1); highlightedField.set(1)"
-					aria-haspopup="true"
+					aria-haspopup="dialog"
+					[attr.aria-expanded]="popoverRef.opened()"
+					[attr.aria-controls]="popoverRef.ariaControls"
 					role="combobox"
 					(click)="editedField.set(1); openPopover(popoverRef, 'end')"
 					(keydown.arrowDown)="arrowDown(popoverRef, 'end')"
@@ -76,6 +80,7 @@
 					type="button"
 					class="button mod-onlyIcon mod-ghost textField-input-affix-toggle"
 					(click)="editedField.set(0)"
+					aria-hidden="true"
 				>
 					<lu-icon [icon]="'calendarPlanning'" [alt]="intl().pickDate" />
 				</button>
@@ -85,7 +90,7 @@
 </fieldset>
 
 <ng-template #calendar>
-	<div class="calendarShortcutsOptional">
+	<div class="calendarShortcutsOptional" role="dialog" aria-modal="true" [attr.aria-label]="intl().pickDate">
 		@if ((shortcuts()?.length ?? 0) > 0) {
 			<ul
 				class="calendarShortcuts"


### PR DESCRIPTION
## Description

Fixes an inconsistency in the date pickers regarding the input fields and buttons that trigger the calendar.

-----

Fix #5244 

-----

<img width="290" height="404" alt="Capture d’écran 2026-08-24 à 15 08 01" src="https://github.com/user-attachments/assets/79a7d0f6-f415-4d7a-9f45-31173fb3eafb" />


