### PR TITLE
fix(core-select): detect user homonyms across pages

### DIFF
--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -75,6 +75,7 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 			clueDebounceMs: this.debounceDuration,
 			getTotalCount: () => this.totalCount$,
 			reset: () => this.clearLastPageByClue(),
+			mapLoadedOptions: (options) => this.mapLoadedOptions(options),
 			getOptions: ({ clue, page }) => {
 				const lastPage = clue === this.#lastClue ? this.#lastPage : undefined;
 				if (lastPage !== undefined && page > lastPage) {
@@ -112,6 +113,10 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	protected clearLastPageByClue() {
 		this.#lastClue = undefined;
 		this.#lastPage = undefined;
+	}
+
+	protected mapLoadedOptions(options: readonly TOption[]): Observable<readonly TOption[]> {
+		return of(options);
 	}
 
 	protected getOptionsPage(params: TParams, page: number): Observable<{ items: TOption[]; isLastPage: boolean }> {

--- a/packages/ng/core-select/input/select-input.utils.ts
+++ b/packages/ng/core-select/input/select-input.utils.ts
@@ -62,6 +62,7 @@ export function buildOptionsFromDataSource<TOption>(ds: SelectDataSource<TOption
 							return lastIndexes.length < 2 || !lastIndexes.every((i) => pages[i]?.length === 0);
 						}),
 						map((pages) => Object.values(pages).flat()),
+						switchMap((options) => (ds.mapLoadedOptions ? ds.mapLoadedOptions(options) : of(options))),
 						finalize(() => setLoading(false)), // Avoid infinite loading on complete API or error
 					);
 				}),

--- a/packages/ng/core-select/select.model.ts
+++ b/packages/ng/core-select/select.model.ts
@@ -14,6 +14,11 @@ export interface SelectDataSource<TOption, TGroup = never> {
 	getOptions(params: SelectDataSourceParams): Observable<readonly TOption[]>;
 	getTotalCount?(params: SelectDataSourceParams): Observable<number>;
 	getGroupOptions?: [TGroup] extends [never] ? never : (group: TGroup) => Observable<TOption[]>;
+	/**
+	 * Optional transformation applied to every loaded page at once, for decorations that depend on
+	 * the whole list (for example, users homonyms spread over several pages).
+	 */
+	mapLoadedOptions?(options: readonly TOption[]): Observable<readonly TOption[]>;
 	reset?(): void;
 }
 

--- a/packages/ng/core-select/user/user-homonym.service.ts
+++ b/packages/ng/core-select/user/user-homonym.service.ts
@@ -10,7 +10,7 @@ export class LuCoreSelectUserHomonymsService {
 	protected http = inject(HttpClient);
 	protected cache: Record<number, string> = {};
 
-	protected extractHomonyms<T extends LuCoreSelectUser>(users: T[], format: LuDisplayFormat): Set<T['id']> {
+	protected extractHomonyms<T extends LuCoreSelectUser>(users: readonly T[], format: LuDisplayFormat): Set<T['id']> {
 		const usersByFullName: Record<string, T[]> = {};
 
 		for (const user of users) {
@@ -26,7 +26,7 @@ export class LuCoreSelectUserHomonymsService {
 		);
 	}
 
-	public handleHomonyms<T extends LuCoreSelectUser>(users: T[], format: LuDisplayFormat): Observable<T[]> {
+	public handleHomonyms<T extends LuCoreSelectUser>(users: readonly T[], format: LuDisplayFormat): Observable<readonly T[]> {
 		const homonyms = this.extractHomonyms(users, format);
 
 		if (homonyms.size === 0) {

--- a/packages/ng/core-select/user/user-homonym.service.ts
+++ b/packages/ng/core-select/user/user-homonym.service.ts
@@ -2,7 +2,7 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { ILuApiCollectionResponse } from '@lucca-front/ng/api';
 import { LuDisplayFormat, luUserDisplay } from '@lucca-front/ng/user';
-import { Observable, map, of, startWith, tap } from 'rxjs';
+import { Observable, combineLatest, map, of, shareReplay, startWith, tap } from 'rxjs';
 import { LuCoreSelectUser } from './user-option.model';
 
 @Injectable({ providedIn: 'root' })
@@ -39,7 +39,7 @@ export class LuCoreSelectUserHomonymsService {
 					homonyms.has(user.id)
 						? {
 								...user,
-								additionalInformation: this.cache[user.id] || additionalInformation[user.id],
+								additionalInformation: additionalInformation[user.id] ?? this.cache[user.id],
 							}
 						: user,
 				),
@@ -49,12 +49,27 @@ export class LuCoreSelectUserHomonymsService {
 	}
 
 	protected getAdditionalInformationByUserId<T extends LuCoreSelectUser>(homonyms: T['id'][]): Observable<Record<number, string>> {
-		const userIds = homonyms.filter((userId) => !this.cache[userId]);
+		// Users without department are cached as an empty string, so `hasOwn` is required to consider them as known
+		const unknownIds = homonyms.filter((userId) => !Object.hasOwn(this.cache, userId));
+		const idsToFetch = unknownIds.filter((userId) => !this.#pendingRequests.has(userId));
 
-		if (userIds.length === 0) {
+		if (idsToFetch.length > 0) {
+			const request$ = this.fetchAdditionalInformation(idsToFetch).pipe(shareReplay(1));
+			idsToFetch.forEach((userId) => this.#pendingRequests.set(userId, request$));
+		}
+
+		const requests = Array.from(new Set(unknownIds.map((userId) => this.#pendingRequests.get(userId)).filter((request) => !!request)));
+
+		if (requests.length === 0) {
 			return of({});
 		}
 
+		return combineLatest(requests).pipe(map((infos) => Object.assign({}, ...infos) as Record<number, string>));
+	}
+
+	#pendingRequests = new Map<number, Observable<Record<number, string>>>();
+
+	private fetchAdditionalInformation(userIds: number[]): Observable<Record<number, string>> {
 		return this.http
 			.get<ILuApiCollectionResponse<{ id: number; department?: { name: string } }>>(`/api/v3/users`, {
 				params: {
@@ -64,20 +79,18 @@ export class LuCoreSelectUserHomonymsService {
 			})
 			.pipe(
 				map((res) => res.data.items),
-				map((infos) =>
-					infos.reduce<Record<number, string>>(
-						(acc, info) => ({
-							...acc,
-							[info.id]: info.department?.name || '',
-						}),
-						{},
-					),
-				),
+				map((infos) => {
+					// Ids missing from the response are cached as well, to never fetch them again
+					const additionalInformation: Record<number, string> = Object.fromEntries(userIds.map((userId) => [userId, '']));
+					infos.forEach((info) => (additionalInformation[info.id] = info.department?.name || ''));
+					return additionalInformation;
+				}),
 				tap((infos) => {
 					this.cache = {
 						...this.cache,
 						...infos,
 					};
+					userIds.forEach((userId) => this.#pendingRequests.delete(userId));
 				}),
 			);
 	}

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -364,6 +364,40 @@ describe('LuCoreSelectUsersDirective', () => {
 		httpTestingController.verify();
 		expect(options[options.length - 1]).toEqual([meUser, user1, { ...user2, additionalInformation: 'Engineering' }, { ...user3, additionalInformation: 'Marketing' }, user4]);
 	}));
+
+	it('should not fetch additional information again for already known homonyms', fakeAsync(() => {
+		usersDirective.setPageSize(2);
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+		tick();
+
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`).flush(usersResponse([createUser(CURRENT_USER_ID)]));
+		fixture.detectChanges();
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,2`).flush(usersResponse([createUser(1), createUser(2, 'Doe', 'John')]));
+		fixture.detectChanges();
+
+		simpleSelect.nextPage$.next();
+		fixture.detectChanges();
+		tick();
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=2,2`).flush(usersResponse([createUser(3, 'Doe', 'John'), createUser(4)]));
+		fixture.detectChanges();
+		httpTestingController.expectOne(`/api/v3/users?id=2,3&fields=id,department.name`).flush({
+			data: { items: [{ id: 2, department: { name: 'Engineering' } }, { id: 3 }] },
+		});
+		fixture.detectChanges();
+		httpTestingController.verify();
+
+		// Third page, no new homonym
+		simpleSelect.nextPage$.next();
+		fixture.detectChanges();
+		tick();
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=4,2`).flush(usersResponse([createUser(5), createUser(6)]));
+		fixture.detectChanges();
+
+		// User 3 has no department: it is cached as an empty string and must not be fetched again
+		expect(httpTestingController.match((req) => req.url === '/api/v3/users')).toEqual([]);
+		httpTestingController.verify();
+	}));
 });
 
 function createUser(id: number, lastName = 'test ' + id, firstName = 'test ' + id): LuCoreSelectUser {

--- a/packages/ng/core-select/user/users.directive.spec.ts
+++ b/packages/ng/core-select/user/users.directive.spec.ts
@@ -311,6 +311,59 @@ describe('LuCoreSelectUsersDirective', () => {
 			[meUser, user1, { ...user2, additionalInformation: 'Engineering' }, { ...user3, additionalInformation: 'Marketing' }],
 		]);
 	}));
+
+	it('should append additional information for homonyms spread over two pages', fakeAsync(() => {
+		// Arrange
+		usersDirective.setPageSize(2);
+		simpleSelect.openPanel();
+		fixture.detectChanges();
+
+		tick();
+
+		const meUser = createUser(CURRENT_USER_ID);
+		const user1 = createUser(1);
+		const user2 = createUser(2, 'Doe', 'John');
+		const user3 = createUser(3, 'Doe', 'John');
+		const user4 = createUser(4);
+
+		// Act
+		const options: Array<readonly LuCoreSelectUser[]> = [];
+		TestBed.runInInjectionContext(() =>
+			toObservable(simpleSelect.dataSourceOptions)
+				.pipe(skip(1))
+				.subscribe((o) => options.push(o)),
+		);
+
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&id=${CURRENT_USER_ID}`).flush(usersResponse([meUser]));
+		fixture.detectChanges();
+
+		// Page 0 ends with a "John Doe", no homonym detected yet
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=0,2`).flush(usersResponse([user1, user2]));
+		fixture.detectChanges();
+		httpTestingController.verify();
+
+		// Page 1 starts with another "John Doe": both users are homonyms
+		simpleSelect.nextPage$.next();
+		fixture.detectChanges();
+		tick();
+
+		httpTestingController.expectOne(`/api/v3/users/search?fields=${fields}&paging=2,2`).flush(usersResponse([user3, user4]));
+		fixture.detectChanges();
+
+		httpTestingController.expectOne(`/api/v3/users?id=2,3&fields=id,department.name`).flush({
+			data: {
+				items: [
+					{ id: 2, department: { name: 'Engineering' } },
+					{ id: 3, department: { name: 'Marketing' } },
+				],
+			},
+		});
+		fixture.detectChanges();
+
+		// Assert
+		httpTestingController.verify();
+		expect(options[options.length - 1]).toEqual([meUser, user1, { ...user2, additionalInformation: 'Engineering' }, { ...user3, additionalInformation: 'Marketing' }, user4]);
+	}));
 });
 
 function createUser(id: number, lastName = 'test ' + id, firstName = 'test ' + id): LuCoreSelectUser {

--- a/packages/ng/core-select/user/users.directive.ts
+++ b/packages/ng/core-select/user/users.directive.ts
@@ -198,25 +198,18 @@ export class LuCoreSelectUsersDirective<T extends LuCoreSelectUser = LuCoreSelec
 
 		const users$ = this.getOptions(params, page).pipe(map((users) => ({ items: users, isLastPage: users.length < this.pageSize })));
 
-		const page$ = combineLatest([me$, users$]).pipe(
+		return combineLatest([me$, users$]).pipe(
 			map(([me, { items, isLastPage }]) => {
 				// If "me" is displayed as first option, we remove it from the list of users
 				const filteredItems = displayMe ? items.filter((u) => u.id !== this.currentUserId) : items;
 				return { items: me && prependMe ? [me, ...filteredItems] : filteredItems, isLastPage };
 			}),
-		);
-
-		return page$.pipe(
-			switchMap((page) =>
-				this.#userHomonymsService.handleHomonyms(page.items, this.displayFormat()).pipe(
-					map((items) => ({
-						items,
-						isLastPage: page.isLastPage,
-					})),
-				),
-			),
 			tap(() => this.select.loading.set(false)),
 		);
+	}
+
+	protected override mapLoadedOptions(options: readonly LuCoreSelectWithAdditionnalInformation<T>[]): Observable<readonly LuCoreSelectWithAdditionnalInformation<T>[]> {
+		return this.#userHomonymsService.handleHomonyms(options, this.displayFormat());
 	}
 
 	protected override optionKey = (option: T) => option.id;


### PR DESCRIPTION
## Description

In user selects, two homonyms only got their department as additional information when they showed up on the same page of results. The last user of a page and the first of the next one therefore stayed indistinguishable. Detection now runs across all loaded pages.

-----

Homonyms resolution ran in `getOptionsPage`, hence one page at a time, while pages are accumulated downstream in `buildOptionsFromDataSource`.

- `SelectDataSource` exposes an optional `mapLoadedOptions(options)` hook, applied by `buildOptionsFromDataSource` on the whole list of loaded pages;
- `ALuCoreSelectApiDirective` wires it to an overridable `mapLoadedOptions` method (identity by default);
- `LuCoreSelectUsersDirective` implements it with `handleHomonyms`, removed from `getOptionsPage`.

Second commit, on the service cache: users without department were cached as an empty string, which the `!this.cache[id]` lookup read as a miss — their department was refetched on every resolution (twice per page now that resolution runs on the whole list). Ids missing from the response are now cached too, and concurrent resolutions share a single in-flight request. Net result: no extra HTTP call compared to before.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
