### PR TITLE
[tooltip] fix VO support

### DIFF
--- a/packages/prisme/tooltip/panel/tooltip-panel.component.html
+++ b/packages/prisme/tooltip/panel/tooltip-panel.component.html
@@ -1,3 +1,8 @@
 @if (content(); as content) {
-	<div class="tooltip" [class]="contentPositionClasses()" [innerHtml]="content"></div>
+	<div
+		class="tooltip"
+		[class]="contentPositionClasses()"
+		[innerHtml]="content"
+		[style.--components-tooltip-animationDelay]="enterDelay() + 'ms'"
+	></div>
 }

--- a/packages/prisme/tooltip/panel/tooltip-panel.component.ts
+++ b/packages/prisme/tooltip/panel/tooltip-panel.component.ts
@@ -21,6 +21,7 @@ export class LuTooltipPanelComponent {
 	readonly mouseLeave$ = new Subject<void>();
 
 	readonly content = signal<string | SafeHtml | null>(null);
+	readonly enterDelay = signal(300);
 
 	readonly contentPositionClasses = signal<Record<string, boolean>>({});
 

--- a/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
+++ b/packages/prisme/tooltip/trigger/tooltip-trigger.directive.ts
@@ -74,13 +74,13 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly prTooltip = linkedSignal<string | SafeHtml>(() => this.prTooltipInput());
 	readonly tooltipContent = computed(() => this.luTooltip() || this.prTooltip());
 
-	readonly luTooltipEnterDelay = input(300, { transform: numberAttribute });
+	readonly luTooltipEnterDelay = input(0, { transform: numberAttribute });
 	readonly prTooltipEnterDelay = input(300, { transform: numberAttribute });
-	readonly tooltipEnterDelay = computed(() => this.prTooltipEnterDelay() || this.luTooltipEnterDelay());
+	readonly tooltipEnterDelay = computed(() => this.luTooltipEnterDelay() || this.prTooltipEnterDelay());
 
-	readonly luTooltipLeaveDelay = input(100, { transform: numberAttribute });
+	readonly luTooltipLeaveDelay = input(0, { transform: numberAttribute });
 	readonly prTooltipLeaveDelay = input(100, { transform: numberAttribute });
-	readonly tooltipLeaveDelay = computed(() => this.prTooltipLeaveDelay() || this.luTooltipLeaveDelay());
+	readonly tooltipLeaveDelay = computed(() => this.luTooltipLeaveDelay() || this.prTooltipLeaveDelay());
 
 	readonly luTooltipDisabled = input(false, { transform: booleanAttribute });
 	readonly prTooltipDisabled = input(false, { transform: booleanAttribute });
@@ -90,9 +90,9 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly prTooltipOnlyForDisplay = input(false, { transform: booleanAttribute });
 	readonly tooltipOnlyForDisplay = computed(() => this.prTooltipOnlyForDisplay() || this.luTooltipOnlyForDisplay());
 
-	readonly luTooltipPosition = input<TooltipPosition>('above');
+	readonly luTooltipPosition = input<TooltipPosition | null>(null);
 	readonly prTooltipPosition = input<TooltipPosition>('above');
-	readonly tooltipPosition = computed(() => this.prTooltipPosition() || this.luTooltipPosition());
+	readonly tooltipPosition = computed(() => this.luTooltipPosition() ?? this.prTooltipPosition());
 
 	readonly luTooltipWhenEllipsisInput = input(false, { alias: 'luTooltipWhenEllipsis', transform: booleanAttribute });
 	readonly prTooltipWhenEllipsisInput = input(false, { alias: 'prTooltipWhenEllipsis', transform: booleanAttribute });
@@ -101,9 +101,9 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	readonly prTooltipWhenEllipsis = linkedSignal(() => this.prTooltipWhenEllipsisInput());
 	readonly tooltipWhenEllipsis = computed(() => this.prTooltipWhenEllipsis() || this.luTooltipWhenEllipsis());
 
-	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef | null | undefined>(this.#host);
+	readonly luTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef | null | undefined>(null);
 	readonly prTooltipAnchor = input<FlexibleConnectedPositionStrategyOrigin | LuTooltipAnchorRef | null | undefined>(this.#host);
-	readonly tooltipAnchor = computed(() => this.prTooltipAnchor() || this.luTooltipAnchor());
+	readonly tooltipAnchor = computed(() => this.luTooltipAnchor() || this.prTooltipAnchor());
 
 	readonly id = input<string>(`${this.#host.nativeElement.tagName.toLowerCase()}-tooltip-${nextId++}`);
 
@@ -164,14 +164,14 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 	constructor() {
 		this.#destroyRef.onDestroy(() => (this.#destroyed = true));
 
-		// Action debounce pipeline — kept as Observable since signals can't debounce
+		// content attach/detach — immediate on open, VoiceOver/Safari misses a late aria-describedby
 		toObservable(this.#realAction)
 			.pipe(
 				filter(isNotNil),
-				debounce((action) => timer(action === 'open' ? this.tooltipEnterDelay() : this.tooltipLeaveDelay())),
-				tap((event) => {
-					if (event === 'open') {
-						this.openTooltip();
+				debounce((action) => timer(action === 'open' ? 0 : this.tooltipLeaveDelay())),
+				tap((action) => {
+					if (action === 'open') {
+						this.attachTooltip();
 					} else {
 						this.closeTooltip();
 					}
@@ -382,7 +382,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 		}
 	}
 
-	private openTooltip(): void {
+	private attachTooltip(): void {
 		// A pending debounced 'open' is flushed when `toObservable(#realAction)` completes on
 		// destroy (`debounce` re-emits the held value on completion), i.e. AFTER ngOnDestroy has
 		// disposed the overlay. Opening then would recreate an overlay anchored to a detached
@@ -402,6 +402,7 @@ export class LuTooltipTriggerDirective implements OnDestroy {
 		}
 		const portal = new ComponentPortal(LuTooltipPanelComponent);
 		const ref = this.overlayRef.attach(portal);
+		ref.instance.enterDelay.set(this.tooltipEnterDelay());
 		position.positionChanges
 			.pipe(
 				takeUntilDestroyed(this.#destroyRef),

--- a/packages/scss/src/components/tooltip/component.scss
+++ b/packages/scss/src/components/tooltip/component.scss
@@ -13,12 +13,24 @@
 	margin: var(--components-tooltip-margin);
 	text-align: center;
 	inline-size: fit-content;
-	animation-name: scaleIn;
+	animation-name: scaleIn, tooltipPointerEventsIn;
+	animation-delay: var(--components-tooltip-animationDelay);
 	animation-duration: var(--commons-animations-durations-fast);
 	animation-iteration-count: 1;
+	animation-fill-mode: backwards;
 	overflow-wrap: break-word;
 
 	@include keyframe.scaleIn;
+
+	@keyframes tooltipPointerEventsIn {
+		0% {
+			pointer-events: none;
+		}
+
+		1% {
+			pointer-events: auto;
+		}
+	}
 
 	&:empty {
 		display: none;

--- a/packages/scss/src/components/tooltip/vars.scss
+++ b/packages/scss/src/components/tooltip/vars.scss
@@ -4,4 +4,5 @@
 	--components-tooltip-max-width: 15rem;
 	--components-tooltip-transformOrigin: center;
 	--components-tooltip-margin: 0;
+	--components-tooltip-animationDelay: 300ms;
 }

--- a/stories/documentation/overlays/tooltip/tooltip.stories.ts
+++ b/stories/documentation/overlays/tooltip/tooltip.stories.ts
@@ -12,7 +12,7 @@ export default {
 	title: 'Documentation/Overlays/Tooltip/Basic',
 	argTypes: {
 		luTooltipEnterDelay: {
-			description: 'Délai d’apparition du tooltip au survol (en ms).',
+			description: 'Délai d’apparition du tooltip (en ms).',
 			control: { type: 'number' },
 			table: {
 				category: 'inputs',
@@ -64,7 +64,14 @@ export default {
 		}),
 	],
 	render: (args, { argTypes }) => {
-		const inputs = generateInputs(args, argTypes);
+		const filteredArgs = { ...args };
+		if (filteredArgs['luTooltipEnterDelay'] === 300) {
+			delete filteredArgs['luTooltipEnterDelay'];
+		}
+		if (filteredArgs['luTooltipLeaveDelay'] === 100) {
+			delete filteredArgs['luTooltipLeaveDelay'];
+		}
+		const inputs = generateInputs(filteredArgs, argTypes);
 		return {
 			styles: [
 				`
@@ -84,35 +91,35 @@ export default {
 	luButton
 	luTooltip="👋 Hello"
 	${inputs}
->Tooltip au survol</button>
+>Tooltip au survol ou au focus</button>
 <h3>Tooltip sur un texte</h3>
 <span
-
+  class="pr-u-focusVisible pr-u-borderRadiusSmall"
 	luTooltip="👋 Hello"
 	${inputs}
->Tooltip au survol</span>
+>Tooltip au survol ou au focus</span>
 <h3>Tooltip et ellipse</h3>
 <div
 	data-testid="ellipsis-truncated"
-	class="pr-u-ellipsis"
+	class="pr-u-ellipsis pr-u-focusVisible pr-u-borderRadiusSmall"
 	style="inline-size: 10rem;"
 	tabindex="0"
-	luTooltip="Ce texte est trop long pour être affiché entièrement. Le tooltip apparait au survol."
-	${generateInputs(args, argTypes)}
+	luTooltip="Ce texte est trop long pour être affiché entièrement. Le tooltip apparait au survol ou au focus."
+	${generateInputs(filteredArgs, argTypes)}
 	[luTooltipWhenEllipsis]="true"
->Ce texte est trop long pour être affiché entièrement. Le tooltip apparait au survol.</div>
+>Ce texte est trop long pour être affiché entièrement. Le tooltip apparait au survol ou au focus.</div>
 <div
 	data-testid="ellipsis-not-truncated"
-	class="pr-u-ellipsis"
-	luTooltip="Ce texte est affiché entièrement. Le tooltip n'apparait pas au survol."
-	${generateInputs(args, argTypes)}
+	class="pr-u-ellipsis pr-u-focusVisible pr-u-borderRadiusSmall"
+	luTooltip="Ce texte est affiché entièrement. Le tooltip n'apparait ni au survol ni au focus."
+	${generateInputs(filteredArgs, argTypes)}
 	[luTooltipWhenEllipsis]="true"
->Ce texte est affiché entièrement. Le tooltip n'apparait pas au survol.</div>
+>Ce texte est affiché entièrement. Le tooltip n'apparait ni au survol, ni au focus.</div>
 <h3>Tooltip et icône (avec alternative)</h3>
-<lu-icon data-testid="icon-tooltip" icon="star" alt="Favoris" luTooltip="Favoris" ${inputs} luTooltipOnlyForDisplay="true" />
+<lu-icon data-testid="icon-tooltip" icon="star" alt="Favoris" luTooltip="Favoris" ${inputs} luTooltipOnlyForDisplay="true" class="pr-u-focusVisible pr-u-borderRadiusSmall" />
 
 <h3>Tooltip affiché avec un host séparé</h3>
-<span class="pr-u-marginInlineEnd800" luTooltip="… mais apparait là !" [luTooltipAnchor]="target">Tooltip déclenché ici…</span><span aria-hidden="true" #target class="lucca-icon icon-target">
+<span class="pr-u-marginInlineEnd800 pr-u-focusVisible pr-u-borderRadiusSmall" luTooltip="… mais apparait là !" [luTooltipAnchor]="target">Tooltip déclenché ici…</span><span aria-hidden="true" #target class="lucca-icon icon-target">
 `,
 		};
 	},


### PR DESCRIPTION
## Description

Tooltips were not always read aloud by VoiceOver, which does not allow any delay when their content is inserted into the DOM. To fix this, the display delay is now managed via CSS, and the DOM is always populated immediately.

-----

A small additional fix as a bonus regarding the proper integration between luTooltip and prTooltip.

-----
<img width="224" height="70" alt="Capture d’écran 2026-09-07 à 12 17 25" src="https://github.com/user-attachments/assets/bb834b77-61a4-468a-a2b2-927e11435e27" />



