### PR TITLE
fix(modal): render header and footer of ILuModalContent modals

### DIFF
--- a/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
+++ b/packages/ng/modal/dialog-adapter/dialog-content-adapter/dialog-content-adapter.component.ts
@@ -7,7 +7,7 @@ import { getIntl, Palette } from '@lucca-front/ng/core';
 import { DialogComponent, DialogContentComponent, DialogFooterComponent, DialogHeaderComponent, injectDialogData, injectDialogRef } from '@lucca-front/ng/dialog';
 import { NumericBadgeComponent } from '@lucca-front/ng/numeric-badge';
 import { isObservable, Observable, of, ReplaySubject, Subject, timer } from 'rxjs';
-import { delay, distinctUntilChanged, map, switchMap, tap } from 'rxjs/operators';
+import { delay, distinctUntilChanged, filter, map, switchMap, tap } from 'rxjs/operators';
 import { ALuModalRef } from '../../modal-ref.model';
 import { ILuModalContent, LuModalContentResult } from '../../modal.model';
 import { LU_MODAL_DATA } from '../../modal.token';
@@ -60,6 +60,9 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 	private observeValue<TValue>(selector: () => TValue | Observable<TValue>): Observable<TValue> {
 		return this.doCheck$.pipe(
 			takeUntilDestroyed(this.#destroyRef),
+			// The content component only exists from `ngAfterViewInit` onwards, while `doCheck$` (a ReplaySubject)
+			// replays the first `ngDoCheck` to the template's async pipes before that.
+			filter(() => !!this.#contentComponentInstance),
 			map(selector),
 			distinctUntilChanged(),
 			switchMap((value) => (isObservable(value) ? value : of(value))),
@@ -120,5 +123,7 @@ export class DialogContentAdapterComponent<D, C extends ILuModalContent> impleme
 		this.#contentComponentInstance = this.contentProjectionRef().createComponent(this.dialogData.component, {
 			injector,
 		}).instance;
+		// The instance is now available: replay a check so the header/footer observables emit their first value.
+		this.doCheck$.next();
 	}
 }

--- a/packages/ng/modal/modal.service.spec.ts
+++ b/packages/ng/modal/modal.service.spec.ts
@@ -1,0 +1,71 @@
+import { DialogModule } from '@angular/cdk/dialog';
+import { OverlayModule } from '@angular/cdk/overlay';
+import { ApplicationRef, ChangeDetectionStrategy, Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ILuModalContent } from './modal.model';
+import { provideLuModal } from './modal.module';
+import { LuModal } from './modal.service';
+
+@Component({
+	selector: 'lu-modal-content-test',
+	template: `<p>content</p>`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ModalContentTestComponent implements ILuModalContent<string> {
+	title = 'Modal title';
+	submitLabel = of('Save');
+	cancelLabel = 'Nope';
+
+	submitAction(): string {
+		return 'submitted';
+	}
+}
+
+@Component({
+	selector: 'lu-modal-host-test',
+	template: ``,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class ModalHostTestComponent {}
+
+describe(LuModal.name, () => {
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [OverlayModule, DialogModule],
+			providers: [provideLuModal()],
+		});
+	});
+
+	it('should render the header and footer of an ILuModalContent modal', () => {
+		const fixture = TestBed.createComponent(ModalHostTestComponent);
+		fixture.detectChanges();
+
+		TestBed.inject(LuModal).open(ModalContentTestComponent);
+		fixture.detectChanges();
+
+		const dialog = document.querySelector('.dialog');
+		expect(dialog).not.toBeNull();
+		assert(dialog !== null);
+		// Regression guard: the header/footer observables must not error on the replayed `ngDoCheck`
+		// emitted before the content component instance exists, otherwise those slots stay empty.
+		expect(dialog.querySelector('h1')?.textContent?.trim()).toBe('Modal title');
+
+		const buttons = Array.from(dialog.querySelectorAll('button')).map((button) => button.textContent?.trim());
+		expect(buttons).toContain('Save');
+		expect(buttons).toContain('Nope');
+	});
+
+	it('should render the header and footer within a single change detection cycle, without an ExpressionChanged error', () => {
+		const fixture = TestBed.createComponent(ModalHostTestComponent);
+		fixture.detectChanges();
+
+		TestBed.inject(LuModal).open(ModalContentTestComponent);
+
+		// The content component is created in `ngAfterViewInit`, so its values reach the header/footer after the
+		// view has been checked. `ApplicationRef.tick()` runs the dev-mode `checkNoChanges` over the overlay views,
+		// which `fixture.detectChanges()` on the host does not reach.
+		expect(() => TestBed.inject(ApplicationRef).tick()).not.toThrow();
+		expect(document.querySelector('.dialog h1')?.textContent?.trim()).toBe('Modal title');
+	});
+});


### PR DESCRIPTION
## Description

Since #4737, `ILuModalContent` modals opened with `LuModal.open()` render an empty
header and footer, with `TypeError: can't access property "title"` in the console.

The content component is created in `ngAfterViewInit`, but the header/footer
observables read it through `doCheck$`, a ReplaySubject fed by `ngDoCheck`. The
async pipes replay that first check before the instance exists, so every selector
throws on `undefined` — and since an error terminates an observable, `title$`,
`submitLabel$`, `cancelLabel$` and `hasSubmit$` are dead for good.

### Options considered

- **A — restore the original timing**: go back to `@ViewChild({ static: true })` +
  `ngOnInit`, so the instance exists before the first `ngDoCheck`. Removes the
  problematic window entirely, but reintroduces a decorator query.

- **B — keep the signal query (chosen)**: `filter()` out emissions received before
  the instance is available, and push a check once it is created. Stays aligned
  with the signal-queries migration.

-----

-----
