### PR TITLE
fix(dialog): mark the overlay wrapper stacked, not the backdrop's parent

### DIFF
--- a/packages/ng/dialog/dialog/dialog.component.ts
+++ b/packages/ng/dialog/dialog/dialog.component.ts
@@ -52,7 +52,7 @@ export class DialogComponent implements AfterViewInit {
 
 	ngAfterViewInit(): void {
 		if (this.stacked()) {
-			this.dialogRef.cdkRef.overlayRef.backdropElement?.parentElement?.classList.add('mod-stacked');
+			this.dialogRef.cdkRef.overlayRef.hostElement.classList.add('mod-stacked');
 		}
 
 		if (this.dialogRef.config.autoFocus === 'first-input' && !this.dialogRef.config.cdkConfigOverride?.autoFocus) {

--- a/stories/documentation/overlays/dialog/dialog-multiple.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-multiple.stories.ts
@@ -1,3 +1,4 @@
+import { OVERLAY_DEFAULT_CONFIG } from '@angular/cdk/overlay';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import {
@@ -209,3 +210,21 @@ export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) 
 		await expect(screen.queryByText('dialog')).toBeNull();
 	});
 });
+
+export const WithoutPopoverTopLayer: StoryObj = {
+	...Basic,
+	name: 'Without the popover top layer',
+	decorators: [
+		applicationConfig({
+			providers: [{ provide: OVERLAY_DEFAULT_CONFIG, useValue: { usePopover: false } }],
+		}),
+	],
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'An app can opt out of the cdk popover top layer, for instance to keep its toasts above dialogs. The backdrop is then a sibling of the overlay wrapper instead of one of its children: the dialogs must stack all the same.',
+			},
+		},
+	},
+};


### PR DESCRIPTION
## Description

Stacked dialogs step back again when the dialog above them has no backdrop, or when the app renders cdk overlays outside the popover top layer.

-----

#4626 moved `mod-stacked` from the pane to the overlay wrapper, so the css could tell a stacked overlay from a plain one. `backdropElement.parentElement` is that wrapper under two conditions only: the cdk renders overlays in the popover top layer (its default), and the dialog actually has a backdrop. Otherwise the backdrop is a sibling of the wrapper — or absent altogether — and the class lands on `.cdk-overlay-container`, which no rule reads.

`overlayRef.hostElement` is the wrapper in every case: `GlobalPositionStrategy.attach()` is what adds `cdk-global-overlay-wrapper` to it. It is also non-nullable, unlike `backdropElement`, whose optional chaining was quietly swallowing the no-backdrop case.

Two situations were broken:

- `modal: false`, hence `hasBackdrop: false`: nothing was marked at all, whatever the cdk configuration.
- an app providing `OVERLAY_DEFAULT_CONFIG: { usePopover: false }`, for instance to keep its toasts above dialogs: the class went to the overlay container.

The new `Multiple/Without the popover top layer` story covers the second one, and fails without this change (`--components-dialog-level` stays at `0`). The existing `Multiple` story is unaffected: in the popover top layer both expressions resolve to the same element.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [ ] `npm run build` is OK
- [ ] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
