### PR TITLE
[popover] fix size recalculation

### DIFF
--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -273,7 +273,8 @@ export class PopoverDirective implements OnDestroy {
 					.position()
 					.flexibleConnectedTo(this.luPopoverAnchor())
 					.withViewportMargin(getPushPanelViewportMargin(this.elementRef.nativeElement))
-					.withPositions(this.customPositions() || this.#buildPositions()),
+					.withPositions(this.customPositions() || this.#buildPositions())
+					.withGrowAfterOpen(true),
 				scrollStrategy: this.overlay.scrollStrategies[this.overlayScrollStrategy() ?? 'reposition'](),
 				// No blocking backdrop: outside interactions are handled via outsidePointerEvents() below.
 				hasBackdrop: false,


### PR DESCRIPTION
## Description

The size of the popover panel can change once it's open, so we tell Angular to recalculate as needed.

-----

#5154 

-----
