### PR TITLE
fix(button): center the success checkmark on S and XS sizes

### DIFF
--- a/packages/scss/src/components/button/index.scss
+++ b/packages/scss/src/components/button/index.scss
@@ -177,14 +177,6 @@
 		&.is-success {
 			@include success;
 
-			&.mod-S {
-				@include successS;
-			}
-
-			&.mod-XS {
-				@include successXS;
-			}
-
 			&.mod-AI,
 			&.mod-outlined {
 				@include successOutlined;

--- a/packages/scss/src/components/button/index.scss
+++ b/packages/scss/src/components/button/index.scss
@@ -177,6 +177,14 @@
 		&.is-success {
 			@include success;
 
+			&.mod-S {
+				@include successS;
+			}
+
+			&.mod-XS {
+				@include successXS;
+			}
+
 			&.mod-AI,
 			&.mod-outlined {
 				@include successOutlined;

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -86,6 +86,20 @@
 	}
 }
 
+@mixin successS {
+	&::after {
+		font-size: var(--pr-t-font-body-S-lineHeight);
+		block-size: var(--pr-t-font-body-S-lineHeight);
+	}
+}
+
+@mixin successXS {
+	&::after {
+		font-size: var(--pr-t-font-body-XS-lineHeight);
+		block-size: var(--pr-t-font-body-XS-lineHeight);
+	}
+}
+
 @mixin loadingAI {
 	--components-button-color: transparent;
 	--components-button-backgroundColor: var(--palettes-neutral-0);

--- a/packages/scss/src/components/button/states.scss
+++ b/packages/scss/src/components/button/states.scss
@@ -74,8 +74,8 @@
 		@include icon.generate('sign_confirm');
 
 		color: var(--palettes-neutral-0);
-		font-size: calc(1.5 * var(--pr-t-font-body-M-fontSize));
-		block-size: var(--pr-t-font-body-M-lineHeight);
+		font-size: calc(1.5 * var(--components-button-font-size));
+		block-size: var(--components-button-line-height);
 		inset: 0;
 		margin: auto;
 		position: absolute;
@@ -83,20 +83,6 @@
 
 	.numericBadge {
 		@include numericBadge.state;
-	}
-}
-
-@mixin successS {
-	&::after {
-		font-size: var(--pr-t-font-body-S-lineHeight);
-		block-size: var(--pr-t-font-body-S-lineHeight);
-	}
-}
-
-@mixin successXS {
-	&::after {
-		font-size: var(--pr-t-font-body-XS-lineHeight);
-		block-size: var(--pr-t-font-body-XS-lineHeight);
 	}
 }
 


### PR DESCRIPTION
## Description

The `success` state checkmark is now vertically centered on `size="S"` and `size="XS"` buttons, as the `loading` spinner already was.

-----

The `success` mixin hardcoded the M font tokens on its `::after`, which overrode the status-icon sizing declared by the `S` and `XS` mods: same specificity, and `.is-success` comes later in `index.scss`. The checkmark being a font glyph, it is laid out in the inherited line box rather than in the `::after` box, so a 24px box on a 16px `line-height` pushed it 4px up in `XS`, 2px in `S`.

`successS` / `successXS` size it from the button's own tokens, in the same shape as `loadingS` / `loadingXS`. `size="M"` is untouched.

Fix #5273

-----

## Preview

<img width="2492" height="2188" alt="avant-apres" src="https://github.com/user-attachments/assets/116af0f2-867f-4088-a816-6aca9922f829" />

QA avant : https://lucca-front.lucca.io/master/storybook/?path=/docs/qa-button--docs
