### PR TITLE
fix(listbox): forward the checkboxField sheet from @lucca-front/ng/styles

### DIFF
--- a/packages/ng/styles/components/_listbox.scss
+++ b/packages/ng/styles/components/_listbox.scss
@@ -1,8 +1,14 @@
-// The select/listbox Angular components (`lu-listbox`, `lu-select-option`, `lu-listbox-option`,
-// color picker) ship no component-scoped CSS — their visuals live in the shared `@lucca-front/scss`
-// component sheets. Forward them here so importing `@lucca-front/ng/styles` is enough to render the
-// selects, without the consuming app also having to pull `@lucca-front/scss` `main-all` (or these
-// sheets à la carte). Loaded once per compilation, so apps that also import the scss components
-// won't emit these twice.
+// These components render listbox markup styled by shared `@lucca-front/scss` sheets, not by component-scoped CSS:
+// - `lu-listbox`.
+// - `lu-select-option`.
+// - `lu-listbox-option`.
+// - `lu-color-input`.
+//
+// Those sheets are forwarded here:
+// - Importing `@lucca-front/ng/styles` is enough to render the selects.
+// - Consumers don't need `@lucca-front/scss` `main-all`, nor these sheets à la carte.
+// - Sass loads each sheet once per compilation: apps importing them too emit them once.
+// - `checkboxField`: `multiple` option renders HTML, not `lu-checkbox-input`.
 @forward '@lucca-front/scss/src/components/listboxOption';
+@forward '@lucca-front/scss/src/components/checkboxField';
 @forward '@lucca-front/scss/src/components/color';


### PR DESCRIPTION
## Description

Multi-select options render their checkboxes when the app imports only `@lucca-front/ng/styles`.

-----

* Context:
	* The `multiple` listbox option renders `checkboxField` HTML, not `lu-checkbox-input`.
	* Its rules reached the page only when the app:
		* Loaded `lu-checkbox-input`.
		* Imported the sheet itself.
* Start with `packages/ng/styles/components/_listbox.scss`.

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [ ] E2E test or UI diff is added if required
- [ ] `npm run build` is OK
- [ ] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----

(Related to #https://github.com/LuccaSA/lucca-front/pull/5329)