### PR TITLE
[tooltip] fix measurement during animation/transformation

### DIFF
--- a/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
@@ -230,8 +230,11 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 					this.#hasEllipsis.set(false);
 					return;
 				}
-				const cloneWidth = measurement.clone.getBoundingClientRect().width;
-				const hostWidth = measurement.host.getBoundingClientRect().width;
+				// Computed `width`, unlike `getBoundingClientRect`, ignores ancestor CSS transforms
+				// (e.g. the popover's scale-in animation), so a mid-animation read can't mistake the
+				// host for narrower than it is and get stuck with a false "has ellipsis".
+				const cloneWidth = parseFloat(getComputedStyle(measurement.clone).width);
+				const hostWidth = parseFloat(getComputedStyle(measurement.host).width);
 				// rounded to 3 decimals to ignore sub-pixel noise
 				this.#hasEllipsis.set(Math.round(cloneWidth * 1000) > Math.round(hostWidth * 1000));
 			},


### PR DESCRIPTION
## Description

During animations when popovers open, calculations could be skewed by the transform. Changing the method used to read the width fixes this.

-----



-----

<img width="479" height="602" alt="2026-08-25 14 51 59" src="https://github.com/user-attachments/assets/e7378223-f217-48e9-9c38-a36e223a5fc5" />

