### PR TITLE
fix: tree indent after level 2

### DIFF
--- a/packages/ng/core-select/option/option.component.html
+++ b/packages/ng/core-select/option/option.component.html
@@ -4,15 +4,13 @@
 	[disabled]="selectableItem.disabled"
 	(click)="selectOption($event)"
 	[elementId]="selectableItem.idAttribute()"
+	[treeitemLevel]="treeitemContent() ? level : null"
 >
 	<ng-container [ngTemplateOutlet]="optionContent" />
+	<!-- Re-projected into the option's own wrapper, so the tree rows are stacked by the listbox
+	itself: the level has to be passed along because a content query stops at this ng-content -->
+	<ng-content select="[treeitem]" ngProjectAs="[treeitem]" />
 </lu-listbox-option>
-@if (treeitemContent()) {
-	<!-- The listbox derives the indentation level from the DOM nesting of these wrappers -->
-	<div class="listboxOptionWrapper" role="group">
-		<ng-content select="[treeitem]" />
-	</div>
-}
 
 <ng-template #optionContent>
 	<div>

--- a/packages/ng/core-select/option/option.component.ts
+++ b/packages/ng/core-select/option/option.component.ts
@@ -52,6 +52,15 @@ export class LuOptionComponent<T> implements OnInit {
 	 */
 	readonly treeitemContent = contentChild(Treeitem);
 
+	readonly #parentOption = inject<LuOptionComponent<T>>(LuOptionComponent, { skipSelf: true, optional: true });
+
+	/**
+	 * Depth this option sits at, handed to the listbox option that wraps the projected
+	 * `[treeitem]` children: option indentation is absolute, so the stylesheet cannot work out a
+	 * depth it has no rule for, and every level below its deepest one would share an indentation.
+	 */
+	readonly level: number = (this.#parentOption?.level ?? 0) + 1;
+
 	readonly optionContext = viewChild(LU_OPTION_CONTEXT);
 
 	private cdr = inject(ChangeDetectorRef);

--- a/packages/ng/listbox/option/option.component.html
+++ b/packages/ng/listbox/option/option.component.html
@@ -16,8 +16,8 @@
 </div>
 <ng-content select="[optgroup]" />
 
-@if (treeitemContent()) {
-	<div class="listboxOptionWrapper" role="group" [attr.style]="level ? '--components-listboxOptionWrapper-level: ' + level : null">
+@if (hasTreeitems()) {
+	<div class="listboxOptionWrapper" role="group" [attr.style]="'--components-listboxOptionWrapper-level: ' + wrapperLevel()">
 		<ng-content select="[treeitem]" />
 	</div>
 }

--- a/packages/ng/listbox/option/option.component.ts
+++ b/packages/ng/listbox/option/option.component.ts
@@ -75,5 +75,17 @@ export class OptionComponent {
 
 	readonly treeitemContent = contentChild(Treeitem);
 
+	/**
+	 * Depth of the nested `[treeitem]` wrapper, for consumers that hand their own projected
+	 * content over to this option: a content query does not cross an `ng-content` boundary, so
+	 * the option can then neither see those children nor derive the depth it sits at. Setting it
+	 * renders the wrapper and pins its level; leave it null to let both be worked out here.
+	 */
+	readonly treeitemLevel = input<number | null>(null);
+
 	readonly level: number = (this.#parentOptionRef?.level || 0) + 1;
+
+	readonly hasTreeitems = computed(() => !!this.treeitemContent() || this.treeitemLevel() !== null);
+
+	readonly wrapperLevel = computed(() => this.treeitemLevel() ?? this.level);
 }

--- a/packages/ng/tree-select/tree-branch/tree-branch.component.scss
+++ b/packages/ng/tree-select/tree-branch/tree-branch.component.scss
@@ -1,15 +1,5 @@
 @layer components {
 	lu-tree-branch {
-		// Keep a uniform vertical rhythm between every row: the option row and the nested
-		// children wrapper are both children of `lu-select-option`, so it must stack them with
-		// the same gap the listbox wrapper uses between siblings (otherwise a parent sits flush
-		// against its first child while siblings are spaced apart).
-		> lu-select-option {
-			display: flex;
-			flex-direction: column;
-			gap: var(--pr-t-spacings-50);
-		}
-
 		// The onlyParent/onlyChildren affordances stay hidden until the row is hovered or
 		// keyboard-highlighted. Indentation is handled by the listbox wrapper level, not here.
 		.optionItem-icons {

--- a/packages/ng/tree-select/tree-select.directive.spec.ts
+++ b/packages/ng/tree-select/tree-select.directive.spec.ts
@@ -1,0 +1,161 @@
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { ChangeDetectionStrategy, Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { TreeNode } from '@lucca-front/ng/core-select';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { TreeSelectDirective } from './tree-select.directive';
+
+interface Node {
+	id: number;
+	name: string;
+	parentId: number | null;
+}
+
+// Two branches: "Red" (1 → 2, 3) and "Green" (4 → 5, 6).
+const FULL_TREE: Node[] = [
+	{ id: 1, name: 'Red', parentId: null },
+	{ id: 2, name: 'Tomato', parentId: 1 },
+	{ id: 3, name: 'Radish', parentId: 1 },
+	{ id: 4, name: 'Green', parentId: null },
+	{ id: 5, name: 'Broccoli', parentId: 4 },
+	{ id: 6, name: 'Lettuce', parentId: 4 },
+];
+
+const byName = (name: string): Node => FULL_TREE.find((node) => node.name === name)!;
+
+@Component({
+	template: `<lu-multi-select [treeSelect]="groupingFn" [options]="options()" [optionKey]="optionKey" />`,
+	imports: [LuMultiSelectInputComponent, TreeSelectDirective],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class HostComponent {
+	readonly options = signal<Node[]>(FULL_TREE);
+	readonly optionKey = (node: Node) => node.id;
+
+	// Parents are resolved against the whole dataset, not against the options currently passed to
+	// the select: that's what every tree story does, and it's how a search ends up with an option
+	// whose parent is missing from the resultset.
+	readonly groupingFn = (node: Node): Node | null => (node.parentId == null ? null : (FULL_TREE.find((candidate) => candidate.id === node.parentId) ?? null));
+}
+
+describe(TreeSelectDirective.name, () => {
+	let fixture: ComponentFixture<HostComponent>;
+	let host: HostComponent;
+	let directive: TreeSelectDirective<Node, Node[]>;
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({ imports: [HostComponent] });
+		fixture = TestBed.createComponent(HostComponent);
+		host = fixture.componentInstance;
+		fixture.detectChanges();
+		directive = fixture.debugElement.query(By.directive(TreeSelectDirective)).injector.get(TreeSelectDirective);
+	});
+
+	function namesOf(nodes: TreeNode<Node>[]): string[] {
+		return nodes.map((treeNode) => treeNode.node.name);
+	}
+
+	function flatten(nodes: TreeNode<Node>[]): Node[] {
+		return nodes.flatMap((treeNode) => [treeNode.node, ...flatten(treeNode.children ?? [])]);
+	}
+
+	// The cases below used to wait for a parent that could never come, spinning `generateTrees`'
+	// loop forever. A test that hangs can never fail, so cap how many times the items can be read:
+	// a resultset that isn't converging then throws instead of locking the whole suite up.
+	function withReadBudget(items: Node[], budget = 10_000): Node[] {
+		let reads = 0;
+		return new Proxy(items, {
+			get(target, property, receiver) {
+				if (++reads > budget) {
+					throw new Error(`generateTrees read its items more than ${budget} times: it is looping without making any progress`);
+				}
+				return Reflect.get(target, property, receiver);
+			},
+		});
+	}
+
+	describe('generateTrees', () => {
+		it('nests every item under its parent', () => {
+			const trees = directive.generateTrees(FULL_TREE);
+
+			expect(namesOf(trees)).toEqual(['Red', 'Green']);
+			expect(namesOf(trees[0].children!)).toEqual(['Tomato', 'Radish']);
+			expect(namesOf(trees[1].children!)).toEqual(['Broccoli', 'Lettuce']);
+		});
+
+		// A search only keeps the items matching the clue, so a matching child can very well come
+		// without its parent. Such an item has nothing to nest under, and waiting for a parent that
+		// will never come used to spin the `while` loop forever, freezing the whole tab.
+		it('displays an item whose parent is missing from the resultset at root level', () => {
+			const trees = directive.generateTrees(withReadBudget([byName('Tomato'), byName('Radish'), byName('Green'), byName('Broccoli')]));
+
+			expect(namesOf(trees)).toEqual(['Tomato', 'Radish', 'Green']);
+			expect(namesOf(trees[2].children!)).toEqual(['Broccoli']);
+		});
+
+		it('displays a resultset without any root as a flat list', () => {
+			const trees = directive.generateTrees(withReadBudget([byName('Broccoli'), byName('Lettuce')]));
+
+			expect(namesOf(trees)).toEqual(['Broccoli', 'Lettuce']);
+			expect(trees.every((treeNode) => treeNode.children?.length === 0)).toBe(true);
+		});
+
+		it('keeps every item exactly once, whatever the resultset', () => {
+			const items = [byName('Radish'), byName('Green'), byName('Lettuce')];
+
+			expect(flatten(directive.generateTrees(withReadBudget(items)))).toEqual(items);
+		});
+
+		it('ignores duplicated items', () => {
+			const trees = directive.generateTrees(withReadBudget([byName('Red'), byName('Tomato'), byName('Tomato')]));
+
+			expect(namesOf(trees)).toEqual(['Red']);
+			expect(namesOf(trees[0].children!)).toEqual(['Tomato']);
+		});
+
+		// Items pointing at each other can never be nested either, and are no reason to hang.
+		it('displays items forming a parent cycle at root level', () => {
+			const left: Node = { id: 10, name: 'Left', parentId: 11 };
+			const right: Node = { id: 11, name: 'Right', parentId: 10 };
+			directive.groupingFn.set((node) => (node === left ? right : left));
+
+			expect(namesOf(directive.generateTrees(withReadBudget([left, right])))).toEqual(['Left', 'Right']);
+		});
+
+		it('displays an item that is its own parent at root level', () => {
+			const self: Node = { id: 12, name: 'Self', parentId: 12 };
+			directive.groupingFn.set(() => self);
+
+			expect(namesOf(directive.generateTrees(withReadBudget([self])))).toEqual(['Self']);
+		});
+	});
+
+	// Same scenario as above, but going through the panel: this is exactly what typing a clue that
+	// matches children only does in the tree stories.
+	it('renders one treeitem per option when a search drops the parents', fakeAsync(() => {
+		const select = fixture.debugElement.query(By.directive(LuMultiSelectInputComponent)).componentInstance as LuMultiSelectInputComponent<Node>;
+		const overlay = TestBed.inject(OverlayContainer).getContainerElement();
+		// The panel builds the trees itself, so budget the items on the way in to keep a regression
+		// a failing test rather than a hanging one.
+		const generateTrees = directive.generateTrees.bind(directive);
+		vi.spyOn(directive, 'generateTrees').mockImplementation((items: Node[]) => generateTrees(withReadBudget(items)));
+
+		select.openPanel();
+		fixture.detectChanges();
+		tick(20);
+		fixture.detectChanges();
+		expect(overlay.querySelectorAll('[role="treeitem"]').length).toBe(FULL_TREE.length);
+
+		// "Search": only the leaves match, every parent is filtered out.
+		const leaves = [byName('Tomato'), byName('Broccoli'), byName('Lettuce')];
+		host.options.set(leaves);
+		fixture.detectChanges();
+		tick(20);
+		fixture.detectChanges();
+
+		expect(overlay.querySelectorAll('[role="treeitem"]').length).toBe(leaves.length);
+
+		tick();
+	}));
+});

--- a/packages/ng/tree-select/tree-select.directive.ts
+++ b/packages/ng/tree-select/tree-select.directive.ts
@@ -21,41 +21,55 @@ export class TreeSelectDirective<T, V> implements TreeGenerator<T, TreeNode<T>> 
 		// Keep a registry of what has been handled already
 		const itemToNode = new Map<T, TreeNode<T>>();
 		const parentCache = new Map<T, T | null>();
-		const handled: T[] = [];
+		// Items we are allowed to nest under, so a parent that is missing from `items` can be told
+		// apart from one we simply haven't reached yet. Also deduplicates `items`.
+		const knownItems = new Set(items);
+		const getParent = (item: T): T | null => {
+			if (!parentCache.has(item)) {
+				parentCache.set(item, this.groupingFn()(item, items));
+			}
+			return parentCache.get(item) ?? null;
+		};
+		const createNode = (item: T): TreeNode<T> => {
+			const itemNode: TreeNode<T> = {
+				node: item,
+				children: [],
+			};
+			itemToNode.set(item, itemNode);
+			return itemNode;
+		};
+		const addRoot = (item: T): void => {
+			res.push(createNode(item));
+		};
+		// Items whose parent node doesn't exist in the resultset yet
+		let pending = [...knownItems];
 		// While we haven't handled all the items
-		while (items.length > handled.length) {
-			for (const item of items) {
-				if (itemToNode.has(item)) {
-					// item already in resultset
+		while (pending.length) {
+			const stillPending: T[] = [];
+			for (const item of pending) {
+				const parent = getParent(item);
+				// Parent null or undefined means it's a root element, and so is an item whose parent
+				// isn't part of `items`: filtered out by a search, it will never show up to nest under.
+				if (!parent || !knownItems.has(parent)) {
+					addRoot(item);
 					continue;
 				}
-				let parent: T | null = null;
-				if (parentCache.has(item)) {
-					parent = parentCache.get(item) ?? null;
+				const parentNode = itemToNode.get(parent);
+				// If the parent is already in the resultset, we can add this
+				if (parentNode) {
+					parentNode.children?.push(createNode(item));
 				} else {
-					parent = this.groupingFn()(item, items);
-					parentCache.set(item, parent);
-				}
-				const itemNode: TreeNode<T> = {
-					node: item,
-					children: [],
-				};
-				// Parent null or undefined means it's a root element
-				if (!parent) {
-					res.push(itemNode);
-					itemToNode.set(item, itemNode);
-					handled.push(item);
-				} else {
-					const parentNode = itemToNode.get(parent);
-					// If the parent is already in the resultset, we can add this
-					if (parentNode) {
-						parentNode.children?.push(itemNode);
-						itemToNode.set(item, itemNode);
-						handled.push(item);
-					}
 					// Else, we fizzle till the next iteration
+					stillPending.push(item);
 				}
 			}
+			// A whole pass without progress means the remaining items form a parent cycle: they can
+			// never be nested, so display them as roots rather than looping forever.
+			if (stillPending.length === pending.length) {
+				stillPending.forEach(addRoot);
+				break;
+			}
+			pending = stillPending;
 		}
 		return res;
 	}


### PR DESCRIPTION
## Description

Fix tree indent issue in selects.

-----

Optionally, technical or more in-depth description for reviewers.
Keep an empty line under your text, as well as the 5 lines that follow it.

-----
