### PR TITLE
feat(markdown): add lu-markdown component to display markdown content

### DIFF
--- a/packages/ng/markdown/CHANGELOG.md
+++ b/packages/ng/markdown/CHANGELOG.md
@@ -1,0 +1,6 @@
+### 22.1.0
+
+#### Added
+
+- `lu-markdown` component rendering markdown with `marked` inside a `lu-text-flow`, headings being levelled from `[headingLevel]` and styled with the `pr-u-h*` utility classes.
+- `renderMarkdown()` function returning the same sanitized HTML, to render markdown in an existing `.textFlow` container.

--- a/packages/ng/markdown/markdown.component.spec.ts
+++ b/packages/ng/markdown/markdown.component.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * DOMPurify relies on DOM APIs that happy-dom does not implement faithfully (it lets `<script>` through and drops
+ * block-level elements), so these tests run on jsdom to exercise the real sanitization.
+ *
+ * @vitest-environment jsdom
+ */
+import { render, screen } from '@testing-library/angular';
+import { MarkdownComponent } from './markdown.component';
+
+describe(MarkdownComponent.name, () => {
+	async function renderMarkdownComponent(content: string, headingLevel?: number): Promise<HTMLElement> {
+		const { container } = await render(MarkdownComponent, {
+			inputs: { content, ...(headingLevel === undefined ? {} : { headingLevel }) },
+		});
+
+		return container;
+	}
+
+	it('should render markdown inside a text flow', async () => {
+		const container = await renderMarkdownComponent('A **bold** statement.');
+
+		expect(container.querySelector('.textFlow')).toBeInTheDocument();
+		expect(screen.getByText('bold').tagName).toBe('STRONG');
+	});
+
+	it('should render headings from the first level by default', async () => {
+		await renderMarkdownComponent('# Title\n\n## Subtitle');
+
+		expect(screen.getByRole('heading', { level: 1, name: 'Title' })).toHaveClass('pr-u-h1');
+		expect(screen.getByRole('heading', { level: 2, name: 'Subtitle' })).toHaveClass('pr-u-h2');
+	});
+
+	it('should shift heading levels while keeping their style', async () => {
+		await renderMarkdownComponent('# Title\n\n## Subtitle', 3);
+
+		expect(screen.getByRole('heading', { level: 3, name: 'Title' })).toHaveClass('pr-u-h1');
+		expect(screen.getByRole('heading', { level: 4, name: 'Subtitle' })).toHaveClass('pr-u-h2');
+	});
+
+	it('should sanitize the rendered html', async () => {
+		const container = await renderMarkdownComponent('<img src="x" onerror="alert(1)"><script>alert(1)</script>Safe');
+
+		expect(container.querySelector('script')).toBeNull();
+		expect(container.querySelector('img')).not.toHaveAttribute('onerror');
+		expect(screen.getByText('Safe')).toBeInTheDocument();
+	});
+});

--- a/packages/ng/markdown/markdown.component.ts
+++ b/packages/ng/markdown/markdown.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, computed, input, numberAttribute, ViewEncapsulation } from '@angular/core';
+import { TextFlowComponent } from '@lucca-front/ng/text-flow';
+import { renderMarkdown } from './render-markdown';
+
+@Component({
+	selector: 'lu-markdown',
+	template: '<lu-text-flow [innerHTML]="html()" />',
+	imports: [TextFlowComponent],
+	encapsulation: ViewEncapsulation.None,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MarkdownComponent {
+	readonly content = input.required<string>();
+
+	readonly headingLevel = input(1, { transform: numberAttribute });
+
+	protected html = computed(() => renderMarkdown(this.content(), { headingLevel: this.headingLevel() }));
+}

--- a/packages/ng/markdown/ng-package.json
+++ b/packages/ng/markdown/ng-package.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "../../../node_modules/ng-packagr/ng-package.schema.json",
+  "lib": {
+    "entryFile": "public-api.ts"
+  }
+}

--- a/packages/ng/markdown/public-api.ts
+++ b/packages/ng/markdown/public-api.ts
@@ -1,0 +1,2 @@
+export * from './markdown.component';
+export * from './render-markdown';

--- a/packages/ng/markdown/render-markdown.spec.ts
+++ b/packages/ng/markdown/render-markdown.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * DOMPurify relies on DOM APIs that happy-dom does not implement faithfully (it lets `<script>` through and drops
+ * block-level elements), so these tests run on jsdom to exercise the real sanitization.
+ *
+ * @vitest-environment jsdom
+ */
+import { renderMarkdown } from './render-markdown';
+
+describe(renderMarkdown.name, () => {
+	it('should return an empty string for an empty content', () => {
+		expect(renderMarkdown('')).toBe('');
+	});
+
+	it('should render inline markdown', () => {
+		expect(renderMarkdown('A **bold** [link](https://lucca.fr).')).toBe('<p>A <strong>bold</strong> <a href="https://lucca.fr">link</a>.</p>\n');
+	});
+
+	it('should render headings from the first level by default', () => {
+		expect(renderMarkdown('# Title\n\n## Subtitle')).toBe('<h1 class="pr-u-h1">Title</h1>\n<h2 class="pr-u-h2">Subtitle</h2>\n');
+	});
+
+	it('should shift heading levels while keeping their style', () => {
+		expect(renderMarkdown('# Title\n\n## Subtitle', { headingLevel: 3 })).toBe('<h3 class="pr-u-h1">Title</h3>\n<h4 class="pr-u-h2">Subtitle</h4>\n');
+	});
+
+	it('should clamp heading levels to h6 and utility classes to pr-u-h4', () => {
+		expect(renderMarkdown('##### Deep\n\n###### Deeper', { headingLevel: 5 })).toBe('<h6 class="pr-u-h4">Deep</h6>\n<h6 class="pr-u-h4">Deeper</h6>\n');
+	});
+
+	it('should sanitize the rendered html', () => {
+		expect(renderMarkdown('<img src="x" onerror="alert(1)"><script>alert(1)</script>Safe')).toBe('<p><img src="x">Safe</p>\n');
+	});
+});

--- a/packages/ng/markdown/render-markdown.ts
+++ b/packages/ng/markdown/render-markdown.ts
@@ -1,0 +1,36 @@
+import DOMPurify from 'isomorphic-dompurify';
+import { Marked, Renderer, Tokens } from 'marked';
+
+/** Deepest heading level allowed by HTML. */
+const maxHeadingLevel = 6;
+
+/** Deepest heading utility class provided by Prisme (`pr-u-h5` and `pr-u-h6` are deprecated). */
+const maxHeadingUtilityLevel = 4;
+
+export interface RenderMarkdownOptions {
+	/**
+	 * Heading level used for the top-level markdown heading (`# Heading`), the following ones being nested from it.
+	 * Set it to the level that keeps the document outline valid where the markdown is displayed: with `2`,
+	 * `# Heading` renders a `<h2 class="pr-u-h1">`, keeping the heading semantics clean while preserving its style.
+	 *
+	 * @default 1
+	 */
+	headingLevel?: number;
+}
+
+export function renderMarkdown(content: string, { headingLevel = 1 }: RenderMarkdownOptions = {}): string {
+	if (!content) {
+		return '';
+	}
+
+	const renderer = new Renderer();
+
+	renderer.heading = function (this: Renderer, { tokens, depth }: Tokens.Heading): string {
+		const level = Math.min(depth + headingLevel - 1, maxHeadingLevel);
+		const utilityClass = `pr-u-h${Math.min(depth, maxHeadingUtilityLevel)}`;
+
+		return `<h${level} class="${utilityClass}">${this.parser.parseInline(tokens)}</h${level}>\n`;
+	};
+
+	return DOMPurify.sanitize(new Marked({ renderer }).parse(content, { async: false }));
+}

--- a/packages/ng/package.json
+++ b/packages/ng/package.json
@@ -33,6 +33,7 @@
     "@lucca/prisme": "*",
     "@types/dompurify": "^3.0.0",
     "isomorphic-dompurify": "^2.17.0",
+    "marked": "^14.1.0",
     "date-fns": "^3.6.0",
     "ngx-mask": "^20.0.3",
     "rxjs": "^7.8.0",

--- a/stories/documentation/texts/markdown/angular/basic.stories.ts
+++ b/stories/documentation/texts/markdown/angular/basic.stories.ts
@@ -1,0 +1,78 @@
+import { MarkdownComponent } from '@lucca-front/ng/markdown';
+import { Meta, moduleMetadata, StoryObj } from '@storybook/angular-vite';
+import { createTestStory } from '@/helpers/stories';
+import { waitForAngular } from '@/helpers/test';
+import { expect, within } from 'storybook/test';
+
+interface MarkdownBasicStory {
+	content: string;
+	headingLevel: number;
+}
+
+const defaultContent = `# Titre principal
+
+Un paragraphe avec du **gras**, de l'*italique*, du \`code\` et un [lien](https://prisme.lucca.io).
+
+## Sous-titre
+
+- premier élément
+- deuxième élément
+
+### Sous-sous-titre
+
+1. première étape
+2. deuxième étape
+`;
+
+export default {
+	title: 'Documentation/Texts/Markdown/Angular/Basic',
+	decorators: [
+		moduleMetadata({
+			imports: [MarkdownComponent],
+		}),
+	],
+	argTypes: {
+		content: {
+			control: {
+				type: 'text',
+			},
+			description: 'Source markdown à afficher.',
+			table: { category: 'inputs' },
+		},
+		headingLevel: {
+			control: {
+				type: 'number',
+				min: 1,
+				max: 6,
+			},
+			description: 'Niveau sémantique du titre de premier niveau (`# Titre`), les suivants étant imbriqués à partir de celui-ci.',
+			table: { category: 'inputs' },
+		},
+	},
+} as Meta;
+
+export const Basic: StoryObj<MarkdownBasicStory> = {
+	args: {
+		content: defaultContent,
+		headingLevel: 1,
+	},
+	render: (args) => ({
+		props: args,
+		template: `<lu-markdown [content]="content" [headingLevel]="headingLevel" />`,
+	}),
+};
+
+export const BasicTEST = createTestStory(Basic, async ({ canvasElement, step }) => {
+	await waitForAngular();
+	const canvas = within(canvasElement);
+
+	await step('Vérifie que les titres sont rendus avec leur classe utilitaire', async () => {
+		await expect(canvas.getByRole('heading', { level: 1, name: 'Titre principal' })).toHaveClass('pr-u-h1');
+		await expect(canvas.getByRole('heading', { level: 2, name: 'Sous-titre' })).toHaveClass('pr-u-h2');
+	});
+
+	await step('Vérifie que le contenu inline est rendu', async () => {
+		await expect(canvas.getByRole('link', { name: 'lien' })).toHaveAttribute('href', 'https://prisme.lucca.io');
+		await expect(canvas.getAllByRole('listitem').length).toBeGreaterThan(0);
+	});
+});

--- a/stories/qa/markdown/markdown.stories.html
+++ b/stories/qa/markdown/markdown.stories.html
@@ -1,0 +1,200 @@
+<table class="demo-QAtable">
+	<tbody>
+		<tr>
+			<td></td>
+			<td style="inline-size: 50%">
+				<div class="demo-QAtable-list">HTML</div>
+			</td>
+			<td style="inline-size: 50%">
+				<div class="demo-QAtable-list">Angular</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Default</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<h1 class="pr-u-h1">Lorem ipsum dolor sit amet</h1>
+						<p>Consectetur adipiscing elit, sed do <strong>eiusmod tempor</strong> incididunt ut labore.</p>
+						<h2 class="pr-u-h2">Ut enim ad minim veniam</h2>
+						<ul>
+							<li>Quis nostrud exercitation ullamco</li>
+							<li>Laboris nisi ut aliquip ex ea commodo</li>
+						</ul>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="default" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Headings</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<h1 class="pr-u-h1">Lorem ipsum</h1>
+						<h2 class="pr-u-h2">Dolor sit amet</h2>
+						<h3 class="pr-u-h3">Consectetur adipiscing</h3>
+						<h4 class="pr-u-h4">Elit sed do</h4>
+						<h5 class="pr-u-h4">Eiusmod tempor</h5>
+						<h6 class="pr-u-h4">Incididunt ut labore</h6>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="headings" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>headingLevel = 3</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<h3 class="pr-u-h1">Lorem ipsum</h3>
+						<h4 class="pr-u-h2">Dolor sit amet</h4>
+						<h5 class="pr-u-h3">Consectetur adipiscing</h5>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="headingLevel" [headingLevel]="3" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Inline formatting</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<p>
+							Lorem ipsum dolor sit <strong>amet</strong>, consectetur <em>adipiscing</em> elit, sed do <code>eiusmod</code> tempor
+							<del>incididunt</del> ut <a href="https://prisme.lucca.io">labore</a>.
+						</p>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="inline" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Lists</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<ul>
+							<li>Lorem ipsum dolor</li>
+							<li>
+								Sit amet consectetur
+								<ul>
+									<li>Adipiscing elit</li>
+								</ul>
+							</li>
+						</ul>
+						<ol>
+							<li>Sed do eiusmod</li>
+							<li>Tempor incididunt</li>
+						</ol>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="lists" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Blockquote, code block &amp; separator</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<blockquote>
+							<p>Ut enim ad minim veniam, quis nostrud exercitation.</p>
+						</blockquote>
+						<pre><code>const lorem = 'ipsum';</code></pre>
+						<hr />
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="blocks" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Table</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<table>
+							<thead>
+								<tr>
+									<th>Lorem</th>
+									<th>Ipsum</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr>
+									<td>Dolor sit amet</td>
+									<td>25</td>
+								</tr>
+								<tr>
+									<td>Consectetur</td>
+									<td>10</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="table" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Empty content</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow"></div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="empty" />
+				</div>
+			</td>
+		</tr>
+		<tr>
+			<td>Unsafe content (sanitized)</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<div class="textFlow">
+						<h1 class="pr-u-h1">Lorem ipsum</h1>
+						<img src="x" />
+						<p><a>dolor sit amet</a></p>
+					</div>
+				</div>
+			</td>
+			<td>
+				<div class="demo-QAtable-list">
+					<lu-markdown [content]="unsafe" />
+				</div>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- To tell the ui-diff tool that the page has finished rendering -->
+<span id="ready"></span>

--- a/stories/qa/markdown/markdown.stories.ts
+++ b/stories/qa/markdown/markdown.stories.ts
@@ -1,0 +1,88 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { MarkdownComponent } from '@lucca-front/ng/markdown';
+import { Meta, StoryObj } from '@storybook/angular-vite';
+
+@Component({
+	selector: 'markdown-stories',
+	templateUrl: './markdown.stories.html',
+	imports: [MarkdownComponent],
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class MarkdownStory {
+	default = `# Lorem ipsum dolor sit amet
+
+Consectetur adipiscing elit, sed do **eiusmod tempor** incididunt ut labore.
+
+## Ut enim ad minim veniam
+
+- Quis nostrud exercitation ullamco
+- Laboris nisi ut aliquip ex ea commodo
+`;
+
+	headings = `# Lorem ipsum
+
+## Dolor sit amet
+
+### Consectetur adipiscing
+
+#### Elit sed do
+
+##### Eiusmod tempor
+
+###### Incididunt ut labore
+`;
+
+	headingLevel = `# Lorem ipsum
+
+## Dolor sit amet
+
+### Consectetur adipiscing
+`;
+
+	inline = `Lorem ipsum dolor sit **amet**, consectetur *adipiscing* elit, sed do \`eiusmod\` tempor ~~incididunt~~ ut [labore](https://prisme.lucca.io).
+`;
+
+	lists = `- Lorem ipsum dolor
+- Sit amet consectetur
+  - Adipiscing elit
+
+1. Sed do eiusmod
+2. Tempor incididunt
+`;
+
+	blocks = `> Ut enim ad minim veniam, quis nostrud exercitation.
+
+\`\`\`
+const lorem = 'ipsum';
+\`\`\`
+
+---
+`;
+
+	table = `| Lorem | Ipsum |
+| --- | --- |
+| Dolor sit amet | 25 |
+| Consectetur | 10 |
+`;
+
+	empty = '';
+
+	unsafe = `# Lorem ipsum <script>alert('XSS')</script>
+
+<img src="x" onerror="alert('XSS')" />
+
+<a href="javascript:alert('XSS')">dolor sit amet</a>
+`;
+}
+
+export default {
+	title: 'QA/Markdown',
+	component: MarkdownStory,
+} as Meta;
+
+const template = () => ({});
+
+export const Basic: StoryObj<MarkdownStory> = {
+	args: {},
+	render: template,
+};


### PR DESCRIPTION
## Description

Displaying markdown in an app meant parsing it by hand and wiring the styles yourself.
The new `lu-markdown` component takes a markdown string and renders it with the Text
flow styles: headings, paragraphs, lists, links, bold, italic and code.

Its `headingLevel` input sets the semantic level of the top-level `#` heading. Markdown
usually comes from somewhere else (an API field, a CMS, user input) and lands in a page
that already has its own `<h1>`, which breaks the heading outline for screen reader
users. With `headingLevel="2"`, `# Title` renders an `<h2>` styled like an `<h1>`: the
tag follows the page, the style follows the markdown.

-----

- New `@lucca-front/ng/markdown` with component and method.
- Output is sanitized with DOMPurify, like `LuSafeHtmlPipe`.
- Documentation and QA stories added.

-----
