### PR TITLE
feat(bubble-icon): accept the per-product palettes

### DIFF
--- a/packages/ng/bubble-icon/bubble-icon.component.ts
+++ b/packages/ng/bubble-icon/bubble-icon.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component, computed, input, signal, ViewEncapsulation } from '@angular/core';
 import { LuccaIcon } from '@lucca-front/icons';
-import { DecorativePalette, Palette } from '@lucca-front/ng/core';
+import { DecorativePalette, Palette, ProductPalette } from '@lucca-front/ng/core';
 import { IconComponent } from '@lucca-front/ng/icon';
 import { BubbleIconSize } from './bubble-icon.type';
 
@@ -28,7 +28,7 @@ export class BubbleIconComponent {
 	readonly alt = input<string | null>(null);
 	readonly size = input<BubbleIconSize>('M');
 
-	readonly palette = input<Palette | DecorativePalette>('product');
+	readonly palette = input<Palette | DecorativePalette | ProductPalette>('product');
 	readonly paletteClass = computed(() => ({ [`palette-${this.palette()}`]: !!this.palette() }));
 
 	readonly bubbleDirection = input<'top' | 'bottom' | 'left' | 'right' | 'random'>('random');

--- a/packages/ng/core/type/style.ts
+++ b/packages/ng/core/type/style.ts
@@ -1,1 +1,1 @@
-export { Palette, DecorativePalette } from '@lucca/prisme/core';
+export { Palette, DecorativePalette, ProductPalette } from '@lucca/prisme/core';

--- a/packages/prisme/core/style.ts
+++ b/packages/prisme/core/style.ts
@@ -8,3 +8,6 @@ export type Palette = (typeof PALETTE)[number];
 
 export const DECORATIVE_PALETTE = ['kiwi', 'lime', 'cucumber', 'mint', 'glacier', 'lagoon', 'blueberry', 'lavender', 'grape', 'watermelon', 'pumpkin', 'pineapple'] as const;
 export type DecorativePalette = (typeof DECORATIVE_PALETTE)[number];
+
+export const PRODUCT_PALETTE = ['pagga', 'poplee', 'coreHR', 'timmi', 'cleemy', 'cc'] as const;
+export type ProductPalette = (typeof PRODUCT_PALETTE)[number];

--- a/stories/documentation/structure/bubble-icon/angular/basic.stories.ts
+++ b/stories/documentation/structure/bubble-icon/angular/basic.stories.ts
@@ -1,7 +1,7 @@
 //import { DecorativeIconComponent } from '@lucca-front/ng/';
 import { IconsList } from '@/stories/icons-list';
 import { BUBBLE_ICON_DIRECTION, BUBBLE_ICON_SIZE, BubbleIconComponent } from '@lucca-front/ng/bubble-icon';
-import { DECORATIVE_PALETTE, PALETTE } from '@lucca/prisme/core';
+import { DECORATIVE_PALETTE, PALETTE, PRODUCT_PALETTE } from '@lucca/prisme/core';
 import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
 import { generateInputs, setStoryOptions } from '@/helpers/stories';
 
@@ -23,7 +23,7 @@ export default {
 			description: 'Modifie la taille du composant.',
 		},
 		palette: {
-			options: setStoryOptions([...PALETTE, ...DECORATIVE_PALETTE]),
+			options: setStoryOptions([...PALETTE, ...PRODUCT_PALETTE, ...DECORATIVE_PALETTE]),
 			control: {
 				type: 'select',
 			},

--- a/stories/documentation/structure/bubble-icon/html&css/basic.stories.ts
+++ b/stories/documentation/structure/bubble-icon/html&css/basic.stories.ts
@@ -1,6 +1,6 @@
 import { IconsList } from '@/stories/icons-list';
 import { BUBBLE_ICON_DIRECTION, BUBBLE_ICON_SIZE } from '@lucca-front/ng/bubble-icon';
-import { DECORATIVE_PALETTE, PALETTE } from '@lucca/prisme/core';
+import { DECORATIVE_PALETTE, PALETTE, PRODUCT_PALETTE } from '@lucca/prisme/core';
 import { Meta, StoryObj } from '@storybook/angular-vite';
 import { setStoryOptions } from '@/helpers/stories';
 
@@ -30,7 +30,7 @@ export default {
 			description: 'Modifie la taille du composant.',
 		},
 		palette: {
-			options: setStoryOptions([...PALETTE, ...DECORATIVE_PALETTE]),
+			options: setStoryOptions([...PALETTE, ...PRODUCT_PALETTE, ...DECORATIVE_PALETTE]),
 			control: {
 				type: 'select',
 			},


### PR DESCRIPTION
## Description

`lu-bubble-icon` accepte désormais les palettes logicielles (`pagga`, `poplee`, `coreHR`, `timmi`, `cleemy`, `cc`), en plus des palettes existantes.

-----

## Pourquoi

La fiche [Bubble icon](https://prisme.lucca.io/94310e217/p/00d34a) documente ces palettes sous *Options › Couleurs › Couleurs des logiciels* : son visuel *Option - Color (Product)* montre sept bulles, qui sont `brand` plus les six palettes produit. Les classes `.palette-*` correspondantes existent déjà côté SCSS, générées depuis `$palettesOtherProduct` dans `config.scss`.

Seul l'input `palette` refusait ces valeurs. Le typage était donc en retard sur la fiche et sur le CSS.

## Ce que ça change

`packages/prisme/core/style.ts` gagne une union `PRODUCT_PALETTE` / `ProductPalette` à côté de `PALETTE` et `DECORATIVE_PALETTE`, réexportée par `@lucca-front/ng/core`. L'input de `lu-bubble-icon` devient `Palette | DecorativePalette | ProductPalette`.

**Non-breaking** : le composant se contente de transformer la palette en classe CSS (`palette-${value}`), donc c'est un élargissement de type et rien d'autre — pas de changement de template, de style ni de comportement, et la valeur par défaut reste `product`. L'union n'est qu'augmentée, donc tous les appels existants compilent toujours.

Les deux stories dérivaient leurs options de `PALETTE` + `DECORATIVE_PALETTE`, donc aucune des six valeurs n'était sélectionnable. Elles spreadent maintenant aussi `PRODUCT_PALETTE` ; `.storybook/styles.scss` charge déjà `$palettesOtherProduct: 'all'`, donc les six palettes sont réellement visibles dans le Storybook de preview.

## Notes pour la revue

- Les palettes produit sont **opt-in par valeur** : l'hôte doit lister chacune de celles qu'il utilise dans `$palettesOtherProduct` (`()` par défaut). Une valeur non chargée n'émet aucune classe, et le bubble retombe alors sur `var(--palettes-700, var(--palettes-product-700))`, soit la palette du **produit courant** — donc visuellement identique au défaut. La mauvaise valeur est silencieuse, pas neutre : c'est documenté sur l'input.
- Volontairement **sans** l'échappatoire `| string` que porte `highlight-data` : elle annule le bénéfice du typage.
- `lucca` n'est pas inclus : la palette Lucca est `brand`, déjà présente dans `PALETTE`. `lucca` n'existe que dans `highlight-data`, où il sert à construire une URL d'illustration CDN.
- Suivi identifié, hors périmètre ici : `highlight-data.component.ts:67` porte la même liste en dur et devrait réutiliser `ProductPalette`, sinon les deux listes divergeront au prochain produit.
- Vérifié : `build:prisme` et `build:ng` verts, les typings générés portent bien la nouvelle union. Le warning eslint TS6059 sur `packages/ng/core/type/style.ts` est préexistant.

## Contexte

Vient d'un besoin côté reporting centralisé (Analytics) : les domaines de reporting sont rendus en `lu-bubble-icon` et on souhaite les teinter selon la gamme produit dont ils proviennent, plutôt que d'approximer avec la palette décorative la plus proche.
