### PR TITLE
fix(Tag): IconOnly width adjustments

### DIFF
--- a/packages/scss/src/components/tag/component.scss
+++ b/packages/scss/src/components/tag/component.scss
@@ -5,7 +5,7 @@
 	background-color: var(--components-tag-background);
 	border-radius: var(--pr-t-border-radius-small);
 	padding-block: 0;
-	padding-inline: var(--pr-t-spacings-50);
+	padding-inline: var(--components-tag-padding-inline);
 	text-decoration: var(--components-tag-decoration);
 	box-shadow: 0 0 0 1px var(--components-tag-shadow);
 	gap: var(--components-tag-gap);

--- a/packages/scss/src/components/tag/index.scss
+++ b/packages/scss/src/components/tag/index.scss
@@ -40,6 +40,13 @@
 
 		&:has(.lucca-icon) {
 			@include withIcon;
+
+			// mask condition is necessary for hiddenLabel
+			&:not(:has(.tag-content)),
+			&:has(.tag-content:empty),
+			&:has(.tag-content.pr-u-mask) {
+				@include onlyIcon;
+			}
 		}
 
 		&:has(.tag-content:empty) {

--- a/packages/scss/src/components/tag/mods.scss
+++ b/packages/scss/src/components/tag/mods.scss
@@ -78,3 +78,7 @@
 @mixin withIcon {
 	--components-tag-before-content: ' ';
 }
+
+@mixin onlyIcon {
+	--components-tag-padding-inline: var(--pr-t-spacings-25);
+}

--- a/packages/scss/src/components/tag/vars.scss
+++ b/packages/scss/src/components/tag/vars.scss
@@ -10,6 +10,7 @@
 	--components-tag-position: static;
 	--components-tag-before-content: none;
 	--components-tag-display: inline-flex;
+	--components-tag-padding-inline: var(--pr-t-spacings-50);
 
 	// Deprecated
 	--components-tag-fontSize: var(--pr-t-font-body-S-fontSize);

--- a/stories/qa/tags/tags.stories.html
+++ b/stories/qa/tags/tags.stories.html
@@ -94,24 +94,50 @@
 		<tr>
 			<td>Icon only</td>
 			<td>
-				<span class="tag">
-					<span class="lucca-icon icon-heart" aria-hidden="true"></span>
-				</span>
+				<div class="demo-QAtable-list">
+					<span class="tag mod-S">
+						<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+					</span>
+					<span class="tag">
+						<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+					</span>
+					<span class="tag mod-L">
+						<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+					</span>
+				</div>
 			</td>
 			<td>
-				<lu-tag icon="heart" />
+				<div class="demo-QAtable-list">
+					<lu-tag icon="heart" size="S" />
+					<lu-tag icon="heart" size="M" />
+					<lu-tag icon="heart" size="L" />
+				</div>
 			</td>
 		</tr>
 		<tr>
 			<td>Hidden label</td>
 			<td>
-				<span class="tag">
-					<span class="lucca-icon icon-heart" aria-hidden="true"></span>
-					<span class="tag-content pr-u-mask">Text</span>
-				</span>
+				<div class="demo-QAtable-list">
+					<span class="tag mod-S">
+						<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+						<span class="tag-content pr-u-mask">Text</span>
+					</span>
+					<span class="tag">
+						<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+						<span class="tag-content pr-u-mask">Text</span>
+					</span>
+					<span class="tag mod-L">
+						<span class="lucca-icon icon-heart" aria-hidden="true"></span>
+						<span class="tag-content pr-u-mask">Text</span>
+					</span>
+				</div>
 			</td>
 			<td>
-				<lu-tag icon="heart" label="Text" hiddenLabel />
+				<div class="demo-QAtable-list">
+					<lu-tag icon="heart" label="Text" hiddenLabel size="S" />
+					<lu-tag icon="heart" label="Text" hiddenLabel size="M" />
+					<lu-tag icon="heart" label="Text" hiddenLabel size="L" />
+				</div>
 			</td>
 		</tr>
 		<tr>


### PR DESCRIPTION
## Description

`IconOnly` width adjustments

-----

<img width="851" height="378" alt="Capture d’écran 2026-09-11 à 15 25 25" src="https://github.com/user-attachments/assets/08631330-08c0-489e-8ddc-d98f736881e6" />


-----
