### PR TITLE
fix(core-select): detect user homonyms across pages

### DIFF
--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -75,6 +75,7 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 			clueDebounceMs: this.debounceDuration,
 			getTotalCount: () => this.totalCount$,
 			reset: () => this.clearLastPageByClue(),
+			transformOptions: (options) => this.transformOptions(options),
 			getOptions: ({ clue, page }) => {
 				const lastPage = clue === this.#lastClue ? this.#lastPage : undefined;
 				if (lastPage !== undefined && page > lastPage) {
@@ -98,6 +99,14 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 		};
 
 		this.select.dataSource.set(dataSource);
+	}
+
+	/**
+	 * Post-process the whole list of loaded options (all pages accumulated). Override it for
+	 * decorations that can't be computed page by page, eg. flagging homonyms across pages.
+	 */
+	protected transformOptions(options: readonly TOption[]): Observable<readonly TOption[]> {
+		return of(options);
 	}
 
 	protected buildParamsFromClue(clue: string): Observable<TParams> {

--- a/packages/ng/core-select/input/select-input.utils.spec.ts
+++ b/packages/ng/core-select/input/select-input.utils.spec.ts
@@ -261,6 +261,82 @@ describe('buildOptionsFromDataSource', () => {
 		sub.unsubscribe();
 	}));
 
+	it('should fall back to accumulated options when transformOptions fails', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds: SelectDataSource<TestOption> = {
+			getOptions: () => of([{ id: 1, name: 'A' }]),
+			transformOptions: () => throwError(() => new Error('Additional information error')),
+		};
+		const emitted: (readonly TestOption[])[] = [];
+		let errored = false;
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe({
+			next: (options) => emitted.push(options),
+			error: () => (errored = true),
+		});
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		expect(errored).toBe(false);
+		expect(emitted[emitted.length - 1]).toEqual([{ id: 1, name: 'A' }]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should fall back to accumulated options when transformOptions throws synchronously', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$ } = createDeps();
+		const ds: SelectDataSource<TestOption> = {
+			getOptions: () => of([{ id: 1, name: 'A' }]),
+			transformOptions: () => {
+				throw new Error('Additional information error');
+			},
+		};
+		const emitted: (readonly TestOption[])[] = [];
+		let errored = false;
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe({
+			next: (options) => emitted.push(options),
+			error: () => (errored = true),
+		});
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+
+		expect(errored).toBe(false);
+		expect(emitted[emitted.length - 1]).toEqual([{ id: 1, name: 'A' }]);
+
+		sub.unsubscribe();
+	}));
+
+	it('should keep loading next pages after a transformOptions failure', fakeAsync(() => {
+		const { deps, isPanelOpen$, clue$, nextPage$ } = createDeps();
+		let transformCall = 0;
+		const ds: SelectDataSource<TestOption> = {
+			getOptions: ({ page }) => of([{ id: page, name: `Page ${page}` }]),
+			transformOptions: (options) => (transformCall++ === 0 ? throwError(() => new Error('Additional information error')) : of(options)),
+		};
+		const emitted: (readonly TestOption[])[] = [];
+
+		const sub = buildOptionsFromDataSource(ds, deps).subscribe((options) => emitted.push(options));
+
+		isPanelOpen$.next(true);
+		clue$.next('');
+		tick();
+		expect(emitted[emitted.length - 1]).toEqual([{ id: 0, name: 'Page 0' }]);
+
+		nextPage$.next();
+		tick();
+		expect(emitted[emitted.length - 1]).toEqual([
+			{ id: 0, name: 'Page 0' },
+			{ id: 1, name: 'Page 1' },
+		]);
+
+		sub.unsubscribe();
+	}));
+
 	it('should pass clue and page number to getOptions', fakeAsync(() => {
 		const { deps, isPanelOpen$, clue$, nextPage$ } = createDeps();
 		const ds: SelectDataSource<TestOption> & { getOptions: Mock } = {

--- a/packages/ng/core-select/input/select-input.utils.ts
+++ b/packages/ng/core-select/input/select-input.utils.ts
@@ -62,6 +62,8 @@ export function buildOptionsFromDataSource<TOption>(ds: SelectDataSource<TOption
 							return lastIndexes.length < 2 || !lastIndexes.every((i) => pages[i]?.length === 0);
 						}),
 						map((pages) => Object.values(pages).flat()),
+						// Applied on the accumulated list so cross-page decorations (eg. homonyms) can be computed
+						switchMap((options) => ds.transformOptions?.(options) ?? of(options)),
 						finalize(() => setLoading(false)), // Avoid infinite loading on complete API or error
 					);
 				}),

--- a/packages/ng/core-select/input/select-input.utils.ts
+++ b/packages/ng/core-select/input/select-input.utils.ts
@@ -1,4 +1,4 @@
-import { catchError, concatMap, distinctUntilChanged, finalize, map, Observable, of, scan, startWith, switchMap, takeWhile, tap, timer } from 'rxjs';
+import { catchError, concatMap, defer, distinctUntilChanged, finalize, map, Observable, of, scan, startWith, switchMap, takeWhile, tap, timer } from 'rxjs';
 import { SelectDataSource } from '../select.model';
 
 export interface BuildOptionsFromDataSourceDeps {
@@ -63,7 +63,8 @@ export function buildOptionsFromDataSource<TOption>(ds: SelectDataSource<TOption
 						}),
 						map((pages) => Object.values(pages).flat()),
 						// Applied on the accumulated list so cross-page decorations (eg. homonyms) can be computed
-						switchMap((options) => ds.transformOptions?.(options) ?? of(options)),
+						// Falls back to the raw accumulated options so a failing decoration doesn't kill the whole stream
+						switchMap((options) => defer(() => ds.transformOptions?.(options) ?? of(options)).pipe(catchError(() => of(options)))),
 						finalize(() => setLoading(false)), // Avoid infinite loading on complete API or error
 					);
 				}),

--- a/packages/ng/core-select/select.model.ts
+++ b/packages/ng/core-select/select.model.ts
@@ -12,6 +12,12 @@ export interface SelectDataSource<TOption, TGroup = never> {
 	/** Optional debounce in ms for clue-based re-queries (useful for API data sources) */
 	clueDebounceMs?: number;
 	getOptions(params: SelectDataSourceParams): Observable<readonly TOption[]>;
+	/**
+	 * Optional post-processing applied to the whole list of loaded options (all pages accumulated),
+	 * every time it changes. Use it for decorations that can't be computed page by page —
+	 * for example flagging homonyms, which requires seeing every loaded option at once.
+	 */
+	transformOptions?(options: readonly TOption[]): Observable<readonly TOption[]>;
 	getTotalCount?(params: SelectDataSourceParams): Observable<number>;
 	getGroupOptions?: [TGroup] extends [never] ? never : (group: TGroup) => Observable<TOption[]>;
 	reset?(): void;

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -311,6 +311,61 @@ describe('LuCoreSelectUsersDirective', () => {
 			[meUser, user1, { ...user2, additionalInformation: 'Engineering' }, { ...user3, additionalInformation: 'Marketing' }],
 		]);
 	}));
+
+	it('should append additional information for homonyms split across two pages', fakeAsync(() => {
+		// Arrange
+		usersDirective.setPageSize(2);
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick();
+
+		const meUser = createUser(CURRENT_USER_ID);
+		const user1 = createUser(1);
+		const user2 = createUser(2, 'Doe', 'John');
+		const user3 = createUser(3, 'Doe', 'John');
+		const user4 = createUser(4);
+
+		// Act (Page 1: the first homonym is the last option of the page)
+		const meReq = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`);
+		meReq.flush(usersResponse([meUser]));
+		fixture.detectChanges();
+		tick();
+
+		const page1Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,2`);
+		page1Req.flush(usersResponse([user1, user2]));
+		fixture.detectChanges();
+		tick();
+
+		// Assert (Page 1: no homonym detected yet)
+		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, user1, user2]);
+		httpTestingController.verify();
+
+		// Act (Page 2: the second homonym is the first option of the page)
+		simpleSelect.nextPage$.next();
+		fixture.detectChanges();
+		tick();
+
+		const page2Req = httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=2,2`);
+		page2Req.flush(usersResponse([user3, user4]));
+		fixture.detectChanges();
+		tick();
+
+		const additionalInfoReq = httpTestingController.expectOne(`/api/v3/users?id=2,3&fields=id,department.name`);
+		additionalInfoReq.flush({
+			data: {
+				items: [
+					{ id: 2, department: { name: 'Engineering' } },
+					{ id: 3, department: { name: 'Marketing' } },
+				],
+			},
+		});
+		fixture.detectChanges();
+		tick();
+
+		// Assert (Page 2: both homonyms are decorated, including the one loaded on the previous page)
+		expect(simpleSelect.dataSourceOptions()).toEqual([meUser, user1, { ...user2, additionalInformation: 'Engineering' }, { ...user3, additionalInformation: 'Marketing' }, user4]);
+		httpTestingController.verify();
+	}));
 });
 
 function createUser(id: number, lastName = 'test ' + id, firstName = 'test ' + id): LuCoreSelectUser {

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -206,17 +206,16 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 			}),
 		);
 
-		return page$.pipe(
-			switchMap((page) =>
-				this.#userHomonymsService.handleHomonyms(page.items, this.displayFormat()).pipe(
-					map((items) => ({
-						items,
-						isLastPage: page.isLastPage,
-					})),
-				),
-			),
-			tap(() => this.select.loading.set(false)),
-		);
+		return page$.pipe(tap(() => this.select.loading.set(false)));
+	}
+
+	/**
+	 * Homonyms can only be detected by looking at every loaded option at once: two homonyms may
+	 * land on different pages (last option of a page, first of the next one), in which case a
+	 * page by page detection would find none. So we run it on the accumulated list instead.
+	 */
+	protected override transformOptions(options: readonly LuCoreSelectWithAdditionnalInformation<T>[]): Observable<readonly LuCoreSelectWithAdditionnalInformation<T>[]> {
+		return this.#userHomonymsService.handleHomonyms([...options], this.displayFormat());
 	}
 
 	protected override optionKey = (option: T) => option.id;


### PR DESCRIPTION
## Description

In the users select, when two homonyms are loaded on different pages (last option of a page,
first option of the next one), no homonym is detected: the department information is never
displayed under their names.

Homonyms are now detected as soon as they coexist in the loaded list, whatever their page, and
the option from the previous page is re-emitted decorated. The homonyms service cache prevents
replaying `/api/v3/users?id=…` for already resolved ids on subsequent pages.

-----

https://github.com/LuccaSA/lucca-front/issues/5296

-----
