### PR TITLE
[comment] fix display without name

### DIFF
--- a/packages/scss/src/components/comment/component.scss
+++ b/packages/scss/src/components/comment/component.scss
@@ -49,13 +49,15 @@
 		}
 
 		.comment-infos-name {
-			color: var(--pr-t-color-text);
+			&:not(:empty) {
+				color: var(--pr-t-color-text);
 
-			& + .comment-infos-date {
-				&::before {
-					color: var(--palettes-neutral-400);
-					padding-inline: 1ch;
-					content: var(--components-comment-info-separator) / '';
+				& + .comment-infos-date {
+					&::before {
+						color: var(--palettes-neutral-400);
+						padding-inline: 1ch;
+						content: var(--components-comment-info-separator) / '';
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

The separator between the name and the date is now generated only if a name is present.

-----



-----

<img width="560" height="115" alt="Capture d’écran 2026-08-26 à 12 05 04" src="https://github.com/user-attachments/assets/bce8341a-b049-493b-8e53-16e808d1afc2" />
