### PR TITLE
[common] fix font with supported lang

### DIFF
--- a/packages/scss/src/commons/vars.scss
+++ b/packages/scss/src/commons/vars.scss
@@ -11,7 +11,11 @@
 	// TOKENS : TYPO
 
 	--pr-t-font-family: '#{config.$fontFamily}', Tahoma, sans-serif;
-	--pr-t-font-family-brand: '#{config.$fontFamilyBrand}', Tahoma, sans-serif;
+	--pr-t-font-family-brand: var(--pr-t-font-family);
+
+	&:lang(fr, en, de, nl, it, pt, es) {
+		--pr-t-font-family-brand: '#{config.$fontFamilyBrand}', Tahoma, sans-serif;
+	}
 
 	@if (config.$fontFamilyCursive) {
 		--pr-t-font-family-cursive: '#{config.$fontFamilyCursive}', cursive;


### PR DESCRIPTION
## Description

Fixes the heading font (LuccaSans), which now applies only if the languages are supported.

-----

This only works if the language is specified in the HTML tag and does not take into account language changes within the pages.

-----

Lang EN: 
<img width="1166" height="621" alt="Capture d’écran 2026-09-07 à 17 25 38" src="https://github.com/user-attachments/assets/ba936e92-e6a1-4305-851a-ba3feaed3663" />

Lang PL: 
<img width="1169" height="680" alt="Capture d’écran 2026-09-07 à 17 25 51" src="https://github.com/user-attachments/assets/bfc20867-7991-41c4-b675-53ebf88f7647" />
