### PR TITLE
test: cover missing spec cases across selects, date, time and form-field

### DIFF
--- a/packages/ng/api/api.spec.ts
+++ b/packages/ng/api/api.spec.ts
@@ -1,8 +1,12 @@
 import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
 import { fireEvent, render, screen, waitFor } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { of } from 'rxjs';
+import { ILuApiItem } from './api.model';
 import { LuApiSelectInputComponent } from './select';
 import { ALuApiService, LuApiV3Service } from './service';
 
@@ -71,5 +75,106 @@ describe('lu-api-select', () => {
 
 		const results = await axe(luSelectElement);
 		expect(results).toHaveNoViolations(); // of course not
+	});
+
+	describe('api standard', () => {
+		async function renderStandard(standard: 'v3' | 'v4'): Promise<HttpTestingController> {
+			const template =
+				standard === 'v4' ? `<lu-api-select data-testid="lu-select" standard="v4" [api]="api" sort="job.name,level.position" />` : `<lu-api-select data-testid="lu-select" [api]="api" />`;
+
+			await render(template, {
+				imports: [LuApiSelectInputComponent],
+				providers: [provideHttpClient(), provideHttpClientTesting()],
+				componentProperties: { api: '/api/things' },
+			});
+
+			await userEvent.click(screen.getByTestId('lu-select'));
+
+			return TestBed.inject(HttpTestingController);
+		}
+
+		it('should query the v3 endpoint with its fields, orderBy and paging params', async () => {
+			// Act
+			const httpMock = await renderStandard('v3');
+
+			// Assert
+			const request = await waitFor(() => httpMock.expectOne((req) => req.url.startsWith('/api/things')));
+			expect(request.request.url).toBe('/api/things?orderBy=name,asc&fields=id,name&paging=0,20');
+			request.flush({ data: { items: [] } });
+			httpMock.verify();
+		});
+
+		it('should query the v4 endpoint with its page and sort params', async () => {
+			// Act
+			const httpMock = await renderStandard('v4');
+
+			// Assert
+			const request = await waitFor(() => httpMock.expectOne((req) => req.url.startsWith('/api/things')));
+			expect(request.request.url).toBe('/api/things?page=1&sort=job.name,level.position');
+			request.flush({ items: [] });
+			httpMock.verify();
+		});
+	});
+
+	describe('selection', () => {
+		it('should emit the selected option', async () => {
+			// Arrange
+			const ngModelChange = vi.fn();
+			const optionsMock = {
+				searchPaged: vi.fn(() => of([{ id: 1, name: 'Alice' } as ILuApiItem, { id: 2, name: 'Bob' } as ILuApiItem])),
+			} as Partial<LuApiV3Service> as LuApiV3Service;
+
+			await render(`<lu-api-select data-testid="lu-select" [api]="api" [ngModel]="null" (ngModelChange)="ngModelChange($event)" />`, {
+				imports: [LuApiSelectInputComponent, FormsModule],
+				providers: [provideHttpClient()],
+				componentProviders: [{ provide: ALuApiService, useValue: optionsMock }],
+				componentProperties: { api: '/api/things', ngModelChange },
+			});
+
+			// Act
+			await userEvent.click(screen.getByTestId('lu-select'));
+			await userEvent.click(await screen.findByText('Bob'));
+
+			// Assert
+			await waitFor(() => expect(ngModelChange).toHaveBeenCalledWith(expect.objectContaining({ id: 2, name: 'Bob' })));
+		});
+
+		it('should display the selected option in the input', async () => {
+			// Arrange
+			const optionsMock = {
+				searchPaged: vi.fn(() => of([{ id: 1, name: 'Alice' } as ILuApiItem])),
+			} as Partial<LuApiV3Service> as LuApiV3Service;
+
+			await render(`<lu-api-select data-testid="lu-select" [api]="api" [ngModel]="null" />`, {
+				imports: [LuApiSelectInputComponent, FormsModule],
+				providers: [provideHttpClient()],
+				componentProviders: [{ provide: ALuApiService, useValue: optionsMock }],
+				componentProperties: { api: '/api/things' },
+			});
+
+			// Act
+			await userEvent.click(screen.getByTestId('lu-select'));
+			await userEvent.click(await screen.findByText('Alice'));
+
+			// Assert
+			await waitFor(() => expect(screen.getByTestId('lu-select').querySelector('.lu-select-value')?.textContent).toContain('Alice'));
+		});
+	});
+
+	describe('disabled', () => {
+		it('should not open the panel when disabled', async () => {
+			// Arrange
+			await render(`<lu-api-select data-testid="lu-select" [disabled]="true" [api]="api" />`, {
+				imports: [LuApiSelectInputComponent],
+				providers: [provideHttpClient()],
+				componentProperties: { api: '/api/things' },
+			});
+
+			// Act
+			await userEvent.click(screen.getByTestId('lu-select'));
+
+			// Assert
+			expect(screen.queryByTestId('dialog-panel')).not.toBeInTheDocument();
+		});
 	});
 });

--- a/packages/ng/core/date/string/string-date.adapter.spec.ts
+++ b/packages/ng/core/date/string/string-date.adapter.spec.ts
@@ -1,5 +1,5 @@
-import { LuStringDateAdapter } from './string-date.adapter';
 import { ELuDateGranularity } from '../date-granularity.enum';
+import { LuStringDateAdapter } from './string-date.adapter';
 
 describe('LuStringDateAdapter', () => {
 	let adapter: LuStringDateAdapter;

--- a/packages/ng/date2/date-input/date-input.component.spec.ts
+++ b/packages/ng/date2/date-input/date-input.component.spec.ts
@@ -3,12 +3,13 @@ import localeFr from '@angular/common/locales/fr';
 import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { DATE_FORMAT } from '../date2.type';
 import { DateInputComponent } from './date-input.component';
 
 registerLocaleData(localeFr, 'fr-FR');
 
 @Component({
-	template: `<lu-date-input [formControl]="formControl" />`,
+	template: `<lu-date-input [formControl]="formControl" [min]="min" [max]="max" [mode]="mode" [format]="format" />`,
 	imports: [FormsModule, ReactiveFormsModule, DateInputComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -24,19 +25,31 @@ class HostComponent {
 class WeekHostComponent {
 	formControl = new FormControl<Date | null>(null);
 	min: Date | null = null;
+	max: Date | null = null;
+	mode: CalendarMode = 'day';
+	format: DateFormat = DATE_FORMAT.DATE;
 }
 
 describe('DateInputComponent', () => {
 	let fixture: ComponentFixture<HostComponent>;
 
-	function createHost(formControl: FormControl<Date | null>): HTMLInputElement {
+	function createHost(
+		formControl: FormControl<Date | null> | FormControl<Date | string | null>,
+		min: Date | null = null,
+		max: Date | null = null,
+		options: { mode?: CalendarMode; format?: DateFormat } = {},
+	): HTMLInputElement {
 		TestBed.configureTestingModule({
 			imports: [HostComponent],
 			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
 		});
 
 		fixture = TestBed.createComponent(HostComponent);
-		fixture.componentInstance.formControl = formControl;
+		fixture.componentInstance.formControl = formControl as FormControl<Date | null>;
+		fixture.componentInstance.min = min;
+		fixture.componentInstance.max = max;
+		fixture.componentInstance.mode = options.mode ?? 'day';
+		fixture.componentInstance.format = options.format ?? DATE_FORMAT.DATE;
 		fixture.detectChanges();
 
 		return (fixture.nativeElement as HTMLElement).querySelector('[data-testid="lu-date-input"]') as HTMLInputElement;
@@ -62,6 +75,34 @@ describe('DateInputComponent', () => {
 		typeInElement('', input);
 
 		expect(formControl.value).toBeNull();
+	});
+
+	it('should emit the parsed date when user enters a valid date', () => {
+		// Arrange
+		const valueChanges = vi.fn();
+		const formControl = new FormControl<Date | null>(null);
+		formControl.valueChanges.subscribe((value) => valueChanges(value));
+		const input = createHost(formControl);
+
+		// Act
+		typeInElement('15/03/2024', input);
+
+		// Assert
+		expect(formControl.value).toEqual(new Date(2024, 2, 15));
+		expect(formControl.errors).toBeNull();
+		expect(valueChanges).toHaveBeenCalledTimes(1);
+	});
+
+	it('should emit an ISO string when format is dateISO', () => {
+		// Arrange
+		const formControl = new FormControl<Date | string | null>(null);
+		const input = createHost(formControl, null, null, { format: DATE_FORMAT.DATE_ISO });
+
+		// Act
+		typeInElement('15/03/2024', input);
+
+		// Assert
+		expect(formControl.value).toBe('2024-03-15');
 	});
 
 	it('should emit error when user enter a invalid date', () => {
@@ -155,6 +196,100 @@ describe('DateInputComponent', () => {
 			createWeekHost(formControl, new Date(2024, 9, 14));
 
 			expect(formControl.errors).toBeNull();
+		});
+	});
+
+	describe('granularity', () => {
+		it('should use a month/year placeholder and parse a month in month mode', () => {
+			// Arrange
+			const formControl = new FormControl<Date | null>(null);
+			const input = createHost(formControl, null, null, { mode: 'month' });
+
+			// Assert
+			expect(input.getAttribute('placeholder')).toBe('MM/AAAA');
+
+			// Act
+			typeInElement('03/2024', input);
+
+			// Assert
+			expect(formControl.errors).toBeNull();
+			expect(formControl.value?.getFullYear()).toBe(2024);
+			expect(formControl.value?.getMonth()).toBe(2);
+		});
+
+		it('should use a year placeholder and parse a year in year mode', () => {
+			// Arrange
+			const formControl = new FormControl<Date | null>(null);
+			const input = createHost(formControl, null, null, { mode: 'year' });
+
+			// Assert
+			expect(input.getAttribute('placeholder')).toBe('AAAA');
+
+			// Act
+			typeInElement('2024', input);
+
+			// Assert
+			expect(formControl.errors).toBeNull();
+			expect(formControl.value?.getFullYear()).toBe(2024);
+		});
+
+		it('should compare min against the whole month in month mode', () => {
+			// Arrange
+			const formControl = new FormControl<Date | null>(null);
+			const input = createHost(formControl, new Date('2024-03-15T00:00:00'), null, { mode: 'month' });
+
+			// Act: same month as min, but an earlier day
+			typeInElement('03/2024', input);
+
+			// Assert
+			expect(formControl.errors).toBeNull();
+
+			// Act: previous month
+			typeInElement('02/2024', input);
+
+			// Assert
+			expect(formControl.errors).toEqual({ min: true });
+		});
+	});
+
+	describe('disabled state', () => {
+		it('should disable the input when the control is disabled', () => {
+			// Arrange
+			const formControl = new FormControl<Date | null>(null);
+			formControl.disable();
+
+			// Act
+			const input = createHost(formControl);
+
+			// Assert
+			expect(input.disabled).toBe(true);
+		});
+
+		it('should enable the input back when the control is enabled', () => {
+			// Arrange
+			const formControl = new FormControl<Date | null>(null);
+			formControl.disable();
+			const input = createHost(formControl);
+
+			// Act
+			formControl.enable();
+			fixture.detectChanges();
+
+			// Assert
+			expect(input.disabled).toBe(false);
+		});
+
+		it('should disable the calendar toggle button when the control is disabled', () => {
+			// Arrange
+			const formControl = new FormControl<Date | null>(null);
+			formControl.disable();
+
+			// Act
+			createHost(formControl);
+			const toggle = (fixture.nativeElement as HTMLElement).querySelector('.textField-input-affix-toggle') as HTMLButtonElement;
+
+			// Assert
+			expect(toggle.disabled).toBe(true);
 		});
 	});
 });

--- a/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
+++ b/packages/ng/date2/date-range-input/date-range-input.component.spec.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { addMonths } from 'date-fns';
 import { DateRange } from '../calendar2/date-range';
 import { DateRangeInputComponent } from './date-range-input.component';
@@ -20,12 +21,14 @@ class NgModelHostComponent {
 }
 
 @Component({
-	template: `<lu-date-range-input [formControl]="formControl" />`,
+	template: `<lu-date-range-input [formControl]="formControl" [min]="min" [max]="max" />`,
 	imports: [FormsModule, ReactiveFormsModule, DateRangeInputComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class FormControlHostComponent {
 	formControl = new FormControl<DateRange | null>(null);
+	min: Date | null = null;
+	max: Date | null = null;
 }
 
 describe('DateRangeInputComponent', () => {
@@ -33,6 +36,25 @@ describe('DateRangeInputComponent', () => {
 		input.value = value;
 		input.dispatchEvent(new Event('input'));
 		fixture.detectChanges();
+	}
+
+	function createFormControlHost(formControl: FormControl<DateRange | null>, min: Date | null = null, max: Date | null = null): ComponentFixture<FormControlHostComponent> {
+		TestBed.configureTestingModule({
+			imports: [FormControlHostComponent],
+			providers: [{ provide: LOCALE_ID, useValue: 'fr-FR' }],
+		});
+
+		const fixture = TestBed.createComponent(FormControlHostComponent);
+		fixture.componentInstance.formControl = formControl;
+		fixture.componentInstance.min = min;
+		fixture.componentInstance.max = max;
+		fixture.detectChanges();
+
+		return fixture;
+	}
+
+	function getInput(fixture: ComponentFixture<unknown>, field: 'start' | 'end'): HTMLInputElement {
+		return (fixture.nativeElement as HTMLElement).querySelector(`.mod-${field} > input`) as HTMLInputElement;
 	}
 
 	it('should not called ngModelChange at init if null value', () => {
@@ -175,6 +197,142 @@ describe('DateRangeInputComponent', () => {
 		expect(valueChanges).toHaveBeenCalledWith({
 			start: new Date('2025-06-18T00:00:00.000Z'),
 			scope: 'day',
+		});
+	});
+
+	it('should emit value when the user enters only the end date with a keyboard', () => {
+		// Arrange
+		const valueChanges = vi.fn();
+		const formControl = new FormControl<DateRange | null>(null);
+		formControl.valueChanges.subscribe((value) => valueChanges(value));
+		const fixture = createFormControlHost(formControl);
+
+		// Act
+		typeInElement('20/06/2025', getInput(fixture, 'end'), fixture);
+
+		// Assert
+		expect(valueChanges).toHaveBeenCalledExactlyOnceWith({
+			end: new Date(2025, 5, 20),
+			scope: 'day',
+		});
+	});
+
+	it('should emit the whole range once both dates are entered', () => {
+		// Arrange
+		const formControl = new FormControl<DateRange | null>(null);
+		const fixture = createFormControlHost(formControl);
+
+		// Act
+		typeInElement('18/06/2025', getInput(fixture, 'start'), fixture);
+		typeInElement('20/06/2025', getInput(fixture, 'end'), fixture);
+
+		// Assert
+		expect(formControl.value).toEqual({
+			start: new Date(2025, 5, 18),
+			end: new Date(2025, 5, 20),
+			scope: 'day',
+		});
+		expect(formControl.errors).toBeNull();
+	});
+
+	it('should emit null when the user clears both dates', () => {
+		// Arrange
+		const formControl = new FormControl<DateRange | null>({ start: new Date(2025, 5, 18), end: new Date(2025, 5, 20) });
+		const fixture = createFormControlHost(formControl);
+
+		// Act
+		typeInElement('', getInput(fixture, 'start'), fixture);
+		typeInElement('', getInput(fixture, 'end'), fixture);
+
+		// Assert
+		expect(formControl.value).toBeNull();
+	});
+
+	it('should swap start and end on blur when the range is reversed', () => {
+		// Arrange
+		const formControl = new FormControl<DateRange | null>(null);
+		const fixture = createFormControlHost(formControl);
+		const startInput = getInput(fixture, 'start');
+
+		// Act
+		typeInElement('20/06/2025', getInput(fixture, 'end'), fixture);
+		typeInElement('25/06/2025', startInput, fixture);
+		startInput.dispatchEvent(new Event('blur'));
+		fixture.detectChanges();
+
+		// Assert
+		expect(formControl.value).toEqual({
+			start: new Date(2025, 5, 20),
+			end: new Date(2025, 5, 25),
+			scope: 'day',
+		});
+	});
+
+	it('should report a date error when the start date is not parsable', () => {
+		// Arrange
+		const formControl = new FormControl<DateRange | null>(null);
+		const fixture = createFormControlHost(formControl);
+
+		// Act
+		typeInElement('20/06/2025', getInput(fixture, 'end'), fixture);
+		typeInElement('12', getInput(fixture, 'start'), fixture);
+
+		// Assert
+		expect(formControl.errors).toEqual({ date: true });
+	});
+
+	describe('min / max', () => {
+		it('should disable calendar cells before min', () => {
+			// Arrange
+			const fixture = createFormControlHost(new FormControl<DateRange | null>(null), new Date(2025, 5, 10));
+			const cmp = fixture.debugElement.query(By.directive(DateRangeInputComponent)).componentInstance as DateRangeInputComponent;
+
+			// Assert
+			expect(cmp.combinedGetCellInfo(new Date(2025, 5, 9), 'day').disabled).toBe(true);
+			expect(cmp.combinedGetCellInfo(new Date(2025, 5, 10), 'day').disabled).toBe(false);
+		});
+
+		it('should disable calendar cells after max', () => {
+			// Arrange
+			const fixture = createFormControlHost(new FormControl<DateRange | null>(null), null, new Date(2025, 5, 20));
+			const cmp = fixture.debugElement.query(By.directive(DateRangeInputComponent)).componentInstance as DateRangeInputComponent;
+
+			// Assert
+			expect(cmp.combinedGetCellInfo(new Date(2025, 5, 21), 'day').disabled).toBe(true);
+			expect(cmp.combinedGetCellInfo(new Date(2025, 5, 20), 'day').disabled).toBe(false);
+		});
+	});
+
+	describe('disabled state', () => {
+		it('should disable both inputs and the calendar toggle when the control is disabled', async () => {
+			// Arrange
+			const formControl = new FormControl<DateRange | null>(null);
+			formControl.disable();
+
+			// Act
+			const fixture = createFormControlHost(formControl);
+			await fixture.whenStable();
+
+			// Assert
+			expect(getInput(fixture, 'start').disabled).toBe(true);
+			expect(getInput(fixture, 'end').disabled).toBe(true);
+			expect(((fixture.nativeElement as HTMLElement).querySelector('.textField-input-affix-toggle') as HTMLButtonElement).disabled).toBe(true);
+		});
+
+		it('should enable both inputs back when the control is enabled', async () => {
+			// Arrange
+			const formControl = new FormControl<DateRange | null>(null);
+			formControl.disable();
+			const fixture = createFormControlHost(formControl);
+			await fixture.whenStable();
+
+			// Act
+			formControl.enable();
+			await fixture.whenStable();
+
+			// Assert
+			expect(getInput(fixture, 'start').disabled).toBe(false);
+			expect(getInput(fixture, 'end').disabled).toBe(false);
 		});
 	});
 });

--- a/packages/ng/department/department-select.spec.ts
+++ b/packages/ng/department/department-select.spec.ts
@@ -1,7 +1,8 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { FormsModule } from '@angular/forms';
 import { ILuTree } from '@lucca-front/ng/core';
-import { fireEvent, render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen, within } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import { of } from 'rxjs';
@@ -82,5 +83,111 @@ describe('department select', () => {
 
 		const results = await axe(luSelectElement);
 		expect(results).toHaveNoViolations(); // of course not
+	});
+
+	describe('selection', () => {
+		// Same shape as deptMock, but with unique ids so the `byId` comparer can tell the nodes apart
+		const uniqueIdsTree: ILuTree<ILuDepartment>[] = [
+			{
+				value: { id: 1, name: 'Lucca France' },
+				children: [
+					{ value: { id: 11, name: 'Tech' }, children: [] },
+					{ value: { id: 12, name: 'Admin' }, children: [] },
+				],
+			},
+			{ value: { id: 2, name: 'Lucca UK' }, children: [{ value: { id: 21, name: 'Support' }, children: [] }] },
+		];
+
+		async function renderSelect(options: { multiple?: boolean } = {}): Promise<ReturnType<typeof vi.fn>> {
+			const ngModelChange = vi.fn();
+			const treeMock = {
+				getTrees: vi.fn(() => of(uniqueIdsTree)),
+			} as Partial<LuDepartmentV4Service> as LuDepartmentV4Service;
+
+			await render(
+				`<lu-department-select
+					data-testid="lu-select"
+					${options.multiple ? 'multiple' : ''}
+					[appInstanceId]="15"
+					[ngModel]="null"
+					(ngModelChange)="ngModelChange($event)"
+				></lu-department-select>`,
+				{
+					imports: [LuDepartmentSelectInputComponent, FormsModule],
+					providers: [provideHttpClient(), provideHttpClientTesting()],
+					componentProviders: [{ provide: ALuDepartmentService, useValue: treeMock }],
+					componentProperties: { ngModelChange },
+				},
+			);
+
+			await userEvent.click(screen.getByTestId('lu-select'));
+
+			return ngModelChange;
+		}
+
+		// The selected department is also rendered in the select display, so options are looked up inside the panel
+		function clickOption(name: string): Promise<void> {
+			return userEvent.click(within(screen.getByTestId('dialog-panel')).getByText(name));
+		}
+
+		it('should emit the clicked department', async () => {
+			// Arrange
+			const ngModelChange = await renderSelect();
+
+			// Act
+			await clickOption('Tech');
+
+			// Assert
+			expect(ngModelChange).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ id: 11, name: 'Tech' }));
+		});
+
+		it('should emit a parent department without its children', async () => {
+			// Arrange
+			const ngModelChange = await renderSelect();
+
+			// Act
+			await clickOption('Lucca France');
+
+			// Assert
+			expect(ngModelChange).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ id: 1, name: 'Lucca France' }));
+		});
+
+		it('should replace the previous selection in single mode', async () => {
+			// Arrange
+			const ngModelChange = await renderSelect();
+
+			// Act
+			await clickOption('Tech');
+			await userEvent.click(screen.getByTestId('lu-select'));
+			await clickOption('Support');
+
+			// Assert
+			expect(ngModelChange).toHaveBeenLastCalledWith(expect.objectContaining({ id: 21, name: 'Support' }));
+			expect(ngModelChange).toHaveBeenCalledTimes(2);
+		});
+
+		it('should accumulate departments in multiple mode', async () => {
+			// Arrange
+			const ngModelChange = await renderSelect({ multiple: true });
+
+			// Act
+			await clickOption('Tech');
+			await clickOption('Support');
+
+			// Assert
+			expect(ngModelChange).toHaveBeenLastCalledWith([expect.objectContaining({ id: 11 }), expect.objectContaining({ id: 21 })]);
+		});
+
+		it('should deselect an already selected department in multiple mode', async () => {
+			// Arrange
+			const ngModelChange = await renderSelect({ multiple: true });
+
+			// Act
+			await clickOption('Tech');
+			await clickOption('Tech');
+
+			// Assert
+			expect(ngModelChange).toHaveBeenLastCalledWith([]);
+		});
 	});
 });

--- a/packages/ng/dialog/dialog-routing/dialog-routing.utils.spec.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.utils.spec.ts
@@ -9,48 +9,36 @@ import { vi } from 'vitest';
 import { LuDialogService } from '../dialog.service';
 import { dialogLazyRouteFactory, dialogRouteFactory } from './dialog-routing.utils';
 
-const { $dialogService, set$dialogService, $dialogRef, set$dialogRef, $openDialogs, inc$openDialogs, reset$openDialogs } = vi.hoisted(() => {
-	let _dialogService: LuDialogService;
-	let _dialogRef: LuDialogRef<unknown, unknown>;
-	let _openDialogs = 0;
-	return {
-		$dialogService: () => _dialogService,
-		set$dialogService: (v: LuDialogService) => {
-			_dialogService = v;
-		},
-		$dialogRef: () => _dialogRef,
-		set$dialogRef: (v: LuDialogRef<unknown, unknown>) => {
-			_dialogRef = v;
-		},
-		$openDialogs: () => _openDialogs,
-		inc$openDialogs: () => {
-			_openDialogs++;
-		},
-		reset$openDialogs: () => {
-			_openDialogs = 0;
-		},
-	};
-});
+const originalOpen = LuDialogService.prototype.open;
 
-vi.mock('../dialog.providers', () => ({
-	provideLuDialog: () => ({
-		provide: LuDialogService,
-		useFactory: () => {
-			const service = new LuDialogService();
-			set$dialogService(service);
-			const originalOpen = service.open.bind(service) as LuDialogService['open'];
-			vi.spyOn(service, 'open').mockImplementation((config) => {
-				inc$openDialogs();
-				const ref = originalOpen(config)!;
-				set$dialogRef(ref);
-				vi.spyOn(ref, 'close');
-				vi.spyOn(ref, 'dismiss');
-				return ref;
-			});
-			return service;
-		},
-	}),
-}));
+let _dialogRef: LuDialogRef<unknown, unknown>;
+let _openDialogs = 0;
+
+const $dialogOpen = () => vi.mocked(LuDialogService.prototype.open);
+const $dialogRef = () => _dialogRef;
+const $openDialogs = () => _openDialogs;
+const reset$openDialogs = () => {
+	_openDialogs = 0;
+};
+
+/**
+ * Spies on every `LuDialogService` instance through its prototype rather than mocking
+ * `provideLuDialog`. `dialog-routing.component.ts` calls `provideLuDialog()` while its
+ * decorator is evaluated, so the resulting provider is baked in the first time that module
+ * is loaded. Specs share a module registry (`isolate: false`), which means a module mock
+ * would only apply when this file happens to be the first of its worker to pull the dialog
+ * entrypoint in.
+ */
+function spyOnDialogOpen(): void {
+	vi.spyOn(LuDialogService.prototype, 'open').mockImplementation(function (this: LuDialogService, config) {
+		_openDialogs++;
+		const ref = originalOpen.call(this, config);
+		_dialogRef = ref as LuDialogRef<unknown, unknown>;
+		vi.spyOn(ref, 'close');
+		vi.spyOn(ref, 'dismiss');
+		return ref;
+	});
+}
 
 interface DialogRoutingTestDialogData {
 	foo: string;
@@ -120,6 +108,7 @@ describe('dialog-routing.utils', () => {
 			guard1.mockReset();
 			guard2.mockReset();
 			reset$openDialogs();
+			spyOnDialogOpen();
 		});
 
 		afterEach(() => {
@@ -148,8 +137,8 @@ describe('dialog-routing.utils', () => {
 			await vi.runAllTimersAsync();
 
 			// Assert
-			expect($dialogService().open).toHaveBeenCalledTimes(1);
-			expect($dialogService().open).toHaveBeenCalledWith(
+			expect($dialogOpen()).toHaveBeenCalledTimes(1);
+			expect($dialogOpen()).toHaveBeenCalledWith(
 				expect.objectContaining({
 					data: { foo: 'bar' },
 				}),
@@ -172,8 +161,8 @@ describe('dialog-routing.utils', () => {
 			await vi.runAllTimersAsync();
 
 			// Assert
-			expect($dialogService().open).toHaveBeenCalledTimes(1);
-			expect($dialogService().open).toHaveBeenCalledWith(
+			expect($dialogOpen()).toHaveBeenCalledTimes(1);
+			expect($dialogOpen()).toHaveBeenCalledWith(
 				expect.objectContaining({
 					data: { foo: 'baz' },
 				}),
@@ -199,8 +188,8 @@ describe('dialog-routing.utils', () => {
 			await vi.runAllTimersAsync();
 
 			// Assert
-			expect($dialogService().open).toHaveBeenCalledTimes(1);
-			expect($dialogService().open).toHaveBeenCalledWith(
+			expect($dialogOpen()).toHaveBeenCalledTimes(1);
+			expect($dialogOpen()).toHaveBeenCalledWith(
 				expect.objectContaining({
 					data: { foo: 'bar' },
 				}),
@@ -382,7 +371,7 @@ describe('dialog-routing.utils', () => {
 			expect(router.url).toBe('/test/child1');
 			expect(fixture.debugElement.parent?.query(By.directive(Child1Component))).toBeTruthy();
 			expect(fixture.debugElement.parent?.query(By.directive(Child2Component))).toBeFalsy();
-			expect($dialogService().open).toHaveBeenCalledTimes(1);
+			expect($dialogOpen()).toHaveBeenCalledTimes(1);
 
 			// Act 2
 			await router.navigateByUrl('/test/child2');
@@ -394,7 +383,7 @@ describe('dialog-routing.utils', () => {
 			expect(router.url).toBe('/test/child2');
 			expect(fixture.debugElement.parent?.query(By.directive(Child1Component))).toBeFalsy();
 			expect(fixture.debugElement.parent?.query(By.directive(Child2Component))).toBeTruthy();
-			expect($dialogService().open).toHaveBeenCalledTimes(1); // Still 1, dialog not reopened
+			expect($dialogOpen()).toHaveBeenCalledTimes(1); // Still 1, dialog not reopened
 			expect($dialogRef().close).not.toHaveBeenCalled();
 			expect($dialogRef().dismiss).not.toHaveBeenCalled();
 		});
@@ -423,7 +412,7 @@ describe('dialog-routing.utils', () => {
 			const dialogComponent = fixture.debugElement.parent?.query(By.directive(DialogRoutingTestWithParentDIComponent)).componentInstance as DialogRoutingTestWithParentDIComponent;
 
 			// Assert
-			expect($dialogService().open).toHaveBeenCalledTimes(1);
+			expect($dialogOpen()).toHaveBeenCalledTimes(1);
 			expect(dialogComponent).toBeTruthy();
 			expect(dialogComponent.parentService.value).toBe('provided-in-parent');
 			expect(dialogComponent.routeService.value).toBe('provided-in-parent-route');
@@ -475,8 +464,8 @@ describe('dialog-routing.utils', () => {
 			await vi.runAllTimersAsync();
 
 			// Assert
-			expect($dialogService().open).toHaveBeenCalledTimes(1);
-			expect($dialogService().open).toHaveBeenCalledWith(
+			expect($dialogOpen()).toHaveBeenCalledTimes(1);
+			expect($dialogOpen()).toHaveBeenCalledWith(
 				expect.objectContaining({
 					data: { foo: 'BAZ' },
 				}),

--- a/packages/ng/form-field/form-field.component.spec.ts
+++ b/packages/ng/form-field/form-field.component.spec.ts
@@ -2,6 +2,10 @@ import { ChangeDetectionStrategy, Component, computed, input, viewChild } from '
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FormFieldIdDirective, TextInputComponent } from '@lucca-front/ng/forms';
+import { By } from '@angular/platform-browser';
+import { InlineMessageState } from '@lucca-front/ng/inline-message';
+import { firstValueFrom } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import { vi } from 'vitest';
 import { FormFieldComponent } from './form-field.component';
 
@@ -23,6 +27,26 @@ export class FormFieldComponentTestComponent {
 
 	requiredFormControl = new FormControl('', { validators: Validators.required });
 	normalFormControl = new FormControl('');
+}
+
+@Component({
+	selector: 'lu-form-field-content-test',
+	imports: [TextInputComponent, FormFieldComponent, ReactiveFormsModule],
+	template: `
+		<lu-form-field [label]="label()" [tooltip]="tooltip()" [inlineMessage]="inlineMessage()" [inlineMessageState]="inlineMessageState()" [hiddenLabel]="hiddenLabel()">
+			<lu-text-input [formControl]="formControl" />
+		</lu-form-field>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class FormFieldContentTestComponent {
+	label = input<string>('First name');
+	tooltip = input<string | null>(null);
+	inlineMessage = input<string | null>(null);
+	inlineMessageState = input<InlineMessageState | null>(null);
+	hiddenLabel = input(false);
+
+	formControl = new FormControl('');
 }
 
 describe('FormFieldComponent', () => {
@@ -73,7 +97,7 @@ describe('FormFieldComponent', () => {
 		});
 	});
 
-	it('should handle required when going from normal to required', async () => {
+	it('should handle required when going from required to normal', async () => {
 		// Arrange
 		fixture.componentRef.setInput('formControlToUse', 'required');
 		fixture.detectChanges();
@@ -85,6 +109,108 @@ describe('FormFieldComponent', () => {
 		// Assert
 		await vi.waitFor(() => {
 			expect(isInputRequired()).toBe(false);
+		});
+	});
+
+	describe('label, tooltip and inline message', () => {
+		let contentFixture: ComponentFixture<FormFieldContentTestComponent>;
+
+		async function createContentHost(inputs: Partial<Record<'label' | 'tooltip' | 'inlineMessage' | 'inlineMessageState' | 'hiddenLabel', unknown>> = {}): Promise<void> {
+			// The TestBed is already configured by the outer beforeEach
+			contentFixture = TestBed.createComponent(FormFieldContentTestComponent);
+			Object.entries(inputs).forEach(([name, value]) => contentFixture.componentRef.setInput(name, value));
+			contentFixture.detectChanges();
+			// The form field wires input ids and aria attributes in a later task, wait for it before querying the DOM
+			const formField = contentFixture.debugElement.query(By.directive(FormFieldComponent)).componentInstance as FormFieldComponent;
+			await firstValueFrom(formField.ready$.pipe(filter(Boolean)));
+			contentFixture.detectChanges();
+		}
+
+		function query<T extends Element>(selector: string): T | null {
+			return (contentFixture.nativeElement as HTMLElement).querySelector<T>(selector);
+		}
+
+		function queryRequired<T extends Element>(selector: string): T {
+			const element = query<T>(selector);
+			if (!element) {
+				throw new Error(`Expected to find ${selector}`);
+			}
+			return element;
+		}
+
+		it('should render the label', async () => {
+			// Act
+			await createContentHost({ label: 'First name' });
+
+			// Assert
+			expect(query<HTMLLabelElement>('label.formLabel')?.textContent).toContain('First name');
+		});
+
+		it('should mask the label but keep it in the DOM when hiddenLabel is set', async () => {
+			// Act
+			await createContentHost({ label: 'First name', hiddenLabel: true });
+
+			// Assert
+			const label = queryRequired<HTMLLabelElement>('label.formLabel');
+			expect(label?.textContent).toContain('First name');
+			expect(label?.classList).toContain('pr-u-mask');
+		});
+
+		it('should bind the label to the input through matching for and id attributes', async () => {
+			// Act
+			await createContentHost();
+
+			// Assert
+			const label = queryRequired<HTMLLabelElement>('label.formLabel');
+			const input = queryRequired<HTMLInputElement>('input');
+			expect(input?.id).not.toBe('');
+			expect(label?.getAttribute('for')).toBe(input?.id);
+			expect(label?.getAttribute('id')).toBe(`${input?.id}-label`);
+			expect(input?.getAttribute('aria-labelledby')).toContain(`${input?.id}-label`);
+		});
+
+		it('should not render a tooltip when none is provided', async () => {
+			// Act
+			await createContentHost();
+
+			// Assert
+			expect(query('.formLabel-info')).toBeNull();
+		});
+
+		it('should render the tooltip trigger next to the label', async () => {
+			// Act
+			await createContentHost({ tooltip: 'Your legal first name' });
+
+			// Assert
+			expect(query('.formLabel-info')).not.toBeNull();
+		});
+
+		it('should not render an inline message when none is provided', async () => {
+			// Act
+			await createContentHost();
+
+			// Assert
+			expect(query('lu-inline-message')).toBeNull();
+		});
+
+		it('should render the inline message and describe the input with it', async () => {
+			// Act
+			await createContentHost({ inlineMessage: 'Helper text' });
+
+			// Assert
+			const message = queryRequired('lu-inline-message');
+			const input = queryRequired<HTMLInputElement>('input');
+			expect(message?.textContent).toContain('Helper text');
+			expect(message?.id).toBe(`${input?.id}-message`);
+			expect(input?.getAttribute('aria-describedby')).toContain(`${input?.id}-message`);
+		});
+
+		it('should apply the inline message state', async () => {
+			// Act
+			await createContentHost({ inlineMessage: 'Helper text', inlineMessageState: 'warning' });
+
+			// Assert
+			expect(query('lu-inline-message')?.classList).toContain('is-warning');
 		});
 	});
 });

--- a/packages/ng/simple-select/input/select-input.component.spec.ts
+++ b/packages/ng/simple-select/input/select-input.component.spec.ts
@@ -94,7 +94,7 @@ describe('LuSimpleSelectInputComponent', () => {
 			const input = nativeElement().querySelector('input') as HTMLInputElement;
 
 			// Act
-			fixture.componentInstance.placeholder = 'Pick one';
+			fixture.componentRef.setInput('placeholder', 'Pick one');
 			fixture.detectChanges();
 
 			// Assert
@@ -104,7 +104,7 @@ describe('LuSimpleSelectInputComponent', () => {
 		it('should fall back to the translated placeholder once a value is set', () => {
 			// Arrange
 			const input = nativeElement().querySelector('input') as HTMLInputElement;
-			fixture.componentInstance.placeholder = 'Pick one';
+			fixture.componentRef.setInput('placeholder', 'Pick one');
 			fixture.detectChanges();
 
 			// Act
@@ -134,7 +134,7 @@ describe('LuSimpleSelectInputComponent', () => {
 			const onChange = vi.fn();
 			const component = fixture.componentInstance;
 			component.registerOnChange(onChange);
-			component.options = options;
+			fixture.componentRef.setInput('options', options);
 			component.openPanel();
 			await waitForPanel(component);
 
@@ -151,7 +151,7 @@ describe('LuSimpleSelectInputComponent', () => {
 			const onChange = vi.fn();
 			const component = fixture.componentInstance;
 			component.registerOnChange(onChange);
-			component.options = options;
+			fixture.componentRef.setInput('options', options);
 			component.writeValue(options[0]);
 
 			// Act
@@ -205,7 +205,7 @@ describe('LuSimpleSelectInputComponent', () => {
 
 		it('should not display the clearer when there is no value', () => {
 			// Act
-			fixture.componentInstance.clearable = true;
+			fixture.componentRef.setInput('clearable', true);
 
 			// Assert
 			expect(clearer()).toBeNull();
@@ -213,7 +213,7 @@ describe('LuSimpleSelectInputComponent', () => {
 
 		it('should display the clearer when the select is clearable and has a value', () => {
 			// Act
-			fixture.componentInstance.clearable = true;
+			fixture.componentRef.setInput('clearable', true);
 			fixture.componentInstance.writeValue(options[0]);
 
 			// Assert
@@ -224,7 +224,7 @@ describe('LuSimpleSelectInputComponent', () => {
 			// Arrange
 			const onChange = vi.fn();
 			fixture.componentInstance.registerOnChange(onChange);
-			fixture.componentInstance.clearable = true;
+			fixture.componentRef.setInput('clearable', true);
 			fixture.componentInstance.writeValue(options[0]);
 
 			// Act
@@ -262,7 +262,7 @@ describe('LuSimpleSelectInputComponent', () => {
 
 		it('should hide the clearer when disabled', () => {
 			// Arrange
-			fixture.componentInstance.clearable = true;
+			fixture.componentRef.setInput('clearable', true);
 			fixture.componentInstance.writeValue(options[0]);
 			expect(clearer()).not.toBeNull();
 

--- a/packages/ng/simple-select/input/select-input.component.spec.ts
+++ b/packages/ng/simple-select/input/select-input.component.spec.ts
@@ -1,15 +1,53 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { runALuSelectInputComponentTestSuite } from '../../core-select/input/select-input.component.spec';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { isNotNil } from '@lucca-front/ng/core';
+import { vi } from 'vitest';
+import { TestEntity, runALuSelectInputComponentTestSuite } from '../../core-select/input/select-input.component.spec';
 import { LuSimpleSelectInputComponent } from './select-input.component';
 
 type Entity = { id: number; name: string };
+
+const options: TestEntity[] = [
+	{ id: 1, name: 'test 1' },
+	{ id: 2, name: 'test 2' },
+	{ id: 3, name: 'test 3' },
+];
+
+@Component({
+	selector: 'lu-simple-select-ng-model-host',
+	imports: [FormsModule, LuSimpleSelectInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: ` <lu-simple-select [ngModel]="selected" (ngModelChange)="setSelected($event)" [options]="options" clearable /> `,
+})
+class SimpleSelectNgModelHostComponent {
+	selected: TestEntity | null = null;
+
+	options: TestEntity[] = options;
+
+	setSelected(value: TestEntity | null): void {
+		this.selected = value;
+	}
+}
+
+@Component({
+	selector: 'lu-simple-select-form-control-host',
+	imports: [ReactiveFormsModule, LuSimpleSelectInputComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+	template: ` <lu-simple-select [formControl]="formControl" [options]="options" clearable /> `,
+})
+class SimpleSelectFormControlHostComponent {
+	formControl = new FormControl<TestEntity | null>(null);
+
+	options: TestEntity[] = options;
+}
 
 describe('LuSimpleSelectInputComponent', () => {
 	let fixture: ComponentFixture<LuSimpleSelectInputComponent<Entity>>;
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [LuSimpleSelectInputComponent],
+			imports: [LuSimpleSelectInputComponent, SimpleSelectNgModelHostComponent, SimpleSelectFormControlHostComponent],
 		});
 
 		fixture = TestBed.createComponent<LuSimpleSelectInputComponent<Entity>>(LuSimpleSelectInputComponent);
@@ -22,4 +60,222 @@ describe('LuSimpleSelectInputComponent', () => {
 		emptyValue: null,
 		clearerSelector: '.simpleSelect-field-clear',
 	});
+
+	function nativeElement(): HTMLElement {
+		return fixture.nativeElement as HTMLElement;
+	}
+
+	function displayedValue(): string {
+		fixture.detectChanges();
+		return nativeElement().querySelector('.simpleSelect-field-value')?.textContent?.trim() ?? '';
+	}
+
+	function clearer(): HTMLElement | null {
+		fixture.detectChanges();
+		return nativeElement().querySelector<HTMLElement>('.simpleSelect-field-clear');
+	}
+
+	describe('selected value display', () => {
+		it('should display nothing when there is no value', () => {
+			// Assert
+			expect(displayedValue()).toBe('');
+		});
+
+		it('should display the name of the selected option', () => {
+			// Act
+			fixture.componentInstance.writeValue(options[1]);
+
+			// Assert
+			expect(displayedValue()).toBe('test 2');
+		});
+
+		it('should display the configured placeholder while there is no value', () => {
+			// Arrange
+			const input = nativeElement().querySelector('input') as HTMLInputElement;
+
+			// Act
+			fixture.componentInstance.placeholder = 'Pick one';
+			fixture.detectChanges();
+
+			// Assert
+			expect(input.getAttribute('placeholder')).toBe('Pick one');
+		});
+
+		it('should fall back to the translated placeholder once a value is set', () => {
+			// Arrange
+			const input = nativeElement().querySelector('input') as HTMLInputElement;
+			fixture.componentInstance.placeholder = 'Pick one';
+			fixture.detectChanges();
+
+			// Act
+			fixture.componentInstance.writeValue(options[0]);
+			fixture.detectChanges();
+
+			// Assert
+			expect(input.getAttribute('placeholder')).toBe(fixture.componentInstance.intl().placeholder);
+		});
+
+		it('should update the display when the value changes', () => {
+			// Arrange
+			fixture.componentInstance.writeValue(options[0]);
+			expect(displayedValue()).toBe('test 1');
+
+			// Act
+			fixture.componentInstance.writeValue(options[2]);
+
+			// Assert
+			expect(displayedValue()).toBe('test 3');
+		});
+	});
+
+	describe('value emission', () => {
+		it('should emit the option picked in the panel', async () => {
+			// Arrange
+			const onChange = vi.fn();
+			const component = fixture.componentInstance;
+			component.registerOnChange(onChange);
+			component.options = options;
+			component.openPanel();
+			await waitForPanel(component);
+
+			// Act
+			component.panelRef?.emitValue(options[1]);
+
+			// Assert
+			expect(onChange).toHaveBeenCalledExactlyOnceWith(options[1]);
+			expect(component.value).toEqual(options[1]);
+		});
+
+		it('should replace the previous value when another option is picked', async () => {
+			// Arrange
+			const onChange = vi.fn();
+			const component = fixture.componentInstance;
+			component.registerOnChange(onChange);
+			component.options = options;
+			component.writeValue(options[0]);
+
+			// Act
+			component.openPanel();
+			await waitForPanel(component);
+			component.panelRef?.emitValue(options[2]);
+
+			// Assert
+			expect(onChange).toHaveBeenCalledExactlyOnceWith(options[2]);
+			expect(component.value).toEqual(options[2]);
+		});
+
+		it('should not emit a value when the parent writes one (with NgModel)', () => {
+			// Arrange
+			const hostFixture = TestBed.createComponent(SimpleSelectNgModelHostComponent);
+			const hostComponent = hostFixture.componentInstance;
+			vi.spyOn(hostComponent, 'setSelected');
+
+			// Act
+			hostComponent.selected = options[0];
+			hostFixture.detectChanges();
+
+			// Assert
+			expect(hostComponent.setSelected).not.toHaveBeenCalled();
+		});
+
+		it('should not emit a value when the parent writes one (with FormControl)', () => {
+			// Arrange
+			const hostFixture = TestBed.createComponent(SimpleSelectFormControlHostComponent);
+			hostFixture.detectChanges();
+			const valueChanges = vi.fn();
+			hostFixture.componentInstance.formControl.valueChanges.subscribe(valueChanges);
+
+			// Act
+			hostFixture.componentInstance.formControl.setValue(options[0], { emitEvent: false });
+			hostFixture.detectChanges();
+
+			// Assert
+			expect(valueChanges).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('clearable', () => {
+		it('should not display the clearer when the select is not clearable', () => {
+			// Act
+			fixture.componentInstance.writeValue(options[0]);
+
+			// Assert
+			expect(clearer()).toBeNull();
+		});
+
+		it('should not display the clearer when there is no value', () => {
+			// Act
+			fixture.componentInstance.clearable = true;
+
+			// Assert
+			expect(clearer()).toBeNull();
+		});
+
+		it('should display the clearer when the select is clearable and has a value', () => {
+			// Act
+			fixture.componentInstance.clearable = true;
+			fixture.componentInstance.writeValue(options[0]);
+
+			// Assert
+			expect(clearer()).not.toBeNull();
+		});
+
+		it('should emit null and reset the display when clearing', () => {
+			// Arrange
+			const onChange = vi.fn();
+			fixture.componentInstance.registerOnChange(onChange);
+			fixture.componentInstance.clearable = true;
+			fixture.componentInstance.writeValue(options[0]);
+
+			// Act
+			clearer()?.click();
+
+			// Assert
+			expect(onChange).toHaveBeenCalledExactlyOnceWith(null);
+			expect(displayedValue()).toBe('');
+		});
+	});
+
+	describe('disabled', () => {
+		it('should disable the input when disabled', async () => {
+			// Act
+			fixture.componentInstance.setDisabledState(true);
+			fixture.detectChanges();
+			// The disabled binding goes through NgModel, which applies it asynchronously
+			await fixture.whenStable();
+
+			// Assert
+			expect((nativeElement().querySelector('input') as HTMLInputElement).disabled).toBe(true);
+		});
+
+		it('should not open the panel when disabled', () => {
+			// Arrange
+			fixture.componentInstance.setDisabledState(true);
+			fixture.detectChanges();
+
+			// Act
+			fixture.componentInstance.openPanel();
+
+			// Assert
+			expect(fixture.componentInstance.isPanelOpen).toBe(false);
+		});
+
+		it('should hide the clearer when disabled', () => {
+			// Arrange
+			fixture.componentInstance.clearable = true;
+			fixture.componentInstance.writeValue(options[0]);
+			expect(clearer()).not.toBeNull();
+
+			// Act
+			fixture.componentInstance.setDisabledState(true);
+
+			// Assert
+			expect(clearer()).toBeNull();
+		});
+	});
 });
+
+// openPanel() defers panel creation via setTimeout, wait until panelRef is set
+function waitForPanel(componentInstance: LuSimpleSelectInputComponent<Entity>) {
+	return vi.waitUntil(() => isNotNil(componentInstance.panelRef));
+}

--- a/packages/ng/time/duration-picker/duration-picker.component.spec.ts
+++ b/packages/ng/time/duration-picker/duration-picker.component.spec.ts
@@ -1,7 +1,9 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
+import { ISO8601Duration } from '../core/date-primitives';
 import { DurationPickerComponent } from './duration-picker.component';
 
 @Component({
@@ -46,7 +48,20 @@ class DurationPickerFormControlMaxTestComponent {
 	control = new FormControl<string | null>(null);
 }
 
+@Component({
+	selector: 'lu-duration-picker-configurable-test',
+	imports: [DurationPickerComponent, ReactiveFormsModule],
+	template: `<lu-duration-picker [formControl]="control" [max]="max" [step]="step" />`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DurationPickerConfigurableTestComponent {
+	control = new FormControl<string | null>(null);
+	max: ISO8601Duration = 'PT99H';
+	step: ISO8601Duration | null = null;
+}
+
 const classSpan = '.timePicker-fieldset-group-textfield-display';
+const classInput = '.timePicker-fieldset-group-textfield-input';
 
 function getDisplayTexts(fixture: ComponentFixture<unknown>): { hours: string; minutes: string } {
 	const inputs = (fixture.nativeElement as HTMLElement).querySelectorAll(classSpan);
@@ -55,6 +70,32 @@ function getDisplayTexts(fixture: ComponentFixture<unknown>): { hours: string; m
 		hours: inputs[0].getAttribute('data-content-before')!,
 		minutes: inputs[1].getAttribute('data-content-before')!,
 	};
+}
+
+function getInputs(fixture: ComponentFixture<unknown>): { hours: HTMLInputElement; minutes: HTMLInputElement } {
+	const inputs = (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLInputElement>(classInput);
+	return { hours: inputs[0], minutes: inputs[1] };
+}
+
+function typeInPart(value: string, input: HTMLInputElement, fixture: ComponentFixture<unknown>): void {
+	input.value = value;
+	input.dispatchEvent(new InputEvent('input', { data: value.slice(-1), inputType: 'insertText', bubbles: true }));
+	fixture.detectChanges();
+}
+
+function pressKey(key: string, input: HTMLInputElement, fixture: ComponentFixture<unknown>): void {
+	input.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+	fixture.detectChanges();
+}
+
+function createConfigurableHost(value: string | null, options: { max?: ISO8601Duration; step?: ISO8601Duration } = {}): ComponentFixture<DurationPickerConfigurableTestComponent> {
+	TestBed.configureTestingModule({ imports: [DurationPickerConfigurableTestComponent] });
+	const fixture = TestBed.createComponent(DurationPickerConfigurableTestComponent);
+	fixture.componentInstance.control = new FormControl(value);
+	fixture.componentInstance.max = options.max ?? 'PT99H';
+	fixture.componentInstance.step = options.step ?? null;
+	fixture.detectChanges();
+	return fixture;
 }
 
 describe('DurationPickerComponent', () => {
@@ -113,5 +154,157 @@ describe('DurationPickerComponent', () => {
 		const { hours, minutes } = getDisplayTexts(fixture);
 		expect(hours).toBe('1000');
 		expect(minutes).toBe('00');
+	});
+
+	describe('value emission', () => {
+		it('should emit the ISO duration once hours and minutes are entered', async () => {
+			// Arrange
+			const fixture = TestBed.createComponent(DurationPickerNgModelTestComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+			const inputs = getInputs(fixture);
+
+			// Act
+			typeInPart('2', inputs.hours, fixture);
+			typeInPart('30', inputs.minutes, fixture);
+			await fixture.whenStable();
+
+			// Assert
+			expect(fixture.componentInstance.value).toBe('PT2H30M');
+		});
+
+		it('should emit the ISO duration on the form control once hours and minutes are entered', () => {
+			// Arrange
+			const fixture = createConfigurableHost(null);
+			const inputs = getInputs(fixture);
+
+			// Act
+			typeInPart('2', inputs.hours, fixture);
+			typeInPart('30', inputs.minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT2H30M');
+		});
+
+		it('should emit a durationChange event with its source when typing', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H0M');
+			const picker = fixture.debugElement.query(By.directive(DurationPickerComponent)).componentInstance as DurationPickerComponent;
+			const durationChange = vi.fn();
+			picker.durationChange.subscribe((event) => durationChange(event));
+
+			// Act
+			typeInPart('30', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(durationChange).toHaveBeenCalledExactlyOnceWith({
+				previousValue: 'PT1H0M',
+				value: 'PT1H30M',
+				source: 'input',
+			});
+		});
+	});
+
+	describe('max boundary', () => {
+		it('should reset the hours to 0 when typing more hours than max allows', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H30M', { max: 'PT9H' });
+
+			// Act
+			typeInPart('10', getInputs(fixture).hours, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT0H30M');
+		});
+
+		it('should wrap back to 0 when incrementing the hours past max', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT9H0M', { max: 'PT9H' });
+
+			// Act
+			pressKey('ArrowUp', getInputs(fixture).hours, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT0H0M');
+		});
+
+		it('should keep a value equal to max untouched', () => {
+			// Arrange & Act
+			const fixture = createConfigurableHost('PT9H0M', { max: 'PT9H' });
+
+			// Assert
+			expect(getDisplayTexts(fixture)).toEqual({ hours: '9', minutes: '00' });
+			expect(fixture.componentInstance.control.value).toBe('PT9H0M');
+		});
+	});
+
+	describe('min boundary', () => {
+		it('should wrap to max when decrementing the hours below zero', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT0H0M', { max: 'PT9H' });
+
+			// Act
+			pressKey('ArrowDown', getInputs(fixture).hours, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT9H0M');
+		});
+
+		it('should borrow from the hours when decrementing the minutes below zero', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H0M');
+
+			// Act
+			pressKey('ArrowDown', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT0H59M');
+		});
+	});
+
+	describe('granularity', () => {
+		it('should increment the minutes by the step', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H0M', { step: 'PT15M' });
+
+			// Act
+			pressKey('ArrowUp', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT1H15M');
+		});
+
+		it('should snap the minutes to the step when the current value is off-step', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H20M', { step: 'PT15M' });
+
+			// Act
+			pressKey('ArrowUp', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT1H30M');
+		});
+
+		it('should ignore the minutes arrows when the step has no minutes part', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H0M', { step: 'PT1H' });
+
+			// Act
+			pressKey('ArrowUp', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT1H0M');
+		});
+
+		it('should increment the hours by the step', () => {
+			// Arrange
+			const fixture = createConfigurableHost('PT1H0M', { step: 'PT2H' });
+
+			// Act
+			pressKey('ArrowUp', getInputs(fixture).hours, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('PT2H0M');
+		});
 	});
 });

--- a/packages/ng/time/time-picker/time-picker.component.spec.ts
+++ b/packages/ng/time/time-picker/time-picker.component.spec.ts
@@ -1,6 +1,9 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { registerLocaleData } from '@angular/common';
+import localesFr from '@angular/common/locales/fr';
+import { ChangeDetectionStrategy, Component, LOCALE_ID } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { By } from '@angular/platform-browser';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TimePickerComponent } from './time-picker.component';
 
@@ -32,7 +35,21 @@ class TimePickerFormControlTestComponent {
 	control = new FormControl<string | null>(null);
 }
 
+@Component({
+	selector: 'lu-time-picker-standalone-test',
+	imports: [TimePickerComponent, ReactiveFormsModule],
+	template: `<lu-time-picker [formControl]="control" [forceMeridiemDisplay]="forceMeridiemDisplay" />`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class TimePickerStandaloneTestComponent {
+	control = new FormControl<string | null>(null);
+	forceMeridiemDisplay: boolean | null = null;
+}
+
+registerLocaleData(localesFr);
+
 const classSpan = '.timePicker-fieldset-group-textfield-display';
+const classInput = '.timePicker-fieldset-group-textfield-input';
 
 function getDisplayTexts(fixture: ComponentFixture<unknown>): { hours: string; minutes: string } {
 	const inputs = (fixture.nativeElement as HTMLElement).querySelectorAll(classSpan);
@@ -41,6 +58,22 @@ function getDisplayTexts(fixture: ComponentFixture<unknown>): { hours: string; m
 		hours: inputs[0].getAttribute('data-content-before')!,
 		minutes: inputs[1].getAttribute('data-content-before')!,
 	};
+}
+
+function getInputs(fixture: ComponentFixture<unknown>): { hours: HTMLInputElement; minutes: HTMLInputElement } {
+	const inputs = (fixture.nativeElement as HTMLElement).querySelectorAll<HTMLInputElement>(classInput);
+	return { hours: inputs[0], minutes: inputs[1] };
+}
+
+function typeInPart(value: string, input: HTMLInputElement, fixture: ComponentFixture<unknown>): void {
+	input.value = value;
+	input.dispatchEvent(new InputEvent('input', { data: value.slice(-1), inputType: 'insertText', bubbles: true }));
+	fixture.detectChanges();
+}
+
+function pressKey(key: string, input: HTMLInputElement, fixture: ComponentFixture<unknown>): void {
+	input.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+	fixture.detectChanges();
 }
 
 describe('TimePickerComponent', () => {
@@ -120,5 +153,229 @@ describe('TimePickerComponent', () => {
 		// 12-hour test locale: midnight (hours 0) displays as 12, proving the 0 registered.
 		expect(hours).toBe('12');
 		expect(minutes).toBe('00');
+	});
+
+	describe('value emission', () => {
+		it('should emit the ISO time once hours and minutes are entered', async () => {
+			// Arrange
+			const fixture = TestBed.createComponent(TimePickerNgModelTestComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+			const inputs = getInputs(fixture);
+
+			// Act
+			typeInPart('9', inputs.hours, fixture);
+			typeInPart('45', inputs.minutes, fixture);
+			await fixture.whenStable();
+
+			// Assert
+			expect(fixture.componentInstance.value).toBe('09:45:00');
+		});
+
+		it('should emit the ISO time on the form control once hours and minutes are entered', async () => {
+			// Arrange
+			const valueChanges = vi.fn();
+			const fixture = TestBed.createComponent(TimePickerFormControlTestComponent);
+			fixture.componentInstance.control.valueChanges.subscribe((value) => valueChanges(value));
+			fixture.detectChanges();
+			await fixture.whenStable();
+			const inputs = getInputs(fixture);
+
+			// Act
+			typeInPart('9', inputs.hours, fixture);
+			typeInPart('45', inputs.minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('09:45:00');
+			expect(valueChanges).toHaveBeenLastCalledWith('09:45:00');
+		});
+
+		it('should emit a timeChange event with its source when typing', async () => {
+			// Arrange
+			TestBed.configureTestingModule({ imports: [TimePickerStandaloneTestComponent] });
+			const fixture = TestBed.createComponent(TimePickerStandaloneTestComponent);
+			fixture.detectChanges();
+			await fixture.whenStable();
+			const picker = fixture.debugElement.query(By.directive(TimePickerComponent)).componentInstance as TimePickerComponent;
+			const timeChange = vi.fn();
+			picker.timeChange.subscribe((event) => timeChange(event));
+
+			// Act
+			typeInPart('9', getInputs(fixture).hours, fixture);
+
+			// Assert
+			expect(timeChange).toHaveBeenCalledExactlyOnceWith({
+				previousValue: '––:––:––',
+				value: '09:00:00',
+				source: 'input',
+			});
+		});
+	});
+
+	describe('keyboard navigation', () => {
+		function createStandaloneHost(value: string | null): ComponentFixture<TimePickerStandaloneTestComponent> {
+			TestBed.configureTestingModule({ imports: [TimePickerStandaloneTestComponent] });
+			const fixture = TestBed.createComponent(TimePickerStandaloneTestComponent);
+			fixture.componentInstance.control = new FormControl(value);
+			fixture.detectChanges();
+			return fixture;
+		}
+
+		it('should increment the hours on ArrowUp', () => {
+			// Arrange
+			const fixture = createStandaloneHost('10:30:00');
+
+			// Act
+			pressKey('ArrowUp', getInputs(fixture).hours, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('11:30:00');
+		});
+
+		it('should decrement the minutes on ArrowDown', () => {
+			// Arrange
+			const fixture = createStandaloneHost('10:30:00');
+
+			// Act
+			pressKey('ArrowDown', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('10:29:00');
+		});
+
+		it('should move the focus from hours to minutes on ArrowRight', () => {
+			// Arrange
+			const fixture = createStandaloneHost('10:30:00');
+			const inputs = getInputs(fixture);
+			inputs.hours.focus();
+
+			// Act
+			pressKey('ArrowRight', inputs.hours, fixture);
+
+			// Assert
+			expect(document.activeElement).toBe(inputs.minutes);
+		});
+
+		it('should move the focus from minutes back to hours on ArrowLeft', () => {
+			// Arrange
+			const fixture = createStandaloneHost('10:30:00');
+			const inputs = getInputs(fixture);
+			inputs.minutes.focus();
+
+			// Act
+			pressKey('ArrowLeft', inputs.minutes, fixture);
+
+			// Assert
+			expect(document.activeElement).toBe(inputs.hours);
+		});
+
+		it('should reset the minutes to 0 on Backspace', () => {
+			// Arrange
+			const fixture = createStandaloneHost('10:30:00');
+
+			// Act
+			pressKey('Backspace', getInputs(fixture).minutes, fixture);
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('10:00:00');
+		});
+	});
+
+	describe('locale and meridiem', () => {
+		function createLocalizedHost(locale: string, value: string, forceMeridiemDisplay: boolean | null = null): ComponentFixture<TimePickerStandaloneTestComponent> {
+			TestBed.configureTestingModule({
+				imports: [TimePickerStandaloneTestComponent],
+				providers: [{ provide: LOCALE_ID, useValue: locale }],
+			});
+			const fixture = TestBed.createComponent(TimePickerStandaloneTestComponent);
+			fixture.componentInstance.control = new FormControl(value);
+			fixture.componentInstance.forceMeridiemDisplay = forceMeridiemDisplay;
+			fixture.detectChanges();
+			return fixture;
+		}
+
+		it('should display 24-hour time and no meridiem in a 24-hour locale', () => {
+			// Act
+			const fixture = createLocalizedHost('fr-FR', '13:30:00');
+
+			// Assert
+			expect(getDisplayTexts(fixture)).toEqual({ hours: '13', minutes: '30' });
+			expect((fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset-meridiem')).toBeNull();
+		});
+
+		it('should display 12-hour time and a meridiem in a 12-hour locale', () => {
+			// Act
+			const fixture = createLocalizedHost('en-US', '13:30:00');
+
+			// Assert
+			expect(getDisplayTexts(fixture)).toEqual({ hours: '1', minutes: '30' });
+			expect((fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset-meridiem')).not.toBeNull();
+		});
+
+		it('should force the meridiem display in a 24-hour locale when asked to', () => {
+			// Act
+			const fixture = createLocalizedHost('fr-FR', '13:30:00', true);
+
+			// Assert
+			expect(getDisplayTexts(fixture).hours).toBe('1');
+			expect((fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset-meridiem')).not.toBeNull();
+		});
+
+		it('should hide the meridiem in a 12-hour locale when asked to', () => {
+			// Act
+			const fixture = createLocalizedHost('en-US', '13:30:00', false);
+
+			// Assert
+			expect(getDisplayTexts(fixture).hours).toBe('13');
+			expect((fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset-meridiem')).toBeNull();
+		});
+
+		it('should switch the hours to the afternoon when picking PM', () => {
+			// Arrange
+			const fixture = createLocalizedHost('en-US', '01:30:00');
+			const pm = (fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset-meridiem-post-input') as HTMLInputElement;
+
+			// Act
+			pm.click();
+			fixture.detectChanges();
+
+			// Assert
+			expect(fixture.componentInstance.control.value).toBe('13:30:00');
+		});
+	});
+
+	describe('disabled state', () => {
+		it('should disable the fieldset when the control is disabled', async () => {
+			// Arrange
+			TestBed.configureTestingModule({ imports: [TimePickerStandaloneTestComponent] });
+			const fixture = TestBed.createComponent(TimePickerStandaloneTestComponent);
+			fixture.componentInstance.control = new FormControl('10:30:00');
+			fixture.componentInstance.control.disable();
+
+			// Act
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Assert
+			expect(((fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset') as HTMLFieldSetElement).disabled).toBe(true);
+		});
+
+		it('should enable the fieldset back when the control is enabled', async () => {
+			// Arrange
+			TestBed.configureTestingModule({ imports: [TimePickerStandaloneTestComponent] });
+			const fixture = TestBed.createComponent(TimePickerStandaloneTestComponent);
+			fixture.componentInstance.control = new FormControl('10:30:00');
+			fixture.componentInstance.control.disable();
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Act
+			fixture.componentInstance.control.enable();
+			fixture.detectChanges();
+			await fixture.whenStable();
+
+			// Assert
+			expect(((fixture.nativeElement as HTMLElement).querySelector('.timePicker-fieldset') as HTMLFieldSetElement).disabled).toBe(false);
+		});
 	});
 });


### PR DESCRIPTION
## Description

No functional change: this PR only adds and fixes unit tests.

-----

Adds 79 unit test cases on entrypoints whose behaviour was under-covered, and fixes two specs
that were broken by the API changes landed in the v22 cycle.

### New coverage

| Entrypoint | What is now covered |
| --- | --- |
| `api` | v3 and v4 query params (fields/orderBy/paging vs page/sort), selection emission and display, disabled panel |
| `date2/date-input` | parsed-date and ISO-string emission, `month`/`year` granularity (placeholder + parsing), `min` compared against the whole month, disabled input and calendar toggle |
| `date2/date-range-input` | end-date-only entry, full range emission, clearing, reversed range swapped on blur, unparsable start date error, `min`/`max` cell disabling, disabled state |
| `department` | single vs multiple selection, parent selected without its children, deselection |
| `form-field` | required toggling, label rendering and `for`/`id` binding, `hiddenLabel`, tooltip trigger, inline message rendering, `aria-describedby` and state |
| `simple-select` | selected value display, placeholder fallback, value emission vs parent writes (`NgModel` and `FormControl`), clearer visibility, disabled state |
| `duration-picker` | ISO duration emission, `durationChange` source, `min`/`max` boundaries and wrapping, step granularity and snapping |
| `time-picker` | ISO time emission, `timeChange` source, keyboard navigation (arrows, focus moves, Backspace), 12h/24h locales and meridiem overrides, disabled fieldset |

### Spec fixes

- **`simple-select/input`** — `placeholder`, `clearable` and `options` became signals
  (`input()` / `linkedSignal`). The spec assigned them as plain properties, which overwrote the
  signals themselves (`this.placeholder is not a function`). Now set through
  `fixture.componentRef.setInput(...)`.
- **`dialog/dialog-routing`** — the spec mocked the `dialog.providers` module to intercept
  `LuDialogService`. But `dialog-routing.component.ts` calls `provideLuDialog()` while its
  decorator is evaluated, so the provider is baked in the first time that module is loaded.
  Specs share a module registry (`isolate: false`), so as soon as another spec pulled the dialog
  entrypoint in first — e.g. `form-field` → `@lucca-front/ng/forms` → `rich-text-input/plugins/link`
  → `@lucca-front/ng/dialog` — the mock no longer applied and the 12 tests of the suite failed.
  This was already latent before this PR: the suite only passed on the base branch because the two
  spec files happened to land in different Vitest workers. Replaced the module mock with a spy on
  `LuDialogService.prototype.open` installed in `beforeEach`, which catches every instance whatever
  provider was used.

-----

### Contribution

- [x] `npm test` is OK (58 files, 590 passed, 11 skipped)
- [x] `npm run lint` is OK
