### PR TITLE
fix(tooltip): Do not reopen when a closing overlay refocuses the trigger

### DIFF
--- a/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
@@ -52,6 +52,7 @@ let nextId = 0;
 		'(mouseenter)': 'onMouseEnter()',
 		'(mouseleave)': 'onMouseLeave()',
 		'(focus)': 'onFocus()',
+		'(focusout)': 'onFocusOut($event)',
 		'(blur)': 'onBlur()',
 		'(keydown.escape)': 'onEscape($event)',
 		class: 'tooltip_trigger',
@@ -92,6 +93,10 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly luTooltipPosition = input<TooltipPosition>('above');
 	readonly prTooltipPosition = input<TooltipPosition>('above');
 	readonly tooltipPosition = computed(() => this.prTooltipPosition() || this.luTooltipPosition());
+
+	// Does not open the tooltip when a closing overlay hands the focus back to its trigger.
+	// Hover and keyboard navigation are unaffected.
+	readonly luTooltipNotOnOverlayFocusReturn = input(false, { transform: booleanAttribute });
 
 	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });
 	readonly prTooltipWhenEllipsisInput = input(false, { alias: 'prTooltipWhenEllipsis', transform: booleanAttribute });
@@ -156,6 +161,9 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	});
 
 	#effectRef?: EffectRef;
+
+	// pane the focus moved into when it last left this trigger, or null
+	#focusLeftToPane: Element | null = null;
 
 	constructor() {
 		this.#destroyRef.onDestroy(() => (this.#destroyed = true));
@@ -308,9 +316,34 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	}
 
 	onFocus() {
+		const leftToPane = this.#focusLeftToPane;
+		this.#focusLeftToPane = null;
+
+		// A closing overlay hands the focus back to its trigger.
+		// That is not the user reaching the trigger, so the tooltip stays closed.
+		if (this.luTooltipNotOnOverlayFocusReturn() && this.#isForeignPane(leftToPane)) {
+			return;
+		}
+
 		if (this.#host.nativeElement.getAttribute('aria-expanded') !== 'true') {
 			this.#action.set('open');
 		}
+	}
+
+	onFocusOut(event: FocusEvent) {
+		// Captured on the way out.
+		// Some overlays dispose their pane before handing the focus back, leaving nothing to inspect.
+		this.#focusLeftToPane = event.relatedTarget instanceof Element ? this.#paneOf(event.relatedTarget) : null;
+	}
+
+	#isForeignPane(pane: Element | null): boolean {
+		// Panes, not the whole container.
+		// A trigger inside an overlay keeps its tooltip when the focus moves within that same overlay.
+		return isNotNil(pane) && pane !== this.#paneOf(this.#host.nativeElement);
+	}
+
+	#paneOf(element: Element): Element | null {
+		return element.closest('.cdk-overlay-pane');
 	}
 
 	onBlur() {

--- a/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
@@ -94,12 +94,6 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly prTooltipPosition = input<TooltipPosition>('above');
 	readonly tooltipPosition = computed(() => this.prTooltipPosition() || this.luTooltipPosition());
 
-	/**
-	 * Does not open the tooltip when a closing overlay hands the focus back to its trigger.
-	 * Hover and keyboard navigation are unaffected.
-	 */
-	readonly luTooltipNotOnOverlayFocusReturn = input(false, { transform: booleanAttribute });
-
 	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });
 	readonly prTooltipWhenEllipsisInput = input(false, { alias: 'prTooltipWhenEllipsis', transform: booleanAttribute });
 
@@ -323,7 +317,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 
 		// A closing overlay hands the focus back to its trigger.
 		// That is not the user reaching the trigger, so the tooltip stays closed.
-		if (this.luTooltipNotOnOverlayFocusReturn() && this.#isForeignPane(leftToPane)) {
+		if (this.#isForeignPane(leftToPane)) {
 			return;
 		}
 

--- a/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
@@ -94,8 +94,10 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly prTooltipPosition = input<TooltipPosition>('above');
 	readonly tooltipPosition = computed(() => this.prTooltipPosition() || this.luTooltipPosition());
 
-	// Does not open the tooltip when a closing overlay hands the focus back to its trigger.
-	// Hover and keyboard navigation are unaffected.
+	/**
+	 * Does not open the tooltip when a closing overlay hands the focus back to its trigger.
+	 * Hover and keyboard navigation are unaffected.
+	 */
 	readonly luTooltipNotOnOverlayFocusReturn = input(false, { transform: booleanAttribute });
 
 	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });

--- a/stories/documentation/overlays/tooltip/tooltip-overlay-focus-return.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip-overlay-focus-return.stories.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import {
+	DialogComponent,
+	DialogContentComponent,
+	DialogFooterComponent,
+	DialogHeaderComponent,
+	LuDialogService,
+	configureLuDialog,
+	injectDialogRef,
+	provideLuDialog,
+} from '@lucca-front/ng/dialog';
+import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
+import { Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
+
+@Component({
+	selector: 'sb-tooltip-focus-return-dialog',
+	template: `
+		<lu-dialog>
+			<lu-dialog-header>Fermez cette dialog</lu-dialog-header>
+
+			<lu-dialog-content>À la fermeture, le focus revient sur le bouton déclencheur.</lu-dialog-content>
+
+			<lu-dialog-footer>
+				<button type="button" luButton (click)="ref.close()">Fermer</button>
+			</lu-dialog-footer>
+		</lu-dialog>
+	`,
+	imports: [DialogComponent, DialogHeaderComponent, DialogContentComponent, DialogFooterComponent, ButtonComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TooltipFocusReturnDialogComponent {
+	ref = injectDialogRef<void>();
+}
+
+@Component({
+	selector: 'sb-tooltip-focus-return-story',
+	template: `
+		<p>Ouvrez puis fermez chaque dialog : seul le second garde sa tooltip fermée au retour du focus.</p>
+
+		<button type="button" luButton="outlined" class="pr-u-marginInlineEnd200" luTooltip="Comportement par défaut" (click)="openDialog()">Sans l’option</button>
+
+		<button type="button" luButton="outlined" luTooltip="Pas de tooltip au retour du focus" luTooltipNotOnOverlayFocusReturn (click)="openDialog()">Avec l’option</button>
+	`,
+	imports: [ButtonComponent, LuTooltipTriggerDirective],
+	providers: [provideLuDialog()],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TooltipFocusReturnStory {
+	#dialog = inject(LuDialogService);
+
+	openDialog(): void {
+		this.#dialog.open({ content: TooltipFocusReturnDialogComponent });
+	}
+}
+
+export default {
+	title: 'Documentation/Overlays/Tooltip/Retour de focus depuis un overlay',
+	component: TooltipFocusReturnStory,
+	decorators: [
+		applicationConfig({
+			providers: [configureLuDialog()],
+		}),
+	],
+} as Meta;
+
+export const OverlayFocusReturn: StoryObj<TooltipFocusReturnStory> = {};

--- a/stories/documentation/overlays/tooltip/tooltip-overlay-focus-return.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip-overlay-focus-return.stories.ts
@@ -30,11 +30,9 @@ class TooltipFocusReturnDialogComponent {
 @Component({
 	selector: 'sb-tooltip-focus-return-story',
 	template: `
-		<p>Ouvrez puis fermez chaque dialog : seul le second garde sa tooltip fermée au retour du focus.</p>
+		<p>Ouvrez puis fermez la dialog : la tooltip reste fermée quand le focus revient sur le déclencheur.</p>
 
-		<button type="button" luButton="outlined" class="pr-u-marginInlineEnd200" luTooltip="Comportement par défaut" (click)="openDialog()">Sans l’option</button>
-
-		<button type="button" luButton="outlined" luTooltip="Pas de tooltip au retour du focus" luTooltipNotOnOverlayFocusReturn (click)="openDialog()">Avec l’option</button>
+		<button type="button" luButton="outlined" luTooltip="Ouvrir la dialog" (click)="openDialog()">Déclencheur</button>
 	`,
 	imports: [ButtonComponent, LuTooltipTriggerDirective],
 	providers: [provideLuDialog()],
@@ -64,39 +62,38 @@ export const OverlayFocusReturnTEST = createTestStory(OverlayFocusReturn, async 
 	await waitForAngular();
 
 	const canvas = within(canvasElement);
-	const trigger = (name: RegExp) => canvas.getByRole('button', { name });
-	const tooltip = (text: RegExp) => screen.queryByText(text, { selector: '.tooltip' });
+	const trigger = () => canvas.getByRole('button', { name: /Déclencheur/ });
+	const tooltip = () => screen.queryByText(/Ouvrir la dialog/, { selector: '.tooltip' });
 
-	// The pointer stays off the triggers throughout: hover legitimately opens the tooltip.
-	const openThenCloseWith = async (name: RegExp, closeLabel: RegExp) => {
-		trigger(name).focus();
-		trigger(name).click();
+	// The pointer stays off the trigger throughout: hover legitimately opens the tooltip.
+	const openThenCloseWith = async (closeLabel: RegExp) => {
+		trigger().focus();
+		trigger().click();
 		await waitForAngular();
 		await userEvent.click(await screen.findByRole('button', { name: closeLabel }));
 		await waitForAngular();
 	};
 
 	// The tooltip has a 300ms enter delay, so leave it time to fail to appear.
-	const expectStaysClosed = async (text: RegExp) => {
+	const expectStaysClosed = async () => {
 		await new Promise((resolve) => setTimeout(resolve, 600));
-		await expect(tooltip(text)).toBeNull();
+		await expect(tooltip()).toBeNull();
 	};
 
-	await step('Sans l’option, le retour du focus ouvre la tooltip', async () => {
-		await openThenCloseWith(/Sans l’option/, /Fermer/);
-		await expect(trigger(/Sans l’option/)).toHaveFocus();
-		await waitFor(() => expect(tooltip(/Comportement par défaut/)).toBeVisible());
-	});
-
-	await step('Avec l’option, le retour du focus laisse la tooltip fermée', async () => {
-		await openThenCloseWith(/Avec l’option/, /Fermer/);
-		await expect(trigger(/Avec l’option/)).toHaveFocus();
-		await expectStaysClosed(/Pas de tooltip au retour du focus/);
+	await step('Le retour du focus après une fermeture laisse la tooltip fermée', async () => {
+		await openThenCloseWith(/Fermer/);
+		await expect(trigger()).toHaveFocus();
+		await expectStaysClosed();
 	});
 
 	await step('Idem via une fermeture avec résultat, que le bouton par défaut ne couvre pas', async () => {
-		await openThenCloseWith(/Avec l’option/, /Close/);
-		await expect(trigger(/Avec l’option/)).toHaveFocus();
-		await expectStaysClosed(/Pas de tooltip au retour du focus/);
+		await openThenCloseWith(/Close/);
+		await expect(trigger()).toHaveFocus();
+		await expectStaysClosed();
+	});
+
+	await step('Le survol ouvre toujours la tooltip', async () => {
+		await userEvent.hover(trigger());
+		await waitFor(() => expect(tooltip()).toBeVisible());
 	});
 });

--- a/stories/documentation/overlays/tooltip/tooltip-overlay-focus-return.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip-overlay-focus-return.stories.ts
@@ -1,17 +1,11 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
-import {
-	DialogComponent,
-	DialogContentComponent,
-	DialogFooterComponent,
-	DialogHeaderComponent,
-	LuDialogService,
-	configureLuDialog,
-	injectDialogRef,
-	provideLuDialog,
-} from '@lucca-front/ng/dialog';
+import { DialogComponent, DialogContentComponent, DialogFooterComponent, DialogHeaderComponent, LuDialogService, configureLuDialog, injectDialogRef, provideLuDialog } from '@lucca-front/ng/dialog';
 import { LuTooltipTriggerDirective } from '@lucca-front/ng/tooltip';
 import { Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
+import { createTestStory } from '@/helpers/stories';
+import { waitForAngular } from '@/helpers/test';
+import { expect, screen, userEvent, waitFor, within } from 'storybook/test';
 
 @Component({
 	selector: 'sb-tooltip-focus-return-dialog',
@@ -22,7 +16,7 @@ import { Meta, StoryObj, applicationConfig } from '@storybook/angular-vite';
 			<lu-dialog-content>À la fermeture, le focus revient sur le bouton déclencheur.</lu-dialog-content>
 
 			<lu-dialog-footer>
-				<button type="button" luButton (click)="ref.close()">Fermer</button>
+				<button type="button" luButton (click)="ref.close()">Close</button>
 			</lu-dialog-footer>
 		</lu-dialog>
 	`,
@@ -65,3 +59,44 @@ export default {
 } as Meta;
 
 export const OverlayFocusReturn: StoryObj<TooltipFocusReturnStory> = {};
+
+export const OverlayFocusReturnTEST = createTestStory(OverlayFocusReturn, async ({ canvasElement, step }) => {
+	await waitForAngular();
+
+	const canvas = within(canvasElement);
+	const trigger = (name: RegExp) => canvas.getByRole('button', { name });
+	const tooltip = (text: RegExp) => screen.queryByText(text, { selector: '.tooltip' });
+
+	// The pointer stays off the triggers throughout: hover legitimately opens the tooltip.
+	const openThenCloseWith = async (name: RegExp, closeLabel: RegExp) => {
+		trigger(name).focus();
+		trigger(name).click();
+		await waitForAngular();
+		await userEvent.click(await screen.findByRole('button', { name: closeLabel }));
+		await waitForAngular();
+	};
+
+	// The tooltip has a 300ms enter delay, so leave it time to fail to appear.
+	const expectStaysClosed = async (text: RegExp) => {
+		await new Promise((resolve) => setTimeout(resolve, 600));
+		await expect(tooltip(text)).toBeNull();
+	};
+
+	await step('Sans l’option, le retour du focus ouvre la tooltip', async () => {
+		await openThenCloseWith(/Sans l’option/, /Fermer/);
+		await expect(trigger(/Sans l’option/)).toHaveFocus();
+		await waitFor(() => expect(tooltip(/Comportement par défaut/)).toBeVisible());
+	});
+
+	await step('Avec l’option, le retour du focus laisse la tooltip fermée', async () => {
+		await openThenCloseWith(/Avec l’option/, /Fermer/);
+		await expect(trigger(/Avec l’option/)).toHaveFocus();
+		await expectStaysClosed(/Pas de tooltip au retour du focus/);
+	});
+
+	await step('Idem via une fermeture avec résultat, que le bouton par défaut ne couvre pas', async () => {
+		await openThenCloseWith(/Avec l’option/, /Close/);
+		await expect(trigger(/Avec l’option/)).toHaveFocus();
+		await expectStaysClosed(/Pas de tooltip au retour du focus/);
+	});
+});

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -50,14 +50,6 @@ export default {
 				defaultValue: { summary: 'false' },
 			},
 		},
-		luTooltipNotOnOverlayFocusReturn: {
-			description: 'N’ouvre pas la tooltip lorsque le focus revient d’un overlay (dropdown, dialog…) qui se ferme et le redonne à son déclencheur.',
-			control: { type: 'boolean' },
-			table: {
-				category: 'inputs',
-				defaultValue: { summary: 'false' },
-			},
-		},
 		luTooltipOnlyForDisplay: {
 			description: 'Affiche un tooltip non restituée par les lecteurs d’écran. À utiliser si la réstitution est déjà portée par l’élément déclencheur (ex. une icône avec attribut `alt`)',
 		},

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -50,6 +50,14 @@ export default {
 				defaultValue: { summary: 'false' },
 			},
 		},
+		luTooltipNotOnOverlayFocusReturn: {
+			description: 'N’ouvre pas la tooltip lorsque le focus revient d’un overlay (dropdown, dialog…) qui se ferme et le redonne à son déclencheur.',
+			control: { type: 'boolean' },
+			table: {
+				category: 'inputs',
+				defaultValue: { summary: 'false' },
+			},
+		},
 		luTooltipOnlyForDisplay: {
 			description: 'Affiche un tooltip non restituée par les lecteurs d’écran. À utiliser si la réstitution est déjà portée par l’élément déclencheur (ex. une icône avec attribut `alt`)',
 		},


### PR DESCRIPTION
## Description

The tooltip no longer opens when a closing dialog or menu hands the focus back to its trigger.

-----

* The `aria-expanded` guard covers dropdowns, not dialogs.
* The pane is captured on `focusout`, as some overlays dispose theirs before restoring focus.
* Hover and keyboard navigation still show the tooltip.
* Default behaviour, with no option: a tooltip reopened by a focus restoration is always a defect.
* The user has already seen the tooltip on the trigger, or reads its alternative text with a screen reader when focusing back.
* Found through [CCL-989](https://linear.app/lucca/issue/CCL-989).
* Fixed app-side in:
	* LuccaSA/Cleemy.ExpenseReports.Front#1925.
	* LuccaSA/Cleemy.Expenses#4451.

-----

### Contribution

- [x] Designs are respected and all relevant options are handled
- [x] Responsive behavior addressed when needed
- [x] Feature is accessible (keyboard navigation, screen reader support, ARIA tags, etc.)
- [x] Stories are updated and Storybook controls have descriptions
- [x] Feature is covered by E2E tests or UI diff
- [x] `npm run build` OK
- [x] `npm run lint` OK




