### PR TITLE
fix(rich-text-input): fix tags copy/paste and undo in plain-text mode

### DIFF
--- a/packages/ng/forms/rich-text-input/formatters/plain-text/plain-text-formatter.spec.ts
+++ b/packages/ng/forms/rich-text-input/formatters/plain-text/plain-text-formatter.spec.ts
@@ -1,0 +1,115 @@
+import { $isTagNode, TagNode } from '@lucca-front/ng/forms/rich-text-input';
+import { $createParagraphNode, $createTextNode, $getRoot, $isTextNode, createEditor, LexicalEditor, LexicalNode, ParagraphNode, TextNode } from 'lexical';
+import { PlainTextFormatter } from './plain-text-formatter';
+
+describe(PlainTextFormatter.name, () => {
+	// Do not mock LexicalEditor: node transforms are the behaviour under test
+	let editor: LexicalEditor;
+	let formatter: PlainTextFormatter;
+	let unregister: () => void;
+
+	beforeEach(() => {
+		const container = document.createElement('div');
+		container.contentEditable = 'true';
+		document.body.appendChild(container);
+		editor = createEditor({
+			nodes: [TagNode],
+			onError: (error) => {
+				throw error;
+			},
+		});
+		editor.setRootElement(container);
+		formatter = new PlainTextFormatter();
+		unregister = formatter.registerTextPlugin(editor);
+	});
+
+	afterEach(() => {
+		unregister();
+	});
+
+	function $getFirstParagraphChildren(): LexicalNode[] {
+		return $getRoot().getFirstChildOrThrow<ParagraphNode>().getChildren();
+	}
+
+	function describeNode(node: LexicalNode): string {
+		if ($isTagNode(node)) {
+			return `tag:${node.getTagKey()}`;
+		}
+		if ($isTextNode(node)) {
+			return `text:${node.getTextContent()}`;
+		}
+		return node.getType();
+	}
+
+	describe('parse', () => {
+		it('should convert tags of the initial value into tag nodes', () => {
+			editor.update(() => formatter.parse(editor, 'Hello {{tag1}} world'), { discrete: true });
+
+			editor.read(() => {
+				expect($getFirstParagraphChildren().map(describeNode)).toEqual(['text:Hello ', 'tag:tag1', 'text: world']);
+			});
+		});
+	});
+
+	describe('text node transform', () => {
+		it('should convert a tag pasted as raw text into a tag node', () => {
+			editor.update(
+				() => {
+					const paragraph = $createParagraphNode();
+					paragraph.append($createTextNode('Hello world'));
+					$getRoot().append(paragraph);
+				},
+				{ discrete: true },
+			);
+
+			// Simulates what Lexical does on paste in plain-text mode: the clipboard text is inserted as raw text
+			editor.update(
+				() => {
+					const paragraph = $getRoot().getFirstChildOrThrow<ParagraphNode>();
+					paragraph.getFirstChildOrThrow<TextNode>().select(6, 6).insertRawText('{{tag1}} ');
+				},
+				{ discrete: true },
+			);
+
+			editor.read(() => {
+				expect($getFirstParagraphChildren().map(describeNode)).toEqual(['text:Hello ', 'tag:tag1', 'text: world']);
+			});
+		});
+
+		it('should convert several tags pasted at once', () => {
+			editor.update(
+				() => {
+					const paragraph = $createParagraphNode();
+					paragraph.append($createTextNode('{{tag1}} and {{tag2}}'));
+					$getRoot().append(paragraph);
+				},
+				{ discrete: true },
+			);
+
+			editor.read(() => {
+				expect($getFirstParagraphChildren().map(describeNode)).toEqual(['tag:tag1', 'text: and ', 'tag:tag2']);
+			});
+		});
+
+		it('should leave text without tags untouched', () => {
+			editor.update(
+				() => {
+					const paragraph = $createParagraphNode();
+					paragraph.append($createTextNode('Hello {{ not a tag }} world'));
+					$getRoot().append(paragraph);
+				},
+				{ discrete: true },
+			);
+
+			editor.read(() => {
+				expect($getFirstParagraphChildren().map(describeNode)).toEqual(['text:Hello {{ not a tag }} world']);
+			});
+		});
+
+		it('should keep formatting the tag as {{key}}', () => {
+			editor.update(() => formatter.parse(editor, 'Hello {{tag1}}'), { discrete: true });
+
+			expect(formatter.format(editor)).toBe('Hello {{tag1}}');
+		});
+	});
+});

--- a/packages/ng/forms/rich-text-input/formatters/plain-text/plain-text-formatter.ts
+++ b/packages/ng/forms/rich-text-input/formatters/plain-text/plain-text-formatter.ts
@@ -1,6 +1,7 @@
 import { Provider } from '@angular/core';
 import { registerPlainText } from '@lexical/plain-text';
 import { $rootTextContent } from '@lexical/text';
+import { mergeRegister } from '@lexical/utils';
 import { RICH_TEXT_FORMATTER, RichTextFormatter } from '@lucca-front/ng/forms/rich-text-input';
 import { $createParagraphNode, $createTextNode, $getRoot, LexicalEditor, TextNode } from 'lexical';
 import { PLAINTEXT_TAGS, PlainTextTransformer } from './transformers';
@@ -16,7 +17,11 @@ export class PlainTextFormatter extends RichTextFormatter {
 	}
 
 	override registerTextPlugin(editor: LexicalEditor) {
-		return registerPlainText(editor);
+		return mergeRegister(
+			registerPlainText(editor),
+			// Pasted content is inserted as raw text: apply the transformers whenever a text node changes
+			editor.registerNodeTransform(TextNode, (textNode) => this.#applyTransformers(textNode)),
+		);
 	}
 
 	override parse(editor: LexicalEditor, text?: string | null): void {

--- a/packages/ng/forms/rich-text-input/plugins/tag/tag-node.spec.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag-node.spec.ts
@@ -1,0 +1,114 @@
+import { Component, inject, ViewContainerRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { $createParagraphNode, $getNodeByKey, $getRoot, createEditor, EditorState, LexicalEditor, NodeKey } from 'lexical';
+import { $createTagNode, registerTagChipsCleanup, TagNode } from './tag-node';
+
+@Component({ template: '' })
+class HostComponent {
+	readonly viewContainerRef = inject(ViewContainerRef);
+}
+
+describe(TagNode.name, () => {
+	let editor: LexicalEditor;
+	let container: HTMLElement;
+	let viewContainerRef: ViewContainerRef;
+	let fixture: ComponentFixture<HostComponent>;
+	let tagKey: NodeKey;
+	let unregister: () => void;
+
+	beforeEach(() => {
+		fixture = TestBed.createComponent(HostComponent);
+		viewContainerRef = fixture.componentInstance.viewContainerRef;
+		container = document.createElement('div');
+		container.contentEditable = 'true';
+		document.body.appendChild(container);
+		editor = createEditor({
+			nodes: [TagNode],
+			onError: (error) => {
+				throw error;
+			},
+		});
+		editor.setRootElement(container);
+		unregister = registerTagChipsCleanup(editor);
+	});
+
+	afterEach(() => {
+		unregister();
+		container.remove();
+	});
+
+	function insertTag(): EditorState {
+		editor.update(
+			() => {
+				const paragraph = $createParagraphNode();
+				const tag = $createTagNode('tag1', viewContainerRef, 'Tag 1');
+				tagKey = tag.getKey();
+				paragraph.append(tag);
+				$getRoot().append(paragraph);
+			},
+			{ discrete: true },
+		);
+		fixture.detectChanges();
+		return editor.getEditorState();
+	}
+
+	function clear(): void {
+		editor.update(() => $getRoot().clear(), { discrete: true });
+	}
+
+	function getChips(): HTMLElement[] {
+		return Array.from(container.querySelectorAll<HTMLElement>('.chip'));
+	}
+
+	it('should render the tag as a chip', () => {
+		insertTag();
+
+		expect(getChips()).toHaveLength(1);
+		expect(getChips()[0].firstChild?.textContent).toBe('Tag 1');
+	});
+
+	it('should destroy the chip component when the tag is removed', () => {
+		insertTag();
+		const chip = getChips()[0];
+
+		clear();
+
+		expect(getChips()).toHaveLength(0);
+		expect(chip.isConnected).toBe(false);
+	});
+
+	it('should render a new chip when a removed tag is restored (undo)', () => {
+		const stateWithTag = insertTag();
+		clear();
+
+		// Restoring a previous state reuses the same node instance, as the history plugin does on undo
+		editor.setEditorState(stateWithTag);
+		editor.update(() => {}, { discrete: true });
+
+		expect(getChips()).toHaveLength(1);
+		expect(getChips()[0].firstChild?.textContent).toBe('Tag 1');
+	});
+
+	it('should still allow removing the tag from a restored chip', () => {
+		const stateWithTag = insertTag();
+		clear();
+		editor.setEditorState(stateWithTag);
+		editor.update(() => {}, { discrete: true });
+		fixture.detectChanges();
+
+		getChips()[0].querySelector('button')?.click();
+		editor.update(() => {}, { discrete: true });
+
+		expect(getChips()).toHaveLength(0);
+	});
+
+	it('should not duplicate the label when the tag DOM is recreated', () => {
+		insertTag();
+
+		editor.update(() => $getNodeByKey<TagNode>(tagKey)?.setTagDescription('Tag one'), { discrete: true });
+
+		expect(getChips()).toHaveLength(1);
+		expect(getChips()[0].firstChild?.textContent).toBe('Tag one');
+		expect(getChips()[0].textContent).not.toContain('Tag 1');
+	});
+});

--- a/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
@@ -41,7 +41,7 @@ function getTagChips(editor: LexicalEditor): Map<NodeKey, Set<ComponentRef<ChipC
 }
 
 /** Destroy the chip components of a tag node that are no longer in the editor DOM. */
-export function destroyStaleTagChips(editor: LexicalEditor, nodeKey: NodeKey): void {
+function destroyStaleTagChips(editor: LexicalEditor, nodeKey: NodeKey): void {
 	const chips = getTagChips(editor);
 	const refs = chips.get(nodeKey);
 	if (!refs) {

--- a/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag-node.ts
@@ -1,5 +1,6 @@
 import {
 	$createTextNode,
+	$getNodeByKey,
 	COMMAND_PRIORITY_NORMAL,
 	DecoratorNode,
 	type DOMConversion,
@@ -27,12 +28,48 @@ export type SerializedTagNode = Spread<
 	SerializedLexicalNode
 >;
 
+// Chip components per editor and node key. Not stored on the nodes: Lexical clones them and reuses old instances on undo/redo.
+const tagChips = new WeakMap<LexicalEditor, Map<NodeKey, Set<ComponentRef<ChipComponent>>>>();
+
+function getTagChips(editor: LexicalEditor): Map<NodeKey, Set<ComponentRef<ChipComponent>>> {
+	let chips = tagChips.get(editor);
+	if (!chips) {
+		chips = new Map();
+		tagChips.set(editor, chips);
+	}
+	return chips;
+}
+
+/** Destroy the chip components of a tag node that are no longer in the editor DOM. */
+export function destroyStaleTagChips(editor: LexicalEditor, nodeKey: NodeKey): void {
+	const chips = getTagChips(editor);
+	const refs = chips.get(nodeKey);
+	if (!refs) {
+		return;
+	}
+	const currentElement = editor.getElementByKey(nodeKey);
+	refs.forEach((ref) => {
+		if (ref.location.nativeElement !== currentElement) {
+			ref.destroy();
+			refs.delete(ref);
+		}
+	});
+	if (refs.size === 0) {
+		chips.delete(nodeKey);
+	}
+}
+
+/** Destroy stale chip components once Lexical has reconciled the DOM. */
+export function registerTagChipsCleanup(editor: LexicalEditor): () => void {
+	return editor.registerMutationListener(TagNode, (mutations) => {
+		mutations.forEach((_mutation, nodeKey) => destroyStaleTagChips(editor, nodeKey));
+	});
+}
+
 export class TagNode extends DecoratorNode<string> {
 	#tagKey: string;
 	#tagDescription?: string;
 	#disabled: boolean;
-	// Store the component reference on the node instance
-	#componentRef?: ComponentRef<ChipComponent>;
 	#viewContainerRef?: ViewContainerRef;
 
 	setViewContainerRef(vcr: ViewContainerRef): this {
@@ -101,32 +138,35 @@ export class TagNode extends DecoratorNode<string> {
 	override createDOM(_config: EditorConfig, editor: LexicalEditor): HTMLElement {
 		if (this.#viewContainerRef) {
 			if (!editor.isEditable()) {
-				this.#componentRef?.destroy();
 				const span = document.createElement('span');
 				span.textContent = this.#tagDescription ?? this.#tagKey;
 				return span;
 			}
-			if (!this.#componentRef) {
-				// Create the component
-				this.#componentRef = this.#viewContainerRef.createComponent(ChipComponent);
+			// Always create a new component, stale ones are destroyed by `registerTagChipsCleanup`
+			const componentRef = this.#viewContainerRef.createComponent(ChipComponent);
+			const chips = getTagChips(editor);
+			const nodeKey = this.getKey();
+			if (!chips.has(nodeKey)) {
+				chips.set(nodeKey, new Set());
 			}
+			chips.get(nodeKey)?.add(componentRef);
 
 			// Set inputs on the component instance
-			this.#componentRef.setInput('unkillable', false);
-			this.#componentRef.setInput('palette', 'product');
-			this.#componentRef.setInput('disabled', this.#disabled);
+			componentRef.setInput('unkillable', false);
+			componentRef.setInput('palette', 'product');
+			componentRef.setInput('disabled', this.#disabled);
 
 			// Get the component's DOM element
-			const componentElement = this.#componentRef.location.nativeElement as HTMLElement;
+			const componentElement = componentRef.location.nativeElement as HTMLElement;
 			const textNode = document.createTextNode(this.#tagDescription ?? this.#tagKey);
 			componentElement.insertBefore(textNode, componentElement.firstChild);
 			componentElement.classList.add('mod-S');
 			componentElement.classList.add('richTextField-content-chip');
 
 			// Add click handler ONLY to the delete button, not the whole chip
-			this.#componentRef.instance.kill.subscribe(() => {
+			componentRef.instance.kill.subscribe(() => {
 				editor.update(() => {
-					this.remove();
+					$getNodeByKey(nodeKey)?.remove();
 				});
 			});
 
@@ -140,11 +180,6 @@ export class TagNode extends DecoratorNode<string> {
 
 	override updateDOM(prevNode: TagNode, _dom: HTMLElement, _config: EditorConfig): boolean {
 		return this.#tagDescription !== prevNode.#tagDescription || this.#tagKey !== prevNode.#tagKey || this.#disabled !== prevNode.#disabled || this.#viewContainerRef !== prevNode.#viewContainerRef;
-	}
-
-	override remove(preserveEmptyParent?: boolean): void {
-		super.remove(preserveEmptyParent);
-		this.#componentRef?.destroy();
 	}
 
 	override exportDOM(): DOMExportOutput {

--- a/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
+++ b/packages/ng/forms/rich-text-input/plugins/tag/tag.component.ts
@@ -2,6 +2,7 @@ import { ConnectionPositionPair } from '@angular/cdk/overlay';
 import { ChangeDetectionStrategy, Component, computed, effect, ElementRef, forwardRef, inject, input, OnDestroy, signal, viewChild, viewChildren, ViewContainerRef } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { mergeRegister } from '@lexical/utils';
 import { ButtonComponent } from '@lucca-front/ng/button';
 import { ChipComponent } from '@lucca-front/ng/chip';
 import { intlInputOptions, isNotNil } from '@lucca-front/ng/core';
@@ -11,7 +12,7 @@ import { IconComponent } from '@lucca/prisme/icon';
 import { $getNodeByKey, $getRoot, $getSelection, type Klass, type LexicalEditor, type LexicalNode, type NodeKey, SKIP_DOM_SELECTION_TAG } from 'lexical';
 import { INITIAL_UPDATE_TAG, RICH_TEXT_PLUGIN_COMPONENT, RichTextPluginComponent } from '../../rich-text-input.component';
 import { LU_RICH_TEXT_INPUT_TRANSLATIONS } from '../../rich-text-input.translate';
-import { $createTagNode, TagNode } from './tag-node';
+import { $createTagNode, registerTagChipsCleanup, TagNode } from './tag-node';
 import type { Tag } from './tag.model';
 import { FilterPillComponent } from '@lucca-front/ng/filter-pills';
 
@@ -104,25 +105,28 @@ export class RichTextPluginTagComponent implements RichTextPluginComponent, OnDe
 	setEditorInstance(editor: LexicalEditor): void {
 		this.editor = editor;
 
-		// listen for new partial tag nodes (coming from formatters)
-		this.#registeredCommands = this.editor.registerMutationListener(
-			TagNode,
-			(mutations) => {
-				const newNodes = new Set<NodeKey>(this.#tagNodeKeys());
-				this.editor?.read(() => {
-					mutations.forEach((m, k) => {
-						if (m === 'created') {
-							newNodes.add(k);
-						} else if (m === 'destroyed') {
-							newNodes.delete(k);
+		this.#registeredCommands = mergeRegister(
+			registerTagChipsCleanup(this.editor),
+			// listen for new partial tag nodes (coming from formatters)
+			this.editor.registerMutationListener(
+				TagNode,
+				(mutations) => {
+					const newNodes = new Set<NodeKey>(this.#tagNodeKeys());
+					this.editor?.read(() => {
+						mutations.forEach((m, k) => {
+							if (m === 'created') {
+								newNodes.add(k);
+							} else if (m === 'destroyed') {
+								newNodes.delete(k);
+							}
+						});
+						if (!areSetsEqual(newNodes, this.#tagNodeKeys())) {
+							this.#tagNodeKeys.set(newNodes);
 						}
 					});
-					if (!areSetsEqual(newNodes, this.#tagNodeKeys())) {
-						this.#tagNodeKeys.set(newNodes);
-					}
-				});
-			},
-			{ skipInitialization: true },
+				},
+				{ skipInitialization: true },
+			),
 		);
 	}
 


### PR DESCRIPTION
## Description

Pasting a copied tag in a plain-text rich text input (an email subject, for instance) recreates the tag chip. It used to paste `{{Tag}}` as raw text. Undoing the deletion of a tag no longer breaks the editor, which used to throw `Reconciliation: could not find DOM element` on every following keystroke.

-----

Reported in LuccaSA/Talent.PeopleReview#1645.

Start with `plain-text-formatter.ts`. In plain-text mode Lexical inserts pasted content as raw text, and the formatter only applied its `{{Tag}}` transformers when parsing the initial value. A `TextNode` transform now applies them on every text change, so typing `{{tag}}` by hand also creates a chip.

Then `tag-node.ts`. The chip `ComponentRef` was stored on the node instance and destroyed by `remove()`. Lexical reuses old node instances on undo, so restoring a deleted tag reused a destroyed component and threw NG0953 during the reconciliation. Chips are now created on every `createDOM`, tracked per editor and node key, and the stale ones are destroyed once the DOM is reconciled. This also fixes the chip label being duplicated when its DOM was recreated. The two new specs cover the paste and the undo scenarios.

Stories to check in the Storybook preview: `RichTextInput / Angular / With Tag Plugin Plain Text` and `With Tag Plugin Markdown` (copy, paste, Ctrl+A, delete, undo, redo).

-----

### Contribution

- [x] Root cause of the bug is identified and understood
- [x] Bug is no longer reproducible
- [x] E2E test or UI diff is added if required
- [x] `npm run build` is OK
- [x] `npm run lint` is OK

### Functional review

- [ ] UI diff is OK
- [ ] All related impacted functionalities are manually tested and show no regression

-----
