### PR TITLE
chore(stories): categorize inputs in argTypes of recently added stories

### DIFF
--- a/stories/documentation/loaders/skeleton-card/angular/skeleton-card.stories.ts
+++ b/stories/documentation/loaders/skeleton-card/angular/skeleton-card.stories.ts
@@ -14,6 +14,7 @@ export const Template: StoryObj<SkeletonCardComponent> = {
 				type: 'number',
 				min: 0,
 			},
+			table: { category: 'inputs' },
 		},
 	},
 

--- a/stories/documentation/loaders/skeleton-highlight-data/angular/skeleton-highlight-data.stories.ts
+++ b/stories/documentation/loaders/skeleton-highlight-data/angular/skeleton-highlight-data.stories.ts
@@ -13,6 +13,7 @@ export const Template: StoryObj<SkeletonHighlightDataComponent> = {
 			control: {
 				type: 'boolean',
 			},
+			table: { category: 'inputs' },
 		},
 	},
 

--- a/stories/documentation/structure/approbationInbox/angular/detail.stories.ts
+++ b/stories/documentation/structure/approbationInbox/angular/detail.stories.ts
@@ -13,9 +13,11 @@ export default {
 	argTypes: {
 		insideDialog: {
 			description: 'Adapte l’affichage du composant à une utilisation dans une dialog.',
+			table: { category: 'inputs' },
 		},
 		label: {
 			description: 'Titre affiché dans l’en-tête du composant.',
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			description: 'Affiche une illustration au début de l’en-tête.',
@@ -25,6 +27,7 @@ export default {
 		},
 		delegatedBy: {
 			description: 'Nom de la personne à l’origine de la délégation si elle à lieu.',
+			table: { category: 'inputs' },
 		},
 		moreActions: {
 			description: 'Affiche un bouton d’actions tertaires sous forme de menu déroulant.',

--- a/stories/documentation/structure/approbationInbox/angular/list.stories.ts
+++ b/stories/documentation/structure/approbationInbox/angular/list.stories.ts
@@ -44,15 +44,18 @@ export default {
 				type: 'select',
 			},
 			if: { arg: 'itemCount', eq: 0 },
+			table: { category: 'inputs' },
 		},
 		current: {
 			description: 'Définit le lien (ou le bouton) comme l’élément courant affiché.',
+			table: { category: 'inputs' },
 		},
 		filterBar: {
 			description: 'Exemple de barre de filtres.',
 		},
 		selectable: {
 			description: 'Active la sélection multiple',
+			table: { category: 'inputs' },
 		},
 		rightContent: {
 			description: 'Exemple de données complémentaires.',
@@ -65,14 +68,17 @@ export default {
 		},
 		center: {
 			description: 'Centre verticalement les données d’un élément',
+			table: { category: 'inputs' },
 		},
 		icons: {
 			description: 'Icônes affichées dans les données complémentaires.',
 			control: { type: 'object' },
 			if: { arg: 'rightContent', truthy: true },
+			table: { category: 'inputs' },
 		},
 		emptyResetButton: {
 			if: { arg: 'itemCount', eq: 0 },
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [

--- a/stories/documentation/structure/highlight-section/angular/basic.stories.ts
+++ b/stories/documentation/structure/highlight-section/angular/basic.stories.ts
@@ -10,6 +10,7 @@ export default {
 			control: {
 				type: 'select',
 			},
+			table: { category: 'inputs' },
 		},
 		palette: {
 			options: setStoryOptions(HIGHLIGHT_SECTION_PALETTE),
@@ -17,6 +18,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Applique une palette de couleurs au composant.',
+			table: { category: 'inputs' },
 		},
 		bubbleStart: {
 			options: setStoryOptions(HIGHLIGHT_SECTION_BUBBLE),
@@ -24,6 +26,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Sans valeur, aucune bulle se sera affichée.',
+			table: { category: 'inputs' },
 		},
 		bubbleEnd: {
 			options: setStoryOptions(HIGHLIGHT_SECTION_BUBBLE),
@@ -31,6 +34,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Sans valeur, aucune bulle se sera affichée.',
+			table: { category: 'inputs' },
 		},
 		illustration: {
 			options: setStoryOptions(HIGHLIGHT_SECTION_ILLUSTRATION),
@@ -38,6 +42,7 @@ export default {
 				type: 'select',
 			},
 			description: 'Il est également possible de renseigner une URL.',
+			table: { category: 'inputs' },
 		},
 	},
 	decorators: [


### PR DESCRIPTION
## Description

Applies the argTypes convention introduced in #5184 (`table.category`) to the stories added since then.

Each argType matching a real component `input()` is now grouped under the `inputs` category, so the Storybook controls table separates the component API from the story-only demo toggles.

| Story | argTypes moved to `inputs` |
| --- | --- |
| `loaders/skeleton-card/angular` | `descriptionLines` |
| `loaders/skeleton-highlight-data/angular` | `dark` |
| `structure/highlight-section/angular/basic` | `theme`, `palette`, `bubbleStart`, `bubbleEnd`, `illustration` |
| `structure/approbationInbox/angular/detail` | `insideDialog`, `label`, `delegatedBy` |
| `structure/approbationInbox/angular/list` | `selectable`, `emptyIllustration`, `emptyResetButton`, `current`, `center`, `icons` |

### Notes

- Every categorized name was checked against an actual `input()` in `packages/ng/approbation-inbox`, `packages/ng/highlight-section` and `packages/prisme/skeleton`.
- Story-only demo toggles (`headerContent`, `callout`, `blockCount`, `filterBar`, `group`, `itemCount`…) are intentionally left uncategorized: they are not part of the component API.
- No `model()` is exposed as-is by these stories, so no `model` category was needed. `ApprobationInboxListComponent` outputs (`submitEvent`, `resetEvent`, `forwardEvent`) are still undocumented in the story — adding them is new content rather than a convention fix, so it is left out of this PR.
- `html&css` stories are untouched: their args are CSS modifiers, not inputs (consistent with the existing `horizontal-navigation` story).

## Impact

No rendering change: `generateInputs` only skips an arg when `table.category !== 'inputs'`, so every generated template stays identical.
