### PR TITLE
fix(dialog): keep a routed dialog open on history navigation while its route survives

### DIFF
--- a/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
+++ b/packages/ng/dialog/dialog-routing/dialog-routing.component.ts
@@ -124,6 +124,8 @@ export class DialogRoutingContainerComponent<C> implements OnDestroy, OnInit {
 
 		this.#ref = this.#dialog.open<C>({
 			...dialogConfig,
+			// A routed dialog closes through its route, not through the cdk's closeOnNavigation.
+			cdkConfigOverride: { closeOnNavigation: false, ...dialogConfig.cdkConfigOverride },
 			content: this.dialogTemplate(),
 			data,
 			canClose: this.#getCanCloseFn(dialogConfig),

--- a/stories/documentation/overlays/dialog/dialog-routing-nested.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-routing-nested.stories.ts
@@ -1,0 +1,148 @@
+import { Location } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { provideRouter, Router, RouterLink, RouterOutlet, Routes, withHashLocation, withViewTransitions } from '@angular/router';
+import { ButtonComponent } from '@lucca-front/ng/button';
+import {
+	DialogComponent,
+	DialogContentComponent,
+	DialogDismissDirective,
+	DialogFooterComponent,
+	DialogHeaderComponent,
+	dialogRouteFactory,
+	provideDialogRoutingReuseStrategy,
+} from '@lucca-front/ng/dialog';
+import { LinkComponent } from '@lucca-front/ng/link';
+import { applicationConfig, Meta, StoryObj } from '@storybook/angular-vite';
+import { map } from 'rxjs';
+
+@Component({
+	template: `No route matched`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class EmptyComponent {}
+
+@Component({
+	imports: [DialogComponent, DialogHeaderComponent, DialogContentComponent, DialogFooterComponent, ButtonComponent, DialogDismissDirective],
+	template: `
+		<lu-dialog stacked>
+			<lu-dialog-header>
+				<h1>Nested sub-dialog</h1>
+			</lu-dialog-header>
+			<lu-dialog-content>
+				Close me with the browser back button (or the one below): the detail dialog underneath must still be there.
+				<div class="pr-u-marginBlockStart200">
+					<button luButton type="button" (click)="location.back()">History back</button>
+				</div>
+			</lu-dialog-content>
+			<lu-dialog-footer>
+				<div class="footer-actions">
+					<button luButton="outline" type="button" luDialogDismiss>Dismiss</button>
+				</div>
+			</lu-dialog-footer>
+		</lu-dialog>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class SubDialogComponent {
+	location = inject(Location);
+}
+
+@Component({
+	imports: [DialogComponent, DialogHeaderComponent, DialogContentComponent, DialogFooterComponent, ButtonComponent, LinkComponent, DialogDismissDirective, RouterOutlet],
+	template: `
+		<lu-dialog stacked>
+			<lu-dialog-header>
+				<h1>Detail dialog</h1>
+			</lu-dialog-header>
+			<lu-dialog-content>
+				<a [luLink]="['./', 'sub']" [queryParamsHandling]="'preserve'">Open the nested sub-dialog</a>
+				<!-- Anchor for the nested dialog route -->
+				<router-outlet />
+			</lu-dialog-content>
+			<lu-dialog-footer>
+				<div class="footer-actions">
+					<button luButton="outline" type="button" luDialogDismiss>Dismiss</button>
+				</div>
+			</lu-dialog-footer>
+		</lu-dialog>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DetailDialogComponent {}
+
+@Component({
+	selector: 'dialog-routing-nested-stories',
+	template: `
+		<p>
+			Current URL: <strong>{{ url() }}</strong>
+		</p>
+		<ol>
+			<li>Open the detail dialog, then the nested sub-dialog from inside it.</li>
+			<li>Navigate back in history: the sub-dialog closes, the detail dialog must stay open — its route is still active.</li>
+		</ol>
+		<button luButton type="button" routerLink="/detail/12">Navigate to /detail/12</button>
+		<router-outlet />
+	`,
+	imports: [RouterOutlet, RouterLink, ButtonComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class DialogRoutingNestedStory {
+	router = inject(Router);
+
+	url = toSignal(this.router.events.pipe(map(() => this.router.url)), { initialValue: this.router.url });
+}
+
+const detailDialogRoute = dialogRouteFactory(DetailDialogComponent, {
+	dialogConfig: {
+		mode: 'drawer',
+		size: 'XL',
+	},
+});
+
+const subDialogRoute = dialogRouteFactory(SubDialogComponent, {
+	dialogConfig: {
+		mode: 'drawer',
+		size: 'M',
+	},
+});
+
+const routes: Routes = [
+	detailDialogRoute({
+		path: 'detail/:id',
+		dialogRouteConfig: {
+			children: [subDialogRoute({ path: 'sub' })],
+		},
+	}),
+	{ path: '**', component: EmptyComponent },
+];
+
+export default {
+	title: 'Documentation/Overlays/Dialog/Routing nested',
+	component: DialogRoutingNestedStory,
+} as Meta;
+
+const Template = (args: DialogRoutingNestedStory) => ({
+	props: args,
+});
+
+// Disable controls as they are not modifiable because of ComponentWrapper
+const parameters = { controls: { include: [] } };
+
+// Hash location keeps the router inside the storybook iframe URL, so a history back is a real
+// same-document popstate (a path-based URL would make the iframe reload instead).
+export const WithoutViewTransitions: StoryObj<DialogRoutingNestedStory> = {
+	args: {},
+	render: Template,
+	parameters,
+	decorators: [applicationConfig({ providers: [provideDialogRoutingReuseStrategy(), provideRouter(routes, withHashLocation())] })],
+};
+
+// Same scenario with the router's view transitions on: navigations animate, and the history back
+// over the nested dialog must still keep the detail dialog open.
+export const WithViewTransitions: StoryObj<DialogRoutingNestedStory> = {
+	args: {},
+	render: Template,
+	parameters,
+	decorators: [applicationConfig({ providers: [provideDialogRoutingReuseStrategy(), provideRouter(routes, withHashLocation(), withViewTransitions())] })],
+};

--- a/stories/documentation/overlays/dialog/dialog-routing-nested.stories.ts
+++ b/stories/documentation/overlays/dialog/dialog-routing-nested.stories.ts
@@ -120,6 +120,11 @@ const routes: Routes = [
 export default {
 	title: 'Documentation/Overlays/Dialog/Routing nested',
 	component: DialogRoutingNestedStory,
+	parameters: {
+		// Each story bootstraps its own router on the page's hash; inlined together on the docs page,
+		// a history back would drive both routers at once and duplicate the dialogs.
+		docs: { story: { inline: false, iframeHeight: 500 } },
+	},
 } as Meta;
 
 const Template = (args: DialogRoutingNestedStory) => ({


### PR DESCRIPTION
## Description

A routed dialog no longer closes on a browser back/forward when its route stays active — e.g. the parent dialog of a nested dialog route stayed on screen with no dialog after a history back.

https://github.com/user-attachments/assets/4a003ad5-2042-4516-a059-3ac14efde6a1

-----

Routed dialogs now open with `closeOnNavigation: false`: their lifecycle already belongs to the router (`DialogRoutingContainerComponent` dismisses them when their route deactivates), while the cdk's default disposed every overlay on any popstate. When a history navigation left the dialog's route active (back from a nested dialog route, or a query-params-only back), the overlay was destroyed with no route deactivation to recreate it: depending on timing the dialog either silently closed and reopened (losing its state), or stayed gone with its route still active (with `withViewTransitions`, the recovery navigation loses the race and gets skipped).

Side effect worth noting: on a back that *does* deactivate the dialog's route, `onDismissed` now runs with the `DIALOG_ROUTE_DISMISS_TRIGGER` set to `navigation` (the container drives the dismissal) instead of `dialog:dismissed` (the cdk disposal used to win the race and masquerade as a user dismissal).

A caller passing `cdkConfigOverride: { closeOnNavigation: true }` still takes precedence.

New "Routing nested" stories cover the scenario (a detail dialog with a nested sub-dialog route, closed through a history back), with and without the router's view transitions. They use `withHashLocation` so the back stays a same-document popstate inside the storybook iframe.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
