### PR TITLE
fix(core-select): select the whole group on group select all

### DIFF
--- a/packages/ng/core-select/api/api.directive.ts
+++ b/packages/ng/core-select/api/api.directive.ts
@@ -52,6 +52,13 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 	 */
 	protected abstract getOptions(params: TParams, page: number): Observable<TOption[]>;
 
+	/**
+	 * Return every option of a group, ignoring pagination, so the group "select all" acts on the whole
+	 * group and not only on the pages already loaded. Override it in directives that set a grouping;
+	 * left undefined, the panel keeps its default behaviour and toggles the rendered options only.
+	 */
+	protected getGroupOptions?: (group: unknown) => Observable<TOption[]>;
+
 	#lastClue?: string;
 	#lastPage?: number;
 
@@ -70,8 +77,9 @@ export abstract class ALuCoreSelectApiDirective<TOption, TParams = Record<string
 			this.clearLastPageByClue();
 		});
 
-		const dataSource: SelectDataSource<TOption> = {
+		const dataSource: SelectDataSource<TOption, unknown> = {
 			paramsChange: this.params$,
+			...(this.getGroupOptions ? { getGroupOptions: (group: unknown) => this.getGroupOptions!(group) } : {}),
 			clueDebounceMs: this.debounceDuration,
 			getTotalCount: () => this.totalCount$,
 			reset: () => this.clearLastPageByClue(),

--- a/packages/ng/core-select/establishment/establishments.directive.spec.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.spec.ts
@@ -1,0 +1,119 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ChangeDetectionStrategy, Component, Directive, forwardRef, signal, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { SelectDataSource } from '@lucca-front/ng/core-select';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { LuCoreSelectEstablishmentsDirective } from './establishments.directive';
+import { LuCoreSelectEstablishment } from './models';
+
+const establishmentsUrl = '/organization/structure/api/establishments';
+const legalUnitsUrl = '/organization/structure/api/legal-units';
+
+const establishment = (id: number, legalUnitId: number): LuCoreSelectEstablishment => ({
+	id,
+	name: `Establishment ${id}`,
+	code: `E${id}`,
+	legalUnitId,
+	legalUnit: { id: legalUnitId, name: `Legal unit ${legalUnitId}`, countryId: 1 },
+});
+
+@Directive({
+	selector: '[luTestEstablishments]',
+	providers: [
+		{
+			provide: LuCoreSelectEstablishmentsDirective,
+			useExisting: forwardRef(() => TestEstablishmentsDirective),
+		},
+	],
+})
+class TestEstablishmentsDirective extends LuCoreSelectEstablishmentsDirective {
+	public setPageSize(size: number): void {
+		this.pageSize = size;
+	}
+}
+
+@Component({
+	selector: 'lu-establishments-directive-host',
+	imports: [LuMultiSelectInputComponent, TestEstablishmentsDirective],
+	template: `<lu-multi-select luTestEstablishments [filters]="filters()" [operationIds]="operationIds()" />`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class LuEstablishmentsDirectiveHostComponent {
+	readonly filters = signal<Record<string, string | number | boolean> | null>(null);
+	readonly operationIds = signal<readonly number[] | null>(null);
+	readonly multiSelect = viewChild.required<LuMultiSelectInputComponent<LuCoreSelectEstablishment>>(LuMultiSelectInputComponent);
+	readonly establishmentsDirective = viewChild.required<TestEstablishmentsDirective>(TestEstablishmentsDirective);
+}
+
+describe(LuCoreSelectEstablishmentsDirective.name, () => {
+	let httpTestingController: HttpTestingController;
+	let fixture: ComponentFixture<LuEstablishmentsDirectiveHostComponent>;
+	let host: LuEstablishmentsDirectiveHostComponent;
+
+	/** The grouping service gates every options call behind those two count calls. */
+	function flushGroupingCounts(): void {
+		httpTestingController.match((req) => req.url === legalUnitsUrl).forEach((req) => req.flush({ count: 2 }));
+		httpTestingController.match((req) => req.url === establishmentsUrl && req.params.get('fields.root') === 'count').forEach((req) => req.flush({ count: 42 }));
+	}
+
+	function getGroupOptions(legalUnitId: number): LuCoreSelectEstablishment[] {
+		const dataSource = host.multiSelect().dataSource() as SelectDataSource<LuCoreSelectEstablishment, unknown>;
+		const options: LuCoreSelectEstablishment[] = [];
+		dataSource.getGroupOptions!(legalUnitId).subscribe((groupOptions) => options.push(...groupOptions));
+		return options;
+	}
+
+	function expectGroupPage(legalUnitId: number, page: number) {
+		return httpTestingController.expectOne((req) => req.url === establishmentsUrl && req.params.get('legalUnitId') === `${legalUnitId}` && req.params.get('page') === `${page}`);
+	}
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [LuEstablishmentsDirectiveHostComponent],
+			providers: [provideHttpClient(), provideHttpClientTesting()],
+		});
+
+		httpTestingController = TestBed.inject(HttpTestingController);
+		fixture = TestBed.createComponent(LuEstablishmentsDirectiveHostComponent);
+		host = fixture.componentInstance;
+		fixture.detectChanges();
+		host.establishmentsDirective().setPageSize(2);
+		flushGroupingCounts();
+	});
+
+	afterEach(() => {
+		httpTestingController.verify();
+	});
+
+	it('should expose getGroupOptions on its data source', () => {
+		expect(host.multiSelect().dataSource().getGroupOptions).toBeDefined();
+	});
+
+	it('should load every page of the legal unit, including the options not rendered yet', fakeAsync(() => {
+		const options = getGroupOptions(1);
+
+		expectGroupPage(1, 1).flush([establishment(1, 1), establishment(2, 1)]);
+		tick();
+		// The first page is full, so a second one is requested
+		expectGroupPage(1, 2).flush([establishment(3, 1)]);
+		tick();
+
+		expect(options.map((option) => option.id)).toEqual([1, 2, 3]);
+	}));
+
+	it('should restrict the legal unit call with the same filters as the list', fakeAsync(() => {
+		host.filters.set({ appInstanceId: 5 });
+		host.operationIds.set([12, 13]);
+		fixture.detectChanges();
+
+		getGroupOptions(7);
+
+		const req = expectGroupPage(7, 1);
+		expect(req.request.params.get('appInstanceId')).toBe('5');
+		expect(req.request.params.get('operations')).toBe('12,13');
+		expect(req.request.params.get('search')).toBeNull();
+		req.flush([establishment(1, 7)]);
+		tick();
+	}));
+});

--- a/packages/ng/core-select/establishment/establishments.directive.ts
+++ b/packages/ng/core-select/establishment/establishments.directive.ts
@@ -53,16 +53,44 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 		});
 	}
 
+	/**
+	 * Params shared by every call: the restrictions that define which establishments are selectable,
+	 * without the clue-dependent search and sort.
+	 */
+	readonly #restrictionParams = computed<Record<string, string | number | boolean>>(() => {
+		const operationIds = this.operationIds();
+		const uniqueOperationIds = this.uniqueOperationIds();
+		const appInstanceId = this.appInstanceId();
+		return {
+			...this.filters(),
+			...(operationIds ? { operations: operationIds.join(',') } : {}),
+			...(uniqueOperationIds ? { uniqueOperations: uniqueOperationIds.join(',') } : {}),
+			...(appInstanceId ? { appInstanceId } : {}),
+		};
+	});
+
 	protected override buildParamsFromClue(clue: string): Observable<Record<string, string | number | boolean>> {
 		// Use the clue parameter directly instead of reading from the async signal
 		// to avoid stale params when selection triggers an immediate clue reset
 		return of({
-			...this.filters(),
+			...this.#restrictionParams(),
 			...(clue ? { search: applySearchDelimiter(clue, this.searchDelimiter()), sort: 'name' } : { sort: 'legalunit.name,name' }),
-			...(this.operationIds() ? { operations: this.operationIds()!.join(',') } : {}),
-			...(this.uniqueOperationIds() ? { uniqueOperations: this.uniqueOperationIds()!.join(',') } : {}),
-			...(this.appInstanceId() ? { appInstanceId: this.appInstanceId() } : {}),
 		});
+	}
+
+	/**
+	 * Establishments are grouped by legal unit, but the panel only knows the options of the pages it
+	 * already loaded: a legal unit spanning several pages would be partially selected. Fetch the whole
+	 * legal unit instead, page by page, so "select all" covers the options that are not rendered yet.
+	 * Groups are only displayed when the clue is empty, hence the clue-less params.
+	 */
+	protected override getGroupOptions = (legalUnitId: unknown): Observable<T[]> => this.#getLegalUnitOptions(legalUnitId as number, 0);
+
+	#getLegalUnitOptions(legalUnitId: number, page: number): Observable<T[]> {
+		const params = { ...this.#restrictionParams(), legalUnitId, sort: 'name' };
+		return this.getOptions(params, page).pipe(
+			switchMap((options) => (options.length < this.pageSize ? of(options) : this.#getLegalUnitOptions(legalUnitId, page + 1).pipe(map((nextOptions) => [...options, ...nextOptions])))),
+		);
 	}
 
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
@@ -80,21 +108,15 @@ export class LuCoreSelectEstablishmentsDirective<T extends LuCoreSelectEstablish
 	}
 
 	protected override readonly paramsSignal = computed<Record<string, string | number | boolean>>(() => {
-		const operationIds = this.operationIds();
-		const uniqueOperationIds = this.uniqueOperationIds();
-		const appInstanceId = this.appInstanceId();
 		const clue = this.clue();
 		const searchDelimiter = this.searchDelimiter();
 		return {
-			...this.filters(),
+			...this.#restrictionParams(),
 			...(clue
 				? // When the clue is not empty, sort establishments by name
 					{ search: applySearchDelimiter(clue, searchDelimiter), sort: 'name' }
 				: // When the clue is empty, establishments are grouped by legal unit, so sort them by legal unit name and then by name
 					{ sort: 'legalunit.name,name' }),
-			...(operationIds ? { operations: operationIds.join(',') } : {}),
-			...(uniqueOperationIds ? { uniqueOperations: uniqueOperationIds.join(',') } : {}),
-			...(appInstanceId ? { appInstanceId } : {}),
 		};
 	});
 	protected override readonly params$: Observable<Record<string, string | number | boolean>> = toObservable(this.paramsSignal);

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.spec.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.spec.ts
@@ -1,0 +1,107 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { ChangeDetectionStrategy, Component, Directive, forwardRef, signal, viewChild } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { SelectDataSource } from '@lucca-front/ng/core-select';
+import { LuMultiSelectInputComponent } from '@lucca-front/ng/multi-select';
+import { LuCoreSelectJobQualificationsDirective } from './job-qualifications.directive';
+import { LuCoreSelectJobQualification } from './models';
+
+const jobQualificationsUrl = '/organization/structure/api/job-qualifications';
+
+const jobQualification = (id: number, jobId: number): LuCoreSelectJobQualification => ({
+	id,
+	name: `Qualification ${id}`,
+	job: { id: jobId, name: `Job ${jobId}` },
+	level: { id, name: `Level ${id}` },
+});
+
+@Directive({
+	selector: '[luTestJobQualifications]',
+	providers: [
+		{
+			provide: LuCoreSelectJobQualificationsDirective,
+			useExisting: forwardRef(() => TestJobQualificationsDirective),
+		},
+	],
+})
+class TestJobQualificationsDirective extends LuCoreSelectJobQualificationsDirective {
+	public setPageSize(size: number): void {
+		this.pageSize = size;
+	}
+}
+
+@Component({
+	selector: 'lu-job-qualifications-directive-host',
+	imports: [LuMultiSelectInputComponent, TestJobQualificationsDirective],
+	template: `<lu-multi-select luTestJobQualifications [filters]="filters()" />`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+class LuJobQualificationsDirectiveHostComponent {
+	readonly filters = signal<Record<string, string | number | boolean> | null>(null);
+	readonly multiSelect = viewChild.required<LuMultiSelectInputComponent<LuCoreSelectJobQualification>>(LuMultiSelectInputComponent);
+	readonly jobQualificationsDirective = viewChild.required<TestJobQualificationsDirective>(TestJobQualificationsDirective);
+}
+
+describe(LuCoreSelectJobQualificationsDirective.name, () => {
+	let httpTestingController: HttpTestingController;
+	let fixture: ComponentFixture<LuJobQualificationsDirectiveHostComponent>;
+	let host: LuJobQualificationsDirectiveHostComponent;
+
+	function getGroupOptions(jobId: number): LuCoreSelectJobQualification[] {
+		const dataSource = host.multiSelect().dataSource() as SelectDataSource<LuCoreSelectJobQualification, unknown>;
+		const options: LuCoreSelectJobQualification[] = [];
+		dataSource.getGroupOptions!(jobId).subscribe((groupOptions) => options.push(...groupOptions));
+		return options;
+	}
+
+	function expectGroupPage(jobId: number, page: number) {
+		return httpTestingController.expectOne((req) => req.url === jobQualificationsUrl && req.params.get('job.id') === `${jobId}` && req.params.get('page') === `${page}`);
+	}
+
+	beforeEach(() => {
+		TestBed.configureTestingModule({
+			imports: [LuJobQualificationsDirectiveHostComponent],
+			providers: [provideHttpClient(), provideHttpClientTesting()],
+		});
+
+		httpTestingController = TestBed.inject(HttpTestingController);
+		fixture = TestBed.createComponent(LuJobQualificationsDirectiveHostComponent);
+		host = fixture.componentInstance;
+		fixture.detectChanges();
+		host.jobQualificationsDirective().setPageSize(2);
+	});
+
+	afterEach(() => {
+		httpTestingController.verify();
+	});
+
+	it('should expose getGroupOptions on its data source', () => {
+		expect(host.multiSelect().dataSource().getGroupOptions).toBeDefined();
+	});
+
+	it('should load every page of the job, including the options not rendered yet', fakeAsync(() => {
+		const options = getGroupOptions(1);
+
+		expectGroupPage(1, 1).flush([jobQualification(1, 1), jobQualification(2, 1)]);
+		tick();
+		// The first page is full, so a second one is requested
+		expectGroupPage(1, 2).flush([jobQualification(3, 1)]);
+		tick();
+
+		expect(options.map((option) => option.id)).toEqual([1, 2, 3]);
+	}));
+
+	it('should restrict the job call with the same filters as the list', fakeAsync(() => {
+		host.filters.set({ isActive: true });
+		fixture.detectChanges();
+
+		getGroupOptions(7);
+
+		const req = expectGroupPage(7, 1);
+		expect(req.request.params.get('isActive')).toBe('true');
+		expect(req.request.params.get('search')).toBeNull();
+		req.flush([jobQualification(1, 7)]);
+		tick();
+	}));
+});

--- a/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
+++ b/packages/ng/core-select/job-qualification/job-qualifications.directive.ts
@@ -49,6 +49,21 @@ export class LuCoreSelectJobQualificationsDirective<T extends LuCoreSelectJobQua
 		});
 	}
 
+	/**
+	 * Job qualifications are grouped by job, but the panel only knows the options of the pages it
+	 * already loaded: a job spanning several pages would be partially selected. Fetch the whole job
+	 * instead, page by page, so "select all" covers the options that are not rendered yet. Groups are
+	 * only displayed when the clue is empty, hence the clue-less params.
+	 */
+	protected override getGroupOptions = (jobId: unknown): Observable<T[]> => this.#getJobOptions(jobId as number, 0);
+
+	#getJobOptions(jobId: number, page: number): Observable<T[]> {
+		const params = { ...this.filters(), 'job.id': jobId, sort: 'level.position' };
+		return this.getOptions(params, page).pipe(
+			switchMap((options) => (options.length < this.pageSize ? of(options) : this.#getJobOptions(jobId, page + 1).pipe(map((nextOptions) => [...options, ...nextOptions])))),
+		);
+	}
+
 	protected override getOptions(params: Record<string, string | number | boolean> | null, page: number): Observable<T[]> {
 		return this.httpClient
 			.get<T[] | { items: T[] }>(this.url(), {

--- a/packages/ng/multi-select/panel/panel.component.html
+++ b/packages/ng/multi-select/panel/panel.component.html
@@ -33,7 +33,7 @@
 							(click)="toggleOptions(groupCtx.notSelectedOptions, group.options, group.key)"
 						>
 							@if (groupLoadingKeys().has(group.key)) {
-								<span class="loading"></span>
+								<span class="pr-u-displayInlineBlock pr-u-colorTextSubtle">{{ intl().loading }}</span>
 							} @else {
 								<span class="pr-u-mask">{{ groupingTitleRef.innerText }}&nbsp;– </span
 								>{{ groupCtx.isGroupSelected ? intl().unselectAll : intl().selectAll }}


### PR DESCRIPTION
## Description

In an establishment or job qualification multi-select, the "Select all" button of a group only selected the options already displayed: the ones on the next pages were ignored until you scrolled to load them. The button now selects the whole group, whether it is fully displayed or not.

-----

The panel already loads a full group on the fly through `SelectDataSource.getGroupOptions`, but no API directive implemented it. This PR adds an optional `getGroupOptions` hook on `ALuCoreSelectApiDirective` (wired into the data source only when a child directive defines it), and implements it in the two directives that set a grouping: establishments fetch their legal unit through `legalUnitId`, job qualifications their job through `job.id`. Both keep the same restrictions as the list (`filters`, and for establishments `operations`, `uniqueOperations`, `appInstanceId`).

-----
