### PR TITLE
feat(data-table): empty state attributes

### DIFF
--- a/packages/ng/data-table/data-table-head/data-table-head.component.ts
+++ b/packages/ng/data-table/data-table-head/data-table-head.component.ts
@@ -1,7 +1,8 @@
-import { ChangeDetectionStrategy, Component, contentChildren, forwardRef, input, signal, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, contentChildren, forwardRef, inject, input, signal, ViewEncapsulation } from '@angular/core';
 
 import { luBooleanAttribute } from '@lucca-front/ng/core';
 import { DataTableRowCellHeaderComponent } from '../data-table-cell-header/data-table-cell-header.component';
+import { LU_DATA_TABLE_INSTANCE } from '../data-table.token';
 import { LU_DATA_TABLE_HEAD_INSTANCE } from './data-table-head.token';
 
 @Component({
@@ -14,6 +15,7 @@ import { LU_DATA_TABLE_HEAD_INSTANCE } from './data-table-head.token';
 		class: 'dataTable-head',
 		'[class.mod-sticky]': 'sticky()',
 		'[class.is-firstBodyRowVisible]': 'isFirstVisible()',
+		'[attr.inert]': 'tableRef.empty() ? "inert" : null',
 	},
 	providers: [
 		{
@@ -28,4 +30,6 @@ export class DataTableHeadComponent {
 	readonly isFirstVisible = signal(false);
 
 	readonly cols = contentChildren(DataTableRowCellHeaderComponent, { descendants: true });
+
+	tableRef = inject(LU_DATA_TABLE_INSTANCE);
 }

--- a/packages/ng/data-table/data-table.component.html
+++ b/packages/ng/data-table/data-table.component.html
@@ -1,5 +1,5 @@
 <div class="dataTableShadows">
-	<table [class]="classMods()" #tableRef>
+	<table [class]="classMods()" [attr.role]="empty() ? 'presentation' : null" #tableRef>
 		<ng-content />
 	</table>
 	<div class="dataTableWrapper-pagination">

--- a/packages/ng/data-table/data-table.component.ts
+++ b/packages/ng/data-table/data-table.component.ts
@@ -52,6 +52,7 @@ export class DataTableComponent implements OnInit {
 	readonly nested = input(false, { transform: luBooleanAttribute });
 	readonly drag = input(false, { transform: luBooleanAttribute });
 	readonly noOverflow = input(false, { transform: luBooleanAttribute });
+	readonly empty = input(false, { transform: luBooleanAttribute });
 
 	readonly responsive = input<ResponsiveConfig<'layoutFixed', true>>({});
 

--- a/stories/documentation/listings/data-table/angular/basic.stories.ts
+++ b/stories/documentation/listings/data-table/angular/basic.stories.ts
@@ -316,7 +316,7 @@ export default {
 	</tfoot>`
 			: ``;
 		const modelEditableDisplayer = editable ? `<pr-story-model-display>{{ example }}</pr-story-model-display>` : ``;
-		const tbodyTpl = emptyAttr
+		const tbodyTpl = empty
 			? `<tr luDataTableRow>
 			<th luDataTableCell colspan="${cols}">
 				<lu-empty-state-section

--- a/stories/documentation/listings/data-table/html&css/empty-state.stories.ts
+++ b/stories/documentation/listings/data-table/html&css/empty-state.stories.ts
@@ -16,8 +16,8 @@ export default {
 
 function getTemplate(args: EmptyState): string {
 	return `<div class="dataTableWrapper">
-	<table class="dataTable">
-		<thead class="dataTable-head">
+	<table class="dataTable" role="presentation">
+		<thead class="dataTable-head" inert="inert">
 			<tr class="dataTable-head-row">
 				<th class="dataTable-head-row-cell">Label</th>
 				<th class="dataTable-head-row-cell">Label</th>

--- a/stories/qa/data-table/data-table.stories.html
+++ b/stories/qa/data-table/data-table.stories.html
@@ -2141,8 +2141,8 @@
 			<td>Empty</td>
 			<td>
 				<div class="dataTableWrapper">
-					<table class="dataTable">
-						<thead class="dataTable-head">
+					<table class="dataTable" role="presentation">
+						<thead class="dataTable-head" inert="inert">
 							<tr class="dataTable-head-row">
 								<th class="dataTable-head-row-cell">header</th>
 								<th class="dataTable-head-row-cell">header</th>


### PR DESCRIPTION
## Description

Like the `lu-index-table` component, the `empty` input now should automatically add `role="presentation"` on the `<table>` element and the `inert` attribute to the `thead`.
Stories are updated, even the HTML one.

-----
