### PR TITLE
fix(comment): use a fixed date in QA story

### DIFF
--- a/stories/qa/comment/comment.stories.ts
+++ b/stories/qa/comment/comment.stories.ts
@@ -10,7 +10,7 @@ import { applicationConfig, Meta, StoryObj } from '@storybook/angular-vite';
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 class CommentStory {
-	date = new Date();
+	date = new Date('2026-01-15T10:30:00Z');
 	formatedSample = `Lorem ipsum dolor sit amet, consectetur adipisicing elit.
 
 	Temporibus a veniam necessitatibus aut facilis repellendus provident nulla iste neque ex? `;


### PR DESCRIPTION
## Description

The `QA/Comment` story used `new Date()`, so the rendered comment timestamps changed on
every run. This made the story non-deterministic and produced noisy diffs in visual
regression / interaction snapshots.

-----


-----
