### PR TITLE
feat(popover2): Apply the trigger's aria-haspopup as the panel role

### DIFF
--- a/packages/ng/popover2/content/popover-content/popover-content.component.ts
+++ b/packages/ng/popover2/content/popover-content/popover-content.component.ts
@@ -29,6 +29,9 @@ export class PopoverContentComponent implements AfterViewInit, OnDestroy {
 	@HostBinding('attr.id')
 	contentId = this.config.contentId;
 
+	@HostBinding('attr.role')
+	role = this.config.role;
+
 	content = this.config.content;
 
 	#focusManager = new PopoverFocusTrap(this.#elementRef.nativeElement, this.config.triggerElement, inject(Injector));

--- a/packages/ng/popover2/popover-tokens.ts
+++ b/packages/ng/popover2/popover-tokens.ts
@@ -2,7 +2,7 @@ import { InjectionToken, TemplateRef, Type } from '@angular/core';
 import { OverlayRef } from '@angular/cdk/overlay';
 
 /**
- * Popup roles of the panel, mirrored into `aria-haspopup` on the trigger.
+ * Panel roles derived from the trigger's `aria-haspopup`.
  * Restricted to the roles `aria-haspopup` accepts.
  */
 export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'] as const;

--- a/packages/ng/popover2/popover-tokens.ts
+++ b/packages/ng/popover2/popover-tokens.ts
@@ -1,13 +1,8 @@
 import { InjectionToken, TemplateRef, Type } from '@angular/core';
 import { OverlayRef } from '@angular/cdk/overlay';
 
-/**
- * Panel roles derived from the trigger's `aria-haspopup`.
- * Restricted to the roles `aria-haspopup` accepts.
- */
-export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'] as const;
-
-export type PopoverRole = (typeof POPOVER_ROLES)[number];
+/** Panel roles `aria-haspopup` accepts. */
+export type PopoverRole = 'dialog' | 'menu' | 'listbox' | 'tree' | 'grid';
 
 export interface PopoverConfig {
 	triggerElement: HTMLElement;

--- a/packages/ng/popover2/popover-tokens.ts
+++ b/packages/ng/popover2/popover-tokens.ts
@@ -1,11 +1,20 @@
 import { InjectionToken, TemplateRef, Type } from '@angular/core';
 import { OverlayRef } from '@angular/cdk/overlay';
 
+/**
+ * Popup roles of the panel, mirrored into `aria-haspopup` on the trigger.
+ * Restricted to the roles `aria-haspopup` accepts.
+ */
+export const POPOVER_ROLES = ['dialog', 'menu', 'listbox', 'tree', 'grid'] as const;
+
+export type PopoverRole = (typeof POPOVER_ROLES)[number];
+
 export interface PopoverConfig {
 	triggerElement: HTMLElement;
 	content: TemplateRef<unknown> | Type<unknown>;
 	ref: OverlayRef;
 	contentId: string;
+	role: PopoverRole | null;
 	maxBlockSize: string | null;
 	maxInlineSize: string | null;
 	disableCloseButtonFocus: boolean;

--- a/packages/ng/popover2/popover.directive.spec.ts
+++ b/packages/ng/popover2/popover.directive.spec.ts
@@ -1,67 +1,59 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ChangeDetectionStrategy, Component, viewChildren } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { PopoverDirective } from './popover.directive';
-import { PopoverRole } from './popover-tokens';
 
 @Component({
 	selector: 'lu-popover-test',
 	imports: [PopoverDirective],
 	template: `
 		<ng-template #content>Content</ng-template>
-		<button type="button" id="bare" [luPopover2]="content" [luPopoverRole]="role()">Bare</button>
-		<button type="button" id="valid" [luPopover2]="content" [luPopoverRole]="role()" aria-haspopup="dialog">Valid</button>
-		<button type="button" id="legacy" [luPopover2]="content" [luPopoverRole]="role()" aria-haspopup="true">Legacy</button>
+		<button type="button" id="bare" [luPopover2]="content">Bare</button>
+		<button type="button" id="dialog" [luPopover2]="content" aria-haspopup="dialog">Dialog</button>
+		<button type="button" id="legacy" [luPopover2]="content" aria-haspopup="true">Legacy</button>
+		<button type="button" id="invalid" [luPopover2]="content" aria-haspopup="bogus">Invalid</button>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class PopoverTestComponent {
-	role = input<PopoverRole | null>(null);
+	popovers = viewChildren(PopoverDirective);
 }
-
-@Component({
-	selector: 'lu-popover-invalid-test',
-	imports: [PopoverDirective],
-	template: `
-		<ng-template #content>Content</ng-template>
-		<button type="button" [luPopover2]="content" aria-haspopup="bogus">Invalid</button>
-	`,
-	changeDetection: ChangeDetectionStrategy.OnPush,
-})
-class PopoverInvalidTestComponent {}
 
 describe('PopoverDirective aria-haspopup', () => {
 	let fixture: ComponentFixture<PopoverTestComponent>;
 
-	const haspopup = (id: string) => (fixture.nativeElement as HTMLElement).querySelector(`#${id}`)?.getAttribute('aria-haspopup');
+	const openPopover = (id: string) => {
+		const index = ['bare', 'dialog', 'legacy', 'invalid'].indexOf(id);
+		fixture.componentInstance.popovers()[index].openPopover();
+		fixture.detectChanges();
+	};
+
+	const panelRole = () => document.querySelector('lu-popover-content')?.getAttribute('role');
 
 	beforeEach(() => {
 		TestBed.configureTestingModule({
-			imports: [PopoverTestComponent, PopoverInvalidTestComponent],
+			imports: [PopoverTestComponent],
 		});
 
 		fixture = TestBed.createComponent(PopoverTestComponent);
 		fixture.detectChanges();
 	});
 
-	it('should not set aria-haspopup without luPopoverRole nor a template attribute', () => {
-		expect(haspopup('bare')).toBeNull();
+	it('should apply no panel role without aria-haspopup on the trigger', () => {
+		openPopover('bare');
+		expect(panelRole()).toBeNull();
 	});
 
-	it('should preserve a valid template aria-haspopup while luPopoverRole is unset', () => {
-		expect(haspopup('valid')).toBe('dialog');
-		expect(haspopup('legacy')).toBe('true');
+	it('should apply the trigger aria-haspopup as the panel role', () => {
+		openPopover('dialog');
+		expect(panelRole()).toBe('dialog');
 	});
 
-	it('should throw on an invalid template aria-haspopup', () => {
-		expect(() => TestBed.createComponent(PopoverInvalidTestComponent)).toThrowError(/Invalid aria-haspopup value "bogus"/);
+	it('should apply the menu panel role for aria-haspopup="true"', () => {
+		openPopover('legacy');
+		expect(panelRole()).toBe('menu');
 	});
 
-	it('should mirror luPopoverRole into aria-haspopup, overriding template attributes', () => {
-		fixture.componentRef.setInput('role', 'listbox');
-		fixture.detectChanges();
-
-		for (const id of ['bare', 'valid', 'legacy']) {
-			expect(haspopup(id)).toBe('listbox');
-		}
+	it('should throw on an invalid trigger aria-haspopup', () => {
+		expect(() => openPopover('invalid')).toThrowError(/Invalid aria-haspopup value "bogus"/);
 	});
 });

--- a/packages/ng/popover2/popover.directive.spec.ts
+++ b/packages/ng/popover2/popover.directive.spec.ts
@@ -13,6 +13,7 @@ import { PopoverDirective } from './popover.directive';
 		<button type="button" id="invalid" [luPopover2]="content" aria-haspopup="bogus">Invalid</button>
 		<button type="button" id="empty" [luPopover2]="content" aria-haspopup="">Empty</button>
 		<button type="button" id="mixed-case" [luPopover2]="content" aria-haspopup="Dialog">Mixed case</button>
+		<button type="button" id="inherited" [luPopover2]="content" aria-haspopup="toString">Inherited</button>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -24,7 +25,7 @@ describe('PopoverDirective aria-haspopup', () => {
 	let fixture: ComponentFixture<PopoverTestComponent>;
 
 	const openPopover = (id: string) => {
-		const index = ['bare', 'dialog', 'legacy', 'invalid', 'empty', 'mixed-case'].indexOf(id);
+		const index = ['bare', 'dialog', 'legacy', 'invalid', 'empty', 'mixed-case', 'inherited'].indexOf(id);
 		fixture.componentInstance.popovers()[index].openPopover();
 		fixture.detectChanges();
 	};
@@ -68,6 +69,11 @@ describe('PopoverDirective aria-haspopup', () => {
 	it('should throw on a mixed-case trigger aria-haspopup', () => {
 		// Lowercase only (https://w3c.github.io/html-aria/#case-sensitivity): AT casing support varies.
 		expect(() => openPopover('mixed-case')).toThrowError(/Invalid aria-haspopup value "Dialog"/);
+	});
+
+	it('should throw on an inherited-key trigger aria-haspopup', () => {
+		// Object prototype members must not pass the map lookup.
+		expect(() => openPopover('inherited')).toThrowError(/Invalid aria-haspopup value "toString"/);
 	});
 
 	it('should stay closed after an invalid trigger aria-haspopup threw', () => {

--- a/packages/ng/popover2/popover.directive.spec.ts
+++ b/packages/ng/popover2/popover.directive.spec.ts
@@ -11,6 +11,8 @@ import { PopoverDirective } from './popover.directive';
 		<button type="button" id="dialog" [luPopover2]="content" aria-haspopup="dialog">Dialog</button>
 		<button type="button" id="legacy" [luPopover2]="content" aria-haspopup="true">Legacy</button>
 		<button type="button" id="invalid" [luPopover2]="content" aria-haspopup="bogus">Invalid</button>
+		<button type="button" id="empty" [luPopover2]="content" aria-haspopup="">Empty</button>
+		<button type="button" id="mixed-case" [luPopover2]="content" aria-haspopup="Dialog">Mixed case</button>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -22,7 +24,7 @@ describe('PopoverDirective aria-haspopup', () => {
 	let fixture: ComponentFixture<PopoverTestComponent>;
 
 	const openPopover = (id: string) => {
-		const index = ['bare', 'dialog', 'legacy', 'invalid'].indexOf(id);
+		const index = ['bare', 'dialog', 'legacy', 'invalid', 'empty', 'mixed-case'].indexOf(id);
 		fixture.componentInstance.popovers()[index].openPopover();
 		fixture.detectChanges();
 	};
@@ -55,6 +57,17 @@ describe('PopoverDirective aria-haspopup', () => {
 
 	it('should throw on an invalid trigger aria-haspopup', () => {
 		expect(() => openPopover('invalid')).toThrowError(/Invalid aria-haspopup value "bogus"/);
+	});
+
+	it('should apply no panel role for an empty trigger aria-haspopup', () => {
+		// ARIA 1.2: empty => `false` default.
+		openPopover('empty');
+		expect(panelRole()).toBeNull();
+	});
+
+	it('should throw on a mixed-case trigger aria-haspopup', () => {
+		// Lowercase only (https://w3c.github.io/html-aria/#case-sensitivity): AT casing support varies.
+		expect(() => openPopover('mixed-case')).toThrowError(/Invalid aria-haspopup value "Dialog"/);
 	});
 
 	it('should stay closed after an invalid trigger aria-haspopup threw', () => {

--- a/packages/ng/popover2/popover.directive.spec.ts
+++ b/packages/ng/popover2/popover.directive.spec.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PopoverDirective } from './popover.directive';
+import { PopoverRole } from './popover-tokens';
+
+@Component({
+	selector: 'lu-popover-test',
+	imports: [PopoverDirective],
+	template: `
+		<ng-template #content>Content</ng-template>
+		<button type="button" id="bare" [luPopover2]="content" [luPopoverRole]="role()">Bare</button>
+		<button type="button" id="valid" [luPopover2]="content" [luPopoverRole]="role()" aria-haspopup="dialog">Valid</button>
+		<button type="button" id="legacy" [luPopover2]="content" [luPopoverRole]="role()" aria-haspopup="true">Legacy</button>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class PopoverTestComponent {
+	role = input<PopoverRole | null>(null);
+}
+
+@Component({
+	selector: 'lu-popover-invalid-test',
+	imports: [PopoverDirective],
+	template: `
+		<ng-template #content>Content</ng-template>
+		<button type="button" [luPopover2]="content" aria-haspopup="bogus">Invalid</button>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class PopoverInvalidTestComponent {}
+
+describe('PopoverDirective aria-haspopup', () => {
+	let fixture: ComponentFixture<PopoverTestComponent>;
+
+	const haspopup = (id: string) => (fixture.nativeElement as HTMLElement).querySelector(`#${id}`)?.getAttribute('aria-haspopup');
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [PopoverTestComponent, PopoverInvalidTestComponent],
+		});
+
+		fixture = TestBed.createComponent(PopoverTestComponent);
+		fixture.detectChanges();
+	});
+
+	it('should not set aria-haspopup without luPopoverRole nor a template attribute', () => {
+		expect(haspopup('bare')).toBeNull();
+	});
+
+	it('should preserve a valid template aria-haspopup while luPopoverRole is unset', () => {
+		expect(haspopup('valid')).toBe('dialog');
+		expect(haspopup('legacy')).toBe('true');
+	});
+
+	it('should throw on an invalid template aria-haspopup', () => {
+		expect(() => TestBed.createComponent(PopoverInvalidTestComponent)).toThrowError(/Invalid aria-haspopup value "bogus"/);
+	});
+
+	it('should mirror luPopoverRole into aria-haspopup, overriding template attributes', () => {
+		fixture.componentRef.setInput('role', 'listbox');
+		fixture.detectChanges();
+
+		for (const id of ['bare', 'valid', 'legacy']) {
+			expect(haspopup(id)).toBe('listbox');
+		}
+	});
+});

--- a/packages/ng/popover2/popover.directive.spec.ts
+++ b/packages/ng/popover2/popover.directive.spec.ts
@@ -56,4 +56,10 @@ describe('PopoverDirective aria-haspopup', () => {
 	it('should throw on an invalid trigger aria-haspopup', () => {
 		expect(() => openPopover('invalid')).toThrowError(/Invalid aria-haspopup value "bogus"/);
 	});
+
+	it('should stay closed after an invalid trigger aria-haspopup threw', () => {
+		expect(() => openPopover('invalid')).toThrow();
+		expect(fixture.componentInstance.popovers()[3].opened()).toBe(false);
+		expect(panelRole()).toBeUndefined();
+	});
 });

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -2,6 +2,7 @@ import { ConnectedPosition, ConnectionPositionPair, FlexibleConnectedPositionStr
 import { ComponentPortal } from '@angular/cdk/portal';
 import {
 	booleanAttribute,
+	computed,
 	DestroyRef,
 	Directive,
 	ElementRef,
@@ -18,6 +19,7 @@ import {
 	output,
 	Provider,
 	Renderer2,
+	Signal,
 	signal,
 	TemplateRef,
 	Type,
@@ -27,12 +29,18 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { getPushPanelViewportMargin, intlInputOptions, isNotNil } from '@lucca-front/ng/core';
 import { combineLatest, debounce, filter, map, merge, Subject, switchMap, take, timer } from 'rxjs';
 import { PopoverContentComponent } from './content/popover-content/popover-content.component';
-import { POPOVER_CONFIG, PopoverConfig } from './popover-tokens';
+import { POPOVER_CONFIG, POPOVER_ROLES, PopoverConfig, PopoverRole } from './popover-tokens';
 import { LU_POPOVER2_TRANSLATIONS } from './popover2.translate';
 
 export type PopoverPosition = 'above' | 'below' | 'before' | 'after';
 
 let nextId = 0;
+
+const ARIA_HASPOPUP_TOKENS = new Set<string>([...POPOVER_ROLES, 'true', 'false']);
+
+function sanitizeAriaHaspopup(value: string | null): string | null {
+	return value && ARIA_HASPOPUP_TOKENS.has(value) ? value : null;
+}
 
 const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	above: new ConnectionPositionPair(
@@ -69,6 +77,7 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	selector: '[luPopover2]',
 	host: {
 		'[attr.aria-expanded]': 'opened()',
+		'[attr.aria-haspopup]': 'ariaHaspopup()',
 	},
 	exportAs: 'luPopover2',
 })
@@ -91,6 +100,17 @@ export class PopoverDirective implements OnDestroy {
 	content: TemplateRef<unknown> | Type<unknown>;
 
 	luPopoverPosition = input<PopoverPosition | null>(null);
+
+	/**
+	 * Popup role applied to the panel and mirrored into `aria-haspopup` on the trigger.
+	 * `aria-haspopup` is invalid without the matching role on the panel, so both are driven by this single input.
+	 */
+	luPopoverRole = input<PopoverRole | null>(null);
+
+	// Read before Angular applies host bindings, so a template-set attribute survives an unset input.
+	#initialAriaHaspopup = sanitizeAriaHaspopup(this.elementRef.nativeElement.getAttribute('aria-haspopup'));
+
+	protected ariaHaspopup: Signal<string | null> = computed(() => this.luPopoverRole() ?? this.#initialAriaHaspopup);
 
 	luPopoverMaxBlockSize = input<string | null>(null);
 	luPopoverMaxInlineSize = input<string | null>(null);
@@ -266,6 +286,7 @@ export class PopoverDirective implements OnDestroy {
 				content: this.content,
 				ref: this.#overlayRef,
 				contentId: this.ariaControls,
+				role: this.luPopoverRole(),
 				triggerElement: this.elementRef.nativeElement,
 				maxBlockSize: this.luPopoverMaxBlockSize(),
 				maxInlineSize: this.luPopoverMaxInlineSize(),

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -27,26 +27,34 @@ import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { getPushPanelViewportMargin, intlInputOptions, isNotNil } from '@lucca-front/ng/core';
 import { combineLatest, debounce, filter, map, merge, Subject, switchMap, take, timer } from 'rxjs';
 import { PopoverContentComponent } from './content/popover-content/popover-content.component';
-import { POPOVER_CONFIG, POPOVER_ROLES, PopoverConfig, PopoverRole } from './popover-tokens';
+import { POPOVER_CONFIG, PopoverConfig, PopoverRole } from './popover-tokens';
 import { LU_POPOVER2_TRANSLATIONS } from './popover2.translate';
 
 export type PopoverPosition = 'above' | 'below' | 'before' | 'after';
 
 let nextId = 0;
 
-const ARIA_HASPOPUP_TOKENS = new Set<string>([...POPOVER_ROLES, 'true', 'false']);
+// Valid aria-haspopup => Panel role (ARIA 1.0 equivalence)
+const PANEL_ROLE_BY_ARIA_HASPOPUP: Record<PopoverRole | 'true' | 'false', PopoverRole | null> = {
+	dialog: 'dialog',
+	menu: 'menu',
+	listbox: 'listbox',
+	tree: 'tree',
+	grid: 'grid',
+	true: 'menu',
+	false: null,
+};
 
 function panelRoleFromAriaHaspopup(value: string | null): PopoverRole | null {
-	if (value && !ARIA_HASPOPUP_TOKENS.has(value)) {
-		throw new Error(`[luPopover2] Invalid aria-haspopup value "${value}"; expected one of: ${[...ARIA_HASPOPUP_TOKENS].join(', ')}.`);
-	}
-
-	if (!value || value === 'false') {
+	if (!value) {
 		return null;
 	}
 
-	// `aria-haspopup="true"` means `menu` (ARIA 1.0 equivalence).
-	return value === 'true' ? 'menu' : (value as PopoverRole);
+	if (!(value in PANEL_ROLE_BY_ARIA_HASPOPUP)) {
+		throw new Error(`[luPopover2] Invalid aria-haspopup value "${value}"; expected one of: ${Object.keys(PANEL_ROLE_BY_ARIA_HASPOPUP).join(', ')}.`);
+	}
+
+	return PANEL_ROLE_BY_ARIA_HASPOPUP[value as PopoverRole | 'true' | 'false'];
 }
 
 const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
@@ -281,7 +289,7 @@ export class PopoverDirective implements OnDestroy {
 				content: this.content,
 				ref: this.#overlayRef,
 				contentId: this.ariaControls,
-				// The panel role matches the trigger's `aria-haspopup`: assistive tech finds the popup it was promised.
+				// Assistive tech must find the popup role the trigger's `aria-haspopup` promises.
 				role: panelRoleFromAriaHaspopup(this.elementRef.nativeElement.getAttribute('aria-haspopup')),
 				triggerElement: this.elementRef.nativeElement,
 				maxBlockSize: this.luPopoverMaxBlockSize(),

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -39,7 +39,11 @@ let nextId = 0;
 const ARIA_HASPOPUP_TOKENS = new Set<string>([...POPOVER_ROLES, 'true', 'false']);
 
 function sanitizeAriaHaspopup(value: string | null): string | null {
-	return value && ARIA_HASPOPUP_TOKENS.has(value) ? value : null;
+	if (value && !ARIA_HASPOPUP_TOKENS.has(value)) {
+		throw new Error(`[luPopover2] Invalid aria-haspopup value "${value}"; expected one of: ${[...ARIA_HASPOPUP_TOKENS].join(', ')}.`);
+	}
+
+	return value;
 }
 
 const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -264,6 +264,10 @@ export class PopoverDirective implements OnDestroy {
 
 	openPopover(withBackdrop = false, disableCloseButtonFocus = false, disableInitialTriggerFocus = false): void {
 		if (!this.opened() && !this.luPopoverDisabled && isNotNil(this.content)) {
+			// Assistive tech must find the popup role the trigger's `aria-haspopup` promises.
+			// Resolved before any side effect: an invalid value must throw while the popover is still closed.
+			const role = panelRoleFromAriaHaspopup(this.elementRef.nativeElement.getAttribute('aria-haspopup'));
+
 			this.opened.set(true);
 			this.luPopoverOpened.emit();
 			this.#overlayRef = this.overlay.create({
@@ -289,8 +293,7 @@ export class PopoverDirective implements OnDestroy {
 				content: this.content,
 				ref: this.#overlayRef,
 				contentId: this.ariaControls,
-				// Assistive tech must find the popup role the trigger's `aria-haspopup` promises.
-				role: panelRoleFromAriaHaspopup(this.elementRef.nativeElement.getAttribute('aria-haspopup')),
+				role,
 				triggerElement: this.elementRef.nativeElement,
 				maxBlockSize: this.luPopoverMaxBlockSize(),
 				maxInlineSize: this.luPopoverMaxInlineSize(),

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -50,7 +50,7 @@ function panelRoleFromAriaHaspopup(value: string | null): PopoverRole | null {
 		return null;
 	}
 
-	if (!(value in PANEL_ROLE_BY_ARIA_HASPOPUP)) {
+	if (!Object.hasOwn(PANEL_ROLE_BY_ARIA_HASPOPUP, value)) {
 		throw new Error(`[luPopover2] Invalid aria-haspopup value "${value}"; expected one of: ${Object.keys(PANEL_ROLE_BY_ARIA_HASPOPUP).join(', ')}.`);
 	}
 

--- a/packages/ng/popover2/popover.directive.ts
+++ b/packages/ng/popover2/popover.directive.ts
@@ -2,7 +2,6 @@ import { ConnectedPosition, ConnectionPositionPair, FlexibleConnectedPositionStr
 import { ComponentPortal } from '@angular/cdk/portal';
 import {
 	booleanAttribute,
-	computed,
 	DestroyRef,
 	Directive,
 	ElementRef,
@@ -19,7 +18,6 @@ import {
 	output,
 	Provider,
 	Renderer2,
-	Signal,
 	signal,
 	TemplateRef,
 	Type,
@@ -38,12 +36,17 @@ let nextId = 0;
 
 const ARIA_HASPOPUP_TOKENS = new Set<string>([...POPOVER_ROLES, 'true', 'false']);
 
-function sanitizeAriaHaspopup(value: string | null): string | null {
+function panelRoleFromAriaHaspopup(value: string | null): PopoverRole | null {
 	if (value && !ARIA_HASPOPUP_TOKENS.has(value)) {
 		throw new Error(`[luPopover2] Invalid aria-haspopup value "${value}"; expected one of: ${[...ARIA_HASPOPUP_TOKENS].join(', ')}.`);
 	}
 
-	return value;
+	if (!value || value === 'false') {
+		return null;
+	}
+
+	// `aria-haspopup="true"` means `menu` (ARIA 1.0 equivalence).
+	return value === 'true' ? 'menu' : (value as PopoverRole);
 }
 
 const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
@@ -81,7 +84,6 @@ const defaultPositionPairs: Record<PopoverPosition, ConnectionPositionPair> = {
 	selector: '[luPopover2]',
 	host: {
 		'[attr.aria-expanded]': 'opened()',
-		'[attr.aria-haspopup]': 'ariaHaspopup()',
 	},
 	exportAs: 'luPopover2',
 })
@@ -104,17 +106,6 @@ export class PopoverDirective implements OnDestroy {
 	content: TemplateRef<unknown> | Type<unknown>;
 
 	luPopoverPosition = input<PopoverPosition | null>(null);
-
-	/**
-	 * Popup role applied to the panel and mirrored into `aria-haspopup` on the trigger.
-	 * `aria-haspopup` is invalid without the matching role on the panel, so both are driven by this single input.
-	 */
-	luPopoverRole = input<PopoverRole | null>(null);
-
-	// Read before Angular applies host bindings, so a template-set attribute survives an unset input.
-	#initialAriaHaspopup = sanitizeAriaHaspopup(this.elementRef.nativeElement.getAttribute('aria-haspopup'));
-
-	protected ariaHaspopup: Signal<string | null> = computed(() => this.luPopoverRole() ?? this.#initialAriaHaspopup);
 
 	luPopoverMaxBlockSize = input<string | null>(null);
 	luPopoverMaxInlineSize = input<string | null>(null);
@@ -290,7 +281,8 @@ export class PopoverDirective implements OnDestroy {
 				content: this.content,
 				ref: this.#overlayRef,
 				contentId: this.ariaControls,
-				role: this.luPopoverRole(),
+				// The panel role matches the trigger's `aria-haspopup`: assistive tech finds the popup it was promised.
+				role: panelRoleFromAriaHaspopup(this.elementRef.nativeElement.getAttribute('aria-haspopup')),
 				triggerElement: this.elementRef.nativeElement,
 				maxBlockSize: this.luPopoverMaxBlockSize(),
 				maxInlineSize: this.luPopoverMaxInlineSize(),

--- a/stories/documentation/overlays/popover2/popover2.stories.ts
+++ b/stories/documentation/overlays/popover2/popover2.stories.ts
@@ -33,11 +33,6 @@ export default {
 			options: ['above', 'below', 'before', 'after'],
 			description: 'Position du popover par rapport à son déclencheur.',
 		},
-		luPopoverRole: {
-			control: 'select',
-			options: ['dialog', 'menu', 'listbox', 'tree', 'grid'],
-			description: 'Rôle du panneau, reflété dans « aria-haspopup » sur le déclencheur.',
-		},
 		luPopoverDisabled: {
 			description: 'Désactive le popover.',
 		},

--- a/stories/documentation/overlays/popover2/popover2.stories.ts
+++ b/stories/documentation/overlays/popover2/popover2.stories.ts
@@ -33,6 +33,11 @@ export default {
 			options: ['above', 'below', 'before', 'after'],
 			description: 'Position du popover par rapport à son déclencheur.',
 		},
+		luPopoverRole: {
+			control: 'select',
+			options: ['dialog', 'menu', 'listbox', 'tree', 'grid'],
+			description: 'Rôle du panneau, reflété dans « aria-haspopup » sur le déclencheur.',
+		},
 		luPopoverDisabled: {
 			description: 'Désactive le popover.',
 		},


### PR DESCRIPTION
## Description

`luPopover2` now derives the panel `role` from the trigger's `aria-haspopup`.

-----

### Context

* RGAA 7.1 audit (ELI-3441):
	* Popup triggers can use `aria-haspopup`.
	* The attribute is only valid with the matching `role` on the panel ([ARIA — aria-haspopup][1]).
* Consumers cannot set that role: `luPopover2` renders the panel ([popover-content.component.ts][2]).

### Choices

* The trigger's `aria-haspopup` attribute is the single source: no new input.
* `aria-haspopup="true"` maps to the `menu` panel role (ARIA 1.0 equivalence).
* An invalid `aria-haspopup` throws at open time.

### Follow-up candidates

* date2 announces `aria-haspopup="true"` (≡ `menu`) on the combobox:
	* Its popup contains at least a `grid` calendar.
	* [ARIA — combobox][3];
	* [date-input:15][4] & [date-range-input:23][5].

[1]: https://w3c.github.io/aria/#aria-haspopup
[2]: https://github.com/LuccaSA/lucca-front/blob/master/packages/ng/popover2/content/popover-content/popover-content.component.ts
[3]: https://w3c.github.io/aria/#combobox:~:text=If%20the%20combobox%20popup%20element%20has%20a%20role%20other%20than
[4]: https://github.com/LuccaSA/lucca-front/blob/master/packages/ng/date2/date-input/date-input.component.html#L15
[5]: https://github.com/LuccaSA/lucca-front/blob/master/packages/ng/date2/date-range-input/date-range-input.component.html#L23

-----

### Contribution

- [ ] Designs are respected and all relevant options are handled
- [ ] Responsive behavior addressed when needed
- [x] Feature is accessible (keyboard navigation, screen reader support, ARIA tags, etc.)
- [ ] Stories are updated and Storybook controls have descriptions
- [ ] Feature is covered by E2E tests or UI diff
- [x] `npm run build` OK
- [x] `npm run lint` OK

### Functional review

- [ ] UI diff OK
- [ ] Feature and all options are manually tested and comply with design and guidelines.

-----
