### PR TITLE
[multilanguage] fix display with culture, presentation mode and add lang attribute

### DIFF
--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
@@ -24,6 +24,7 @@
 			[disabled]="disabledInternal()"
 			[autocomplete]="autocomplete()"
 			[attr.lang]="hasNoInvariant() ? displayCultureCode() : null"
+			translate="no"
 			#inputElement
 		/>
 		<div class="textField-input-affix">
@@ -89,6 +90,7 @@
 									[autocomplete]="autocomplete()"
 									[suffix]="hasAIButtons() ? { content: aiSuffix, ariaLabel: '' } : undefined"
 									[attr.lang]="row.cultureCode"
+									translate="no"
 								/>
 							</lu-form-field>
 						}
@@ -100,7 +102,7 @@
 </div>
 <ng-container *luPresentationDisplayDefault>
 	@if (presentationValue()) {
-		<span [attr.lang]="hasNoInvariant() ? displayCultureCode() : null">{{ presentationValue() }}</span>
+		<span [attr.lang]="hasNoInvariant() ? displayCultureCode() : null" translate="no">{{ presentationValue() }}</span>
 	} @else {
 		<span aria-hidden="true" data-content-before="–"></span>
 	}

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.html
@@ -23,6 +23,7 @@
 			(focus)="shouldOpenOnFocus() ? popoverRef.openPopover(true, true, true) : null"
 			[disabled]="disabledInternal()"
 			[autocomplete]="autocomplete()"
+			[attr.lang]="hasNoInvariant() ? displayCultureCode() : null"
 			#inputElement
 		/>
 		<div class="textField-input-affix">
@@ -50,7 +51,7 @@
 						}
 						@for (row of panelInputs(); track row.cultureCode) {
 							<ng-template #prefixLang>
-								<div class="textField-prefix-lang">
+								<div class="textField-prefix-lang" [class.mod-withCulture]="hasCulture(row.cultureCode)">
 									@if (formFieldRef?.isInputRequired()) {
 										{{ row.cultureCode }}<sup class="formLabel-required" aria-hidden="true">*</sup>
 									} @else {
@@ -87,6 +88,7 @@
 									[disabled]="disabledInternal()"
 									[autocomplete]="autocomplete()"
 									[suffix]="hasAIButtons() ? { content: aiSuffix, ariaLabel: '' } : undefined"
+									[attr.lang]="row.cultureCode"
 								/>
 							</lu-form-field>
 						}
@@ -98,7 +100,7 @@
 </div>
 <ng-container *luPresentationDisplayDefault>
 	@if (presentationValue()) {
-		{{ presentationValue() }}
+		<span [attr.lang]="hasNoInvariant() ? displayCultureCode() : null">{{ presentationValue() }}</span>
 	} @else {
 		<span aria-hidden="true" data-content-before="–"></span>
 	}

--- a/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
+++ b/packages/ng/forms/multilanguage-input/multilanguage-input.component.ts
@@ -75,12 +75,23 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	readonly model: WritableSignal<MultilanguageTranslation[]> = signal([] as MultilanguageTranslation[]);
 
-	readonly displayRow = computed(() => {
-		if (this.hasNoInvariant()) {
-			return this.model().find((row) => row.cultureCode === this.displayLocale()) || { value: '', required: false, cultureCode: this.displayLocale() };
-		} else {
-			return this.model().find((row) => row.cultureCode === INVARIANT_CULTURE_CODE) || { value: '', required: false, cultureCode: INVARIANT_CULTURE_CODE };
+	// Resolves the culture code to display: an exact match on `displayLocale` if there is one,
+	// otherwise a match on the language part only (e.g. `displayLocale` `en-US` matches a row `en`).
+	readonly displayCultureCode = computed(() => {
+		if (!this.hasNoInvariant()) {
+			return INVARIANT_CULTURE_CODE;
 		}
+		const displayLocale = this.displayLocale();
+		const rows = this.model();
+		if (rows.some((row) => row.cultureCode === displayLocale)) {
+			return displayLocale;
+		}
+		const language = displayLocale.split('-')[0];
+		return rows.find((row) => row.cultureCode.split('-')[0] === language)?.cultureCode ?? displayLocale;
+	});
+
+	readonly displayRow = computed(() => {
+		return this.model().find((row) => row.cultureCode === this.displayCultureCode()) || { value: '', required: false, cultureCode: this.displayCultureCode() };
 	});
 
 	readonly cultureCodeDisplay = computed(() => {
@@ -88,10 +99,13 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 	});
 
 	readonly panelInputs = computed(() => {
-		return this.model().filter((row) => (this.hasNoInvariant() ? row.cultureCode !== this.displayLocale() && row.cultureCode !== INVARIANT_CULTURE_CODE : row.cultureCode !== INVARIANT_CULTURE_CODE));
+		return this.model().filter((row) => row.cultureCode !== INVARIANT_CULTURE_CODE && (!this.hasNoInvariant() || row.cultureCode !== this.displayCultureCode()));
 	});
 
 	readonly presentationValue = computed(() => {
+		if (this.hasNoInvariant()) {
+			return this.displayRow()?.value;
+		}
 		return this.model().find((row) => row.cultureCode === this.#localeId)?.value || this.displayRow()?.value;
 	});
 
@@ -113,6 +127,10 @@ export class MultilanguageInputComponent implements ControlValueAccessor {
 
 	getLocaleDisplayName(locale: string): string {
 		return this.#intlDisplay.of(locale) ?? locale;
+	}
+
+	protected hasCulture(cultureCode: string): boolean {
+		return cultureCode.includes('-');
 	}
 
 	protected getPopoverInlineSizeRem(inputElement: HTMLInputElement): number {

--- a/packages/scss/src/components/textField/component.scss
+++ b/packages/scss/src/components/textField/component.scss
@@ -131,19 +131,32 @@
 		}
 
 		.textField-prefix-lang {
-			min-inline-size: calc(var(--pr-t-spacings-300) + var(--pr-t-spacings-50));
+			min-inline-size: var(--component-textField-prefix-lang-minInlineSize);
 			padding-inline-end: var(--pr-t-spacings-100);
 			position: relative;
+			text-align: end;
+
+			&:not(.mod-withCulture) {
+				text-transform: uppercase;
+			}
+
+			&:has(.formLabel-required) {
+				--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-400) + var(--pr-t-spacings-50));
+			}
+
+			&.mod-withCulture {
+				--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-600) + var(--pr-t-spacings-50));
+
+				&:has(.formLabel-required) {
+					--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-700) + var(--pr-t-spacings-50));
+				}
+			}
 
 			&::after {
 				content: '';
 				position: absolute;
 				inset: var(--pr-t-spacings-25) 0;
 				border-inline-end: 1px solid var(--palettes-neutral-200);
-			}
-
-			&:has(.formLabel-required) {
-				min-inline-size: calc(var(--pr-t-spacings-400) + var(--pr-t-spacings-50));
 			}
 		}
 

--- a/packages/scss/src/components/textField/mods.scss
+++ b/packages/scss/src/components/textField/mods.scss
@@ -6,6 +6,7 @@
 	--component-textField-font: var(--pr-t-font-body-S);
 	--component-textField-padding: var(--pr-t-spacings-75);
 	--component-textField-affix-size: 1.5rem;
+	--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-300) + var(--pr-t-spacings-50));
 
 	.textField-input-affix-toggle {
 		@include icon.S;
@@ -22,6 +23,20 @@
 
 	.textField-input-affix-icon {
 		@include icon.S;
+	}
+
+	.textField-prefix-lang {
+		&:has(.formLabel-required) {
+			--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-400) + var(--pr-t-spacings-50));
+		}
+
+		&.mod-withCulture {
+			--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-500) + var(--pr-t-spacings-50));
+
+			&:has(.formLabel-required) {
+				--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-600) + var(--pr-t-spacings-50));
+			}
+		}
 	}
 }
 

--- a/packages/scss/src/components/textField/vars.scss
+++ b/packages/scss/src/components/textField/vars.scss
@@ -15,6 +15,7 @@
 	--component-textField-maxHeightFallback: 90vh;
 	--component-textField-borderRadius: var(--pr-t-border-radius-input);
 	--component-textField-width: auto;
+	--component-textField-prefix-lang-minInlineSize: calc(var(--pr-t-spacings-300) + var(--pr-t-spacings-50));
 
 	// Deprecated
 	--component-textField-fontSize: var(--pr-t-font-body-M-fontSize);

--- a/stories/documentation/forms/fields/multilanguage/angular/multilanguage-field.stories.ts
+++ b/stories/documentation/forms/fields/multilanguage/angular/multilanguage-field.stories.ts
@@ -1,3 +1,5 @@
+import { cleanupTemplate, generateInputs, setStoryOptions } from '@/helpers/stories';
+import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { LOCALE_ID } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
@@ -5,8 +7,6 @@ import { FORM_FIELD_WIDTH, FormFieldComponent } from '@lucca-front/ng/form-field
 import { MultilanguageInputComponent, MultilanguageTranslation } from '@lucca-front/ng/forms';
 import { INLINE_MESSAGE_STATE } from '@lucca-front/ng/inline-message';
 import { applicationConfig, Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
-import { cleanupTemplate, generateInputs, setStoryOptions } from '@/helpers/stories';
-import { StoryModelDisplayComponent } from '@/helpers/story-model-display.component';
 import { useState } from 'storybook/preview-api';
 
 export default {
@@ -126,7 +126,7 @@ export const Basic: StoryObj<
 					},
 					{
 						cultureCode: 'de-DE',
-						value: "I don't speak German",
+						value: 'Wert auf Deutsch',
 					},
 				]),
 		);


### PR DESCRIPTION
## Description

- Fixes the display of languages with cultures to visually align the values
- Fixes the presentation mode, which did not support cultures
- Adds the `lang` and `translate` attributes for better behavior in browsers and AT

-----



-----

<img width="969" height="282" alt="Capture d’écran 2026-08-26 à 11 18 39" src="https://github.com/user-attachments/assets/2ad893d7-dfdb-4b96-aaa4-cdec96277b86" />

