### PR TITLE
fix(core-select): keep selects non-searchable without a clueChange binding

### DIFF
--- a/packages/ng/core-select/input/select-input.component.spec.ts
+++ b/packages/ng/core-select/input/select-input.component.spec.ts
@@ -121,6 +121,20 @@ export function runALuSelectInputComponentTestSuite<TValue>(config: LuSelectInpu
 		expect(clueChangeSpy).not.toHaveBeenCalled();
 	});
 
+	it('should stay non-searchable once the panel has been opened', async () => {
+		// Arrange — no `(clueChange)` binding, so the select must never turn searchable
+		const event = new KeyboardEvent('keydown', { key: 'ArrowDown' });
+
+		// Act
+		nativeElement.dispatchEvent(event);
+		await vi.runAllTimersAsync();
+		fixture.detectChanges();
+
+		// Assert
+		expect(component.isPanelOpen).toBe(true);
+		expect(component.searchable).toBe(false);
+	});
+
 	it('should update filter pill disabled signal when disabled state changes', () => {
 		// Assert initial state
 		expect(component.filterPillDisabled?.()).toBe(false);

--- a/packages/ng/core-select/input/select-input.component.ts
+++ b/packages/ng/core-select/input/select-input.component.ts
@@ -182,6 +182,9 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 
 	readonly clueChange$ = new Subject<string>();
 	clueChange = outputFromObservable(this.clueChange$);
+	// searchable is derived from clueChange$.observed, so internal consumers must use this stream instead:
+	// subscribing to clueChange$ would make every select look searchable.
+	readonly #internalClueChange$ = new Subject<string>();
 	readonly nextPage$ = new Subject<void>();
 	nextPage = outputFromObservable(this.nextPage$);
 	readonly addOption = output<string>();
@@ -212,6 +215,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 			this.openPanel(clue);
 		} else if (this.lastEmittedClue !== clue) {
 			this.clueChange$.next(clue);
+			this.#internalClueChange$.next(clue);
 			this.lastEmittedClue = clue;
 		}
 	}
@@ -255,7 +259,7 @@ export abstract class ALuSelectInputComponent<TOption, TValue> implements OnDest
 	clue: string | null = null;
 	// This is the clue stored after we selected an option to know if we should emit an empty clue on open or not
 	lastEmittedClue: string = '';
-	readonly clue$ = defer(() => this.clueChange$.pipe(startWith(this.clue)));
+	readonly clue$ = defer(() => this.#internalClueChange$.pipe(startWith(this.clue)));
 
 	readonly shouldDisplayAddOption = toSignal(
 		toObservable(this.addOptionStrategy).pipe(

--- a/packages/ng/core-select/user/user-option.component.ts
+++ b/packages/ng/core-select/user/user-option.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core
 import { intlInputOptions } from '@lucca-front/ng/core';
 import { ILuOptionContext, LU_OPTION_CONTEXT, ɵLuOptionOutletDirective } from '@lucca-front/ng/core-select';
 import { LuUserDisplayPipe } from '@lucca-front/ng/user';
-import { map, startWith } from 'rxjs';
+import { map } from 'rxjs';
 import { LuCoreSelectUser, LuCoreSelectWithAdditionnalInformation } from './user-option.model';
 import { LU_CORE_SELECT_USER_TRANSLATIONS } from './user.translate';
 import { LuCoreSelectUsersDirective } from './users.directive';
@@ -37,9 +37,6 @@ export class LuUserOptionComponent {
 	protected context = inject<ILuOptionContext<LuCoreSelectWithAdditionnalInformation<LuCoreSelectUser>>>(LU_OPTION_CONTEXT);
 	protected userDirective = inject(LuCoreSelectUsersDirective);
 	readonly intl = input(...intlInputOptions(LU_CORE_SELECT_USER_TRANSLATIONS));
-	protected readonly hasEmptyClue$ = this.userDirective.select.clueChange$.pipe(
-		startWith(this.userDirective.select.clue),
-		map((clue) => !clue),
-	);
+	protected readonly hasEmptyClue$ = this.userDirective.select.clue$.pipe(map((clue) => !clue));
 	protected readonly customUserOptionTpl = this.userDirective.customUserOptionTpl;
 }

--- a/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
+++ b/packages/ng/multi-select/input/select-all/with-select-all.directive.ts
@@ -51,7 +51,7 @@ export class LuMultiSelectWithSelectAllDirective<TValue> extends ɵIsSelectedStr
 	readonly mode = this.#mode.asReadonly();
 	readonly values = this.#values.asReadonly();
 	readonly totalCount = toSignal(inject(CORE_SELECT_API_TOTAL_COUNT_PROVIDER).totalCount$, { initialValue: 0 });
-	readonly clueChange = toSignal(this.select.clueChange$);
+	readonly clueChange = toSignal(this.select.clue$);
 	readonly #options = computed<readonly TValue[]>(() => this.select.options() ?? []);
 
 	readonly singleRemainingOption = computed<TValue | undefined>(() => {


### PR DESCRIPTION
## Description

<!-- placeholder: intention line — one line, never folded -->

- Opening the panel of a plain `[options]` select turned it searchable: magnifier, editable field, and typing that accepted text without filtering anything.
- The field now stays read-only unless something asks for search: a `(clueChange)` binding in the template, or one of the select API directives.
- Regression since v21.0.0, from 4760eb063 (`refactor(core): signalize them all`). The guard test sits in the shared input suite, so simple-select and multi-select are both covered, and both fail without the fix.

<details><summary>Technical details</summary>

`searchable` is inferred from `clueChange$.observed`, that is from RxJS subscriber counting, and it drives `[readonly]="!searchable"`, which in turn drives the `searchable` SCSS mixin keyed on `:not(:has(… :read-only))`.

That inference only worked while internal consumers stayed cold. Since 4760eb063 they subscribe eagerly: both panels take `clue$` at construction, `dataSourceOptions` takes it on panel open, and `withSelectAll` and `lu-user-option` took `clueChange$` directly. Any one of them made `observed` true, so opening the panel was enough to flip the field to editable.

Internal consumers now go through a private `#internalClueChange$`, fed by `clueChanged()` alongside `clueChange$`, with `clue$` derived from it. `clueChange$.observed` is left to mean external subscribers only: a template binding, or `ALuCoreSelectApiDirective`, which subscribes deliberately to keep API selects searchable. `luNoClue` keeps working by completing `clueChange$`; the internal subject stays open, so the panel and the data source keep receiving clues. `withSelectAll` and `lu-user-option` read `clue$` instead, which carries the same values and already replays the current one to a late subscriber, so their `startWith` was dropped as redundant.

</details>

<details><summary>Known limitation</summary>

A subscriber count is still the source of truth: the next internal `toSignal(clueChange$)` brings the same bug back, and a consumer subscribing to `clueChange` just to observe it makes its select searchable. An explicit flag, a `searchable` input or something the API directive sets, would hold, at the cost of a public API change. Not addressed here.

</details>

-----
