### PR TITLE
fix(title): stop passing nil titles to the translate service

### DIFF
--- a/packages/ng/title/README.md
+++ b/packages/ng/title/README.md
@@ -8,15 +8,11 @@ Add `title` properties in your routes config:
 const routes: Routes = [
   {
     path: '',
-    data: {
-      title: 'Parent title',
-    },
+    title: 'Parent title',
     children: [
       {
         path: ':requestId',
-        data: {
-          title: 'Sub route title',
-        },
+        title: 'Sub route title',
       },
     ],
   },
@@ -27,7 +23,26 @@ The service should now be able to collect all `title` properties defined for the
 
 ex: `Sub route title – Parent title – Lucca YourAppName`
 
-For dynamic titles, the `prependTitle` method from `LuTitleStrategy` enables you to add a custom title.
+### Dynamic titles
+
+A `title` can also be a function, which is how Lucca apps declare their titles:
+
+```typescript
+const routes: Routes = [
+  {
+    path: 'requests',
+    title: () => translate('Requests_Title'),
+  },
+  {
+    path: 'requests/:requestId',
+    title: (route) => translate('Request_Title', { id: route.paramMap.get('requestId') }),
+  },
+];
+```
+
+Each resolved title is then handed to your `translateService` as a translation key, along with the route params and the route data (including resolved data) as interpolation arguments. So a static `title: 'Request {{requestId}}'` works too, as long as your translation library interpolates. Params and resolved data of the parent routes are available as well, as long as the router keeps its default `paramsInheritanceStrategy: 'always'`.
+
+When the title is only known from inside a component, the `prependTitle` method from `LuTitleStrategy` enables you to add a custom title.
 In a component, you could do the following:
 
 ```typescript

--- a/packages/ng/title/title.strategy.spec.ts
+++ b/packages/ng/title/title.strategy.spec.ts
@@ -139,6 +139,10 @@ describe('TitleStrategy', () => {
 				},
 			],
 		},
+		{
+			path: 'untitled/:id',
+			component: StubComponent,
+		},
 	];
 
 	async function clickLink(selector: string): Promise<void> {
@@ -184,6 +188,16 @@ describe('TitleStrategy', () => {
 
 		await clickLink('.link-2');
 		expect(resultTitle).toEqual(`Stub${TitleSeparator}Lucca BU`);
+	});
+
+	it('should not send a nil title to the translate service', async () => {
+		let resultTitle = '';
+		pageTitleService.title$.subscribe((title) => (resultTitle = title));
+
+		// A route without any title in its chain resolves to a nil title, which the translate service would choke on
+		await TestBed.inject(Router).navigateByUrl('/untitled/1');
+
+		expect(resultTitle).toEqual('Lucca BU');
 	});
 
 	it('should include named params in title', async () => {

--- a/packages/ng/title/title.strategy.ts
+++ b/packages/ng/title/title.strategy.ts
@@ -57,7 +57,8 @@ export class LuTitleStrategy extends TitleStrategy {
 		// Title page is display from child to root
 		const pageTitles = this.#getPageTitleParts(routerState.root).reverse();
 		const translatedPageTitles = uniqTitle(pageTitles)
-			.filter(({ title }) => title !== '')
+			// Routes without a title expose it as nil, which must not reach the consumer's translate service
+			.filter(({ title }) => !!title)
 			.map(({ title, params }) => (this.translateService ? this.translateService.translate(title, params) : title));
 		// Add the name app
 		const titleParts = [...translatedPageTitles, this.luccaTitle$].filter((x) => !!x);


### PR DESCRIPTION
## Description

<!-- TODO(corentin): why-line, why this PR exists, in one self-carrying line -->

- The README's routes example put `title` inside `data`, which is the deprecated `LuTitleService` contract rather than `LuTitleStrategy`'s: the page title collapsed to the app name.
- A route with no `title` anywhere in its chain no longer hands a nil title to the app's `translateService`, which threw during navigation.
- The README documents `title: () => ...`, the form Lucca apps actually use for dynamic titles.

-----

<details>
<summary>Technical details</summary>

Starting point: check whether `LuTitleStrategy` was at risk from `paramsInheritanceStrategy` defaulting to `'always'` in Angular 22. It is not. `uniqTitle` collapses the titles inherited from parent routes, and the resulting chain is identical under both strategies, including with a `title: ''` on a parent and with title gaps in the middle of the tree. Two other things came out of that check.

`getResolvedTitleForRoute` reads `snapshot.data[RouteTitleKey]`, a Symbol the router only fills from `route.title`. The string key `title` placed in `data` is therefore never read. That example was not invented: `getPageTitleParts` in `title.service.ts` does read `snapshot.data['title']`, so the README still documented the deprecated `LuTitleService` and was never updated when `LuTitleStrategy` took over. The deprecated service is not affected by the nil-title issue, since it defaults the title to an empty string. Measured on the README example copied verbatim, under both strategies, the title is `Lucca BU` with no route fragment at all. And with a `translateService` provided it does not degrade quietly: `translate(undefined, params)` throws `TypeError: Cannot read properties of undefined (reading 'replace')` from `updateTitle`, inside the router's navigation pipeline.

Hence the `.filter(({ title }) => !!title)` replacing `title !== ''` in `title.strategy.ts`. The added test was checked both ways: without the fix it fails on that `TypeError`.

One thing the switch to `'always'` does change, for the better: params and `resolve` data from ancestor routes are now available as interpolation arguments. `title: 'Child of {{id}}'` on a route whose parent carries `:id` used to render `Child of {{id}}` under `emptyOnly`, and renders `Child of 1` under `always`. The new README section notes it, below the `title: () => ...` form that apps actually use.

</details>

-----
