### PR TITLE
feat(FileEntry): Add lu-file-entry-wrapper component

### DIFF
--- a/docs/file-upload.md
+++ b/docs/file-upload.md
@@ -23,12 +23,12 @@ Once the files are sent, the display management changes depending on the approac
 <lu-form-field label="Label">
   <lu-multi-file-upload [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])" />
 </lu-form-field>
-<div class="fileEntryDisplayWrapper">
+<lu-file-entry-wrapper>
   @for(fileUpload of fileUploadFeature.fileUploads(); track $index) {
   <lu-file-entry [entry]="fileUpload | luFileEntry" [state]="fileUpload.state"
                  [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
   }
-</div>
+</lu-file-entry-wrapper>
 ```
 
 ### Single File Upload
@@ -43,14 +43,23 @@ toggle, the component does not do it for you.
 <lu-form-field label="Label">
   @let fileUpload = fileUploadFeature.fileUploads()[0];
   @if (fileUpload) {
-    <lu-file-entry [entry]="fileUpload | luFileEntry" [state]="fileUpload.state"
-                   [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail"
-                   (deleteFile)="deleteFile(fileUpload)" />
+    <lu-file-entry-wrapper>
+      <lu-file-entry [entry]="fileUpload | luFileEntry" [state]="fileUpload.state"
+                     [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail"
+                     (deleteFile)="deleteFile(fileUpload)" />
+    </lu-file-entry-wrapper>
   } @else {
     <lu-single-file-upload [accept]="accept" (filePicked)="fileUploadFeature.uploadFiles([$event])" />
   }
 </lu-form-field>
 ```
+
+### Layout of the entries
+
+`lu-file-entry-wrapper` (from `@lucca-front/ng/file-upload`) is the container laying out the
+`lu-file-entry`. It replaces the former `fileEntryDisplayWrapper` CSS class, collapses itself when it holds no entry,
+and handles the spacing with a preceding `lu-form-field` containing a file upload. Use it in both the single and the
+multi variants.
 
 ### Details
 

--- a/packages/ng/file-upload/file-entry-wrapper/file-entry-wrapper.component.scss
+++ b/packages/ng/file-upload/file-entry-wrapper/file-entry-wrapper.component.scss
@@ -1,0 +1,1 @@
+@use '@lucca-front/scss/src/components/fileEntry';

--- a/packages/ng/file-upload/file-entry-wrapper/file-entry-wrapper.component.ts
+++ b/packages/ng/file-upload/file-entry-wrapper/file-entry-wrapper.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+
+@Component({
+	selector: 'lu-file-entry-wrapper',
+	template: '<ng-content />',
+	styleUrl: './file-entry-wrapper.component.scss',
+	encapsulation: ViewEncapsulation.None,
+	host: {
+		class: 'fileEntryDisplayWrapper',
+	},
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FileEntryWrapperComponent {}

--- a/packages/ng/file-upload/public-api.ts
+++ b/packages/ng/file-upload/public-api.ts
@@ -1,6 +1,7 @@
 export * from './file-dropzone/file-dropzone.component';
 export * from './file-entry/file-entry.type';
 export * from './file-entry/file-entry.component';
+export * from './file-entry-wrapper/file-entry-wrapper.component';
 export * from './file-upload-entry';
 export * from './file-upload.type';
 export { formatFileSize } from './formatter';

--- a/stories/documentation/forms/file-upload/angular/basic.stories.ts
+++ b/stories/documentation/forms/file-upload/angular/basic.stories.ts
@@ -1,7 +1,7 @@
 import { HttpErrorResponse, HttpStatusCode, provideHttpClient } from '@angular/common/http';
 import { Injectable, LOCALE_ID, Pipe, PipeTransform, signal } from '@angular/core';
 import { ButtonComponent } from '@lucca-front/ng/button';
-import { FILE_UPLOAD_SIZE, FileEntry, FileEntryComponent, MultiFileUploadComponent, SingleFileUploadComponent } from '@lucca-front/ng/file-upload';
+import { FILE_UPLOAD_SIZE, FileEntry, FileEntryComponent, FileEntryWrapperComponent, MultiFileUploadComponent, SingleFileUploadComponent } from '@lucca-front/ng/file-upload';
 import { FormFieldComponent } from '@lucca-front/ng/form-field';
 import { TextInputComponent } from '@lucca-front/ng/forms';
 import { LuInputDirective } from '@lucca-front/ng/input';
@@ -167,6 +167,7 @@ export default {
 				ButtonComponent,
 				FileUploadToLFEntryPipe,
 				FileEntryComponent,
+				FileEntryWrapperComponent,
 				TagComponent,
 			],
 		}),
@@ -244,11 +245,11 @@ export const Multi = {
 			<lu-tag icon="weatherStars" label="Scan intelligent" AI />
 		</lu-multi-file-upload>
 	</lu-form-field>
-	<div class="fileEntryDisplayWrapper">
+	<lu-file-entry-wrapper>
 		@for(fileUpload of fileUploadFeature.fileUploads(); track $index) {
 			<lu-file-entry${sizeLFileEntryParam}${displayFileNameParam}${mediaParam} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
 		}
-	</div>`,
+	</lu-file-entry-wrapper>`,
 			};
 		} else {
 			return {
@@ -274,11 +275,11 @@ export const Multi = {
 				template: `<lu-form-field label="Label">
 		<lu-multi-file-upload${sizeLFileUploadParam}${generateInputs(mainArgs, argTypes)} (filePicked)="fileUploadFeature.uploadFiles([$event])" />
 	</lu-form-field>
-	<div class="fileEntryDisplayWrapper">
+	<lu-file-entry-wrapper>
 		@for(fileUpload of fileUploadFeature.fileUploads(); track $index) {
 			<lu-file-entry${sizeLFileEntryParam}${displayFileNameParam}${mediaParam} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
 		}
-	</div>`,
+	</lu-file-entry-wrapper>`,
 			};
 		}
 	},
@@ -308,7 +309,9 @@ export const Single = {
 		const isLarge = !!size;
 		const entryAttrs = `size="L"${isLarge ? ` media` : ``}${isLarge && displayFileName ? ` displayFileName` : ``}`;
 		const sizeLFileUploadParam = size ? ` size="L"` : ``;
-		const fileEntry = `<lu-file-entry ${entryAttrs} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />`;
+		const fileEntry = `<lu-file-entry-wrapper>
+			<lu-file-entry ${entryAttrs} [entry]="fileUpload | fileUploadToLFEntry" [state]="fileUpload.state" [previewUrl]="getPreviewUrl(fileUpload)" [inlineMessageError]="fileUpload.error?.detail" (deleteFile)="deleteFile(fileUpload)" />
+		</lu-file-entry-wrapper>`;
 		if (args.AItag) {
 			return {
 				props: { ...multi.props, accept },

--- a/stories/qa/file-entry/file-entry.stories.html
+++ b/stories/qa/file-entry/file-entry.stories.html
@@ -117,7 +117,7 @@
 			</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="fileEntryDisplayWrapper">
+					<lu-file-entry-wrapper>
 						<lu-file-entry
 							size="L"
 							(deleteFile)="deleteFile()"
@@ -151,7 +151,7 @@
 							}"
 							previewUrl="https://dummyimage.com/500"
 						/>
-					</div>
+					</lu-file-entry-wrapper>
 				</div>
 			</td>
 		</tr>
@@ -263,7 +263,7 @@
 			</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="fileEntryDisplayWrapper">
+					<lu-file-entry-wrapper>
 						<lu-file-entry
 							(deleteFile)="deleteFile()"
 							[entry]="{
@@ -294,7 +294,7 @@
 							}"
 							previewUrl="https://dummyimage.com/500"
 						/>
-					</div>
+					</lu-file-entry-wrapper>
 				</div>
 			</td>
 		</tr>
@@ -395,7 +395,7 @@
 			</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="fileEntryDisplayWrapper">
+					<lu-file-entry-wrapper>
 						<lu-file-entry
 							media
 							size="L"
@@ -432,7 +432,7 @@
 							}"
 							previewUrl="https://dummyimage.com/500"
 						/>
-					</div>
+					</lu-file-entry-wrapper>
 				</div>
 			</td>
 		</tr>
@@ -527,7 +527,7 @@
 			</td>
 			<td>
 				<div class="demo-QAtable-list">
-					<div class="fileEntryDisplayWrapper">
+					<lu-file-entry-wrapper>
 						<lu-file-entry
 							media
 							(deleteFile)="deleteFile()"
@@ -561,7 +561,7 @@
 							}"
 							previewUrl="https://dummyimage.com/500"
 						/>
-					</div>
+					</lu-file-entry-wrapper>
 				</div>
 			</td>
 		</tr>

--- a/stories/qa/file-entry/file-entry.stories.ts
+++ b/stories/qa/file-entry/file-entry.stories.ts
@@ -1,11 +1,11 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { FileEntryComponent } from '@lucca-front/ng/file-upload';
+import { FileEntryComponent, FileEntryWrapperComponent } from '@lucca-front/ng/file-upload';
 import { Meta, StoryObj, moduleMetadata } from '@storybook/angular-vite';
 
 @Component({
 	selector: 'file-entry-stories',
 	templateUrl: './file-entry.stories.html',
-	imports: [FileEntryComponent],
+	imports: [FileEntryComponent, FileEntryWrapperComponent],
 	changeDetection: ChangeDetectionStrategy.OnPush,
 	styles: [
 		`


### PR DESCRIPTION
## Description

cc: https://github.com/LuccaSA/lucca-front/issues/5153

The `fileEntryDisplayWrapper` CSS class is now available as an Angular component, `lu-file-entry-wrapper`, exported from `@lucca-front/ng/file-upload`.

It projects its content, carries the `fileEntryDisplayWrapper` class, and is used in both the single and the multi FileUpload examples. The CSS class is unchanged, so the HTML/CSS usage keeps working as before.

- New `FileEntryWrapperComponent` + public API export
- Documentation (`docs/file-upload.md`) and stories (documentation + QA) updated

-----


-----
